### PR TITLE
fix: guard localStorage usage to avoid startup crash

### DIFF
--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -15,14 +15,11 @@ import {
 import { auth, provider, db } from "../lib/firebase";
 import { CLIENT_ID } from "../lib/paths";
 import { normalizeRole } from "../lib/rbac";
+import { readStorage, removeStorage, writeStorage } from "../lib/safeStorage";
 
 const LAST_ROLE_STORAGE_KEY = "auth:last-known-role";
 
-const readStoredRole = () => {
-  if (typeof window === "undefined") return null;
-  const stored = window.localStorage.getItem(LAST_ROLE_STORAGE_KEY);
-  return normalizeRole(stored) || null;
-};
+const readStoredRole = () => normalizeRole(readStorage(LAST_ROLE_STORAGE_KEY)) || null;
 
 export const AuthContext = createContext({
   user: null,
@@ -68,11 +65,10 @@ export function AuthProvider({ children }) {
   }, []);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
     if (role) {
-      window.localStorage.setItem(LAST_ROLE_STORAGE_KEY, role);
+      writeStorage(LAST_ROLE_STORAGE_KEY, role);
     } else {
-      window.localStorage.removeItem(LAST_ROLE_STORAGE_KEY);
+      removeStorage(LAST_ROLE_STORAGE_KEY);
     }
   }, [role]);
 

