### PR TITLE
fix: restore shot edit modal scrolling

### DIFF
--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -1173,7 +1173,7 @@ function PlannerPageContent() {
           open
           onClose={closeShotEdit}
           labelledBy="planner-shot-edit-title"
-          contentClassName="p-0 max-h-[90vh] overflow-hidden"
+          contentClassName="p-0 max-h-[90vh] overflow-y-auto"
         >
           <Card className="border-0 shadow-none">
             <CardHeader>

--- a/src/pages/ShotsPage.jsx
+++ b/src/pages/ShotsPage.jsx
@@ -1406,7 +1406,7 @@ export default function ShotsPage() {
           open
           onClose={closeShotEditor}
           labelledBy="edit-shot-modal-title"
-          contentClassName="p-0 max-h-[90vh] overflow-hidden"
+          contentClassName="p-0 max-h-[90vh] overflow-y-auto"
         >
           <Card className="border-0 shadow-none">
             <CardHeader>


### PR DESCRIPTION
## Summary
- allow the shot edit modal on the Shots page to scroll when content exceeds the viewport
- apply the same scrollable configuration to the Planner shot edit modal to keep behavior consistent

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0ba3487b0832eba46fe9870def2b9