### PR TITLE
feat: streamline sticky headers on library pages

### DIFF
--- a/src/pages/LocationsPage.jsx
+++ b/src/pages/LocationsPage.jsx
@@ -401,23 +401,21 @@ export default function LocationsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold text-slate-900">Locations</h1>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
-            <Input
-              placeholder="Search locations by name, address, or notes..."
-              aria-label="Search locations"
-              value={queryText}
-              onChange={(event) => setQueryText(event.target.value)}
-              className="w-full sm:w-72 lg:w-96"
-            />
-            {canManage && (
-              <Button type="button" onClick={scrollToCreateLocation} className="w-full sm:w-auto">
-                New location
-              </Button>
-            )}
-          </div>
+      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="flex-none text-2xl font-semibold text-slate-900">Locations</h1>
+          <Input
+            placeholder="Search locations by name, address, or notes..."
+            aria-label="Search locations"
+            value={queryText}
+            onChange={(event) => setQueryText(event.target.value)}
+            className="min-w-[200px] flex-1"
+          />
+          {canManage && (
+            <Button type="button" onClick={scrollToCreateLocation} className="flex-none whitespace-nowrap">
+              New location
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1518,42 +1518,39 @@ export default function ProductsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <h1 className="text-2xl font-semibold text-slate-900">Products</h1>
-          <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:gap-3 lg:w-auto">
-            <Input
-              placeholder="Search by style, number, colour, or SKU..."
-              aria-label="Search products"
-              value={queryText}
-              onChange={(event) => setQueryText(event.target.value)}
-              className="w-full sm:w-64 lg:w-80"
-            />
-            <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-medium uppercase tracking-wide text-slate-500">
-                  Sort
-                </span>
-                <select
-                  className="w-full rounded border border-slate-300 px-3 py-2 text-sm sm:w-52"
-                  value={sortOrder}
-                  onChange={(event) => setSortOrder(event.target.value)}
-                  aria-label="Sort products"
-                >
-                  {SORT_OPTIONS.map((option) => (
-                    <option key={option.value} value={option.value}>
-                      {option.label}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              {canEdit && (
-                <Button onClick={() => setNewModalOpen(true)} className="w-full sm:w-auto">
-                  New product
-                </Button>
-              )}
-            </div>
-          </div>
+      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="flex-none text-2xl font-semibold text-slate-900">Products</h1>
+          <Input
+            placeholder="Search by style, number, colour, or SKU..."
+            aria-label="Search products"
+            value={queryText}
+            onChange={(event) => setQueryText(event.target.value)}
+            className="min-w-[200px] flex-1"
+          />
+          <label
+            className="flex flex-none items-center gap-2 text-xs font-medium uppercase tracking-wide text-slate-500"
+            htmlFor="products-sort-order"
+          >
+            <span className="whitespace-nowrap">Sort</span>
+            <select
+              id="products-sort-order"
+              className="h-10 rounded border border-slate-300 px-3 text-sm"
+              value={sortOrder}
+              onChange={(event) => setSortOrder(event.target.value)}
+            >
+              {SORT_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          {canEdit && (
+            <Button onClick={() => setNewModalOpen(true)} className="flex-none whitespace-nowrap">
+              New product
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/pages/ShotsPage.jsx
+++ b/src/pages/ShotsPage.jsx
@@ -802,23 +802,21 @@ export default function ShotsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold text-slate-900">Shots</h1>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
-            <Input
-              placeholder="Search shots by name, talent, product, or location..."
-              aria-label="Search shots"
-              value={queryText}
-              onChange={(event) => setQueryText(event.target.value)}
-              className="w-full sm:w-72 lg:w-96"
-            />
-            {canEditShots && (
-              <Button type="button" onClick={scrollToCreateShot} className="w-full sm:w-auto">
-                New shot
-              </Button>
-            )}
-          </div>
+      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="flex-none text-2xl font-semibold text-slate-900">Shots</h1>
+          <Input
+            placeholder="Search shots by name, talent, product, or location..."
+            aria-label="Search shots"
+            value={queryText}
+            onChange={(event) => setQueryText(event.target.value)}
+            className="min-w-[200px] flex-1"
+          />
+          {canEditShots && (
+            <Button type="button" onClick={scrollToCreateShot} className="flex-none whitespace-nowrap">
+              New shot
+            </Button>
+          )}
         </div>
       </div>
       <p className="text-sm text-slate-600">

--- a/src/pages/TalentPage.jsx
+++ b/src/pages/TalentPage.jsx
@@ -427,23 +427,21 @@ export default function TalentPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold text-slate-900">Talent</h1>
-          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center sm:gap-3">
-            <Input
-              placeholder="Search talent by name, agency, or contact..."
-              aria-label="Search talent"
-              value={queryText}
-              onChange={(event) => setQueryText(event.target.value)}
-              className="w-full sm:w-72 lg:w-96"
-            />
-            {canManage && (
-              <Button type="button" onClick={scrollToCreateTalent} className="w-full sm:w-auto">
-                New talent
-              </Button>
-            )}
-          </div>
+      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="flex-none text-2xl font-semibold text-slate-900">Talent</h1>
+          <Input
+            placeholder="Search talent by name, agency, or contact..."
+            aria-label="Search talent"
+            value={queryText}
+            onChange={(event) => setQueryText(event.target.value)}
+            className="min-w-[200px] flex-1"
+          />
+          {canManage && (
+            <Button type="button" onClick={scrollToCreateTalent} className="flex-none whitespace-nowrap">
+              New talent
+            </Button>
+          )}
         </div>
       </div>
 

--- a/src/pages/__tests__/ProductsPage.test.jsx
+++ b/src/pages/__tests__/ProductsPage.test.jsx
@@ -176,7 +176,7 @@ describe("ProductsPage", () => {
       expect(readOrder()).toEqual(["Alpha Jacket", "Bravo Coat"]);
     });
 
-    const sortSelect = screen.getByLabelText("Sort products");
+    const sortSelect = screen.getByLabelText(/Sort/i);
 
     fireEvent.change(sortSelect, { target: { value: "styleNameDesc" } });
     await waitFor(() => {


### PR DESCRIPTION
## Summary
- update shots, products, talent, and locations headers to use a single sticky band with consistent styling
- align header controls in one responsive row that keeps search inputs flexible and action buttons accessible
- set sticky offset to 0 with raised z-index to ensure headers remain visible while scrolling

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d09ff06ebc832ea2ae2460e64d34c2