--- a/src/lib/__tests__/safeStorage.test.js
+++ b/src/lib/__tests__/safeStorage.test.js
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { readStorage, writeStorage, removeStorage } from "../safeStorage";
+
+const KEY = "__test_key__";
+
+describe("safeStorage", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns fallback when the key is missing", () => {
+    expect(readStorage(KEY, "fallback")).toBe("fallback");
+  });
+
+  it("persists values with writeStorage", () => {
+    expect(writeStorage(KEY, "value")).toBe(true);
+    expect(readStorage(KEY)).toBe("value");
+  });
+
+  it("removes values via removeStorage", () => {
+    writeStorage(KEY, "value");
+    expect(removeStorage(KEY)).toBe(true);
+    expect(readStorage(KEY, "fallback")).toBe("fallback");
+  });
+
+  it("handles getItem errors gracefully", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    expect(readStorage(KEY, "fallback")).toBe("fallback");
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("handles setItem errors gracefully", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    expect(writeStorage(KEY, "value")).toBe(false);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/src/lib/paths.js
+++ b/src/lib/paths.js
@@ -1,5 +1,7 @@
 // src/lib/paths.js (global shots version)
 
+import { readStorage } from "./safeStorage";
+
 // Identifier for the client/tenant collection.  If you support multiple
 // organisations you can parameterise this as needed.  This constant is
 // referenced by various Firestore path helpers.
@@ -17,17 +19,11 @@ const resolveClientId = (explicitClientId) => explicitClientId ?? CLIENT_ID;
 const DEFAULT_PROJECT_ID = "default-project";
 
 export function getActiveProjectId() {
-  if (typeof window === "undefined") {
-    return DEFAULT_PROJECT_ID;
+  const stored = readStorage("ACTIVE_PROJECT_ID", DEFAULT_PROJECT_ID);
+  if (stored && typeof stored === "string") {
+    return stored;
   }
-
-  try {
-    const stored = window.localStorage?.getItem("ACTIVE_PROJECT_ID");
-    return stored || DEFAULT_PROJECT_ID;
-  } catch (error) {
-    console.warn("[paths] Unable to read ACTIVE_PROJECT_ID from storage", error);
-    return DEFAULT_PROJECT_ID;
-  }
+  return DEFAULT_PROJECT_ID;
 }
 
 // -----------------------------------------------------------------------------

--- a/src/lib/safeStorage.js
+++ b/src/lib/safeStorage.js
@@ -1,0 +1,35 @@
+const isBrowser = typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+
+export function readStorage(key, fallback = null) {
+  if (!isBrowser) return fallback;
+  try {
+    const value = window.localStorage.getItem(key);
+    return value === null ? fallback : value;
+  } catch (error) {
+    console.warn(`[storage] Failed to read key "${key}"`, error);
+    return fallback;
+  }
+}
+
+export function writeStorage(key, value) {
+  if (!isBrowser) return false;
+  if (value == null) return removeStorage(key);
+  try {
+    window.localStorage.setItem(key, String(value));
+    return true;
+  } catch (error) {
+    console.warn(`[storage] Failed to write key "${key}"`, error);
+    return false;
+  }
+}
+
+export function removeStorage(key) {
+  if (!isBrowser) return false;
+  try {
+    window.localStorage.removeItem(key);
+    return true;
+  } catch (error) {
+    console.warn(`[storage] Failed to remove key "${key}"`, error);
+    return false;
+  }
+}

--- a/src/pages/PlannerPage.jsx
+++ b/src/pages/PlannerPage.jsx
@@ -63,6 +63,7 @@ import {
   mapTalentForWrite,
 } from "../lib/shotDraft";
 import { z } from "zod";
+import { readStorage, writeStorage } from "../lib/safeStorage";
 
 const PLANNER_VIEW_STORAGE_KEY = "planner:viewMode";
 const PLANNER_FIELDS_STORAGE_KEY = "planner:visibleFields";
@@ -374,15 +375,13 @@ const calculateTalentSummaries = (lanesForExport) => {
 };
 
 const readStoredPlannerView = () => {
-  if (typeof window === "undefined") return "board";
-  const stored = window.localStorage.getItem(PLANNER_VIEW_STORAGE_KEY);
+  const stored = readStorage(PLANNER_VIEW_STORAGE_KEY);
   return stored === "list" ? "list" : "board";
 };
 
 const readStoredVisibleFields = () => {
-  if (typeof window === "undefined") return { ...defaultVisibleFields };
   try {
-    const raw = window.localStorage.getItem(PLANNER_FIELDS_STORAGE_KEY);
+    const raw = readStorage(PLANNER_FIELDS_STORAGE_KEY);
     if (!raw) return { ...defaultVisibleFields };
     const parsed = JSON.parse(raw);
     return {
@@ -921,16 +920,11 @@ function PlannerPageContent() {
   }, [clientId, currentTalentPath, currentLocationsPath]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(PLANNER_VIEW_STORAGE_KEY, viewMode);
+    writeStorage(PLANNER_VIEW_STORAGE_KEY, viewMode);
   }, [viewMode]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(
-      PLANNER_FIELDS_STORAGE_KEY,
-      JSON.stringify(visibleFields)
-    );
+    writeStorage(PLANNER_FIELDS_STORAGE_KEY, JSON.stringify(visibleFields));
   }, [visibleFields]);
 
   useEffect(() => {

--- a/src/pages/ProductsPage.jsx
+++ b/src/pages/ProductsPage.jsx
@@ -30,6 +30,7 @@ import { ROLE, canArchiveProducts, canDeleteProducts, canEditProducts } from "..
 import Modal from "../components/ui/modal";
 import { toast } from "../lib/toast";
 import { buildSkuAggregates, createProductFamily, genderLabel } from "../lib/productMutations";
+import { readStorage, writeStorage } from "../lib/safeStorage";
 
 const statusLabel = (status) => {
   if (status === "discontinued") return "Discontinued";
@@ -95,15 +96,13 @@ const chunkArray = (items, size) => {
 const normaliseText = (value) => (value || "").toString().trim().toLowerCase();
 
 const readStoredViewMode = () => {
-  if (typeof window === "undefined") return "gallery";
-  const stored = window.localStorage.getItem(VIEW_STORAGE_KEY);
+  const stored = readStorage(VIEW_STORAGE_KEY);
   return stored === "list" ? "list" : "gallery";
 };
 
 const readStoredColumns = () => {
-  if (typeof window === "undefined") return { ...defaultListColumns };
   try {
-    const raw = window.localStorage.getItem(COLUMN_STORAGE_KEY);
+    const raw = readStorage(COLUMN_STORAGE_KEY);
     if (!raw) return { ...defaultListColumns };
     const parsed = JSON.parse(raw);
     return {
@@ -305,13 +304,11 @@ export default function ProductsPage() {
   }, [menuFamilyId]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(VIEW_STORAGE_KEY, viewMode);
+    writeStorage(VIEW_STORAGE_KEY, viewMode);
   }, [viewMode]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(COLUMN_STORAGE_KEY, JSON.stringify(listColumns));
+    writeStorage(COLUMN_STORAGE_KEY, JSON.stringify(listColumns));
   }, [listColumns]);
 
   useEffect(() => {

--- a/src/pages/ShotsPage.jsx
+++ b/src/pages/ShotsPage.jsx
@@ -59,6 +59,7 @@ import {
   extractProductIds,
   mapTalentForWrite,
 } from "../lib/shotDraft";
+import { readStorage, writeStorage } from "../lib/safeStorage";
 
 const SHOTS_VIEW_STORAGE_KEY = "shots:viewMode";
 const SHOTS_FILTERS_STORAGE_KEY = "shots:filters";
@@ -102,15 +103,13 @@ const filterSelectStyles = {
 };
 
 const readStoredShotsView = () => {
-  if (typeof window === "undefined") return "gallery";
-  const stored = window.localStorage.getItem(SHOTS_VIEW_STORAGE_KEY);
+  const stored = readStorage(SHOTS_VIEW_STORAGE_KEY);
   return stored === "list" ? "list" : "gallery";
 };
 
 const readStoredShotFilters = () => {
-  if (typeof window === "undefined") return { ...defaultShotFilters };
   try {
-    const raw = window.localStorage.getItem(SHOTS_FILTERS_STORAGE_KEY);
+    const raw = readStorage(SHOTS_FILTERS_STORAGE_KEY);
     if (!raw) return { ...defaultShotFilters };
     const parsed = JSON.parse(raw);
     return {
@@ -293,13 +292,11 @@ export default function ShotsPage() {
   }, [shots, queryText, filters, talentOptions, locationById]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(SHOTS_VIEW_STORAGE_KEY, viewMode);
+    writeStorage(SHOTS_VIEW_STORAGE_KEY, viewMode);
   }, [viewMode]);
 
   useEffect(() => {
-    if (typeof window === "undefined") return;
-    window.localStorage.setItem(
+    writeStorage(
       SHOTS_FILTERS_STORAGE_KEY,
       JSON.stringify({
         locationId: filters.locationId || "",


### PR DESCRIPTION
## Summary
- add a shared safeStorage helper that guards localStorage reads/writes and logs failures
- update auth context, shared path helpers, and major pages to use the safe helper so the UI still boots when storage is unavailable
- cover the new helper with unit tests to assert graceful fallbacks

## Testing
- npm run lint
- npm run test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1b0450ca8832e87355aecc3977d61