### PR TITLE
fix: ensure page headers clear global nav

### DIFF
--- a/src/pages/LocationsPage.jsx
+++ b/src/pages/LocationsPage.jsx
@@ -401,7 +401,7 @@ export default function LocationsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+      <div className="sticky inset-x-0 top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="flex-none text-2xl font-semibold text-slate-900">Locations</h1>
           <Input

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -1518,7 +1518,7 @@ export default function ProductsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+      <div className="sticky inset-x-0 top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="flex-none text-2xl font-semibold text-slate-900">Products</h1>
           <Input

--- a/src/pages/ShotsPage.jsx
+++ b/src/pages/ShotsPage.jsx
@@ -802,7 +802,7 @@ export default function ShotsPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+      <div className="sticky inset-x-0 top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="flex-none text-2xl font-semibold text-slate-900">Shots</h1>
           <Input

--- a/src/pages/TalentPage.jsx
+++ b/src/pages/TalentPage.jsx
@@ -427,7 +427,7 @@ export default function TalentPage() {
 
   return (
     <div className="space-y-6">
-      <div className="sticky inset-x-0 top-0 z-30 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
+      <div className="sticky inset-x-0 top-14 z-20 border-b border-slate-200 bg-white/95 py-4 shadow-sm backdrop-blur">
         <div className="flex flex-wrap items-center gap-3">
           <h1 className="flex-none text-2xl font-semibold text-slate-900">Talent</h1>
           <Input


### PR DESCRIPTION
## Summary
- offset each page-level sticky header by the layout nav height so they remain visible while scrolling
- lower the stacking context so the global navigation stays on top of the sticky header content

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a95d3648832eaf4834642798b81f