### PR TITLE
Micro-PR #9: Gate one protected route by auth readiness

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { FLAGS } from "./lib/flags";
 import { useAuth } from "./context/AuthContext";
 import { adaptUser } from "./auth/adapter";
 import ImportProducts from "./pages/ImportProducts";
+import AuthReadyGate from "./auth/AuthReadyGate";
 import LoginPage from "./pages/LoginPage";
 import ShotsPage from "./pages/ShotsPage";
 import PlannerPage from "./pages/PlannerPage";
@@ -71,7 +72,16 @@ export default function App() {
       <Routes>
         <Route path="/login" element={<LoginPage />} />
         <Route path="/" element={<Navigate to="/projects" replace />} />
-        <Route path="/projects" element={<RequireAuth user={userForGuard}><ProjectsPage /></RequireAuth>} />
+        <Route
+          path="/projects"
+          element={
+            <AuthReadyGate fallback={null}>
+              <RequireAuth user={userForGuard}>
+                <ProjectsPage />
+              </RequireAuth>
+            </AuthReadyGate>
+          }
+        />
         <Route path="/shots" element={<RequireAuth user={userForGuard}><ShotsPage /></RequireAuth>} />
         <Route path="/planner" element={<RequireAuth user={userForGuard}><PlannerPage /></RequireAuth>} />
         <Route path="/products" element={<RequireAuth user={userForGuard}><ProductsPage /></RequireAuth>} />

--- a/src/auth/AuthReadyGate.jsx
+++ b/src/auth/AuthReadyGate.jsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { FLAGS } from "../lib/flags";
+import { useAuth } from "../context/AuthContext";
+
+export default function AuthReadyGate({ children, fallback = null }) {
+  if (!FLAGS.newAuthContext) return <>{children}</>;
+  const { initializing } = useAuth();
+  const ready = !initializing;
+  return ready ? <>{children}</> : <>{fallback}</>;
+}
+


### PR DESCRIPTION
Adds <AuthReadyGate>; wraps the /projects route so it waits for useAuth().ready (derived from !initializing) when the flag is ON. Reduces flash-of-unauth on hard refresh, with flag OFF = no-op.