### PR TITLE
docs(env): add firebase env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Example environment variables for Firebase configuration.
+#
+# Copy this file to `.env.local` (which is ignored by git) and populate with
+# values from Firebase Console → Project Settings → General → Your Web App's
+# SDK configuration.
+#
+# Never commit your real credentials to version control. Instead, use CI secrets
+# to supply these variables during `npm run build`.
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=
+VITE_FIREBASE_PROJECT_ID=
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=
+VITE_FIREBASE_APP_ID=
+VITE_FIREBASE_MEASUREMENT_ID=

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pnpm-debug.log*
 # Env & credentials
 .env
 .env.*
+!.env.example
 !.env.sample
 
 # Firebase

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This repository contains a starter implementation for a shot‑planning and ward
 
    Select **Hosting**, **Functions**, and **Firestore**. Use the existing `firebase.json`, `firestore.rules`, and `storage.rules` files when prompted. Choose TypeScript for functions if you prefer.
 
-   Create a `.env.local` file (git-ignored) with the Firebase config copied from the **same project** you plan to deploy to. All keys must use the Vite `VITE_FIREBASE_*` prefix that our app reads at build time:
+  Create a `.env.local` file (git-ignored) with the Firebase config copied from the **same project** you plan to deploy to. Start by copying `.env.example` and then fill in the values from Firebase. All keys must use the Vite `VITE_FIREBASE_*` prefix that our app reads at build time:
 
    ```bash
    VITE_FIREBASE_API_KEY=...


### PR DESCRIPTION
## Summary
- expose `.env.example` with placeholders for required Firebase configuration
- allow committing the example file and point the README to copy from it

## Testing
- npm run lint

## Plan
- add a shareable Firebase environment template without exposing secrets
- document how to seed `.env.local` from the example file

## Acceptance Checklist
- [ ] Tests cover the new/changed behavior
- [ ] Auth flows preserve `state.from` on redirects
- [ ] No flashes while `auth.initializing`
- [ ] Flags default OFF; override precedence works; console warns when overridden
- [ ] CI green; preview deploy conditionally skipped on missing secrets


------
https://chatgpt.com/codex/tasks/task_e_68d1a8e82004832e847a37f30a0a52da