### PR TITLE
Fix export modal focus and layout issues

### DIFF
--- a/src/components/planner/PlannerExportModal.jsx
+++ b/src/components/planner/PlannerExportModal.jsx
@@ -595,299 +595,305 @@ const PlannerExportModal = ({ open, onClose, lanes, defaultVisibleFields, isLoad
         if (!isGenerating) onClose?.();
       }}
       labelledBy="planner-export-title"
-      contentClassName="p-0"
+      contentClassName="p-0 overflow-hidden"
     >
-      <div className="flex flex-col gap-6 p-6">
-        <div className="flex items-start justify-between gap-4">
-          <div>
-            <h2 id="planner-export-title" className="text-lg font-semibold text-slate-900">
-              Export planner
-            </h2>
-            <p className="text-sm text-slate-500">
-              Configure the layout and select which planner details to include in your export.
-            </p>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="rounded-md border border-transparent p-2 text-slate-500 transition hover:border-slate-200 hover:text-slate-900"
-            aria-label="Close export settings"
-            disabled={isGenerating}
-          >
-            ×
-          </button>
-        </div>
-        <div className="grid gap-4 lg:grid-cols-2">
-          <Card>
-            <CardContent className="space-y-4 pt-6">
+      <div className="flex h-full flex-col bg-white">
+        <div className="flex-1 overflow-y-auto">
+          <div className="flex flex-col gap-6 p-6">
+            <div className="flex items-start justify-between gap-4">
               <div>
-                <label className="text-sm font-medium text-slate-700" htmlFor="planner-export-title-input">
-                  Page title
-                </label>
-                <input
-                  id="planner-export-title-input"
-                  type="text"
-                  value={title}
-                  onChange={(event) => setTitle(event.target.value)}
-                  className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
-                  placeholder="Planner overview"
-                />
-              </div>
-              <div>
-                <label className="text-sm font-medium text-slate-700" htmlFor="planner-export-subtitle-input">
-                  Subtitle
-                </label>
-                <input
-                  id="planner-export-subtitle-input"
-                  type="text"
-                  value={subtitle}
-                  onChange={(event) => setSubtitle(event.target.value)}
-                  className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
-                  placeholder="Generated automatically"
-                />
-              </div>
-              <div>
-                <span className="text-sm font-medium text-slate-700">Page orientation</span>
-                <div className="mt-2 inline-flex overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm">
-                  {["portrait", "landscape"].map((option) => (
-                    <button
-                      key={option}
-                      type="button"
-                      onClick={() => setOrientation(option)}
-                      className={`px-3 py-1.5 text-sm capitalize transition ${
-                        orientation === option
-                          ? "bg-slate-900 text-white"
-                          : "text-slate-600 hover:bg-slate-100"
-                      }`}
-                    >
-                      {option}
-                    </button>
-                  ))}
-                </div>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-slate-700">Include sections</span>
-                <div className="mt-2 space-y-2 text-sm text-slate-700">
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={includeLaneSummary}
-                      onChange={(event) => setIncludeLaneSummary(event.target.checked)}
-                    />
-                    Lane summary
-                  </label>
-                  <label className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      checked={includeTalentSummary}
-                      onChange={(event) => setIncludeTalentSummary(event.target.checked)}
-                    />
-                    Talent summary
-                  </label>
-                </div>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-slate-700">Filter shots</span>
-                <p className="text-xs text-slate-500">
-                  Choose which lanes, talent, and dates to include in your export.
+                <h2 id="planner-export-title" className="text-lg font-semibold text-slate-900">
+                  Export planner
+                </h2>
+                <p className="text-sm text-slate-500">
+                  Configure the layout and select which planner details to include in your export.
                 </p>
-                <div className="mt-3 space-y-4">
+              </div>
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-md border border-transparent p-2 text-slate-500 transition hover:border-slate-200 hover:text-slate-900"
+                aria-label="Close export settings"
+                disabled={isGenerating}
+              >
+                ×
+              </button>
+            </div>
+            <div className="grid gap-4 lg:grid-cols-2">
+              <Card>
+                <CardContent className="space-y-4 pt-6">
                   <div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Lanes</span>
