### PR TITLE
Feat/talent modal ux

### DIFF
--- a/src/components/Thumb.jsx
+++ b/src/components/Thumb.jsx
@@ -1,28 +1,71 @@
 // src/components/Thumb.jsx
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getBestImageUrl } from "../lib/images";
 
-export default function Thumb({ path, size = 200, alt = "" }) {
+const DEFAULT_FALLBACK_CLASS =
+  "flex h-full w-full items-center justify-center bg-slate-100 text-xs font-medium uppercase tracking-wide text-slate-400";
+
+export default function Thumb({
+  path,
+  size = 200,
+  alt = "",
+  className = "",
+  imageClassName = "h-full w-full object-cover",
+  fallback,
+  loading = "lazy",
+}) {
   const [url, setUrl] = useState(null);
+
   useEffect(() => {
     let alive = true;
     (async () => {
-      if (!path) return setUrl(null);
-      const u = await getBestImageUrl(path, size);
-      if (alive) setUrl(u);
+      if (!path) {
+        if (alive) setUrl(null);
+        return;
+      }
+
+      if (typeof path === "string" && (/^https?:\/\//i.test(path) || path.startsWith("data:"))) {
+        if (alive) setUrl(path);
+        return;
+      }
+
+      try {
+        const resolved = await getBestImageUrl(path, size);
+        if (alive) setUrl(resolved);
+      } catch (error) {
+        if (process.env.NODE_ENV !== "test") {
+          console.warn("[Thumb] Failed to load image", { path, error });
+        }
+        if (alive) setUrl(null);
+      }
     })();
-    return () => { alive = false; };
+    return () => {
+      alive = false;
+    };
   }, [path, size]);
 
-  if (!url) return <div style={{ width: size, height: size, background: "#eee", borderRadius: 8 }} />;
+  const fallbackNode = useMemo(() => {
+    if (fallback !== undefined) return fallback;
+    return (
+      <div className={DEFAULT_FALLBACK_CLASS} aria-hidden="true">
+        No image
+      </div>
+    );
+  }, [fallback]);
+
   return (
-    <img
-      src={url}
-      alt={alt}
-      width={size}
-      height={size}
-      style={{ objectFit: "cover", borderRadius: 8 }}
-      crossOrigin="anonymous"
-    />
+    <div className={className || undefined}>
+      {url ? (
+        <img
+          src={url}
+          alt={alt}
+          loading={loading}
+          className={imageClassName}
+          crossOrigin="anonymous"
+        />
+      ) : (
+        fallbackNode
+      )}
+    </div>
   );
 }

--- a/src/components/talent/TalentCreateModal.jsx
+++ b/src/components/talent/TalentCreateModal.jsx
@@ -1,0 +1,224 @@
+import { useEffect, useRef, useState } from "react";
+import { Modal } from "../ui/modal";
+import { Card, CardContent, CardHeader } from "../ui/card";
+import { Button } from "../ui/button";
+import { Input } from "../ui/input";
+import Thumb from "../Thumb";
+import { useFilePreview } from "../../hooks/useFilePreview";
+
+const emptyForm = {
+  firstName: "",
+  lastName: "",
+  agency: "",
+  phone: "",
+  email: "",
+  sizing: "",
+  url: "",
+  gender: "",
+};
+
+export default function TalentCreateModal({ open, busy = false, onClose, onCreate }) {
+  const [form, setForm] = useState(emptyForm);
+  const [file, setFile] = useState(null);
+  const [error, setError] = useState("");
+  const firstFieldRef = useRef(null);
+
+  const preview = useFilePreview(file);
+
+  useEffect(() => {
+    if (!open) return;
+    setForm(emptyForm);
+    setFile(null);
+    setError("");
+  }, [open]);
+
+  const updateField = (field) => (event) => {
+    setForm((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleFileChange = (event) => {
+    const nextFile = event.target.files?.[0] || null;
+    setFile(nextFile);
+    if (event.target) {
+      event.target.value = "";
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    if (!onCreate) return;
+    try {
+      setError("");
+      await onCreate({ ...form, headshotFile: file });
+      onClose?.();
+    } catch (err) {
+      const message = err?.message || "Unable to create talent. Please try again.";
+      setError(message);
+    }
+  };
+
+  const modalTitleId = "talent-create-title";
+
+  return (
+    <Modal
+      open={open}
+      onClose={busy ? undefined : onClose}
+      labelledBy={modalTitleId}
+      initialFocusRef={firstFieldRef}
+      contentClassName="p-0 max-h-[90vh] overflow-y-auto"
+    >
+      <Card className="border-0 shadow-none">
+        <CardHeader>
+          <h2 id={modalTitleId} className="text-lg font-semibold text-slate-900">
+            Create talent
+          </h2>
+          <p className="text-sm text-slate-500">
+            Provide at least a first or last name. Headshots can be added now or later.
+          </p>
+        </CardHeader>
+        <CardContent className="pb-6">
+          <form className="space-y-5" onSubmit={handleSubmit}>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-first">
+                  First name
+                </label>
+                <Input
+                  id="talent-create-first"
+                  ref={firstFieldRef}
+                  value={form.firstName}
+                  onChange={updateField("firstName")}
+                  placeholder="First name"
+                  disabled={busy}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-last">
+                  Last name
+                </label>
+                <Input
+                  id="talent-create-last"
+                  value={form.lastName}
+                  onChange={updateField("lastName")}
+                  placeholder="Last name"
+                  disabled={busy}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-agency">
+                  Agency
+                </label>
+                <Input
+                  id="talent-create-agency"
+                  value={form.agency}
+                  onChange={updateField("agency")}
+                  placeholder="Agency (optional)"
+                  disabled={busy}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-gender">
+                  Gender
+                </label>
+                <Input
+                  id="talent-create-gender"
+                  value={form.gender}
+                  onChange={updateField("gender")}
+                  placeholder="Gender (optional)"
+                  disabled={busy}
+                />
+              </div>
+            </div>
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-phone">
+                  Phone
+                </label>
+                <Input
+                  id="talent-create-phone"
+                  value={form.phone}
+                  onChange={updateField("phone")}
+                  placeholder="Phone (optional)"
+                  disabled={busy}
+                />
+              </div>
+              <div className="space-y-1.5">
+                <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-email">
+                  Email
+                </label>
+                <Input
+                  id="talent-create-email"
+                  type="email"
+                  value={form.email}
+                  onChange={updateField("email")}
+                  placeholder="Email (optional)"
+                  disabled={busy}
+                />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-sizing">
+                Sizing notes
+              </label>
+              <Input
+                id="talent-create-sizing"
+                value={form.sizing}
+                onChange={updateField("sizing")}
+                placeholder="Sizing info (optional)"
+                disabled={busy}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-url">
+                Reference URL
+              </label>
+              <Input
+                id="talent-create-url"
+                type="url"
+                value={form.url}
+                onChange={updateField("url")}
+                placeholder="URL (optional)"
+                disabled={busy}
+              />
+            </div>
+            <div className="space-y-2">
+              <label className="text-sm font-medium text-slate-700" htmlFor="talent-create-headshot">
+                Headshot
+              </label>
+              <Thumb
+                path={preview || null}
+                size={512}
+                alt="Selected headshot preview"
+                className="h-40 w-32 overflow-hidden rounded-lg bg-slate-100"
+                imageClassName="h-full w-full object-cover"
+                fallback={
+                  <div className="flex h-full items-center justify-center text-xs text-slate-500">
+                    Optional 4:5 image
+                  </div>
+                }
+              />
+              <Input
+                id="talent-create-headshot"
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                disabled={busy}
+              />
+            </div>
+            {error && <div className="rounded-md bg-red-50 px-4 py-2 text-sm text-red-600">{error}</div>}
+            <div className="flex flex-wrap items-center justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={busy}>
+                {busy ? "Creating…" : "Create talent"}
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </Modal>
+  );
+}

--- a/src/components/talent/TalentEditModal.jsx
+++ b/src/components/talent/TalentEditModal.jsx
@@ -3,8 +3,8 @@ import { Modal } from "../ui/modal";
 import { Card, CardContent, CardHeader } from "../ui/card";
 import { Button } from "../ui/button";
 import { Input } from "../ui/input";
-import { useStorageImage } from "../../hooks/useStorageImage";
 import { useFilePreview } from "../../hooks/useFilePreview";
+import Thumb from "../Thumb";
 
 function buildDisplayName(firstName, lastName) {
   const first = (firstName || "").trim();
@@ -38,7 +38,6 @@ export default function TalentEditModal({
   const [deleteText, setDeleteText] = useState("");
   const [deleting, setDeleting] = useState(false);
 
-  const storedHeadshotUrl = useStorageImage(talent?.headshotPath, { preferredSize: 512 });
   const previewUrl = useFilePreview(file);
   const displayName = buildDisplayName(form.firstName, form.lastName) || talent?.name || "Edit talent";
 
@@ -63,8 +62,8 @@ export default function TalentEditModal({
   const currentImage = useMemo(() => {
     if (previewUrl) return previewUrl;
     if (removeImage) return null;
-    return storedHeadshotUrl || null;
-  }, [previewUrl, removeImage, storedHeadshotUrl]);
+    return talent?.headshotPath || null;
+  }, [previewUrl, removeImage, talent?.headshotPath]);
 
   const handleFieldChange = (field) => (event) => {
     setForm((prev) => ({ ...prev, [field]: event.target.value }));
@@ -201,18 +200,14 @@ export default function TalentEditModal({
           <form className="space-y-6" onSubmit={handleSubmit}>
             <div className="grid gap-4 md:grid-cols-[160px_1fr]">
               <div className="flex flex-col items-center gap-3">
-                <div className="h-40 w-32 overflow-hidden rounded-lg bg-slate-100 text-slate-400">
-                  {currentImage ? (
-                    <img
-                      src={currentImage}
-                      alt={displayName}
-                      className="h-full w-full object-cover"
-                      crossOrigin="anonymous"
-                    />
-                  ) : (
-                    <div className="flex h-full items-center justify-center text-sm">No image</div>
-                  )}
-                </div>
+                <Thumb
+                  path={currentImage}
+                  size={512}
+                  alt={displayName}
+                  className="h-40 w-32 overflow-hidden rounded-lg bg-slate-100"
+                  imageClassName="h-full w-full object-cover"
+                  fallback={<div className="flex h-full items-center justify-center text-sm text-slate-400">No image</div>}
+                />
                 <div className="flex flex-col items-center gap-2 text-sm">
                   <Input type="file" accept="image/*" onChange={handleFileChange} />
                   {(talent?.headshotPath || file) && (

--- a/src/pages/__tests__/createFlows.test.jsx
+++ b/src/pages/__tests__/createFlows.test.jsx
@@ -195,8 +195,12 @@ describe("Create flows", () => {
     const { default: TalentPage } = await import("../TalentPage.jsx");
     render(<TalentPage />);
 
-    fireEvent.change(screen.getByLabelText("First name"), { target: { value: "Amelia" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add Talent" }));
+    fireEvent.click(screen.getByRole("button", { name: "New talent" }));
+
+    const modal = await screen.findByRole("dialog", { name: /create talent/i });
+    const firstNameInput = within(modal).getByLabelText("First name");
+    fireEvent.change(firstNameInput, { target: { value: "Amelia" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "Create talent" }));
 
     await waitFor(() => expect(addDocCalls.length).toBe(1));
     expect(addDocCalls[0].path).toEqual(["clients", "unbound-merino", "talent"]);
@@ -214,8 +218,11 @@ describe("Create flows", () => {
     const { default: TalentPage } = await import("../TalentPage.jsx");
     render(<TalentPage />);
 
-    fireEvent.change(screen.getByLabelText("First name"), { target: { value: "Donna" } });
-    fireEvent.click(screen.getByRole("button", { name: "Add Talent" }));
+    fireEvent.click(screen.getByRole("button", { name: "New talent" }));
+
+    const modal = await screen.findByRole("dialog", { name: /create talent/i });
+    fireEvent.change(within(modal).getByLabelText("First name"), { target: { value: "Donna" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "Create talent" }));
 
     await waitFor(() => expect(toastMock.error).toHaveBeenCalled());
     expect(addDocCalls[0].path).toEqual(["clients", "unbound-merino", "talent"]);


### PR DESCRIPTION
Replace the inline Talent create form with a create card that opens a modal.
  - Reuse the shared Thumb image helper for Talent cards + modals to ensure consistent CORS-safe loading and fallbacks.
  - Update create-flow tests to exercise the modal path.

  Manual QA

  - npm run dev
  - Sign in, open /talent.
  - Confirm Talent page shows cards + “Create talent” card (no inline form).
  - Click “Create talent” → modal opens, submit a new record → card appears without navigation.
  - Open an existing card’s “Edit” → modal renders with headshot via shared image component.
  - Validate dropdowns/portals overlay correctly above the modal.

  Automated Tests

  - npm run test -- createFlows
