### PR TITLE
fix: harden storage image path handling

### DIFF
--- a/src/hooks/__tests__/useStorageImage.test.js
+++ b/src/hooks/__tests__/useStorageImage.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("../../lib/firebase", () => ({
+  storage: {},
+}));
+
+vi.mock("firebase/storage", () => ({
+  getDownloadURL: vi.fn(),
+  ref: vi.fn(),
+}));
+
+const { buildSizedPath, resolveStoragePath } = await import("../useStorageImage.js");
+
+describe("resolveStoragePath", () => {
+  it("returns null for falsy values", () => {
+    expect(resolveStoragePath(null)).toBeNull();
+    expect(resolveStoragePath(undefined)).toBeNull();
+  });
+
+  it("returns string paths untouched", () => {
+    expect(resolveStoragePath("images/foo.jpg")).toBe("images/foo.jpg");
+  });
+
+  it("prefers fullPath when provided on an object", () => {
+    expect(resolveStoragePath({ fullPath: "images/bar.jpg" })).toBe("images/bar.jpg");
+  });
+
+  it("falls back to path when available", () => {
+    expect(resolveStoragePath({ path: "images/baz.jpg" })).toBe("images/baz.jpg");
+  });
+});
+
+describe("buildSizedPath", () => {
+  it("returns the resolved path when sizing cannot be applied", () => {
+    expect(buildSizedPath(null, 320)).toBeNull();
+    expect(buildSizedPath("", 320)).toBe("");
+  });
+
+  it("keeps http urls untouched", () => {
+    const url = "https://cdn.example.com/image.jpg";
+    expect(buildSizedPath(url, 480)).toBe(url);
+  });
+
+  it("appends the requested dimensions to storage paths", () => {
+    expect(buildSizedPath("images/foo.jpg", 320)).toBe("images/foo_320x400.jpg");
+  });
+
+  it("preserves query strings when adding the suffix", () => {
+    expect(buildSizedPath("images/foo.jpg?alt=media", 200)).toBe("images/foo_200x250.jpg?alt=media");
+  });
+
+  it("avoids duplicating the suffix when already sized", () => {
+    expect(buildSizedPath("images/foo_200x250.jpg", 200)).toBe("images/foo_200x250.jpg");
+  });
+
+  it("coerces objects with path metadata", () => {
+    expect(buildSizedPath({ path: "images/foo.jpg" }, 120)).toBe("images/foo_120x150.jpg");
+    expect(buildSizedPath({ fullPath: "images/bar.jpg" }, 180)).toBe("images/bar_180x225.jpg");
+  });
+});

--- a/src/hooks/useStorageImage.js
+++ b/src/hooks/useStorageImage.js
@@ -2,24 +2,41 @@ import { useEffect, useState } from "react";
 import { getDownloadURL, ref as storageRef } from "firebase/storage";
 import { storage } from "../lib/firebase";
 
-export const buildSizedPath = (path, size = 480) => {
-  if (typeof path !== "string" || path.length === 0) {
-    return path;
+export const resolveStoragePath = (candidate) => {
+  if (typeof candidate === "string") {
+    return candidate;
   }
-  if (/^https?:\/\//i.test(path)) {
-    return path;
+  if (candidate && typeof candidate === "object") {
+    if (typeof candidate.fullPath === "string") {
+      return candidate.fullPath;
+    }
+    if (typeof candidate.path === "string") {
+      return candidate.path;
+    }
+  }
+  return null;
+};
+
+export const buildSizedPath = (path, size = 480) => {
+  const resolvedPath = resolveStoragePath(path);
+  if (typeof resolvedPath !== "string" || resolvedPath.length === 0) {
+    return resolvedPath;
+  }
+  if (/^https?:\/\//i.test(resolvedPath)) {
+    return resolvedPath;
   }
   const suffix = `_${size}x${Math.round(size * 1.25)}`;
-  const [base, ...rest] = path.split("?");
-  const query = rest.length ? `?${rest.join("?")}` : "";
+  const queryIndex = resolvedPath.indexOf("?");
+  const base = queryIndex === -1 ? resolvedPath : resolvedPath.slice(0, queryIndex);
+  const query = queryIndex === -1 ? "" : resolvedPath.slice(queryIndex);
   const lastSlash = base.lastIndexOf("/");
   const lastDot = base.lastIndexOf(".");
   if (lastDot === -1 || lastDot < lastSlash) {
-    return path;
+    return resolvedPath;
   }
   const sliceStart = Math.max(lastDot - suffix.length, 0);
   if (base.slice(sliceStart, lastDot) === suffix) {
-    return path;
+    return resolvedPath;
   }
   const sizedBase = `${base.slice(0, lastDot)}${suffix}${base.slice(lastDot)}`;
   return `${sizedBase}${query}`;
@@ -30,15 +47,16 @@ export function useStorageImage(path, { preferredSize = 480 } = {}) {
 
   useEffect(() => {
     let cancelled = false;
-    if (!path) {
+    const resolvedPath = resolveStoragePath(path);
+    if (!resolvedPath) {
       setUrl(null);
       return () => {
         cancelled = true;
       };
     }
 
-    if (typeof path === "string" && /^https?:\/\//i.test(path)) {
-      setUrl(path);
+    if (/^https?:\/\//i.test(resolvedPath)) {
+      setUrl(resolvedPath);
       return () => {
         cancelled = true;
       };
@@ -46,12 +64,12 @@ export function useStorageImage(path, { preferredSize = 480 } = {}) {
 
     (async () => {
       try {
-        const sized = buildSizedPath(path, preferredSize);
+        const sized = buildSizedPath(resolvedPath, preferredSize);
         const preferred = await getDownloadURL(storageRef(storage, sized));
         if (!cancelled) setUrl(preferred);
       } catch (err) {
         try {
-          const original = await getDownloadURL(storageRef(storage, path));
+          const original = await getDownloadURL(storageRef(storage, resolvedPath));
           if (!cancelled) setUrl(original);
         } catch {
           if (!cancelled) setUrl(null);


### PR DESCRIPTION
## Plan
- Inspect storage image helper to understand how undefined paths trigger runtime errors.
- Normalize storage paths before requesting Firebase URLs to tolerate null/metadata objects.
- Add unit coverage for the helper and run the existing lint/test suites.

## Summary
- Added a `resolveStoragePath` helper so storage references, plain strings, and falsy values normalize consistently before sizing.
- Updated `buildSizedPath`/`useStorageImage` to operate on the normalized path and avoid calling `.split` on undefined inputs.
- Introduced focused unit tests covering the new normalization and sizing scenarios.

## Testing
- npm run lint
- npm run test

## Checklist
- [x] Tests cover the new/changed behavior
- [ ] Auth flows preserve `state.from` on redirects (n/a)
- [ ] No flashes while `auth.initializing` (n/a)
- [x] Flags default OFF; override precedence works; console warns when overridden
- [x] CI green; preview deploy conditionally skipped on missing secrets

------
https://chatgpt.com/codex/tasks/task_e_68d1f8ee7d58832ebb264f42a7f7b5e0