### PR TITLE
chore: add feature flags scaffolding (no behavior change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,7 @@ This starter kit intentionally leaves many implementation details up to you. You
 
 ## Deploy Status
 [![Deploy to Firebase Hosting (WIF)](https://github.com/ted-design/shot-builder-app/actions/workflows/deploy.yml/badge.svg)](https://github.com/ted-design/shot-builder-app/actions/workflows/deploy.yml)
+
+## Feature Flags & Rollout
+New features are gated in `src/lib/flags.js` and default to `false`.
+Enable flags only for testing/rollout; remove the flag once a feature is fully stable.

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -1,0 +1,7 @@
+export const FLAGS = {
+  pdfExport: false,
+  productSearch: false,
+  newNavbar: false,
+  calendarPlanner: false,
+  newAuthContext: false,
+};


### PR DESCRIPTION
  - Summary — Introduces src/lib/flags.js and a “Feature Flags & Rollout” README section.
  - Behavior — No runtime changes; all flags default to false.
  - Testing — npm ci && npm run lint && npm test --if-present && npm run build passed locally.
  - Rollback — Revert this commit.
  - Follow-ups — Phase 2 will add PDF demo gated by FLAGS.pdfExport + ?pdfDemo=1.