+                    <label className="text-sm font-medium text-slate-700" htmlFor="planner-export-title-input">
+                      Page title
+                    </label>
+                    <input
+                      id="planner-export-title-input"
+                      type="text"
+                      value={title}
+                      onChange={(event) => setTitle(event.target.value)}
+                      className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
+                      placeholder="Planner overview"
+                    />
+                  </div>
+                  <div>
+                    <label className="text-sm font-medium text-slate-700" htmlFor="planner-export-subtitle-input">
+                      Subtitle
+                    </label>
+                    <input
+                      id="planner-export-subtitle-input"
+                      type="text"
+                      value={subtitle}
+                      onChange={(event) => setSubtitle(event.target.value)}
+                      className="mt-1 w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
+                      placeholder="Generated automatically"
+                    />
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-slate-700">Page orientation</span>
+                    <div className="mt-2 inline-flex overflow-hidden rounded-md border border-slate-200 bg-white shadow-sm">
+                      {["portrait", "landscape"].map((option) => (
+                        <button
+                          key={option}
+                          type="button"
+                          onClick={() => setOrientation(option)}
+                          className={`px-3 py-1.5 text-sm capitalize transition ${
+                            orientation === option
+                              ? "bg-slate-900 text-white"
+                              : "text-slate-600 hover:bg-slate-100"
+                          }`}
+                        >
+                          {option}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                  <div>
+                    <span className="text-sm font-medium text-slate-700">Include sections</span>
                     <div className="mt-2 space-y-2 text-sm text-slate-700">
                       <label className="flex items-center gap-2">
                         <input
-                          type="radio"
-                          name="planner-export-lane-filter"
-                          value="all"
-                          checked={laneFilterMode === "all"}
-                          onChange={() => setLaneFilterMode("all")}
+                          type="checkbox"
+                          checked={includeLaneSummary}
+                          onChange={(event) => setIncludeLaneSummary(event.target.checked)}
                         />
-                        All lanes
+                        Lane summary
                       </label>
                       <label className="flex items-center gap-2">
                         <input
-                          type="radio"
-                          name="planner-export-lane-filter"
-                          value="selected"
-                          checked={laneFilterMode === "selected"}
-                          onChange={() => {
-                            setLaneFilterMode("selected");
-                            if (selectedLaneIds.length === 0) {
-                              handleSelectAllLanes();
-                            }
-                          }}
+                          type="checkbox"
+                          checked={includeTalentSummary}
+                          onChange={(event) => setIncludeTalentSummary(event.target.checked)}
                         />
-                        Specific lanes
+                        Talent summary
                       </label>
                     </div>
-                    {isLaneSelectionMode ? (
-                      <div className="mt-2 space-y-2">
-                        <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                          {laneOptions.map((lane) => (
-                            <label key={lane.id} className="flex items-center gap-2 text-sm text-slate-700">
-                              <input
-                                type="checkbox"
-                                checked={selectedLaneIdSet.has(lane.id)}
-                                onChange={() => handleToggleLane(lane.id)}
-                              />
-                              {lane.name}
-                            </label>
-                          ))}
-                        </div>
-                        {laneOptions.length > 0 ? (
-                          <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
-                            <button
-                              type="button"
-                              className="text-primary hover:underline"
-                              onClick={handleSelectAllLanes}
-                            >
-                              Select all lanes
-                            </button>
-                            <span aria-hidden="true">•</span>
-                            <span>{selectedLaneIds.length} selected</span>
-                          </div>
-                        ) : (
-                          <p className="text-xs text-slate-500">No lanes available.</p>
-                        )}
-                      </div>
-                    ) : null}
                   </div>
                   <div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Talent</span>
-                    <p className="mt-1 text-xs text-slate-500">
-                      Leave blank to include every talent. Select one or more names to limit the export.
+                    <span className="text-sm font-medium text-slate-700">Filter shots</span>
+                    <p className="text-xs text-slate-500">
+                      Choose which lanes, talent, and dates to include in your export.
                     </p>
-                    {talentOptions.length ? (
-                      <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                        {talentOptions.map((option) => (
-                          <label key={option.value} className="flex items-center gap-2 text-sm text-slate-700">
+                    <div className="mt-3 space-y-4">
+                      <div>
+                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Lanes</span>
+                        <div className="mt-2 space-y-2 text-sm text-slate-700">
+                          <label className="flex items-center gap-2">
                             <input
-                              type="checkbox"
-                              checked={selectedTalentNames.includes(option.value)}
-                              onChange={() => handleToggleTalent(option.value)}
+                              type="radio"
+                              name="planner-export-lane-filter"
+                              value="all"
+                              checked={laneFilterMode === "all"}
+                              onChange={() => setLaneFilterMode("all")}
                             />
-                            {option.label}
+                            All lanes
                           </label>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="mt-2 text-xs text-slate-500">No talent assignments yet.</p>
-                    )}
-                    {selectedTalentNames.length ? (
-                      <button
-                        type="button"
-                        className="mt-2 text-xs text-primary hover:underline"
-                        onClick={clearTalentFilters}
-                      >
-                        Clear talent filters
-                      </button>
-                    ) : null}
-                  </div>
-                  <div>
-                    <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Dates</span>
-                    <div className="mt-2 space-y-2 text-sm text-slate-700">
-                      <label className="flex items-center gap-2">
-                        <input
-                          type="radio"
-                          name="planner-export-date-filter"
-                          value="any"
-                          checked={dateFilterMode === "any"}
-                          onChange={() => {
-                            setDateFilterMode("any");
-                            setSelectedDate("");
-                          }}
-                        />
-                        Any date
-                      </label>
-                      <label className="flex items-center gap-2">
-                        <input
-                          type="radio"
-                          name="planner-export-date-filter"
-                          value="specific"
-                          checked={dateFilterMode === "specific"}
-                          onChange={() => {
-                            setDateFilterMode("specific");
-                            if (!selectedDate && availableDates.length) {
-                              setSelectedDate(availableDates[0]);
-                            }
-                          }}
-                        />
-                        Specific date
-                      </label>
-                    </div>
-                    {dateFilterMode === "specific" ? (
-                      <div className="mt-2">
-                        <input
-                          type="date"
-                          value={selectedDate}
-                          onChange={(event) => setSelectedDate(event.target.value)}
-                          className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
-                        />
-                        {availableDates.length ? (
-                          <p className="mt-1 text-xs text-slate-500">
-                            Available dates: {availableDates.join(", ")}
-                          </p>
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="radio"
+                              name="planner-export-lane-filter"
+                              value="selected"
+                              checked={laneFilterMode === "selected"}
+                              onChange={() => {
+                                setLaneFilterMode("selected");
+                                if (selectedLaneIds.length === 0) {
+                                  handleSelectAllLanes();
+                                }
+                              }}
+                            />
+                            Specific lanes
+                          </label>
+                        </div>
+                        {isLaneSelectionMode ? (
+                          <div className="mt-2 space-y-2">
+                            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                              {laneOptions.map((lane) => (
+                                <label key={lane.id} className="flex items-center gap-2 text-sm text-slate-700">
+                                  <input
+                                    type="checkbox"
+                                    checked={selectedLaneIdSet.has(lane.id)}
+                                    onChange={() => handleToggleLane(lane.id)}
+                                  />
+                                  {lane.name}
+                                </label>
+                              ))}
+                            </div>
+                            {laneOptions.length > 0 ? (
+                              <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                                <button
+                                  type="button"
+                                  className="text-primary hover:underline"
+                                  onClick={handleSelectAllLanes}
+                                >
+                                  Select all lanes
+                                </button>
+                                <span aria-hidden="true">•</span>
+                                <span>{selectedLaneIds.length} selected</span>
+                              </div>
+                            ) : (
+                              <p className="text-xs text-slate-500">No lanes available.</p>
+                            )}
+                          </div>
                         ) : null}
                       </div>
-                    ) : null}
+                      <div>
+                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Talent</span>
+                        <p className="mt-1 text-xs text-slate-500">
+                          Leave blank to include every talent. Select one or more names to limit the export.
+                        </p>
+                        {talentOptions.length ? (
+                          <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                            {talentOptions.map((option) => (
+                              <label key={option.value} className="flex items-center gap-2 text-sm text-slate-700">
+                                <input
+                                  type="checkbox"
+                                  checked={selectedTalentNames.includes(option.value)}
+                                  onChange={() => handleToggleTalent(option.value)}
+                                />
+                                {option.label}
+                              </label>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="mt-2 text-xs text-slate-500">No talent assignments yet.</p>
+                        )}
+                        {selectedTalentNames.length ? (
+                          <button
+                            type="button"
+                            className="mt-2 text-xs text-primary hover:underline"
+                            onClick={clearTalentFilters}
+                          >
+                            Clear talent filters
+                          </button>
+                        ) : null}
+                      </div>
+                      <div>
+                        <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">Dates</span>
+                        <div className="mt-2 space-y-2 text-sm text-slate-700">
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="radio"
+                              name="planner-export-date-filter"
+                              value="any"
+                              checked={dateFilterMode === "any"}
+                              onChange={() => {
+                                setDateFilterMode("any");
+                                setSelectedDate("");
+                              }}
+                            />
+                            Any date
+                          </label>
+                          <label className="flex items-center gap-2">
+                            <input
+                              type="radio"
+                              name="planner-export-date-filter"
+                              value="specific"
+                              checked={dateFilterMode === "specific"}
+                              onChange={() => {
+                                setDateFilterMode("specific");
+                                if (!selectedDate && availableDates.length) {
+                                  setSelectedDate(availableDates[0]);
+                                }
+                              }}
+                            />
+                            Specific date
+                          </label>
+                        </div>
+                        {dateFilterMode === "specific" ? (
+                          <div className="mt-2">
+                            <input
+                              type="date"
+                              value={selectedDate}
+                              onChange={(event) => setSelectedDate(event.target.value)}
+                              className="w-full rounded-md border border-slate-200 px-3 py-2 text-sm focus:border-transparent focus:outline-none focus:ring-2 focus:ring-primary/60"
+                            />
+                            {availableDates.length ? (
+                              <p className="mt-1 text-xs text-slate-500">
+                                Available dates: {availableDates.join(", ")}
+                              </p>
+                            ) : null}
+                          </div>
+                        ) : null}
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="space-y-4 pt-6">
-              <div>
-                <span className="text-sm font-medium text-slate-700">Shot details</span>
-                <p className="text-xs text-slate-500">Select the information that will appear for each shot.</p>
-                <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  {fieldOptions.map((option) => (
-                    <label key={option.key} className="flex items-center gap-2 text-sm text-slate-700">
-                      <input
-                        type="checkbox"
-                        checked={Boolean(fields[option.key])}
-                        onChange={(event) =>
-                          setFields((prev) => ({
-                            ...prev,
-                            [option.key]: event.target.checked,
-                          }))
-                        }
-                      />
-                      {option.label}
-                    </label>
-                  ))}
-                </div>
-              </div>
-              <div className="rounded-md bg-slate-50 p-3 text-xs text-slate-600">
-                Shots that are too tall to fit on the current page will automatically move to the next page so that
-                content never appears cropped.
-              </div>
-            </CardContent>
-          </Card>
+                </CardContent>
+              </Card>
+              <Card>
+                <CardContent className="space-y-4 pt-6">
+                  <div>
+                    <span className="text-sm font-medium text-slate-700">Shot details</span>
+                    <p className="text-xs text-slate-500">Select the information that will appear for each shot.</p>
+                    <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
+                      {fieldOptions.map((option) => (
+                        <label key={option.key} className="flex items-center gap-2 text-sm text-slate-700">
+                          <input
+                            type="checkbox"
+                            checked={Boolean(fields[option.key])}
+                            onChange={(event) =>
+                              setFields((prev) => ({
+                                ...prev,
+                                [option.key]: event.target.checked,
+                              }))
+                            }
+                          />
+                          {option.label}
+                        </label>
+                      ))}
+                    </div>
+                  </div>
+                  <div className="rounded-md bg-slate-50 p-3 text-xs text-slate-600">
+                    Shots that are too tall to fit on the current page will automatically move to the next page so that
+                    content never appears cropped.
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
         </div>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p className="text-sm text-slate-500">
-            {hasShots
-              ? "Exports include shots that match your filters. CSV files can be opened in spreadsheet tools like Excel or Google Sheets."
-              : "Adjust your filters or add shots to the planner to enable exports."}
-          </p>
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              onClick={handleDownloadCsv}
-              disabled={!hasShots || isLoading || isGenerating}
-              className="bg-slate-200 text-slate-700 hover:bg-slate-300"
-            >
-              Download CSV
-            </Button>
-            <Button
-              type="button"
-              onClick={handleDownloadPdf}
-              disabled={!hasShots || isLoading || isGenerating}
-            >
-              {isGenerating ? "Preparing PDF…" : "Download PDF"}
-            </Button>
+        <div className="border-t border-slate-200 p-6">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <p className="text-sm text-slate-500">
+              {hasShots
+                ? "Exports include shots that match your filters. CSV files can be opened in spreadsheet tools like Excel or Google Sheets."
+                : "Adjust your filters or add shots to the planner to enable exports."}
+            </p>
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                onClick={handleDownloadCsv}
+                disabled={!hasShots || isLoading || isGenerating}
+                className="bg-slate-200 text-slate-700 hover:bg-slate-300"
+              >
+                Download CSV
+              </Button>
+              <Button
+                type="button"
+                onClick={handleDownloadPdf}
+                disabled={!hasShots || isLoading || isGenerating}
+              >
+                {isGenerating ? "Preparing PDF…" : "Download PDF"}
+              </Button>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/ui/modal.jsx
+++ b/src/components/ui/modal.jsx
@@ -33,6 +33,11 @@ export function Modal({
   const contentRef = useRef(null);
   const lastActiveRef = useRef(null);
   const mouseDownTarget = useRef(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useEffect(() => {
     if (typeof document === "undefined") return undefined;
@@ -70,7 +75,7 @@ export function Modal({
       if (event.key === "Escape") {
         event.stopPropagation();
         event.preventDefault();
-        onClose?.();
+        onCloseRef.current?.();
         return;
       }
       if (event.key !== "Tab") return;
@@ -100,7 +105,7 @@ export function Modal({
       lastActiveRef.current?.focus?.({ preventScroll: true });
       lastActiveRef.current = null;
     };
-  }, [open, onClose, initialFocusRef, mountNode]);
+  }, [open, initialFocusRef, mountNode]);
 
   const overlayProps = useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- keep the modal focus trap stable by caching the onClose handler in a ref
- restructure the planner export modal so the form scrolls while the footer buttons stay inside the panel
- ensure the modal container clips overflow to avoid controls spilling outside the dialog

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15f1975c8832e9722cc83e20f7c61