### PR TITLE
fix/planner shot modal

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,0 +1,14 @@
+{
+  "indexes": [
+    {
+      "collectionGroup": "shots",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "projectId", "mode": "ASCENDING" },
+        { "fieldPath": "date", "mode": "ASCENDING" },
+        { "fieldPath": "__name__", "mode": "ASCENDING" }
+      ]
+    }
+  ],
+  "fieldOverrides": []
+}

--- a/src/hooks/useStorageImage.js
+++ b/src/hooks/useStorageImage.js
@@ -2,8 +2,28 @@ import { useEffect, useState } from "react";
 import { getDownloadURL, ref as storageRef } from "firebase/storage";
 import { storage } from "../lib/firebase";
 
-export const buildSizedPath = (path, size = 480) =>
-  path.replace(/(\.[^./]+)$/, `_${size}x${Math.round(size * 1.25)}$1`);
+export const buildSizedPath = (path, size = 480) => {
+  if (typeof path !== "string" || path.length === 0) {
+    return path;
+  }
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+  const suffix = `_${size}x${Math.round(size * 1.25)}`;
+  const [base, ...rest] = path.split("?");
+  const query = rest.length ? `?${rest.join("?")}` : "";
+  const lastSlash = base.lastIndexOf("/");
+  const lastDot = base.lastIndexOf(".");
+  if (lastDot === -1 || lastDot < lastSlash) {
+    return path;
+  }
+  const sliceStart = Math.max(lastDot - suffix.length, 0);
+  if (base.slice(sliceStart, lastDot) === suffix) {
+    return path;
+  }
+  const sizedBase = `${base.slice(0, lastDot)}${suffix}${base.slice(lastDot)}`;
+  return `${sizedBase}${query}`;
+};
 
 export function useStorageImage(path, { preferredSize = 480 } = {}) {
   const [url, setUrl] = useState(null);
@@ -12,6 +32,13 @@ export function useStorageImage(path, { preferredSize = 480 } = {}) {
     let cancelled = false;
     if (!path) {
       setUrl(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    if (typeof path === "string" && /^https?:\/\//i.test(path)) {
+      setUrl(path);
       return () => {
         cancelled = true;
       };

--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -339,6 +339,13 @@ function ShotCard({ shot, viewMode, visibleFields, onEdit, canEdit, products }) 
                     event.stopPropagation();
                     onEdit?.(shot);
                   }}
+                  onPointerDownCapture={(event) => {
+                    // Prevent the parent draggable from hijacking pointer events.
+                    event.stopPropagation();
+                  }}
+                  onPointerUpCapture={(event) => {
+                    event.stopPropagation();
+                  }}
                   className="flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-slate-500 transition hover:border-slate-200 hover:bg-slate-100 hover:text-slate-900"
                   aria-label={`Edit ${shot.name}`}
                 >


### PR DESCRIPTION
- **fix(products): import checkbox component**
- **feat(products): add family sizes and shot product picker**
- **build: allow firebase env fallbacks for ci**
- **fix(products): stabilize family editors**
- **fix(paths): export product family helper**
- **fix(images): expose format helper and compression**
- **feat(rbac): expose granular product permissions**
- **feat(resources): modernize talent and location management**
- **feat(shots): make product picker scrollable and defer size**
- **feat: improve shot product modal with enhanced scrolling and button logic**
- **fix: update tests to handle dynamic button text**
- **feat: add comprehensive debug logging for color selection functionality**
- **test(shots): harden ShotProductAddModal specs and tooling**
- **feat(firebase): harden app rules and handlers**
- **fix(modal): restore shot modal scrolling**
- **feat(auth): surface claim info for create flows**
- **feat(ui): improve product and planner views**
- **fix(planner): replace rows3 icon with list**
- **fix(auth+planner): preserve role and improve planner ux**
- **fix(planner): harden planner interactions**
- **fix(planner): stabilize shots board and restore edit modal**
- **fix(planner): normalise roles before checking permissions**
- **fix(rbac): normalise roles before permission checks**
- **ci(firebase): fix preview prune flag**
- **fix(planner): stabilise shot editing flow**
