### PR TITLE
feat(ui): improve product and planner views

### DIFF
--- a/src/components/ProductForm.jsx
+++ b/src/components/ProductForm.jsx
@@ -1,0 +1,395 @@
+import { useMemo, useState } from "react";
+import { Button } from "./ui/button";
+import { Input, Checkbox } from "./ui/input";
+
+const GENDER_OPTIONS = [
+  { value: "men", label: "Men" },
+  { value: "women", label: "Women" },
+  { value: "unisex", label: "Unisex" },
+];
+
+const uid = () => Math.random().toString(36).slice(2, 10);
+
+function normaliseSizes(value = []) {
+  const seen = new Set();
+  const result = [];
+  value.forEach((size) => {
+    const trimmed = (size || "").trim();
+    if (!trimmed || seen.has(trimmed)) return;
+    seen.add(trimmed);
+    result.push(trimmed);
+  });
+  return result;
+}
+
+function syncColorways(colorways, sizes) {
+  return colorways.map((colorway) => {
+    const map = new Map();
+    (colorway.sizes || []).forEach((entry) => map.set(entry.size, entry));
+    const nextSizes = sizes.map((size) => {
+      const existing = map.get(size) || {};
+      return {
+        size,
+        sku: existing.sku || "",
+        oldSku: existing.oldSku || "",
+      };
+    });
+    return {
+      id: colorway.id || uid(),
+      name: colorway.name || "",
+      sizes: nextSizes,
+    };
+  });
+}
+
+function buildInitialState(initialValue) {
+  const defaults = {
+    name: "",
+    styleNumber: "",
+    category: "",
+    gender: "men",
+    sizes: [],
+    colorways: [],
+    active: true,
+    skuList: [],
+    thumbnailFile: null,
+  };
+  const base = { ...defaults, ...(initialValue || {}) };
+  const baseSizes = normaliseSizes(base.sizes);
+  const derivedSizes = base.colorways?.length
+    ? normaliseSizes(
+        base.colorways.flatMap((colorway) =>
+          (colorway.sizes || []).map((entry) => entry.size)
+        )
+      )
+    : [];
+  const sizes = baseSizes.length ? baseSizes : derivedSizes;
+  const colourwaySizes = sizes.length ? sizes : ["One Size"];
+  const colorways = base.colorways?.length
+    ? syncColorways(base.colorways, colourwaySizes)
+    : [];
+  return {
+    name: base.name,
+    styleNumber: base.styleNumber,
+    category: base.category || "",
+    gender: base.gender || "men",
+    sizes: sizes.length ? sizes : [],
+    colorways,
+    active: base.active !== false,
+    thumbnailFile: null,
+  };
+}
+
+export default function ProductForm({
+  initialValue,
+  onSubmit,
+  onCancel,
+  submitLabel = "Save product",
+  allowThumbnail = false,
+}) {
+  const [state, setState] = useState(() => buildInitialState(initialValue));
+  const [newSize, setNewSize] = useState("");
+  const [error, setError] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasSizes = state.sizes.length > 0;
+
+  const colorways = useMemo(() => syncColorways(state.colorways, state.sizes.length ? state.sizes : state.colorways.length ? normaliseSizes(state.colorways[0].sizes?.map((entry) => entry.size)) : []), [state.colorways, state.sizes]);
+
+  const updateState = (updates) => {
+    setState((prev) => ({ ...prev, ...updates }));
+  };
+
+  const addSize = () => {
+    const value = newSize.trim();
+    if (!value) return;
+    if (state.sizes.includes(value)) {
+      setNewSize("");
+      return;
+    }
+    const nextSizes = [...state.sizes, value];
+    updateState({ sizes: nextSizes, colorways: syncColorways(colorways, nextSizes) });
+    setNewSize("");
+  };
+
+  const removeSize = (value) => {
+    const nextSizes = state.sizes.filter((size) => size !== value);
+    updateState({ sizes: nextSizes, colorways: syncColorways(colorways, nextSizes) });
+  };
+
+  const addColorway = () => {
+    const next = {
+      id: uid(),
+      name: "",
+      sizes: (state.sizes.length ? state.sizes : ["One Size"]).map((size) => ({ size, sku: "", oldSku: "" })),
+    };
+    updateState({ colorways: [...colorways, next] });
+  };
+
+  const updateColorway = (id, updates) => {
+    const next = colorways.map((colorway) =>
+      colorway.id === id ? { ...colorway, ...updates } : colorway
+    );
+    updateState({ colorways: next });
+  };
+
+  const removeColorway = (id) => {
+    updateState({ colorways: colorways.filter((colorway) => colorway.id !== id) });
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setError(null);
+
+    const name = state.name.trim();
+    const styleNumber = state.styleNumber.trim();
+    const category = state.category.trim();
+    const gender = state.gender || "men";
+    const sizes = normaliseSizes(state.sizes);
+
+    const normalisedColorways = syncColorways(colorways, sizes.length ? sizes : []);
+
+    const preparedColorways = normalisedColorways
+      .map((colorway) => ({
+        id: colorway.id,
+        name: (colorway.name || "").trim(),
+        sizes: (colorway.sizes || [])
+          .map((entry) => ({
+            size: entry.size,
+            sku: (entry.sku || "").trim(),
+            oldSku: (entry.oldSku || "").trim() || null,
+          }))
+          .filter((entry) => entry.size && entry.sku),
+      }))
+      .filter((colorway) => colorway.name && colorway.sizes.length);
+
+    const skuList = preparedColorways.flatMap((colorway) =>
+      colorway.sizes.map((entry) => entry.sku)
+    );
+
+    if (!name) {
+      setError("Product name is required.");
+      return;
+    }
+    if (!styleNumber) {
+      setError("Style number is required.");
+      return;
+    }
+    if (!sizes.length) {
+      setError("Add at least one size.");
+      return;
+    }
+    if (!preparedColorways.length) {
+      setError("Add at least one colourway with SKUs.");
+      return;
+    }
+    if (!skuList.length) {
+      setError("Each colourway needs at least one SKU.");
+      return;
+    }
+
+    const payload = {
+      name,
+      styleNumber,
+      category: category || null,
+      gender,
+      sizes,
+      colorways: preparedColorways,
+      skuList,
+      primarySku: skuList[0] || null,
+      active: state.active,
+    };
+
+    if (allowThumbnail) {
+      payload.thumbnailFile = state.thumbnailFile || null;
+    }
+
+    try {
+      setSubmitting(true);
+      await onSubmit?.(payload);
+      setSubmitting(false);
+    } catch (err) {
+      setSubmitting(false);
+      setError(err?.message || "Failed to save product.");
+    }
+  };
+
+  const handleThumbnail = (event) => {
+    const file = event.target.files?.[0] || null;
+    updateState({ thumbnailFile: file });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Gender</label>
+          <select
+            className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
+            value={state.gender}
+            onChange={(event) => updateState({ gender: event.target.value })}
+          >
+            {GENDER_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Category</label>
+          <Input
+            placeholder="Optional category"
+            value={state.category}
+            onChange={(event) => updateState({ category: event.target.value })}
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Product name</label>
+          <Input
+            placeholder="e.g. Honeycomb Knit Merino Henley"
+            value={state.name}
+            onChange={(event) => updateState({ name: event.target.value })}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Style number</label>
+          <Input
+            placeholder="e.g. UM2026-3013-01"
+            value={state.styleNumber}
+            onChange={(event) => updateState({ styleNumber: event.target.value })}
+            required
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Checkbox
+          checked={state.active}
+          onChange={(event) => updateState({ active: event.target.checked })}
+        />
+        <span className="text-sm text-slate-700">Product is active</span>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium text-slate-700">Available sizes</label>
+          <span className="text-xs text-slate-500">
+            Press Enter to add. Sizes appear in colourway tables below.
+          </span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {state.sizes.map((size) => (
+            <span key={size} className="flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 text-sm">
+              {size}
+              <button
+                type="button"
+                className="text-slate-500 hover:text-slate-700"
+                onClick={() => removeSize(size)}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {!state.sizes.length && <span className="text-sm text-slate-500">No sizes yet</span>}
+        </div>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Add size (e.g. S, 32R)"
+            value={newSize}
+            onChange={(event) => setNewSize(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault();
+                addSize();
+              }
+            }}
+          />
+          <Button type="button" onClick={addSize} disabled={!newSize.trim()}>
+            Add size
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <label className="text-sm font-medium text-slate-700">Colourways</label>
+          <Button type="button" variant="secondary" size="sm" onClick={addColorway}>
+            Add colourway
+          </Button>
+        </div>
+        {!colorways.length && (
+          <div className="rounded border border-dashed border-slate-300 p-4 text-sm text-slate-500">
+            Add colourways to capture SKUs for each size.
+          </div>
+        )}
+        {colorways.map((colorway) => (
+          <div key={colorway.id} className="rounded-lg border border-slate-200 p-4 space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <Input
+                placeholder="Colour name (e.g. Black)"
+                value={colorway.name}
+                onChange={(event) =>
+                  updateColorway(colorway.id, { name: event.target.value })
+                }
+              />
+              <Button type="button" variant="ghost" size="sm" onClick={() => removeColorway(colorway.id)}>
+                Remove
+              </Button>
+            </div>
+            {hasSizes ? (
+              <div className="space-y-2">
+                {colorway.sizes.map((entry) => (
+                  <div key={entry.size} className="grid gap-3 sm:grid-cols-[120px,1fr]">
+                    <div className="text-sm font-medium text-slate-600">{entry.size}</div>
+                    <Input
+                      placeholder="SKU"
+                      value={entry.sku}
+                      onChange={(event) => {
+                        const nextSizes = colorway.sizes.map((sizeEntry) =>
+                          sizeEntry.size === entry.size
+                            ? { ...sizeEntry, sku: event.target.value }
+                            : sizeEntry
+                        );
+                        updateColorway(colorway.id, { sizes: nextSizes });
+                      }}
+                      required
+                    />
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <div className="rounded border border-amber-200 bg-amber-50 p-3 text-sm text-amber-700">
+                Add sizes before assigning SKUs.
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {allowThumbnail && (
+        <div className="space-y-2">
+          <label className="block text-sm font-medium text-slate-700">Thumbnail image</label>
+          <Input type="file" accept="image/*" onChange={handleThumbnail} />
+          {state.thumbnailFile && (
+            <div className="text-xs text-slate-500">Selected: {state.thumbnailFile.name}</div>
+          )}
+        </div>
+      )}
+
+      {error && <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{error}</div>}
+
+      <div className="flex items-center justify-end gap-3">
+        {onCancel && (
+          <Button type="button" variant="ghost" onClick={onCancel}>
+            Cancel
+          </Button>
+        )}
+        <Button type="submit" disabled={submitting}>
+          {submitting ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/src/components/products/ColorListEditor.jsx
+++ b/src/components/products/ColorListEditor.jsx
@@ -15,20 +15,15 @@ export default function ColorListEditor({
   skuHelper,
 }) {
   return (
-    <div className="space-y-3">
-      <div className="flex items-center justify-between">
-        <h3 className="text-sm font-semibold text-slate-700">Colours</h3>
-        <Button type="button" variant="secondary" size="sm" onClick={onAddColor}>
-          Add colour
-        </Button>
-      </div>
+    <div className="relative space-y-3">
+      <h3 className="text-sm font-semibold text-slate-700">Colours</h3>
       {sizeNote && <p className="text-sm text-slate-500">{sizeNote}</p>}
       {skuHelper && <p className="text-xs text-slate-500">{skuHelper}</p>}
       <div className="space-y-4">
         {colors.map((color) => (
           <fieldset key={color.localId} className="space-y-4 rounded-lg border border-slate-200 p-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
-              <div className="flex-1 space-y-2">
+            <div className="grid gap-3 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)_minmax(0,0.9fr)]">
+              <div className="space-y-2">
                 <label className="text-sm font-medium text-slate-700">Colour name</label>
                 <Input
                   value={color.colorName}
@@ -36,7 +31,7 @@ export default function ColorListEditor({
                   placeholder="e.g. Black"
                 />
               </div>
-              <div className="flex-1 space-y-2">
+              <div className="space-y-2">
                 <label className="text-sm font-medium text-slate-700">SKU (optional)</label>
                 <Input
                   value={color.skuCode}
@@ -44,20 +39,20 @@ export default function ColorListEditor({
                   placeholder="e.g. UM-3021-BLK"
                 />
               </div>
-            </div>
-            <div className="space-y-2">
-              <label className="text-sm font-medium text-slate-700">Status</label>
-              <select
-                value={color.status}
-                onChange={(event) => onFieldChange(color.localId, { status: event.target.value })}
-                className="w-full rounded border border-gray-300 px-3 py-2 text-sm"
-              >
-                {statusOptions.map((option) => (
-                  <option key={option.value} value={option.value}>
-                    {option.label}
-                  </option>
-                ))}
-              </select>
+              <div className="space-y-2">
+                <label className="text-sm font-medium text-slate-700">Status</label>
+                <select
+                  value={color.status}
+                  onChange={(event) => onFieldChange(color.localId, { status: event.target.value })}
+                  className="w-full rounded border border-gray-300 px-2 py-2 text-sm md:max-w-[180px]"
+                >
+                  {statusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </div>
             <div className="space-y-2">
               <label className="text-sm font-medium text-slate-700">Colour image</label>
@@ -104,6 +99,11 @@ export default function ColorListEditor({
             </div>
           </fieldset>
         ))}
+      </div>
+      <div className="sticky bottom-0 flex justify-end border-t border-slate-200 bg-white/95 px-2 py-3 backdrop-blur">
+        <Button type="button" variant="secondary" onClick={onAddColor}>
+          Add colour
+        </Button>
       </div>
     </div>
   );

--- a/src/components/shots/NotesEditor.jsx
+++ b/src/components/shots/NotesEditor.jsx
@@ -1,0 +1,164 @@
+import { useEffect, useRef } from "react";
+import { Button } from "../ui/button";
+import { sanitizeNotesHtml } from "../../lib/sanitize";
+
+const colorOptions = [
+  { label: "Slate", value: "#1f2937" },
+  { label: "Indigo", value: "#6366f1" },
+  { label: "Emerald", value: "#10b981" },
+  { label: "Rose", value: "#f43f5e" },
+];
+
+const ensureFocus = (element) => {
+  if (!element) return;
+  element.focus();
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount) return;
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  selection.removeAllRanges();
+  selection.addRange(range);
+};
+
+export default function NotesEditor({ value = "", onChange, disabled = false, id }) {
+  const editorRef = useRef(null);
+  const lastHtmlRef = useRef("");
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const safeValue = sanitizeNotesHtml(value || "");
+    if (lastHtmlRef.current === safeValue) return;
+    if (editor.innerHTML !== safeValue) {
+      editor.innerHTML = safeValue;
+    }
+    lastHtmlRef.current = safeValue;
+  }, [value]);
+
+  const emitChange = () => {
+    const editor = editorRef.current;
+    if (!editor) return;
+    const safeValue = sanitizeNotesHtml(editor.innerHTML);
+    if (editor.innerHTML !== safeValue) {
+      editor.innerHTML = safeValue;
+    }
+    if (lastHtmlRef.current === safeValue) return;
+    lastHtmlRef.current = safeValue;
+    onChange?.(safeValue);
+  };
+
+  const handleCommand = (command, valueArg) => {
+    const editor = editorRef.current;
+    if (!editor || disabled) return;
+    if (typeof document.execCommand !== "function") return;
+    ensureFocus(editor);
+    document.execCommand(command, false, valueArg);
+    setTimeout(emitChange, 0);
+  };
+
+  const handlePaste = (event) => {
+    if (disabled) return;
+    event.preventDefault();
+    const text = event.clipboardData.getData("text/plain");
+    if (typeof document.execCommand === "function") {
+      document.execCommand("insertText", false, text);
+    } else {
+      const editor = editorRef.current;
+      if (!editor) return;
+      ensureFocus(editor);
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return;
+      selection.deleteFromDocument();
+      const node = document.createTextNode(text);
+      const range = selection.getRangeAt(0);
+      range.insertNode(node);
+      range.setStartAfter(node);
+      range.collapse(true);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    }
+    setTimeout(emitChange, 0);
+  };
+
+  const handleInput = () => {
+    if (disabled) return;
+    emitChange();
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onMouseDown={(event) => {
+            event.preventDefault();
+            handleCommand("bold");
+          }}
+          disabled={disabled}
+        >
+          Bold
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="secondary"
+          onMouseDown={(event) => {
+            event.preventDefault();
+            handleCommand("italic");
+          }}
+          disabled={disabled}
+        >
+          Italic
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          variant="ghost"
+          onMouseDown={(event) => {
+            event.preventDefault();
+            handleCommand("removeFormat");
+          }}
+          disabled={disabled}
+        >
+          Clear
+        </Button>
+        <div className="flex items-center gap-1">
+          {colorOptions.map((option) => (
+            <button
+              type="button"
+              key={option.value}
+              className="h-8 w-8 rounded-full border border-slate-200"
+              style={{ backgroundColor: option.value }}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                handleCommand("foreColor", option.value);
+              }}
+              aria-label={`Set text colour to ${option.label}`}
+              disabled={disabled}
+            >
+              <span className="sr-only">{option.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div
+        id={id}
+        ref={editorRef}
+        className={`min-h-[140px] w-full rounded-md border border-slate-200 bg-white px-3 py-2 text-sm leading-relaxed shadow-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60 ${
+          disabled ? "pointer-events-none bg-slate-50 text-slate-500" : ""
+        }`}
+        contentEditable={!disabled}
+        role="textbox"
+        aria-multiline="true"
+        data-placeholder="Write notes with basic formatting…"
+        suppressContentEditableWarning
+        onInput={handleInput}
+        onBlur={emitChange}
+        onPaste={handlePaste}
+      />
+    </div>
+  );
+}

--- a/src/components/shots/__tests__/TASK_4_VALIDATION_SUMMARY.md
+++ b/src/components/shots/__tests__/TASK_4_VALIDATION_SUMMARY.md
@@ -35,7 +35,7 @@ This document summarizes the comprehensive testing and validation performed for 
 
 **Validated Layout Features:**
 1. Proper scrollable container structure with correct attributes
-2. Sufficient bottom padding (pb-32) to clear sticky footer
+2. Sufficient bottom padding (pb-20) to clear sticky footer
 3. Sticky footer with proper styling and accessibility
 4. Action buttons accessible in sticky footer
 5. Handles different content heights with many colourways (tested with 20 colors)
@@ -111,7 +111,7 @@ Tests  23 passed (23)
 
 ### ✅ Scrolling Accessibility (Requirements 1.1-1.4)
 - Verified scrollable container has proper `overflow-y-auto` and `tabindex="0"`
-- Confirmed bottom padding of `pb-32` provides sufficient clearance for sticky footer
+- Confirmed bottom padding of `pb-20` provides sufficient clearance for sticky footer
 - Tested with 20 colourways to ensure layout works with extensive content
 - Validated sticky footer positioning and backdrop blur styling
 

--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -5,6 +5,8 @@
 // referenced by various Firestore path helpers.
 export const CLIENT_ID = "unbound-merino";
 
+const resolveClientId = (explicitClientId) => explicitClientId ?? CLIENT_ID;
+
 /**
  * Return the currently active project ID.  We read from localStorage on
  * demand rather than caching the value at import time.  This allows the
@@ -28,34 +30,54 @@ export function getActiveProjectId() {
 
 // Top‑level path to a project document.  Pass a project ID (not optional)
 // because project documents still live under the `projects` subcollection.
-export const projectPath = (projectId) => [
+export const projectPath = (projectId, clientId) => [
   "clients",
-  CLIENT_ID,
+  resolveClientId(clientId),
   "projects",
   projectId,
 ];
 
 // Path to the global shots collection.  Do not pass a project ID here.
-export const shotsPath = () => ["clients", CLIENT_ID, "shots"];
+export const shotsPath = (clientId) => ["clients", resolveClientId(clientId), "shots"];
 
 // Paths to other top‑level collections.  These remain unchanged from the
 // original app because products, talent and locations are not scoped to a
 // project.
-export const legacyProductsPath = ["clients", CLIENT_ID, "products"];
-export const productFamiliesPath = ["clients", CLIENT_ID, "productFamilies"];
-export const productsPath = productFamiliesPath;
-export const productFamilyPath = (familyId) => [...productsPath, familyId];
-export const productFamilySkusPath = (familyId) => [...productFamiliesPath, familyId, "skus"];
-export const productFamilySkuPath = (familyId, skuId) => [...productFamiliesPath, familyId, "skus", skuId];
-export const talentPath = ["clients", CLIENT_ID, "talent"];
-export const locationsPath = ["clients", CLIENT_ID, "locations"];
+export const legacyProductsPath = (clientId) => [
+  "clients",
+  resolveClientId(clientId),
+  "products",
+];
+export const productFamiliesPath = (clientId) => [
+  "clients",
+  resolveClientId(clientId),
+  "productFamilies",
+];
+export const productsPath = (clientId) => productFamiliesPath(clientId);
+export const productFamilyPath = (familyId, clientId) => [
+  ...productFamiliesPath(clientId),
+  familyId,
+];
+export const productFamilySkusPath = (familyId, clientId) => [
+  ...productFamiliesPath(clientId),
+  familyId,
+  "skus",
+];
+export const productFamilySkuPath = (familyId, skuId, clientId) => [
+  ...productFamiliesPath(clientId),
+  familyId,
+  "skus",
+  skuId,
+];
+export const talentPath = (clientId) => ["clients", resolveClientId(clientId), "talent"];
+export const locationsPath = (clientId) => ["clients", resolveClientId(clientId), "locations"];
 
 // Lanes (for the planner) remain scoped to the project.  They are stored
 // under `projects/{projectId}/lanes` because each project maintains its own
 // set of lanes (e.g. shoot dates).  These helpers take a project ID so you
 // can explicitly target a project or call them with getActiveProjectId().
-export const lanesPath = (projectId) => [...projectPath(projectId), "lanes"];
+export const lanesPath = (projectId, clientId) => [...projectPath(projectId, clientId), "lanes"];
 
 // Pulls continue to live under a project as well.  In the future you might
 // centralise pulls like shots, but for now we leave the existing structure.
-export const pullsPath = (projectId) => [...projectPath(projectId), "pulls"];
+export const pullsPath = (projectId, clientId) => [...projectPath(projectId, clientId), "pulls"];

--- a/src/lib/sanitize.js
+++ b/src/lib/sanitize.js
@@ -1,0 +1,92 @@
+export const allowedNoteColors = ["#1f2937", "#6366f1", "#10b981", "#f43f5e", "#0f172a"];
+
+const allowedTags = new Set(["strong", "em", "span", "p", "br", "ul", "ol", "li"]);
+
+const normalizeColor = (value) => value?.toString().trim().toLowerCase() || "";
+
+const removeElementKeepChildren = (element) => {
+  while (element.firstChild) {
+    element.parentNode.insertBefore(element.firstChild, element);
+  }
+  element.remove();
+};
+
+const replaceTag = (element, tagName) => {
+  const doc = element.ownerDocument || document;
+  const replacement = doc.createElement(tagName);
+  while (element.firstChild) {
+    replacement.appendChild(element.firstChild);
+  }
+  element.parentNode.replaceChild(replacement, element);
+  return replacement;
+};
+
+const sanitizeElement = (element) => {
+  const childNodes = Array.from(element.childNodes);
+  for (let child of childNodes) {
+    if (child.nodeType === Node.TEXT_NODE) {
+      continue;
+    }
+    if (child.nodeType !== Node.ELEMENT_NODE) {
+      child.remove();
+      continue;
+    }
+
+    let tag = child.tagName.toLowerCase();
+    if (tag === "b") {
+      child = replaceTag(child, "strong");
+      tag = "strong";
+    } else if (tag === "i") {
+      child = replaceTag(child, "em");
+      tag = "em";
+    } else if (tag === "font") {
+      child = replaceTag(child, "span");
+      tag = "span";
+    } else if (tag === "div") {
+      child = replaceTag(child, "p");
+      tag = "p";
+    }
+
+    if (!allowedTags.has(tag)) {
+      removeElementKeepChildren(child);
+      continue;
+    }
+
+    // Remove all attributes before adding back safe ones.
+    while (child.attributes.length > 0) {
+      child.removeAttribute(child.attributes[0].name);
+    }
+
+    if (tag === "span") {
+      const style = child.style?.color;
+      const attrColor = child.getAttribute?.("color");
+      const dataColor = child.getAttribute?.("data-color");
+      const colour = normalizeColor(style || attrColor || dataColor);
+      if (allowedNoteColors.includes(colour)) {
+        child.style.color = colour;
+      } else {
+        child.removeAttribute("style");
+      }
+    }
+
+    sanitizeElement(child);
+  }
+};
+
+export const sanitizeNotesHtml = (input) => {
+  if (!input) return "";
+  if (typeof window === "undefined") return String(input);
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(`<div>${input}</div>`, "text/html");
+  const root = doc.body.firstElementChild;
+  if (!root) return "";
+  sanitizeElement(root);
+  return root.innerHTML.replace(/\s+$/, "");
+};
+
+export const formatNotesForDisplay = (input) => {
+  const source = input ? input.toString() : "";
+  const enriched = source.includes("<") ? source : source.replace(/\n/g, "<br />");
+  const sanitized = sanitizeNotesHtml(enriched);
+  return sanitized || "";
+};

--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -41,7 +41,7 @@ import {
 } from "../lib/paths";
 import { useAuth } from "../context/AuthContext";
 import { canManagePlanner, canManageShots, ROLE } from "../lib/rbac";
-import { LayoutGrid, Rows3, Settings2, PencilLine } from "lucide-react";
+import { LayoutGrid, List, Settings2, PencilLine } from "lucide-react";
 import { formatNotesForDisplay } from "../lib/sanitize";
 import { Modal } from "../components/ui/modal";
 import { Button } from "../components/ui/button";
@@ -665,7 +665,7 @@ export default function PlannerPage() {
               }`}
               aria-pressed={viewMode === "list"}
             >
-              <Rows3 className="h-4 w-4" aria-hidden="true" />
+              <List className="h-4 w-4" aria-hidden="true" />
               List
             </button>
           </div>

--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -9,7 +9,7 @@
 // `date` field is updated as well.  All other behaviour matches the
 // previous Planner implementation.
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -27,16 +27,79 @@ import {
   orderBy,
   where,
   getDocs,
+  arrayUnion,
+  arrayRemove,
 } from "firebase/firestore";
 import { db } from "../lib/firebase";
 import {
   lanesPath,
-  projectPath,
   shotsPath,
   getActiveProjectId,
+  productFamiliesPath,
+  productFamilySkusPath,
+  productFamilyPath,
 } from "../lib/paths";
 import { useAuth } from "../context/AuthContext";
-import { canManagePlanner, ROLE } from "../lib/rbac";
+import { canManagePlanner, canManageShots, ROLE } from "../lib/rbac";
+import { LayoutGrid, Rows3, Settings2, PencilLine } from "lucide-react";
+import { formatNotesForDisplay } from "../lib/sanitize";
+import { Modal } from "../components/ui/modal";
+import { Button } from "../components/ui/button";
+import ShotProductsEditor from "../components/shots/ShotProductsEditor";
+import { Card, CardHeader, CardContent } from "../components/ui/card";
+import { toast } from "../lib/toast";
+
+const PLANNER_VIEW_STORAGE_KEY = "planner:viewMode";
+const PLANNER_FIELDS_STORAGE_KEY = "planner:visibleFields";
+
+const defaultVisibleFields = {
+  notes: true,
+  location: true,
+  talent: true,
+  products: true,
+};
+
+const formatShotDate = (value) => {
+  if (!value) return "";
+  if (value instanceof Date) return value.toISOString().slice(0, 10);
+  if (value && typeof value.toDate === "function") {
+    return value.toDate().toISOString().slice(0, 10);
+  }
+  if (typeof value === "string") return value.slice(0, 10);
+  return "";
+};
+
+const readStoredPlannerView = () => {
+  if (typeof window === "undefined") return "board";
+  const stored = window.localStorage.getItem(PLANNER_VIEW_STORAGE_KEY);
+  return stored === "list" ? "list" : "board";
+};
+
+const readStoredVisibleFields = () => {
+  if (typeof window === "undefined") return { ...defaultVisibleFields };
+  try {
+    const raw = window.localStorage.getItem(PLANNER_FIELDS_STORAGE_KEY);
+    if (!raw) return { ...defaultVisibleFields };
+    const parsed = JSON.parse(raw);
+    return {
+      notes:
+        typeof parsed.notes === "boolean" ? parsed.notes : defaultVisibleFields.notes,
+      location:
+        typeof parsed.location === "boolean"
+          ? parsed.location
+          : defaultVisibleFields.location,
+      talent:
+        typeof parsed.talent === "boolean" ? parsed.talent : defaultVisibleFields.talent,
+      products:
+        typeof parsed.products === "boolean"
+          ? parsed.products
+          : defaultVisibleFields.products,
+    };
+  } catch (error) {
+    console.warn("[Planner] Failed to parse field visibility preferences", error);
+    return { ...defaultVisibleFields };
+  }
+};
 
 // Simple droppable component for DnD kit
 function DroppableLane({ laneId, children }) {
@@ -45,20 +108,125 @@ function DroppableLane({ laneId, children }) {
 }
 
 // Simple draggable shot card for DnD kit
-function DraggableShot({ shot, disabled }) {
+function DraggableShot({
+  shot,
+  disabled,
+  viewMode,
+  visibleFields,
+  onEdit,
+  canEditShots,
+  normaliseProducts,
+}) {
   const { attributes, listeners, setNodeRef, transform } = useDraggable({ id: shot.id, disabled });
-  const style = {
-    transform: transform ? `translate3d(${transform.x}px, ${transform.y}px, 0)` : undefined,
-    border: "1px solid #eee",
-    padding: "8px 10px",
-    borderRadius: 8,
-    background: "#fff",
-  };
+  const style = transform
+    ? { transform: `translate3d(${transform.x}px, ${transform.y}px, 0)` }
+    : undefined;
   const dragProps = disabled ? {} : { ...listeners, ...attributes };
+  const products = typeof normaliseProducts === "function" ? normaliseProducts(shot) : shot.products || [];
   return (
-    <div ref={setNodeRef} style={style} {...dragProps}>
-      <div style={{ fontWeight: 600 }}>{shot.name}</div>
-      <div style={{ fontSize: 12, opacity: 0.7 }}>{shot.type || "-"} • {shot.date || "-"}</div>
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="w-full"
+      {...dragProps}
+    >
+      <ShotCard
+        shot={shot}
+        viewMode={viewMode}
+        visibleFields={visibleFields}
+        onEdit={onEdit}
+        canEdit={canEditShots}
+        products={products}
+      />
+    </div>
+  );
+}
+
+function ShotCard({ shot, viewMode, visibleFields, onEdit, canEdit, products }) {
+  const typeLabel = shot.type || "–";
+  const dateLabel = formatShotDate(shot.date) || "—";
+  const notesHtml = visibleFields.notes ? formatNotesForDisplay(shot.description) : "";
+  const talentList = Array.isArray(shot.talent)
+    ? shot.talent
+        .map((entry) => entry?.name)
+        .filter(Boolean)
+    : Array.isArray(shot.talentIds)
+    ? shot.talentIds
+        .map((id) => {
+          if (!shot.talent) return null;
+          const match = shot.talent.find((entry) => entry?.talentId === id);
+          return match?.name || null;
+        })
+        .filter(Boolean)
+    : [];
+  const productLabels = Array.isArray(products)
+    ? products.map((product) => {
+        const name = product?.familyName || product?.productName || "Product";
+        const colour = product?.colourName ? ` – ${product.colourName}` : "";
+        return `${name}${colour}`;
+      })
+    : [];
+  const locationLabel = shot.locationName || "–";
+
+  const cardBaseClass =
+    viewMode === "list"
+      ? "flex flex-col gap-2 rounded-md border border-slate-200 bg-white p-3 shadow-sm md:flex-row md:items-center md:justify-between"
+      : "flex flex-col gap-3 rounded-lg border border-slate-200 bg-white p-3 shadow-sm";
+
+  return (
+    <div className={`${cardBaseClass} transition hover:border-primary/40 hover:shadow-md`}>
+      <div className={viewMode === "list" ? "flex flex-1 flex-col gap-2" : "flex flex-col gap-2"}>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h4 className="text-sm font-semibold text-slate-900">{shot.name}</h4>
+            <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+              <span>{typeLabel}</span>
+              <span>•</span>
+              <span>{dateLabel}</span>
+              {shot.laneId && shot.laneId === "__unassigned__" && (
+                <span className="rounded-full bg-slate-100 px-2 py-0.5">Unassigned</span>
+              )}
+            </div>
+          </div>
+          {canEdit && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                onEdit?.(shot);
+              }}
+              className="flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-slate-500 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-900"
+              aria-label={`Edit ${shot.name}`}
+            >
+              <PencilLine className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
+        {visibleFields.notes && notesHtml && (
+          <div
+            className="rounded-md bg-slate-50 px-3 py-2 text-xs leading-relaxed text-slate-700"
+            dangerouslySetInnerHTML={{ __html: notesHtml }}
+          />
+        )}
+        {visibleFields.location && (
+          <div className="text-xs text-slate-600">
+            <span className="font-medium text-slate-700">Location:</span> {locationLabel}
+          </div>
+        )}
+        {visibleFields.talent && (
+          <div className="text-xs text-slate-600">
+            <span className="font-medium text-slate-700">Talent:</span>{" "}
+            {talentList.length ? talentList.join(", ") : "–"}
+          </div>
+        )}
+        {visibleFields.products && (
+          <div className="text-xs text-slate-600">
+            <span className="font-medium text-slate-700">Products:</span>{" "}
+            {productLabels.length ? productLabels.slice(0, 3).join(", ") : "–"}
+            {productLabels.length > 3 && "…"}
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -67,14 +235,36 @@ export default function PlannerPage() {
   const [lanes, setLanes] = useState([]);
   const [name, setName] = useState("");
   const [shotsByLane, setShotsByLane] = useState({});
+  const [families, setFamilies] = useState([]);
+  const [viewMode, setViewMode] = useState(() => readStoredPlannerView());
+  const [visibleFields, setVisibleFields] = useState(() => readStoredVisibleFields());
+  const [fieldSettingsOpen, setFieldSettingsOpen] = useState(false);
+  const fieldSettingsRef = useRef(null);
+  const [activeShot, setActiveShot] = useState(null);
+  const familyDetailCacheRef = useRef(new Map());
   const projectId = getActiveProjectId();
-  const { role: globalRole } = useAuth();
+  const { clientId, role: globalRole } = useAuth();
   const userRole = globalRole || ROLE.VIEWER;
   const canEditPlanner = canManagePlanner(userRole);
+  const canEditShots = canManageShots(userRole);
+  const currentLanesPath = useMemo(() => lanesPath(projectId, clientId), [projectId, clientId]);
+  const currentShotsPath = useMemo(() => shotsPath(clientId), [clientId]);
+  const currentProductFamiliesPath = useMemo(
+    () => productFamiliesPath(clientId),
+    [clientId]
+  );
+  const productFamilySkusPathForClient = useCallback(
+    (familyId) => productFamilySkusPath(familyId, clientId),
+    [clientId]
+  );
+  const productFamilyPathForClient = useCallback(
+    (familyId) => productFamilyPath(familyId, clientId),
+    [clientId]
+  );
 
   useEffect(() => {
     // Subscribe to lanes for the current project
-    const laneRef = collection(db, ...lanesPath(projectId));
+    const laneRef = collection(db, ...currentLanesPath);
     const unsubL = onSnapshot(query(laneRef, orderBy("order", "asc")), (s) =>
       setLanes(s.docs.map((d) => ({ id: d.id, ...d.data() })))
     );
@@ -82,7 +272,7 @@ export default function PlannerPage() {
     // Subscribe to shots for the current project.  We query the global shots
     // collection and filter by projectId.  Snapshots update the map of shots
     // keyed by laneId, with "__unassigned__" used for null laneId.
-    const shotsRef = collection(db, ...shotsPath());
+    const shotsRef = collection(db, ...currentShotsPath);
     const shotsQuery = query(shotsRef, where("projectId", "==", projectId));
     const unsubS = onSnapshot(shotsQuery, (s) => {
       const all = s.docs.map((d) => ({ id: d.id, ...d.data() }));
@@ -94,11 +284,46 @@ export default function PlannerPage() {
       setShotsByLane(map);
     });
 
+    // Subscribe to product families so the edit modal can reuse shared data.
+    const familiesRef = collection(db, ...currentProductFamiliesPath);
+    const unsubFamilies = onSnapshot(
+      query(familiesRef, orderBy("styleName", "asc")),
+      (snapshot) => {
+        setFamilies(snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() })));
+      }
+    );
+
     return () => {
       unsubL();
       unsubS();
+      unsubFamilies();
     };
-  }, [projectId]);
+  }, [projectId, currentLanesPath, currentShotsPath, currentProductFamiliesPath]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(PLANNER_VIEW_STORAGE_KEY, viewMode);
+  }, [viewMode]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(
+      PLANNER_FIELDS_STORAGE_KEY,
+      JSON.stringify(visibleFields)
+    );
+  }, [visibleFields]);
+
+  useEffect(() => {
+    if (!fieldSettingsOpen) return undefined;
+    const handleClick = (event) => {
+      if (!fieldSettingsRef.current) return;
+      if (!fieldSettingsRef.current.contains(event.target)) {
+        setFieldSettingsOpen(false);
+      }
+    };
+    window.addEventListener("mousedown", handleClick);
+    return () => window.removeEventListener("mousedown", handleClick);
+  }, [fieldSettingsOpen]);
 
   // Create a new lane with a given name.  Lanes are ordered sequentially
   // based on the length of the current lane array.  Names are arbitrary but
@@ -109,16 +334,263 @@ export default function PlannerPage() {
       return;
     }
     if (!name) return;
-    await addDoc(collection(db, ...lanesPath(projectId)), { name, order: lanes.length });
+    await addDoc(collection(db, ...currentLanesPath), { name, order: lanes.length });
     setName("");
   };
+
+  const handleOpenShotEdit = (shot) => {
+    if (!canEditShots) return;
+    setActiveShot({
+      shot,
+      products: normaliseShotProducts(shot),
+    });
+  };
+
+  const closeShotEdit = () => setActiveShot(null);
+
+  const isListView = viewMode === "list";
+  const laneWrapperClass = isListView
+    ? "flex min-w-[320px] flex-col gap-2 rounded-xl border border-slate-200 bg-white p-3 shadow-sm"
+    : "flex min-w-[280px] flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm";
+  const shotListClass = isListView ? "flex flex-col gap-2" : "flex flex-col gap-3";
+
+  const generateProductId = useCallback(() => Math.random().toString(36).slice(2, 10), []);
+
+  const withDerivedProductFields = useCallback(
+    (product) => {
+      const family = families.find((entry) => entry.id === product.familyId);
+      const fallbackSizes = Array.isArray(family?.sizes) ? family.sizes : [];
+      const sizeList = Array.isArray(product.sizeList) ? product.sizeList : fallbackSizes;
+      const rawStatus = product.status;
+      const rawScope = product.sizeScope;
+      const hasExplicitSize = product.size != null && product.size !== "";
+      const derivedStatus =
+        rawStatus === "pending-size"
+          ? "pending-size"
+          : rawScope === "pending"
+          ? "pending-size"
+          : hasExplicitSize
+          ? "complete"
+          : "complete";
+      const derivedScope =
+        derivedStatus === "pending-size"
+          ? "pending"
+          : rawScope === "all"
+          ? "all"
+          : hasExplicitSize
+          ? "single"
+          : rawScope === "single"
+          ? "single"
+          : "all";
+      const effectiveSize = derivedStatus === "pending-size" ? null : product.size || null;
+      const colourImage = product.colourImagePath || product.colourThumbnail || null;
+      const imageCandidates = Array.isArray(product.images)
+        ? product.images
+        : colourImage
+        ? [colourImage]
+        : [];
+
+      return {
+        ...product,
+        familyId: product.familyId || family?.id || null,
+        familyName: product.familyName || family?.styleName || "",
+        styleNumber: product.styleNumber || family?.styleNumber || null,
+        thumbnailImagePath:
+          product.thumbnailImagePath || family?.thumbnailImagePath || family?.headerImagePath || null,
+        colourId: product.colourId || product.colourwayId || null,
+        colourwayId: product.colourwayId || product.colourId || null,
+        colourName: product.colourName || "",
+        colourImagePath: colourImage || null,
+        images: imageCandidates,
+        skuCode: product.skuCode || null,
+        skuId: product.skuId || null,
+        size: effectiveSize,
+        sizeId: product.sizeId || (effectiveSize ? effectiveSize : null),
+        sizeScope: derivedScope,
+        status: derivedStatus,
+        sizeList,
+      };
+    },
+    [families]
+  );
+
+  const normaliseShotProducts = useCallback(
+    (shot) => {
+      if (Array.isArray(shot?.products) && shot.products.length) {
+        return shot.products.map((product) => withDerivedProductFields(product)).filter(Boolean);
+      }
+      if (!Array.isArray(shot?.productIds)) return [];
+      return shot.productIds
+        .map((familyId) => {
+          const family = families.find((entry) => entry.id === familyId);
+          if (!family) return null;
+          return withDerivedProductFields({
+            id: `legacy-${familyId}`,
+            familyId,
+            familyName: family.styleName,
+            styleNumber: family.styleNumber || null,
+            thumbnailImagePath: family.thumbnailImagePath || family.headerImagePath || null,
+            colourId: null,
+            colourwayId: null,
+            colourName: "Any colour",
+            colourImagePath: null,
+            skuCode: null,
+            size: null,
+            sizeList: Array.isArray(family.sizes) ? family.sizes : [],
+            status: "complete",
+            sizeScope: "all",
+          });
+        })
+        .filter(Boolean);
+    },
+    [families, withDerivedProductFields]
+  );
+
+  const buildShotProduct = useCallback(
+    (selection, previous = null) => {
+      const { family, colour, size, status: requestedStatus, sizeScope } = selection;
+      const baseStatus = requestedStatus === "pending-size" ? "pending-size" : "complete";
+      const resolvedScope =
+        baseStatus === "pending-size"
+          ? "pending"
+          : sizeScope === "all"
+          ? "all"
+          : size
+          ? "single"
+          : sizeScope === "single"
+          ? "single"
+          : "all";
+      const resolvedSize =
+        baseStatus === "pending-size"
+          ? null
+          : resolvedScope === "all"
+          ? null
+          : size || null;
+      const colourImage = colour.imagePath || colour.thumbnailImagePath || null;
+      const colourImages = Array.isArray(colour.images)
+        ? colour.images
+        : colourImage
+        ? [colourImage]
+        : [];
+
+      return {
+        id: previous?.id || generateProductId(),
+        familyId: family.id,
+        familyName: family.styleName,
+        styleNumber: family.styleNumber || null,
+        thumbnailImagePath:
+          family.thumbnailImagePath || family.headerImagePath || colourImage || null,
+        colourId: colour.id || null,
+        colourwayId: colour.id || null,
+        colourName: colour.colorName || "",
+        colourImagePath: colourImage || null,
+        images: colourImages,
+        skuCode: colour.skuCode || null,
+        skuId: colour.skuId || null,
+        size: resolvedSize,
+        sizeId: resolvedSize || null,
+        sizeScope: resolvedScope,
+        status: baseStatus,
+        sizeList: Array.isArray(family.sizes) ? family.sizes : [],
+      };
+    },
+    [generateProductId]
+  );
+
+  const loadFamilyDetails = useCallback(
+    async (familyId) => {
+      if (familyDetailCacheRef.current.has(familyId)) {
+        return familyDetailCacheRef.current.get(familyId);
+      }
+      const skusPath = productFamilySkusPathForClient(familyId);
+      const snapshot = await getDocs(
+        query(collection(db, ...skusPath), orderBy("colorName", "asc"))
+      );
+      const colours = snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+      const details = {
+        colours,
+        sizes: families.find((family) => family.id === familyId)?.sizes || [],
+      };
+      familyDetailCacheRef.current.set(familyId, details);
+      return details;
+    },
+    [families, productFamilySkusPathForClient]
+  );
+
+  const extractProductIds = useCallback((products = []) => {
+    const ids = new Set();
+    products.forEach((product) => {
+      const id = product.familyId || product.productId || product.productIdRef;
+      if (id) ids.add(id);
+    });
+    return Array.from(ids);
+  }, []);
+
+  const prepareProductForWrite = useCallback((product) => {
+    const sizeScope =
+      product.sizeScope ||
+      (product.status === "pending-size" ? "pending" : product.size ? "single" : "all");
+    return {
+      productId: product.familyId || product.productId || "",
+      productName: (product.familyName || product.productName || "Product").trim(),
+      styleNumber: product.styleNumber || null,
+      colourId: product.colourId || null,
+      colourName: product.colourName || null,
+      colourImagePath: product.colourImagePath || null,
+      thumbnailImagePath: product.thumbnailImagePath || null,
+      size: product.size || null,
+      sizeScope,
+      status: product.status === "pending-size" ? "pending-size" : "complete",
+    };
+  }, []);
+
+  const updateProductIndexes = useCallback(
+    async (shotId, beforeProducts, afterProducts) => {
+      const beforeIds = new Set(extractProductIds(beforeProducts));
+      const afterIds = new Set(extractProductIds(afterProducts));
+      const adds = [...afterIds].filter((id) => !beforeIds.has(id));
+      const removals = [...beforeIds].filter((id) => !afterIds.has(id));
+
+      await Promise.all(
+        adds.map((id) =>
+          updateDoc(doc(db, ...productFamilyPathForClient(id)), {
+            shotIds: arrayUnion(shotId),
+          }).catch(() => {})
+        )
+      );
+      await Promise.all(
+        removals.map((id) =>
+          updateDoc(doc(db, ...productFamilyPathForClient(id)), {
+            shotIds: arrayRemove(shotId),
+          }).catch(() => {})
+        )
+      );
+    },
+    [extractProductIds, productFamilyPathForClient]
+  );
+
+  const saveShotProducts = useCallback(
+    async (shot, products) => {
+      if (!canEditShots) return;
+      const docRef = doc(db, ...currentShotsPath, shot.id);
+      const prepared = products.map((product) => prepareProductForWrite(product));
+      const nextProductIds = extractProductIds(prepared);
+      await updateDoc(docRef, {
+        products: prepared,
+        productIds: nextProductIds,
+        updatedAt: Date.now(),
+      });
+      await updateProductIndexes(shot.id, shot.products || [], prepared);
+    },
+    [canEditShots, currentShotsPath, extractProductIds, prepareProductForWrite, updateProductIndexes]
+  );
 
   // Prompt to rename a lane.  Empty input aborts the rename.
   const renameLane = async (lane) => {
     if (!canEditPlanner) return;
     const newName = prompt("Lane name", lane.name);
     if (!newName) return;
-    await updateDoc(doc(db, ...lanesPath(projectId), lane.id), { name: newName });
+    await updateDoc(doc(db, ...currentLanesPath, lane.id), { name: newName });
   };
 
   // Remove a lane.  Before deleting the lane document we set laneId=null for
@@ -129,17 +601,17 @@ export default function PlannerPage() {
     if (!canEditPlanner) return;
     if (!confirm("Delete lane?")) return;
     const q = query(
-      collection(db, ...shotsPath()),
+      collection(db, ...currentShotsPath),
       where("projectId", "==", projectId),
       where("laneId", "==", lane.id)
     );
     const snap = await getDocs(q);
     await Promise.all(
       snap.docs.map((dref) =>
-        updateDoc(doc(db, ...shotsPath(), dref.id), { laneId: null })
+        updateDoc(doc(db, ...currentShotsPath, dref.id), { laneId: null })
       )
     );
-    await deleteDoc(doc(db, ...lanesPath(projectId), lane.id));
+    await deleteDoc(doc(db, ...currentLanesPath, lane.id));
   };
 
   // Handle drag end events.  Update the shot's laneId (and date if the lane
@@ -156,7 +628,7 @@ export default function PlannerPage() {
       const lane = lanes.find((l) => l.id === laneId);
       if (lane && /^\d{4}-\d{2}-\d{2}$/.test(lane.name)) patch.date = lane.name;
     }
-    await updateDoc(doc(db, ...shotsPath(), shotId), patch);
+    await updateDoc(doc(db, ...currentShotsPath, shotId), patch);
   };
 
   return (
@@ -167,6 +639,79 @@ export default function PlannerPage() {
           Arrange shots into lanes for the active project. Drag cards between lanes to
           update assignments and keep shoot days organised.
         </p>
+      </div>
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
+            View
+          </span>
+          <div className="inline-flex overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm">
+            <button
+              type="button"
+              onClick={() => setViewMode("board")}
+              className={`flex items-center gap-2 px-3 py-1.5 text-sm transition ${
+                viewMode === "board" ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-100"
+              }`}
+              aria-pressed={viewMode === "board"}
+            >
+              <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+              Board
+            </button>
+            <button
+              type="button"
+              onClick={() => setViewMode("list")}
+              className={`flex items-center gap-2 px-3 py-1.5 text-sm transition ${
+                viewMode === "list" ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-100"
+              }`}
+              aria-pressed={viewMode === "list"}
+            >
+              <Rows3 className="h-4 w-4" aria-hidden="true" />
+              List
+            </button>
+          </div>
+        </div>
+        <div className="relative" ref={fieldSettingsRef}>
+          <button
+            type="button"
+            onClick={() => setFieldSettingsOpen((prev) => !prev)}
+            className="flex h-9 w-9 items-center justify-center rounded-md border border-slate-200 text-slate-600 transition hover:bg-slate-100"
+            aria-haspopup="menu"
+            aria-expanded={fieldSettingsOpen}
+            aria-label="Select visible fields"
+          >
+            <Settings2 className="h-4 w-4" aria-hidden="true" />
+          </button>
+          {fieldSettingsOpen && (
+            <div className="absolute right-0 z-20 mt-2 w-52 rounded-md border border-slate-200 bg-white p-3 shadow-lg">
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Shot details
+              </p>
+              {[
+                { key: "notes", label: "Notes" },
+                { key: "location", label: "Location" },
+                { key: "talent", label: "Talent" },
+                { key: "products", label: "Products" },
+              ].map((option) => (
+                <label
+                  key={option.key}
+                  className="mt-2 flex items-center gap-2 rounded px-2 py-1 text-sm text-slate-700 hover:bg-slate-50"
+                >
+                  <input
+                    type="checkbox"
+                    checked={visibleFields[option.key]}
+                    onChange={(event) =>
+                      setVisibleFields((prev) => ({
+                        ...prev,
+                        [option.key]: event.target.checked,
+                      }))
+                    }
+                  />
+                  {option.label}
+                </label>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
       <div className="flex flex-wrap items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
         <input
@@ -185,16 +730,25 @@ export default function PlannerPage() {
         </button>
       </div>
       <DndContext collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-        <div className="flex gap-4 overflow-x-auto pb-6">
+        <div className={`flex ${isListView ? "gap-3" : "gap-4"} overflow-x-auto pb-6`}>
           {/* Unassigned column */}
           <DroppableLane laneId="__unassigned__">
-            <div className="flex min-w-[280px] flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className={laneWrapperClass}>
               <div className="flex items-center justify-between">
                 <span className="text-sm font-semibold text-slate-900">Unassigned</span>
               </div>
-              <div className="flex flex-col gap-3">
+              <div className={shotListClass}>
                 {(shotsByLane["__unassigned__"] || []).map((sh) => (
-                  <DraggableShot key={sh.id} shot={sh} disabled={!canEditPlanner} />
+                  <DraggableShot
+                    key={sh.id}
+                    shot={sh}
+                    disabled={!canEditPlanner}
+                    viewMode={viewMode}
+                    visibleFields={visibleFields}
+                    onEdit={handleOpenShotEdit}
+                    canEditShots={canEditShots}
+                    normaliseProducts={normaliseShotProducts}
+                  />
                 ))}
               </div>
             </div>
@@ -202,7 +756,7 @@ export default function PlannerPage() {
           {/* Project lanes */}
           {lanes.map((lane) => (
             <DroppableLane key={lane.id} laneId={lane.id}>
-              <div className="flex min-w-[280px] flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className={laneWrapperClass}>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-semibold text-slate-900">{lane.name}</span>
                   {canEditPlanner && (
@@ -216,9 +770,18 @@ export default function PlannerPage() {
                     </span>
                   )}
                 </div>
-                <div className="flex flex-col gap-3">
+                <div className={shotListClass}>
                   {(shotsByLane[lane.id] || []).map((sh) => (
-                    <DraggableShot key={sh.id} shot={sh} disabled={!canEditPlanner} />
+                    <DraggableShot
+                      key={sh.id}
+                      shot={sh}
+                      disabled={!canEditPlanner}
+                      viewMode={viewMode}
+                      visibleFields={visibleFields}
+                      onEdit={handleOpenShotEdit}
+                      canEditShots={canEditShots}
+                      normaliseProducts={normaliseShotProducts}
+                    />
                   ))}
                 </div>
               </div>
@@ -226,6 +789,67 @@ export default function PlannerPage() {
           ))}
         </div>
       </DndContext>
+      {canEditShots && activeShot && (
+        <Modal
+          open
+          onClose={closeShotEdit}
+          labelledBy="planner-shot-edit-title"
+          contentClassName="p-0 max-h-[90vh] overflow-hidden"
+        >
+          <Card className="border-0 shadow-none">
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <h2 id="planner-shot-edit-title" className="text-lg font-semibold">
+                    Edit products for {activeShot.shot.name}
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    Adjust linked colours and sizes, then save to update the shot.
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  aria-label="Close"
+                  className="text-xl text-slate-400 hover:text-slate-600"
+                  onClick={closeShotEdit}
+                >
+                  ×
+                </button>
+              </div>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <ShotProductsEditor
+                value={activeShot.products}
+                onChange={(next) => setActiveShot((prev) => ({ ...prev, products: next }))}
+                families={families}
+                loadFamilyDetails={loadFamilyDetails}
+                createProduct={buildShotProduct}
+                emptyHint="No products linked"
+              />
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={closeShotEdit}>
+                  Cancel
+                </Button>
+                <Button
+                  onClick={async () => {
+                    try {
+                      await saveShotProducts(activeShot.shot, activeShot.products);
+                      toast.success("Shot products updated");
+                      closeShotEdit();
+                    } catch (error) {
+                      console.error("[Planner] Failed to update shot products", error);
+                      toast.error("Unable to save products");
+                    }
+                  }}
+                  disabled={!activeShot.products}
+                >
+                  Save changes
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </Modal>
+      )}
       {!canEditPlanner && (
         <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600">
           Planner actions are read-only for your role. Producers or crew can organise shot lanes.


### PR DESCRIPTION
## Summary
  - add gallery/list toggle on Products with column preferences persisted per user
  - replace Shots “Notes” field with a sanitised rich-text editor and render notes consistently
  - update Planner cards with configurable fields, board/list views, and inline product editing
  - tighten Add Colour modal layout so status aligns with inputs and the add button stays visible

  ## Testing
  - npm run lint

## Plan (before coding)
- [ ] Outline the approach and files to touch
- [ ] Note risks/assumptions

## Acceptance Criteria
- [ ] Tests cover new/changed behavior
- [ ] Auth redirect preserves `state.from`
- [ ] No render while `auth.initializing`
- [ ] Flags default OFF; override precedence works; console warns when overridden
- [ ] CI green; preview deploy guarded when secrets missing

## Risk & Mitigations
- Risk:
- Mitigation:

## Manual QA Steps
1.
2.

## Notes / Follow-ups
-

