### PR TITLE
Tests: add unit tests for adaptUser()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,6 @@ src/.DS_Store
 _phase0_*
 *.patch
 
+# local helper and backups
+codex_step.sh
+*.bak

--- a/src/auth/__tests__/adapter.test.ts
+++ b/src/auth/__tests__/adapter.test.ts
@@ -2,30 +2,43 @@ import { describe, it, expect } from "vitest";
 import { adaptUser } from "../adapter";
 
 describe("adaptUser", () => {
-  it("maps firebase user to nav user shape", () => {
+  it("maps a Firebase user to the NavBar-friendly shape", () => {
     const u: any = {
       uid: "abc",
       displayName: "Ted",
       email: "ted@example.com",
       photoURL: "http://x/y.jpg",
       emailVerified: true,
-      providerData: [{ providerId: "google.com" }],
+      providerData: [{ providerId: "google.com" }, { providerId: "password" }],
     };
-    expect(adaptUser(u)).toEqual({
+    const out = adaptUser(u);
+    expect(out).toStrictEqual({
       id: "abc",
       name: "Ted",
       email: "ted@example.com",
       avatarUrl: "http://x/y.jpg",
       verified: true,
-      providers: ["google.com"],
+      providers: ["google.com", "password"],
     });
   });
 
-  it("handles null/undefined user", () => {
-    // @ts-expect-error testing null
+  it("returns null for null/undefined input", () => {
+    // @ts-expect-error intentional edge case
     expect(adaptUser(null)).toBeNull();
-    // @ts-expect-error testing undefined
+    // @ts-expect-error intentional edge case
     expect(adaptUser(undefined)).toBeNull();
   });
-});
 
+  it("handles missing optional fields safely", () => {
+    const u: any = { uid: "x1", displayName: null, email: null, photoURL: null, providerData: [] };
+    const out = adaptUser(u);
+    expect(out).toStrictEqual({
+      id: "x1",
+      name: null,
+      email: null,
+      avatarUrl: null,
+      verified: false,
+      providers: [],
+    });
+  });
+});


### PR DESCRIPTION
Covers happy path, null/undefined, and missing optional fields to lock adapter semantics.