### PR TITLE
fix: handle missing storage when resolving active project

### DIFF
--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -14,8 +14,20 @@ const resolveClientId = (explicitClientId) => explicitClientId ?? CLIENT_ID;
  * Active” in the Projects page) without requiring a full reload of the
  * module.
  */
+const DEFAULT_PROJECT_ID = "default-project";
+
 export function getActiveProjectId() {
-  return localStorage.getItem("ACTIVE_PROJECT_ID") || "default-project";
+  if (typeof window === "undefined") {
+    return DEFAULT_PROJECT_ID;
+  }
+
+  try {
+    const stored = window.localStorage?.getItem("ACTIVE_PROJECT_ID");
+    return stored || DEFAULT_PROJECT_ID;
+  } catch (error) {
+    console.warn("[paths] Unable to read ACTIVE_PROJECT_ID from storage", error);
+    return DEFAULT_PROJECT_ID;
+  }
 }
 
 // -----------------------------------------------------------------------------

--- a/src/pages/ProjectsPage.jsx
+++ b/src/pages/ProjectsPage.jsx
@@ -138,8 +138,15 @@ export default function ProjectsPage() {
     }
   };
   const setActive = (id) => {
-    localStorage.setItem("ACTIVE_PROJECT_ID", id);
-    alert(`Active project set to ${id}. Planner/Shots will use this.`);
+    try {
+      if (typeof window !== "undefined" && window.localStorage) {
+        window.localStorage.setItem("ACTIVE_PROJECT_ID", id);
+      }
+      alert(`Active project set to ${id}. Planner/Shots will use this.`);
+    } catch (error) {
+      console.error("Failed to persist active project", error);
+      alert("We couldn't save the active project selection. Try again.");
+    }
   };
   const remove = async (p) => {
     if (!canDelete) {


### PR DESCRIPTION
## Summary
- guard getActiveProjectId against missing or inaccessible localStorage so planner loads even when storage is unavailable
- wrap the Projects dashboard "Set Active" action with storage error handling to surface failures to the user

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d17a388d20832ea9c706889ae05f88