### PR TITLE
Auth: add RequireAuth route guard component + tests

### DIFF
--- a/src/routes/RequireAuth.jsx
+++ b/src/routes/RequireAuth.jsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+import { FLAGS } from "../lib/flags";
+
+/**
+ * RequireAuth
+ * - Flag OFF: pass-through (renders children via <Outlet/>).
+ * - Flag ON:
+ *    - while auth not ready → render nothing (preserves current "loading" behavior)
+ *    - signed-out → redirect to `to` (default "/login")
+ *    - signed-in → render children via <Outlet/>
+ */
+export default function RequireAuth({ to = "/login" }) {
+  const flagOn = !!(FLAGS && FLAGS.newAuthContext);
+  if (!flagOn) return <Outlet />;
+
+  const { user, ready, initializing } = (typeof useAuth === "function" ? useAuth() : { user: null, ready: false, initializing: true });
+  const authReady = typeof ready === "boolean" ? ready : !initializing;
+  if (!authReady) return null;
+  if (!user) return <Navigate to={to} replace />;
+  return <Outlet />;
+}

--- a/src/routes/__tests__/RequireAuth.test.jsx
+++ b/src/routes/__tests__/RequireAuth.test.jsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+
+async function renderScenario({ flagOn, auth, start = "/secret", to = "/login" }) {
+  vi.resetModules();
+  vi.doMock("../../lib/flags", () => ({ FLAGS: { newAuthContext: flagOn } }), { virtual: true });
+  vi.doMock("../../context/AuthContext", () => ({ useAuth: () => auth }), { virtual: true });
+  const { default: RequireAuth } = await import("../RequireAuth.jsx");
+  render(
+    <MemoryRouter initialEntries={[start]}>
+      <Routes>
+        <Route path="/login" element={<div>LOGIN</div>} />
+        <Route element={<RequireAuth to={to} />}>
+          <Route path="/secret" element={<div>SECRET</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe("RequireAuth", () => {
+  it("flag OFF: passes through (renders protected content)", async () => {
+    await renderScenario({ flagOn: false, auth: { user: null, ready: false } });
+    expect(screen.queryByText("SECRET")).toBeTruthy();
+  });
+
+  it("flag ON + not ready: renders nothing (no redirect, no content)", async () => {
+    await renderScenario({ flagOn: true, auth: { user: null, ready: false } });
+    expect(screen.queryByText("SECRET")).toBeNull();
+    expect(screen.queryByText("LOGIN")).toBeNull();
+  });
+
+  it("flag ON + signed out: redirects to login", async () => {
+    await renderScenario({ flagOn: true, auth: { user: null, ready: true } });
+    expect(screen.queryByText("LOGIN")).toBeTruthy();
+  });
+
+  it("flag ON + signed in: renders protected content", async () => {
+    await renderScenario({ flagOn: true, auth: { user: { uid: "u1" }, ready: true } });
+    expect(screen.queryByText("SECRET")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Introduces a small, tested route-guard. Flag OFF = passthrough; Flag ON = wait for ready, redirect when signed out. No wiring change yet.