### PR TITLE
feat(products): enhance planner exports and product batch actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Planner board now preloads date lanes (plus an Unassigned lane), offers a talent filter, and exports the current view to PDF for offline sharing.
+- Products page multi-select enables archiving, restoring, deleting, and bulk editing style numbers across multiple families with chunked batched writes.
+
+### Changed
+- Sticky headers keep titles, search, and primary actions visible on the Shots, Products, Talent, and Locations pages.
+- Products page header adds sort controls for style name and style number.
+
+### Fixed
+- _None yet_

--- a/README.md
+++ b/README.md
@@ -102,13 +102,38 @@ shot-builder-app/
 └── ...
 ```
 
+## Planner
+
+- The Planner board preloads lanes for each upcoming shoot date and always shows an **Unassigned** lane for undated shots.
+- Drag shots between lanes to schedule or clear dates; changes sync instantly to the underlying Firestore documents.
+- A talent multi-select filter above the board narrows the view to specific cast members without persisting the filter to Firestore.
+- Use the **Export PDF** button to capture the current board (including active filters) via jsPDF for quick handoffs.
+
+## Shots
+
+- Manage per-project shot lists with inline creation, talent assignments, product tagging, and rich notes.
+- The page header stays pinned so the search field and `New shot` action remain visible while scrolling long lists.
+
+## Talent
+
+- Centralise model records with agency contacts, sizing details, links, and headshots.
+- The sticky header keeps global search and the `New talent` shortcut accessible on both mobile and desktop.
+
+## Locations
+
+- Catalogue studios and on-site venues with addresses, reference photos, notes, and contact info.
+- The page header pins search and the `New location` action so you can add venues without losing your place in the list.
+
 ## Product management
 
+- The sticky header keeps product search and the `New product` button within reach while you browse large catalogues.
+- Sort families by style name (A→Z / Z→A) or style number using the header sort menu.
 - Product families appear as responsive cards (two columns on tablet, three on desktop) with 4:5 imagery, status badges and quick action menus. A dedicated tile and toolbar button launch the creation flow.
 - `NewProductModal` and `EditProductModal` share the `ProductFamilyForm`, capturing style metadata, optional previous style numbers, timestamped notes and header imagery (aim for 1600×2000 px under 2.5 MB; uploads are compressed client-side).
 - SKUs are stored as documents under `/productFamilies/{familyId}/skus`, each recording colour name, SKU code, optional size list, status and image. Producers can add, archive or restore SKUs without touching the family document.
 - Role helpers (`canEditProducts`, `canArchiveProducts`, `canDeleteProducts`) gate UI actions: producers can create/edit/archive, while only admins can permanently delete families or SKUs. Updated Firestore rules enforce the same constraints and provide a soft-delete archive path.
 - The callable `migrateProductsToFamilies` function lifts legacy `/products/{productId}` documents into the new structure. The CSV importer (`ImportProducts` page) now writes directly to product families and nested SKUs.
+- Select multiple families to archive, restore, delete, or bulk edit style numbers—the batch action bar chunks Firestore writes in sets of 200 for safety.
 
 ## Next steps
 

--- a/src/pages/LocationsPage.jsx
+++ b/src/pages/LocationsPage.jsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   addDoc,
   collection,
@@ -112,6 +112,8 @@ export default function LocationsPage() {
   const [editTarget, setEditTarget] = useState(null);
   const [editBusy, setEditBusy] = useState(false);
   const [pendingDeleteId, setPendingDeleteId] = useState(null);
+  const createCardRef = useRef(null);
+  const firstFieldRef = useRef(null);
 
   const { clientId, role: globalRole, user, claims } = useAuth();
   const role = globalRole || ROLE.VIEWER;
@@ -376,35 +378,66 @@ export default function LocationsPage() {
 
   const closeEditModal = () => setEditTarget(null);
 
+  const scrollToCreateLocation = () => {
+    if (!canManage) return;
+    if (createCardRef.current) {
+      createCardRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+    const focusField = () => {
+      if (firstFieldRef.current) {
+        try {
+          firstFieldRef.current.focus({ preventScroll: true });
+        } catch {
+          firstFieldRef.current.focus();
+        }
+      }
+    };
+    if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(focusField);
+    } else {
+      focusField();
+    }
+  };
+
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-1">
-        <h1 className="text-2xl font-semibold text-slate-900">Locations</h1>
-        <p className="text-sm text-slate-600">
-          Catalogue studios and on-site venues with reference photos and notes.
-        </p>
+      <div className="sticky top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <h1 className="text-2xl font-semibold text-slate-900">Locations</h1>
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
+            <Input
+              placeholder="Search locations by name, address, or notes..."
+              aria-label="Search locations"
+              value={queryText}
+              onChange={(event) => setQueryText(event.target.value)}
+              className="w-full sm:w-72 lg:w-96"
+            />
+            {canManage && (
+              <Button type="button" onClick={scrollToCreateLocation} className="w-full sm:w-auto">
+                New location
+              </Button>
+            )}
+          </div>
+        </div>
       </div>
 
-      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-        <Input
-          placeholder="Search locations by name, address, or notes…"
-          value={queryText}
-          onChange={(event) => setQueryText(event.target.value)}
-          className="md:max-w-sm"
-        />
-        {feedback && (
-          <div
-            className={`rounded-md px-4 py-2 text-sm ${
-              feedback.type === "success" ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-600"
-            }`}
-          >
-            {feedback.text}
-          </div>
-        )}
-      </div>
+      <p className="text-sm text-slate-600">
+        Catalogue studios and on-site venues with reference photos and notes.
+      </p>
+
+      {feedback && (
+        <div
+          className={`rounded-md px-4 py-2 text-sm ${
+            feedback.type === "success" ? "bg-emerald-50 text-emerald-700" : "bg-red-50 text-red-600"
+          }`}
+        >
+          {feedback.text}
+        </div>
+      )}
 
       {canManage ? (
-        <Card>
+        <div ref={createCardRef}>
+          <Card>
           <CardHeader>
             <h2 className="text-lg font-semibold text-slate-900">Add location</h2>
             <p className="text-sm text-slate-500">
@@ -419,6 +452,7 @@ export default function LocationsPage() {
                 </label>
                 <Input
                   id="location-create-name"
+                  ref={firstFieldRef}
                   value={draft.name}
                   onChange={handleDraftChange("name")}
                   placeholder="Location name"
@@ -541,7 +575,8 @@ export default function LocationsPage() {
               </div>
             </form>
           </CardContent>
-        </Card>
+          </Card>
+        </div>
       ) : (
         <div className="rounded-lg border border-slate-200 bg-white p-4 text-sm text-slate-600">
           Locations are read-only for your role. Producers can create and update venue records.

--- a/src/pages/__tests__/ProductsPage.test.jsx
+++ b/src/pages/__tests__/ProductsPage.test.jsx
@@ -1,0 +1,337 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+globalThis.React = React;
+
+const toastMock = {
+  success: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warning: vi.fn(),
+};
+
+const authState = {
+  clientId: "unbound-merino",
+  role: "producer",
+  user: { uid: "tester" },
+};
+
+const snapshotData = new Map();
+const writeBatchCalls = [];
+const deleteImageMock = vi.fn(() => Promise.resolve());
+
+const pathKey = (segments) => (Array.isArray(segments) ? segments.join("/") : "");
+
+const setSnapshot = (segments, docs) => {
+  snapshotData.set(
+    pathKey(segments),
+    docs.map((entry) => ({ id: entry.id, data: entry.data }))
+  );
+};
+
+const getSnapshotForPath = (path) => {
+  const docs = snapshotData.get(path) || [];
+  const entries = docs.map((doc) => ({
+    id: doc.id,
+    data: () => ({ ...doc.data }),
+  }));
+  return {
+    docs: entries,
+    forEach: (callback) => entries.forEach((entry) => callback(entry)),
+  };
+};
+
+const collapseArgs = (maybeDb, segments) => {
+  if (segments.length) return segments;
+  if (Array.isArray(maybeDb)) return maybeDb;
+  if (maybeDb && Array.isArray(maybeDb.__path)) return maybeDb.__path;
+  return [];
+};
+
+const collectionMock = vi.fn((maybeDb, ...segments) => ({ __path: collapseArgs(maybeDb, segments) }));
+const docMock = vi.fn((maybeDb, ...segments) => ({ __path: collapseArgs(maybeDb, segments) }));
+const queryMock = vi.fn((ref) => ({ __path: ref.__path, __ref: ref }));
+const orderByMock = vi.fn((...args) => ({ __orderBy: args }));
+const setDocMock = vi.fn(async () => {});
+const updateDocMock = vi.fn(async () => {});
+const deleteDocMock = vi.fn(async () => {});
+const addDocMock = vi.fn(async () => ({ id: "new-doc", __path: [] }));
+
+const onSnapshotMock = vi.fn((ref, onNext) => {
+  const key = pathKey(ref.__path || []);
+  onNext?.(getSnapshotForPath(key));
+  return () => {};
+});
+
+const getDocsMock = vi.fn(async (ref) => getSnapshotForPath(pathKey(ref.__path || [])));
+
+const writeBatchMock = vi.fn(() => {
+  const operations = [];
+  return {
+    update: (ref, data) => operations.push({ type: "update", ref, data }),
+    delete: (ref) => operations.push({ type: "delete", ref }),
+    set: (ref, data, options) => operations.push({ type: "set", ref, data, options }),
+    commit: vi.fn(async () => {
+      writeBatchCalls.push(operations.slice());
+    }),
+  };
+});
+
+vi.mock("firebase/firestore", () => ({
+  collection: collectionMock,
+  doc: docMock,
+  query: queryMock,
+  orderBy: orderByMock,
+  onSnapshot: onSnapshotMock,
+  getDocs: getDocsMock,
+  addDoc: addDocMock,
+  updateDoc: updateDocMock,
+  deleteDoc: deleteDocMock,
+  setDoc: setDocMock,
+  writeBatch: writeBatchMock,
+}));
+
+vi.mock("../../lib/firebase", () => ({
+  db: {},
+  uploadImageFile: vi.fn(async () => ({ path: "uploaded" })),
+  deleteImageByPath: deleteImageMock,
+}));
+
+vi.mock("../../lib/toast", () => ({ toast: toastMock }));
+
+vi.mock("../../context/AuthContext", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("../../hooks/useStorageImage", () => ({
+  useStorageImage: () => null,
+}));
+
+vi.mock("../../components/products/NewProductModal", () => ({
+  default: () => null,
+}));
+
+vi.mock("../../components/products/EditProductModal", () => ({
+  default: () => null,
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  snapshotData.clear();
+  writeBatchCalls.length = 0;
+  deleteImageMock.mockClear();
+  toastMock.success.mockClear();
+  toastMock.error.mockClear();
+  toastMock.info.mockClear();
+  toastMock.warning.mockClear();
+  authState.role = "producer";
+  authState.user = { uid: "tester" };
+  window.localStorage.clear();
+  window.localStorage.setItem("products:viewMode", "list");
+});
+
+describe("ProductsPage", () => {
+  it("sorts products by the selected option", async () => {
+    setSnapshot([
+      "clients",
+      "unbound-merino",
+      "productFamilies",
+    ], [
+      {
+        id: "fam-bravo",
+        data: {
+          styleName: "Bravo Coat",
+          styleNumber: "200",
+          status: "active",
+          archived: false,
+        },
+      },
+      {
+        id: "fam-alpha",
+        data: {
+          styleName: "Alpha Jacket",
+          styleNumber: "100",
+          status: "active",
+          archived: false,
+        },
+      },
+    ]);
+
+    vi.resetModules();
+    const { default: ProductsPage } = await import("../ProductsPage.jsx");
+    render(<ProductsPage />);
+
+    const table = await screen.findByRole("table");
+    const readOrder = () =>
+      Array.from(table.querySelectorAll("tbody tr")).map((row) =>
+        row.querySelector('[data-testid^="style-name-"]').textContent.trim()
+      );
+
+    await waitFor(() => {
+      expect(readOrder()).toEqual(["Alpha Jacket", "Bravo Coat"]);
+    });
+
+    const sortSelect = screen.getByLabelText("Sort products");
+
+    fireEvent.change(sortSelect, { target: { value: "styleNameDesc" } });
+    await waitFor(() => {
+      expect(readOrder()).toEqual(["Bravo Coat", "Alpha Jacket"]);
+    });
+
+    fireEvent.change(sortSelect, { target: { value: "styleNumberAsc" } });
+    await waitFor(() => {
+      expect(readOrder()).toEqual(["Alpha Jacket", "Bravo Coat"]);
+    });
+
+    fireEvent.change(sortSelect, { target: { value: "styleNumberDesc" } });
+    await waitFor(() => {
+      expect(readOrder()).toEqual(["Bravo Coat", "Alpha Jacket"]);
+    });
+  });
+
+  it("shows batch actions for multi-select and archives selected products", async () => {
+    setSnapshot([
+      "clients",
+      "unbound-merino",
+      "productFamilies",
+    ], [
+      {
+        id: "fam-alpha",
+        data: {
+          styleName: "Alpha Jacket",
+          styleNumber: "100",
+          status: "active",
+          archived: false,
+        },
+      },
+      {
+        id: "fam-bravo",
+        data: {
+          styleName: "Bravo Coat",
+          styleNumber: "200",
+          status: "active",
+          archived: false,
+        },
+      },
+    ]);
+
+    vi.resetModules();
+    const { default: ProductsPage } = await import("../ProductsPage.jsx");
+    render(<ProductsPage />);
+
+    await screen.findByText("Alpha Jacket");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Alpha Jacket" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Bravo Coat" }));
+
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Archive$/ }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Archived 2 product families.");
+    });
+
+    expect(writeBatchMock).toHaveBeenCalledTimes(1);
+    expect(writeBatchCalls).toHaveLength(1);
+    expect(writeBatchCalls[0]).toHaveLength(2);
+    writeBatchCalls[0].forEach((operation) => {
+      expect(operation.type).toBe("update");
+      expect(operation.data.archived).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/selected/)).not.toBeInTheDocument();
+    });
+  });
+
+  it("deletes selected products using batched writes", async () => {
+    authState.role = "admin";
+    setSnapshot([
+      "clients",
+      "unbound-merino",
+      "productFamilies",
+    ], [
+      {
+        id: "fam-alpha",
+        data: {
+          styleName: "Alpha Jacket",
+          styleNumber: "100",
+          status: "active",
+          archived: false,
+          headerImagePath: "alpha-header.jpg",
+          thumbnailImagePath: "alpha-thumb.jpg",
+        },
+      },
+      {
+        id: "fam-bravo",
+        data: {
+          styleName: "Bravo Coat",
+          styleNumber: "200",
+          status: "active",
+          archived: false,
+          headerImagePath: "bravo-header.jpg",
+          thumbnailImagePath: "bravo-thumb.jpg",
+        },
+      },
+    ]);
+
+    setSnapshot(
+      ["clients", "unbound-merino", "productFamilies", "fam-alpha", "skus"],
+      [
+        {
+          id: "sku-alpha",
+          data: { imagePath: "alpha-sku.jpg" },
+        },
+      ]
+    );
+
+    setSnapshot(
+      ["clients", "unbound-merino", "productFamilies", "fam-bravo", "skus"],
+      [
+        {
+          id: "sku-bravo",
+          data: { imagePath: "bravo-sku.jpg" },
+        },
+      ]
+    );
+
+    vi.resetModules();
+    const { default: ProductsPage } = await import("../ProductsPage.jsx");
+    render(<ProductsPage />);
+
+    await screen.findByText("Alpha Jacket");
+
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Alpha Jacket" }));
+    fireEvent.click(screen.getByRole("checkbox", { name: "Select Bravo Coat" }));
+
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Delete$/ }));
+
+    await waitFor(() => {
+      expect(toastMock.success).toHaveBeenCalledWith("Deleted 2 product families.");
+    });
+
+    expect(writeBatchCalls).toHaveLength(1);
+    expect(writeBatchCalls[0]).toHaveLength(4);
+    writeBatchCalls[0].forEach((operation) => {
+      expect(operation.type).toBe("delete");
+      expect(Array.isArray(operation.ref.__path)).toBe(true);
+    });
+
+    expect(deleteImageMock).toHaveBeenCalledWith("alpha-header.jpg");
+    expect(deleteImageMock).toHaveBeenCalledWith("alpha-thumb.jpg");
+    expect(deleteImageMock).toHaveBeenCalledWith("alpha-sku.jpg");
+    expect(deleteImageMock).toHaveBeenCalledWith("bravo-header.jpg");
+    expect(deleteImageMock).toHaveBeenCalledWith("bravo-thumb.jpg");
+    expect(deleteImageMock).toHaveBeenCalledWith("bravo-sku.jpg");
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/src/routes/SidebarLayout.jsx
+++ b/src/routes/SidebarLayout.jsx
@@ -133,7 +133,7 @@ export default function SidebarLayout({ fallbackUser = null, fallbackRole = null
         </aside>
 
         <div className="flex flex-1 flex-col">
-          <header className="sticky top-0 z-30 flex items-center justify-between border-b border-slate-200 bg-white/95 px-4 py-3 backdrop-blur md:justify-end">
+          <header className="sticky top-0 z-30 flex h-14 items-center justify-between border-b border-slate-200 bg-white/95 px-4 backdrop-blur md:justify-end">
             <button
               onClick={toggleMobile}
               className="inline-flex items-center rounded-md border border-slate-200 px-2.5 py-1.5 text-sm text-slate-600 transition hover:bg-slate-100 md:hidden"


### PR DESCRIPTION
## Summary
<What changed and why>

## Plan (before coding)
- [ ] Outline the approach and files to touch
- [ ] Note risks/assumptions

## Acceptance Criteria
- [ ] Tests cover new/changed behavior
- [ ] Auth redirect preserves `state.from`
- [ ] No render while `auth.initializing`
- [ ] Flags default OFF; override precedence works; console warns when overridden
- [ ] CI green; preview deploy guarded when secrets missing

## Summary
  - Extend the Products page header with explicit sort controls (style name asc/desc, style number asc/desc) and drive ordering via sortedFamilies.
  - Add multi-select to both gallery and list views with select-all, sticky selection state, and batched archive/restore/delete/style-number edits (chunked at 200 writes, with confirmation + toasts).
  - Introduce a bulk style-number modal and UI affordances for selection (checkboxes, selection banner) while keeping planner/other page headers aligned to the new global height.
  - Document the Planner lane/talent/PDF workflow and the new Products sorting/batch capabilities; record both in CHANGELOG.md.
  - Back the changes with a focused Products page test suite (sorting, batch archive, batch delete).

## Risk & Mitigations
- Risk:
- Mitigation:

## Manual QA Steps
1.
2.

## Notes / Follow-ups
-

