### PR TITLE
feat: support gender filtering and inline product creation for shot modal

### DIFF
--- a/src/components/shots/ShotProductsEditor.jsx
+++ b/src/components/shots/ShotProductsEditor.jsx
@@ -9,6 +9,8 @@ export default function ShotProductsEditor({
   families,
   loadFamilyDetails,
   createProduct,
+  canCreateProduct = false,
+  onCreateProduct,
   emptyHint,
 }) {
   const [modalOpen, setModalOpen] = useState(false);
@@ -68,6 +70,8 @@ export default function ShotProductsEditor({
           families={families}
           loadFamilyDetails={loadFamilyDetails}
           initialProduct={editingIndex != null ? value[editingIndex] : null}
+          canCreateProduct={canCreateProduct}
+          onCreateProduct={onCreateProduct}
           onSubmit={(selection) => {
             handleSubmit(selection);
             setModalOpen(false);

--- a/src/components/shots/__tests__/ShotProductAddModal.buttonLogic.test.jsx
+++ b/src/components/shots/__tests__/ShotProductAddModal.buttonLogic.test.jsx
@@ -9,14 +9,15 @@ vi.mock("../../../hooks/useStorageImage", () => ({
 }));
 
 const mockFamilies = [
-    {
-        id: "family1",
-        styleName: "Test Style",
-        styleNumber: "TS001",
-        colorNames: ["Red", "Blue"],
-        archived: false,
-        sizes: ["S", "M", "L"],
-    },
+  {
+    id: "family1",
+    styleName: "Test Style",
+    styleNumber: "TS001",
+    colorNames: ["Red", "Blue"],
+    archived: false,
+    sizes: ["S", "M", "L"],
+    gender: "women",
+  },
 ];
 
 const mockFamilyDetails = {

--- a/src/components/shots/__tests__/ShotProductAddModal.comprehensive.test.jsx
+++ b/src/components/shots/__tests__/ShotProductAddModal.comprehensive.test.jsx
@@ -10,14 +10,15 @@ vi.mock("../../../hooks/useStorageImage", () => ({
 }));
 
 const mockFamilies = [
-    {
-        id: "family1",
-        styleName: "Test Style",
-        styleNumber: "TS001",
-        colorNames: ["Red", "Blue"],
-        archived: false,
-        sizes: ["S", "M", "L"],
-    },
+  {
+    id: "family1",
+    styleName: "Test Style",
+    styleNumber: "TS001",
+    colorNames: ["Red", "Blue"],
+    archived: false,
+    sizes: ["S", "M", "L"],
+    gender: "women",
+  },
 ];
 
 const mockFamilyDetails = {

--- a/src/components/shots/__tests__/ShotProductAddModal.test.jsx
+++ b/src/components/shots/__tests__/ShotProductAddModal.test.jsx
@@ -17,6 +17,7 @@ const mockFamilies = [
         colorNames: ["Red", "Blue"],
         archived: false,
         sizes: ["S", "M", "L"],
+        gender: "women",
     },
 ];
 
@@ -253,6 +254,63 @@ describe("ShotProductAddModal - Button State Logic", () => {
             status: "complete",
             sizeScope: "single",
         });
+    });
+
+    it("shows create new product button when creation is allowed", () => {
+        render(
+            <ShotProductAddModal
+                {...defaultProps}
+                canCreateProduct
+                onCreateProduct={vi.fn()}
+            />
+        );
+
+        expect(screen.getByText("Create new product")).toBeInTheDocument();
+    });
+
+    it("filters product families by gender", async () => {
+        const user = userEvent.setup();
+        const extraFamilies = [
+            {
+                id: "family2",
+                styleName: "Mens Jacket",
+                styleNumber: "MJ002",
+                colorNames: ["Black"],
+                archived: false,
+                sizes: ["M", "L"],
+                gender: "men",
+            },
+            {
+                id: "family3",
+                styleName: "Unisex Tee",
+                styleNumber: "UT003",
+                colorNames: ["White"],
+                archived: false,
+                sizes: ["S", "M", "L"],
+                gender: "unisex",
+            },
+        ];
+
+        render(
+            <ShotProductAddModal
+                {...defaultProps}
+                families={[...mockFamilies, ...extraFamilies]}
+            />
+        );
+
+        const genderSelect = screen.getByLabelText("Gender");
+        expect(genderSelect).toBeInTheDocument();
+        expect(screen.getByText("Test Style")).toBeInTheDocument();
+        expect(screen.getByText("Mens Jacket")).toBeInTheDocument();
+        expect(screen.getByText("Unisex Tee")).toBeInTheDocument();
+
+        await user.selectOptions(genderSelect, "men");
+
+        await waitFor(() => {
+            expect(screen.getByText("Mens Jacket")).toBeInTheDocument();
+        });
+        expect(screen.queryByText("Test Style")).not.toBeInTheDocument();
+        expect(screen.queryByText("Unisex Tee")).not.toBeInTheDocument();
     });
 });
 

--- a/src/components/shots/__tests__/ShotProductAddModal.validation.test.jsx
+++ b/src/components/shots/__tests__/ShotProductAddModal.validation.test.jsx
@@ -10,14 +10,15 @@ vi.mock("../../../hooks/useStorageImage", () => ({
 }));
 
 const mockFamilies = [
-    {
-        id: "family1",
-        styleName: "Test Style",
-        styleNumber: "TS001",
-        colorNames: ["Red", "Blue"],
-        archived: false,
-        sizes: ["S", "M", "L"],
-    },
+  {
+    id: "family1",
+    styleName: "Test Style",
+    styleNumber: "TS001",
+    colorNames: ["Red", "Blue"],
+    archived: false,
+    sizes: ["S", "M", "L"],
+    gender: "women",
+  },
 ];
 
 const mockFamilyDetails = {

--- a/src/lib/productMutations.js
+++ b/src/lib/productMutations.js
@@ -1,0 +1,148 @@
+import { addDoc, collection, doc, setDoc, updateDoc } from "firebase/firestore";
+import { uploadImageFile } from "./firebase";
+import { productFamiliesPath, productFamilySkusPath } from "./paths";
+
+const buildSkuAggregates = (skus, familySizes = []) => {
+  const skuCodes = new Set();
+  const colorNames = new Set();
+  const sizes = new Set((familySizes || []).filter(Boolean));
+  let activeSkuCount = 0;
+
+  (skus || []).forEach((sku) => {
+    if (sku.skuCode) skuCodes.add(sku.skuCode);
+    if (sku.colorName) colorNames.add(sku.colorName);
+    (sku.sizes || []).forEach((size) => size && sizes.add(size));
+    if (sku.status === "active") activeSkuCount += 1;
+  });
+
+  return {
+    skuCodes: Array.from(skuCodes),
+    colorNames: Array.from(colorNames),
+    sizeOptions: Array.from(sizes),
+    skuCount: (skus || []).length,
+    activeSkuCount,
+  };
+};
+
+export const genderLabel = (value) => {
+  switch ((value || "").toLowerCase()) {
+    case "men":
+    case "mens":
+      return "Men's";
+    case "women":
+    case "womens":
+      return "Women's";
+    case "unisex":
+      return "Unisex";
+    case "other":
+      return "Other";
+    default:
+      return "Unspecified";
+  }
+};
+
+export const createProductFamily = async ({ db, clientId, payload, userId }) => {
+  if (!db) throw new Error("Database instance is required to create a product.");
+  if (!clientId) throw new Error("Missing client identifier for product creation.");
+
+  const now = Date.now();
+  const familySizes = Array.isArray(payload.family?.sizes) ? payload.family.sizes : [];
+  const aggregates = buildSkuAggregates(payload.skus, familySizes);
+  const familiesCollection = collection(db, ...productFamiliesPath(clientId));
+  const baseData = {
+    styleName: payload.family?.styleName,
+    styleNumber: payload.family?.styleNumber,
+    previousStyleNumber: payload.family?.previousStyleNumber,
+    gender: payload.family?.gender,
+    status: payload.family?.status,
+    archived: payload.family?.archived,
+    notes: payload.family?.notes,
+    headerImagePath: null,
+    thumbnailImagePath: null,
+    sizes: familySizes,
+    skuCount: aggregates.skuCount,
+    activeSkuCount: aggregates.activeSkuCount,
+    skuCodes: aggregates.skuCodes,
+    colorNames: aggregates.colorNames,
+    sizeOptions: aggregates.sizeOptions,
+    shotIds: [],
+    createdAt: now,
+    updatedAt: now,
+    createdBy: userId || null,
+    updatedBy: userId || null,
+  };
+
+  const familyRef = await addDoc(familiesCollection, baseData);
+  const familyId = familyRef.id;
+  let thumbnailPath = null;
+
+  if (payload.family?.thumbnailImageFile) {
+    const { path } = await uploadImageFile(payload.family.thumbnailImageFile, {
+      folder: "productFamilies",
+      id: `${familyId}/thumbnail`,
+    });
+    thumbnailPath = path;
+    await updateDoc(familyRef, {
+      thumbnailImagePath: path,
+      updatedAt: Date.now(),
+      updatedBy: userId || null,
+    });
+  }
+
+  if (payload.family?.headerImageFile) {
+    const { path } = await uploadImageFile(payload.family.headerImageFile, {
+      folder: "productFamilies",
+      id: familyId,
+    });
+    await updateDoc(familyRef, {
+      headerImagePath: path,
+      updatedAt: Date.now(),
+      updatedBy: userId || null,
+    });
+  }
+
+  const skuCollection = collection(db, ...productFamilySkusPath(familyId, clientId));
+  let fallbackImagePath = null;
+
+  for (const sku of payload.skus || []) {
+    const skuRef = doc(skuCollection);
+    let imagePath = sku.imagePath || null;
+
+    if (sku.imageFile) {
+      const result = await uploadImageFile(sku.imageFile, {
+        folder: `productFamilies/${familyId}/skus`,
+        id: skuRef.id,
+      });
+      imagePath = result.path;
+    }
+
+    if (!fallbackImagePath && imagePath && !sku.removeImage) {
+      fallbackImagePath = imagePath;
+    }
+
+    await setDoc(skuRef, {
+      colorName: sku.colorName,
+      skuCode: sku.skuCode,
+      sizes: sku.sizes,
+      status: sku.status,
+      archived: sku.archived,
+      imagePath,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: userId || null,
+      updatedBy: userId || null,
+    });
+  }
+
+  if (!thumbnailPath && fallbackImagePath) {
+    await updateDoc(familyRef, {
+      thumbnailImagePath: fallbackImagePath,
+      updatedAt: Date.now(),
+      updatedBy: userId || null,
+    });
+  }
+
+  return familyId;
+};
+
+export { buildSkuAggregates };


### PR DESCRIPTION
## Summary
- surface each product family's gender in the shot product picker and allow filtering results
- add an inline "Create new product" flow and reuse shared product creation helpers
- update shots/products pages and tests to accommodate the new picker behaviour

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d0be8058fc832ea52dfe9acb92571e