### PR TITLE
fix: three-panel crash — missing lifecycle menu props

### DIFF
--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -296,6 +296,8 @@ export default function ShotListPage() {
           onShotCreated={(shotId, title) => {
             toast.success("Shot created", { description: title })
           }}
+          projects={projects}
+          existingTitles={existingShotTitles}
         />
       </ErrorBoundary>
     )
@@ -829,7 +831,7 @@ export default function ShotListPage() {
         title={`Delete scene "${deleteSceneTarget?.name ?? ""}"?`}
         description="All shots in this scene will be ungrouped. This cannot be undone."
         confirmLabel="Delete Scene"
-        variant="destructive"
+        destructive
         onConfirm={() => {
           if (clientId && deleteSceneTarget) {
             void ungroupAllShotsFromLane({ shots, laneId: deleteSceneTarget.id, projectId, clientId })

--- a/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
@@ -15,7 +15,7 @@ import {
 import { textPreview } from "@/shared/lib/textPreview"
 import { useAuth } from "@/app/providers/AuthProvider"
 import type { SaveState } from "@/shared/hooks/useAutoSave"
-import type { Shot } from "@/shared/types"
+import type { Shot, Project } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Props
@@ -28,6 +28,8 @@ interface ThreePanelCanvasPanelProps {
   readonly canDoOperational: boolean
   readonly onClose: () => void
   readonly onShareClick?: () => void
+  readonly projects: ReadonlyArray<Project>
+  readonly existingTitles: ReadonlySet<string>
 }
 
 // ---------------------------------------------------------------------------
@@ -41,6 +43,8 @@ export function ThreePanelCanvasPanel({
   canDoOperational,
   onClose,
   onShareClick,
+  projects,
+  existingTitles,
 }: ThreePanelCanvasPanelProps) {
   const { clientId } = useAuth()
   const safeDescription = textPreview(shot.description, Number.POSITIVE_INFINITY)
@@ -76,6 +80,8 @@ export function ThreePanelCanvasPanel({
           {canDoOperational && (
             <ShotLifecycleActionsMenu
               shot={shot}
+              projects={projects}
+              existingTitles={existingTitles}
               disabled={!canDoOperational}
             />
           )}

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -15,7 +15,7 @@ import { ThreePanelCanvasPanel } from "@/features/shots/components/ThreePanelCan
 import { ThreePanelPropertiesPanel } from "@/features/shots/components/ThreePanelPropertiesPanel"
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
 import { toast } from "sonner"
-import type { Shot, ShotFirestoreStatus } from "@/shared/types"
+import type { Shot, ShotFirestoreStatus, Project } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -56,6 +56,8 @@ interface ThreePanelLayoutProps {
   readonly onDeselect: () => void
   readonly onSelectShot: (shotId: string) => void
   readonly onShotCreated?: (shotId: string, title: string) => void
+  readonly projects: ReadonlyArray<Project>
+  readonly existingTitles: ReadonlySet<string>
 }
 
 // ---------------------------------------------------------------------------
@@ -70,6 +72,8 @@ export function ThreePanelLayout({
   onDeselect,
   onSelectShot,
   onShotCreated,
+  projects,
+  existingTitles,
 }: ThreePanelLayoutProps) {
   const { data: shot, loading, error } = useShot(selectedShotId)
   const { role, clientId, user } = useAuth()
@@ -218,6 +222,8 @@ export function ThreePanelLayout({
         canDoOperational={canDoOperational}
         onClose={onDeselect}
         onShareClick={canShare ? () => setShareOpen(true) : undefined}
+        projects={projects}
+        existingTitles={existingTitles}
       />
     )
   }


### PR DESCRIPTION
## Summary

- **P0 hotfix**: Production crash on Shots page — "Cannot read properties of undefined (reading 'filter')"
- Root cause: `ShotLifecycleActionsMenu` was added to `ThreePanelCanvasPanel` in PR #406 without passing the required `projects` and `existingTitles` props. The component calls `projects.filter(...)` internally, which crashes when `projects` is `undefined`.
- Fix: Thread `projects` and `existingTitles` through `ShotListPage → ThreePanelLayout → ThreePanelCanvasPanel → ShotLifecycleActionsMenu`
- Also fixes `ConfirmDialog` prop mismatch (`variant="destructive"` → `destructive` boolean)

## Test plan
- [ ] Open any project's Shots page — should load without crash
- [ ] Click a shot in three-panel view — lifecycle menu (⋯) should work
- [ ] Verify duplicate/move/archive actions function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)