### PR TITLE
Auth/Nav: encapsulate NavBar user logic behind flag

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,13 +39,11 @@ export default function App() {
   const [user, setUser] = useState(null);
   useEffect(() => onAuthStateChanged(auth, setUser), []);
 
-  // Read from new AuthContext (always call hook; only used when flag is ON)
+  // Read from new AuthContext only for route guards when flag is ON
   const authCtx = useAuth();
   const authSel = FLAGS.newAuthContext ? authCtx : { user: null, ready: false, initializing: false };
-  const userForNav = FLAGS.newAuthContext ? adaptUser(authSel.user) : user; // legacyUser = user
-  // Second consumer behind flag: route guard truthiness
-  const userForGuard = FLAGS.newAuthContext ? (adaptUser(authSel.user)) : user;
-  const authReady = FLAGS.newAuthContext ? (authSel.ready ?? !authSel.initializing) : true;
+  // Route guard truthiness remains behind flag
+  const userForGuard = FLAGS.newAuthContext ? adaptUser(authSel.user) : user;
 
   const PDFExportModalLazy = lazy(() => import("./components/PDFExportModal"));
 
@@ -64,7 +62,7 @@ export default function App() {
 
   return (
     <BrowserRouter>
-      {user && <NavBar user={userForNav} __authReady={authReady} />}
+      <NavBar />
       {/* Guarded + lazy-loaded PDF demo: requires flag AND ?pdfDemo=1 */}
       <PDFDemoMount />
       <MaybeRedirectLogin user={user} />

--- a/src/components/NavBarWithAuth.jsx
+++ b/src/components/NavBarWithAuth.jsx
@@ -1,21 +1,39 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import NavBar from "./NavBar";
 import { FLAGS } from "../lib/flags";
 import { useAuth } from "../context/AuthContext";
+import { adaptUser } from "../auth/adapter";
+import { onAuthStateChanged } from "firebase/auth";
+import { auth } from "../firebase";
 
 /**
  * Wraps the existing NavBar. When the feature flag is ON, it supplies `user`
  * from AuthContext; when OFF, it renders NavBar exactly as before.
  * No route/guard changes; no writes; read-only migration.
  */
-export default function NavBarWithAuth(props) {
-  if (!FLAGS.newAuthContext) {
-    // Default path: zero behavior change
-    return <NavBar {...props} />;
-  }
-  // Flagged path: read `user` from the new context
-  const { user } = useAuth();
-  // Ensure our `user` prop wins if parent passed one
-  return <NavBar {...props} user={user} />;
-}
+export default function NavBarWithAuth() {
+  const flagOn = FLAGS.newAuthContext === true;
 
+  // Legacy path: mirror previous App.jsx behavior (render only when signed-in)
+  const [legacyUser, setLegacyUser] = useState(null);
+  useEffect(() => {
+    if (flagOn) return; // no legacy wire-up when flag is ON
+    const unsub = onAuthStateChanged(auth, setLegacyUser);
+    return () => {
+      if (unsub) unsub();
+    };
+  }, [flagOn]);
+
+  if (!flagOn) {
+    // Render only when we have a legacy Firebase user, matching previous gating
+    if (!legacyUser) return null;
+    return <NavBar user={legacyUser} />;
+  }
+
+  // Flagged path: use new AuthContext; honor readiness; adapt to NavBar shape
+  const { user, ready, initializing } = useAuth();
+  const authReady = (typeof ready === "boolean") ? ready : !initializing;
+  if (!authReady || !user) return null;
+  const userForNav = adaptUser(user);
+  return <NavBar user={userForNav} />;
+}


### PR DESCRIPTION
No behavior change. App.jsx no longer computes userForNav/__authReady; NavBarWithAuth owns it.