### PR TITLE
fix(firebase): guard env detection in import-meta-less runtimes

### DIFF
--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -41,10 +41,14 @@ const REQUIRED_ENV_KEYS: RequiredEnvKey[] = [
   "VITE_FIREBASE_APP_ID",
 ];
 
-const rawEnv = (typeof import.meta !== "undefined" ? import.meta.env : {}) as Record<
-  string,
-  string | undefined
->;
+const importMetaEnv =
+  (typeof import.meta !== "undefined" && import.meta?.env)
+    ? import.meta.env
+    : ({} as Record<string, unknown>);
+
+const rawEnv = importMetaEnv as Record<string, string | undefined>;
+const isProd = Boolean(importMetaEnv.PROD);
+const isDev = Boolean(importMetaEnv.DEV);
 
 function readRawEnv(key: string): string | undefined {
   const value = rawEnv?.[key];
@@ -107,7 +111,7 @@ const { options: firebaseConfig, missing } = getFirebaseOptions();
 
 if (missing.missing.length > 0) {
   const warning = `Missing Firebase env vars: ${missing.missing.join(", ")}.`;
-  if (import.meta.env.PROD) {
+  if (isProd) {
     throw new Error(`${warning} Production builds require all Firebase keys.`);
   }
   console.warn(
@@ -115,7 +119,7 @@ if (missing.missing.length > 0) {
   );
 }
 
-if (missing.optionalMissing.length > 0 && import.meta.env.DEV) {
+if (missing.optionalMissing.length > 0 && isDev) {
   console.info(
     `[Firebase] Optional env vars missing: ${missing.optionalMissing.join(", ")}. Analytics remains disabled.`,
   );
@@ -130,7 +134,7 @@ export const db = getFirestore(app);
 export const storage = getStorage(app);
 export const functions = getFunctions(app);
 
-const useEmulators = import.meta.env.DEV && readBoolEnv("VITE_USE_FIREBASE_EMULATORS");
+const useEmulators = isDev && readBoolEnv("VITE_USE_FIREBASE_EMULATORS");
 
 if (useEmulators) {
   const host = readRawEnv("VITE_FIREBASE_EMULATOR_HOST") ?? "localhost";


### PR DESCRIPTION
## Plan
- audit Firebase initialization for direct `import.meta` references
- derive dev/prod booleans from a guarded env object to avoid runtime reference errors
- rerun lint and test suites to confirm no regressions

## Summary
- replace direct `import.meta.env` checks in `firebase.ts` with guarded accessors so planner Firebase imports don't crash when `import.meta` is unavailable
- reuse the derived dev/prod flags for emulator toggles and logging to keep behavior unchanged across environments

## Testing
- npm run lint
- npm run test

## Acceptance Checklist
- [x] Tests cover the new/changed behavior (relies on existing Vitest coverage)
- [x] Auth flows preserve `state.from` on redirects (unchanged)
- [x] No flashes while `auth.initializing` (unchanged)
- [x] Flags default OFF; override precedence works; console warns when overridden (unchanged)
- [x] CI green; preview deploy conditionally skipped on missing secrets (unchanged)


------
https://chatgpt.com/codex/tasks/task_e_68d1843c33bc832eb49cf5a219ac187b