### PR TITLE
feat: S29 scene enhancement — table grouping, notes, letter-suffix numbering

### DIFF
--- a/docs/_runtime/CHECKPOINT.md
+++ b/docs/_runtime/CHECKPOINT.md
@@ -1,47 +1,94 @@
-# CHECKPOINT — Sprint S28: Shot Scenes + Three-Panel Parity (2026-04-09)
+# CHECKPOINT — Sprint S29 Implementation Complete (2026-04-10)
 
-## Build clean. Lint zero. 164 test files / 1905 tests pass.
+## Build clean. Lint zero. 167 test files / 1975 tests passing. Ready for commit + PR.
 
-## Sprint S28 — Progress
+## Sprint S29 — All Phases Complete
 
-### Three-Panel Parity Fixes
-- [x] TalentPicker projectId in ThreePanelPropertiesPanel
-- [x] LocationPicker projectId in ThreePanelPropertiesPanel
-- [x] ProductSummaryStrip in ThreePanelCanvasPanel
-- [x] Deleted shot guard in ThreePanelLayout (useRef gate)
-- [x] ShotVersionHistorySection in ThreePanelPropertiesPanel
-- [x] ShotLifecycleActionsMenu in ThreePanelCanvasPanel
-- [x] ShotsShareDialog in ThreePanelLayout + share icon in canvas
+### Phase 0: HTML Mockups
+- [x] `mockups/s29-scene-enhancements.html` — 5 sections, dark/light mode, 74KB
+- [x] Visually verified in Chrome (claude-in-chrome + local HTTP server)
 
-### Shot Scenes Infrastructure
-- [x] Lane type definition (shared/types/index.ts)
-- [x] laneDocPath helper (shared/lib/paths.ts)
-- [x] useLanes hook (Firestore subscription + laneNameById)
-- [x] laneActions CRUD (createLane, updateLane, deleteLane, assignShotsToLane, ungroupAllShotsFromLane)
-- [x] "scene" GroupKey + groupShots logic
-- [x] useShotListState wiring (laneNameById, laneOrder)
+### Phase 1: Data Model + Scene Notes UI
+- [x] Lane type extended (`sceneNumber`, `direction`, `notes`)
+- [x] `useLanes` returns `laneById` map + backfills legacy `sceneNumber = sortOrder + 1`
+- [x] `createLane` accepts `existingLanes` and auto-increments `sceneNumber`
+- [x] `LanePatch` type exported with `direction`, `notes`, `sceneNumber`
+- [x] `ShotGroup` type extended with scene metadata
+- [x] `SceneDetailSheet.tsx` component (14 tests)
+- [x] `SceneContextBanner.tsx` component (10 tests)
+- [x] `SceneHeader.tsx` enhanced with sceneNumber + direction + onEdit
+- [x] SceneContextBanner + SceneDetailSheet integrated in all 3 surfaces:
+  - [x] ShotDetailPage
+  - [x] ThreePanelCanvasPanel
+  - [x] ThreePanelPropertiesPanel
+- [x] `window.prompt()` rename flow replaced by SceneDetailSheet
 
-### Shot Scenes UI
-- [x] SceneHeader component (card variant with collapse, context menu)
-- [x] ScenePicker dropdown component
-- [x] GroupIntoSceneDialog (Create New / Add to Existing tabs)
-- [x] ShotListToolbar "Scenes" toggle button
-- [x] Card view scene grouping with collapsible SceneHeaders
-- [x] BulkActionBar "Group into Scene" button
-- [x] ShotListPage wiring (useLanes, collapse state, dialog)
+### Phase 2: Scene Grouping in Table View
+- [x] `SceneTableRow.tsx` component (refactored to avoid nested interactives)
+- [x] `ShotsTable` accepts `groups`, `collapsedScenes`, scene action callbacks
+- [x] `ShotListPage` removes "switch to cards" banner; wires scene grouping
+- [x] Orphan `laneId` guard in `groupShots` (with load-race safeguard)
+- [x] Backward compat preserved — flat mode unchanged
 
-### Tests
-- [x] 9 scene grouping tests (sceneGrouping.test.ts)
-- [x] SCENE_COLORS validation tests (laneActions.test.ts)
+### Phase 3: Scene-Aware Sub-Numbering
+- [x] `indexToLetterSuffix` (base-26, clamped at 701/ZZ)
+- [x] `formatSceneShotNumber`
+- [x] `parseSceneShotNumber` (scene / flat / legacy formats)
+- [x] `computeMaxBaseNumber`
+- [x] `projectSceneTargets` (pure helper)
+- [x] `buildSceneRenumberUpdates` (pure, testable)
+- [x] `previewRenumberWithScenes` (immutable via reduce)
+- [x] `renumberShotsWithScenes` (MAX_RENUMBER_SHOTS guard, maxSceneNumberOverride)
+- [x] `RenumberShotsDialog` Sequential / By Scene toggle
+- [x] Grouped preview with scene headers + color dots
+- [x] Warning banner when sequential mode would destroy scene letters
+- [x] PDF export padStart removed (handles alphanumeric)
+- [x] Export sort fix (localeCompare numeric)
 
-### Code Reviews
-- [x] Initial code review: APPROVED
-- [x] Senior code review (infrastructure): all HIGH/MAJOR fixed
-- [ ] Final code review: IN PROGRESS
+### Phase 4: Easier Scene Assignment + Polish
+- [x] "scene" column in `SHOT_TABLE_COLUMNS` (default hidden)
+- [x] Scene cell renderer with colored dot + badge
+- [x] `ShotRowContext` extended with scene fields
+- [x] `SceneAssignPopover.tsx` component (5 tests)
+- [x] Wired into ShotsTable with `lanes` + `onAssignScene` props
+- [x] `BulkActionBar` button renamed to "Set Scene"
 
-### Remaining
-- [ ] ScenePicker wired into ThreePanelPropertiesPanel
-- [ ] Scene breadcrumb in ThreePanelCanvasPanel
-- [ ] Table view scene row separators
-- [ ] Visual verification via dev server
-- [ ] PR creation
+### Phase 5: Verification + Docs
+- [x] Internal reviews (architect + code-reviewer + pre-impl audit)
+- [x] All CRITICAL + HIGH findings fixed and re-verified
+- [x] MEDIUM items 4, 5, 7 (partial), 8, 9 also fixed
+- [x] Mockup visually verified
+- [x] Full test suite passing
+- [x] Dev server starts cleanly
+- [x] HANDOFF.md + CHECKPOINT.md updated
+- [ ] Commit + PR
+- [ ] Deploy Firestore rules
+- [ ] User visual smoke test with live data
+
+## Critical File State
+
+**Files changed:** 27 modified, 9 new (including 4 test files + 1 mockup)
+
+**New files:**
+- `src-vnext/features/shots/components/SceneDetailSheet.tsx` + test
+- `src-vnext/features/shots/components/SceneContextBanner.tsx` + test
+- `src-vnext/features/shots/components/SceneTableRow.tsx`
+- `src-vnext/features/shots/components/SceneAssignPopover.tsx` + test
+- `mockups/s29-scene-enhancements.html`
+
+**Test count delta:** 1905 (S28 baseline) → 1975 (+70 new tests)
+
+## Known Deferred (acceptable per reviewers, documented for follow-up)
+
+- M1: Scene groups still sort by `sortOrder` (not `sceneNumber`) — strategic decision awaiting user input
+- M3: Duplicate SceneDetailSheet state in canvas + properties panels (portal-rendered, works but not ideal)
+- M7: DnD reorder not auto-disabled for > 500 shots (perf concern, no UX regression)
+- L9: Export sort places null shotNumbers first in asc — could move to last with `?? "\uffff"` if desired
+
+## Deployment Checklist
+
+- [ ] `git add` + commit with conventional message
+- [ ] Open PR with full test/lint/build status
+- [ ] `firebase deploy --only firestore:rules` (new lanes rule)
+- [ ] User visual smoke test across table + detail + renumber flows
+- [ ] Merge after CI + approval

--- a/docs/_runtime/CHECKPOINT.md
+++ b/docs/_runtime/CHECKPOINT.md
@@ -78,12 +78,14 @@
 
 **Test count delta:** 1905 (S28 baseline) → 1975 (+70 new tests)
 
-## Known Deferred (acceptable per reviewers, documented for follow-up)
+## Known Deferred
 
-- M1: Scene groups still sort by `sortOrder` (not `sceneNumber`) — strategic decision awaiting user input
-- M3: Duplicate SceneDetailSheet state in canvas + properties panels (portal-rendered, works but not ideal)
-- M7: DnD reorder not auto-disabled for > 500 shots (perf concern, no UX regression)
-- L9: Export sort places null shotNumbers first in asc — could move to last with `?? "\uffff"` if desired
+All items previously listed here (M1, M3, M7, L9) have been resolved per CLAUDE.md
+rule 6b ("no deferring known issues") in round-2 and round-3 review fixes:
+- M1: groupShots scene sort now uses `sceneNumber` as primary key (sortOrder fallback)
+- M3: SceneDetailSheet lifted to ThreePanelLayout — single instance
+- M7: ShotsTable auto-disables DnD reorder when shot count > 500
+- L9: blockDataResolvers sort places null shot numbers last in both directions
 
 ## Deployment Checklist
 

--- a/docs/_runtime/HANDOFF.md
+++ b/docs/_runtime/HANDOFF.md
@@ -1,77 +1,154 @@
-# HANDOFF — Sprint S28: Shot Scenes + Three-Panel Parity (2026-04-09)
+# HANDOFF — Sprint S29: Scene Enhancement (2026-04-10)
 
 ## State
-Sprint S28 IN PROGRESS. Build clean. Lint zero. 164 test files / 1905 tests pass. Awaiting final code review.
+Sprint S29 implementation COMPLETE. Build clean. Lint zero. 167 test files / 1975 tests passing. Not yet committed or deployed. Ready for PR.
 
 ## What Was Built
 
-### WS1: Three-Panel Bug Fixes (CRITICAL)
-- **TalentPicker projectId**: Added `projectId={shot.projectId}` to `ThreePanelPropertiesPanel.tsx` — talent dropdown was showing ALL org-wide talent instead of project-scoped
-- **LocationPicker projectId**: Same fix for location picker
-- **ProductSummaryStrip**: Added import + conditional render to `ThreePanelCanvasPanel.tsx` — product thumbnails were completely missing from center panel
+Sprint S29 closes three gaps in the S28 scene system:
+1. Scene grouping only worked in card view — now works in **table view** too
+2. Scenes had only a name and color — now support **scene number, creative direction, and production notes**
+3. Shot numbering ignored scenes — now supports **letter-suffix sub-numbering** (51A, 51B, 51C) relative to the scene number
 
-### WS2: Three-Panel Parity Fixes (from architect audit)
-- **Deleted shot guard** (CRITICAL): Added `useRef`-gated `useEffect` in `ThreePanelLayout.tsx` — deselects + toasts when shot is soft-deleted while selected
-- **ShotVersionHistorySection** (HIGH): Added to `ThreePanelPropertiesPanel.tsx` below comments
-- **ShotLifecycleActionsMenu** (HIGH): Added to `ThreePanelCanvasPanel.tsx` header bar (duplicate/move/archive)
-- **ShotsShareDialog** (HIGH): Added share button + dialog to `ThreePanelLayout.tsx` + `ThreePanelCanvasPanel.tsx`
+### Data Model (Phase 1)
+- Extended `Lane` interface with 3 optional fields: `sceneNumber?: number`, `direction?: string`, `notes?: string`
+- `useLanes` hook now exposes `laneById: Map<string, Lane>` and auto-backfills `sceneNumber = sortOrder + 1` for legacy lanes that lack it
+- `createLane` accepts `existingLanes` param and auto-increments `sceneNumber` as `max(existing) + 1`
+- `LanePatch` type extended and exported from `laneActions.ts`
+- `ShotGroup` type extended with optional `color`, `sceneNumber`, `direction` scene metadata
+- `groupShots` scene branch populates metadata from new `laneById` lookup parameter
 
-### WS3: Shot Scenes Infrastructure
-- **Lane type**: `shared/types/index.ts` — `{ id, name, projectId, clientId, sortOrder, color?, timestamps, createdBy }`
-- **Path helper**: `shared/lib/paths.ts` — `laneDocPath`
-- **useLanes hook**: `features/shots/hooks/useLanes.ts` — Firestore subscription + laneNameById map
-- **CRUD actions**: `features/shots/lib/laneActions.ts` — createLane (name validation), updateLane (LanePatch type), deleteLane, assignShotsToLane (MAX_BULK_OPS=500, projectId), ungroupAllShotsFromLane
-- **GroupKey extension**: Added `"scene"` to GroupKey type, scene case in `groupShots()` with lane order + alphabetical fallback
-- **State wiring**: `useShotListState` accepts laneNameById + laneOrder, passes to groupShots
+### Scene UI Components (Phase 1 UI)
+- **NEW `SceneDetailSheet.tsx`** — Right-side slide-over sheet for editing scene properties. Fields: name, number, color (6 swatches), creative direction (≤500 chars), production notes (≤5000 chars). Blur-only saves (no debounced keystroke writes). `useRef` init gate prevents Firestore snapshot echoes from clobbering in-progress edits.
+- **NEW `SceneContextBanner.tsx`** — Thin banner shown at top of shot detail when shot belongs to a scene. Shows color dot, `#sceneNumber sceneName`, truncated direction preview, "View scene" link.
+- **Enhanced `SceneHeader.tsx`** — Shows `#sceneNumber` prefix, direction preview, "Edit Scene" dropdown item.
+- **Integration:** SceneContextBanner + SceneDetailSheet in all 3 surfaces (ShotDetailPage, ThreePanelCanvasPanel, ThreePanelPropertiesPanel) for parity.
 
-### WS4: Shot Scenes UI
-- **SceneHeader component**: Collapsible header with accent color bar, name, count badge, context menu (Rename, Ungroup All, Delete Scene). Ungrouped variant with muted styling.
-- **ScenePicker dropdown**: Assign/move/remove shots from scenes. Shows color dots. "None (ungrouped)" option.
-- **GroupIntoSceneDialog**: Two-tab dialog (Create New + Add to Existing) with name input, 6-color picker, existing scene radio list with counts.
-- **Toolbar integration**: "Scenes" toggle button (with Layers icon) in ShotListToolbar, visible when lanes exist
-- **Card view integration**: SceneHeader renders as collapsible group dividers. Shots contained within bordered scene containers. Collapse state tracked in ShotListPage.
-- **BulkActionBar**: "Group into Scene" primary button added before Delete
+### Table Grouping (Phase 2)
+- **NEW `SceneTableRow.tsx`** — Scene header row for the table (single `<td colSpan>`, 3px left color bar, chevron toggle, kebab menu with Edit/Ungroup/Delete). Uses `<div>` + sibling `<button>` to avoid nested interactive elements.
+- `ShotsTable.tsx` accepts new `groups`, `collapsedScenes`, `onToggleSceneCollapse`, `onEditScene`, `onDeleteScene`, `onUngroupScene`, `laneById`, `lanes`, `onAssignScene` props
+- `ShotListPage.tsx` removed the "Grouping is available in Card view" banner and wires scene grouping to the table
+- Orphan `laneId` guard in `groupShots` with size>0 check to prevent load-race flicker
 
-### WS5: Tests
-- 9 scene grouping tests: groups by laneId, ungrouped last, sorts by laneOrder, handles empty, unknown lanes, alphabetical fallback, preserves shot order
-- SCENE_COLORS validation: 6 colors, unique keys, valid hex
-- 1905 total tests (up from 1892)
+### Scene-Aware Sub-Numbering (Phase 3)
+- **New functions in `shotNumbering.ts`:**
+  - `indexToLetterSuffix(index)` — base-26 letter encoding (0→A, 25→Z, 26→AA, 701→ZZ, clamped)
+  - `formatSceneShotNumber(sceneNumber, indexInScene)` — composes "51" + "A" → "51A"
+  - `parseSceneShotNumber(shotNumber)` — regex parser for scene / flat / legacy formats
+  - `computeMaxBaseNumber(shots)` — extracts highest base from all formats
+  - `projectSceneTargets` (private helper) — pure projection of scene groups + ungrouped onto numbering targets
+  - `buildSceneRenumberUpdates` — pure Firestore update list builder (testable without mocks)
+  - `previewRenumberWithScenes` — dry-run preview, immutable via `reduce`
+  - `renumberShotsWithScenes` — Firestore batch writer, uses `buildSceneRenumberUpdates`, `MAX_RENUMBER_SHOTS=2000` guard, `maxSceneNumberOverride` param for cross-filter safety
+- **Enhanced `RenumberShotsDialog.tsx`** — Sequential / By Scene mode toggle, grouped preview with scene headers + color dots, warning when sequential mode would destroy existing scene letter suffixes
 
-## Review Cycle
-- Initial code review (Wave 1 fixes): APPROVED — zero CRITICAL/HIGH findings
-- Senior code review (infrastructure): H1 deleted guard re-fire fixed (useRef gate), H2 projectId validation added, M1 LanePatch narrowed, M2 MAX_BULK_OPS added, m1-m5 all addressed
-- Final senior code review: IN PROGRESS (background)
+### Scene Assignment (Phase 4)
+- **Scene column** added to `shotTableColumns.ts` (default hidden, order 14)
+- **Scene cell renderer** in `shotColumnRenderers.tsx` — colored dot + scene name badge or em-dash. `ShotRowContext` extended with `sceneName`, `sceneColor`. `computeShotRowContext` accepts optional `laneById`.
+- **NEW `SceneAssignPopover.tsx`** — Popover with None/ungrouped, scene list with color dots + `#sceneNumber`, checkmark on active
+- `BulkActionBar.tsx` — Renamed "Group into Scene" button to "Set Scene"
 
-## Firestore Rules
-- No changes needed — lanes collection covered by existing wildcard catch-all at line 731
-- Read: admin + producer + all project roles. Write: admin + producer + warehouse.
+### Pre-Existing Bug Fixes (discovered during audit)
+- **CRITICAL** `blockDataResolvers.ts` — Export sort used `Number(shotNumber)` which returns `NaN` for alphanumeric. Fixed to `localeCompare` with `{ numeric: true, sensitivity: "base" }`.
+- 4 export files (`ShotGridBlockPdf`, `ShotDetailBlockPdf`, `ShotGridBlockView`, `ShotDetailBlockView`) — Removed `padStart(3, "0")` which produced "05A" from "5A". Now displays raw shotNumber with em-dash fallback.
 
-## Key Files Created
-- `src-vnext/features/shots/hooks/useLanes.ts` — Firestore subscription hook
-- `src-vnext/features/shots/lib/laneActions.ts` — CRUD + batch operations
-- `src-vnext/features/shots/components/SceneHeader.tsx` — collapsible scene header
-- `src-vnext/features/shots/components/ScenePicker.tsx` — scene assignment dropdown
-- `src-vnext/features/shots/components/GroupIntoSceneDialog.tsx` — bulk scene dialog
-- `src-vnext/features/shots/lib/__tests__/sceneGrouping.test.ts` — 9 grouping tests
-- `src-vnext/features/shots/lib/__tests__/laneActions.test.ts` — validation tests
-- `mockups/s28-shot-scenes.html` — 4-panel interactive mockup (approved)
+### Firestore Rules
+- Added explicit `match /lanes/{laneId}` rule with `direction.size() <= 500` and `notes.size() <= 5000` validation, placed BEFORE the wildcard catch-all.
 
-## Key Files Modified
-- `src-vnext/shared/types/index.ts` — Lane interface added
-- `src-vnext/shared/lib/paths.ts` — laneDocPath helper
-- `src-vnext/features/shots/lib/shotListFilters.ts` — "scene" GroupKey + groupShots case
-- `src-vnext/features/shots/hooks/useShotListState.ts` — lane data wiring
-- `src-vnext/features/shots/components/ThreePanelLayout.tsx` — deleted guard, share dialog
-- `src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx` — ProductSummaryStrip, lifecycle menu, share button
-- `src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx` — projectId props, version history
-- `src-vnext/features/shots/components/ShotListPage.tsx` — useLanes, scene grouping, collapse state, dialog
-- `src-vnext/features/shots/components/ShotListToolbar.tsx` — Scenes toggle button
-- `src-vnext/features/shots/components/BulkActionBar.tsx` — "Group into Scene" button
+## Review Cycle (Internal)
 
-## What's Next
-- Final code review results (background agent)
-- ScenePicker in ThreePanelPropertiesPanel (assign scene from properties panel)
-- Scene breadcrumb in ThreePanelCanvasPanel ("Part of: Scene Name")
-- Table view scene grouping (currently card view only)
-- Visual verification via dev server
-- PR creation
+**Pre-Implementation Audit (code-reviewer):**
+- CRITICAL: Export sort NaN → fixed
+- HIGH: 4× padStart on shotNumber → fixed
+- MEDIUM: Three-panel parity flagged for implementation planning
+
+**Data Model + Numbering Review (code-reviewer):**
+- CRITICAL: previewRenumberWithScenes sortOrder divergence from write function → fixed with globalSortOrder counter
+- HIGH: indexToLetterSuffix clamping at 701 (ZZ) → fixed
+- HIGH: Missing MAX_RENUMBER_SHOTS guard on renumberShotsWithScenes → fixed
+- HIGH: push mutation in numbering functions → deferred initially, fully fixed in final review
+- MEDIUM: Missing direction/notes null write in createLane → fixed
+- MEDIUM: Simplified direction truncation
+
+**Architecture Review (architect) — 13 findings:**
+- CRITICAL: `createLane` missing `existingLanes` in ShotListPage → every new scene would collide at sceneNumber=1 → fixed
+- HIGH: Legacy lane sceneNumber backfill → fixed with read-time fallback in `useLanes.mapLane`
+- HIGH: Orphan laneId produces phantom groups → fixed with guard in `groupShots`
+- HIGH: Debounced direction write causes multi-user conflict → removed, blur-only
+- HIGH: Sequential renumber silently destroys scene letters → warning banner added
+- MEDIUM: Type-safe `LanePatch` export → fixed
+- MEDIUM: Scene number validation (non-negative integer) → fixed
+
+**Full Sprint Review (code-reviewer) — 23 findings:**
+- CRITICAL: Initial test regression from orphan guard (5 tests) → fixed, backward-compat restored, new orphan test added
+- CRITICAL: `RenumberShotsDialog` scene mode is dead code — `lanes`/`groupKey` props not passed from ShotListPage → FIXED (Phase 3 UI now reachable)
+- HIGH: `SceneDetailSheet` re-render trap — Firestore snapshot echoes would clobber in-progress edits → fixed with `useRef` init gate + 2 new regression tests
+- HIGH: Mutation violations in `previewRenumberWithScenes`, `renumberShotsWithScenes`, `ScenePreviewRows` → rewrote using `reduce` + extracted pure `buildSceneRenumberUpdates` / `projectSceneTargets` helpers
+- HIGH: Nested interactive HTML in SceneTableRow (button inside button) → refactored to `<div>` + sibling `<button>`
+- HIGH: No Firestore rule size validation for lanes → added explicit rule with 500/5000 char limits
+- HIGH: Missing unit tests for `renumberShotsWithScenes` → added 5 tests for `buildSceneRenumberUpdates`
+- MEDIUM: Unused `updateLane` import → removed
+- MEDIUM: O(n) `lanes.find()` in ShotListPage → replaced with `laneById.get()`
+- MEDIUM: `maxSceneNumberOverride` param for cross-filter safety → added
+- Codex CLI independent review attempted — `gpt-5.4-high` unavailable on ChatGPT account (known limitation). Internal 2-tier review (architect + code-reviewer) was the substitute.
+
+## Files
+
+**New (9):**
+- `src-vnext/features/shots/components/SceneDetailSheet.tsx`
+- `src-vnext/features/shots/components/SceneContextBanner.tsx`
+- `src-vnext/features/shots/components/SceneTableRow.tsx`
+- `src-vnext/features/shots/components/SceneAssignPopover.tsx`
+- `src-vnext/features/shots/components/SceneAssignPopover.test.tsx` (5 tests)
+- `src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx` (14 tests)
+- `src-vnext/features/shots/components/__tests__/SceneContextBanner.test.tsx` (10 tests)
+- `mockups/s29-scene-enhancements.html` (74KB, 5 sections, dark/light mode)
+
+**Modified (27):**
+- `src-vnext/shared/types/index.ts` (Lane)
+- `src-vnext/features/shots/hooks/useLanes.ts` (laneById, backfill)
+- `src-vnext/features/shots/hooks/useShotListState.ts` (laneById thread-through)
+- `src-vnext/features/shots/lib/laneActions.ts` (createLane existingLanes, LanePatch export)
+- `src-vnext/features/shots/lib/shotListFilters.ts` (ShotGroup, orphan guard, scene field)
+- `src-vnext/features/shots/lib/shotNumbering.ts` (6 new functions + helpers)
+- `src-vnext/features/shots/lib/shotNumbering.test.ts` (+39 tests total 59)
+- `src-vnext/features/shots/lib/shotTableColumns.ts` (scene column)
+- `src-vnext/features/shots/lib/shotTableColumns.test.ts` (column count)
+- `src-vnext/features/shots/lib/shotColumnRenderers.tsx` (scene cell)
+- `src-vnext/features/shots/lib/__tests__/sceneGrouping.test.ts` (+1 orphan test)
+- `src-vnext/features/shots/components/SceneHeader.tsx` (sceneNumber, direction, onEdit)
+- `src-vnext/features/shots/components/ShotsTable.tsx` (groups, laneById, scene assign)
+- `src-vnext/features/shots/components/ShotListPage.tsx` (scene wiring, SceneDetailSheet)
+- `src-vnext/features/shots/components/ShotDetailPage.tsx` (SceneContextBanner + sheet)
+- `src-vnext/features/shots/components/ThreePanelLayout.tsx` (laneById threading)
+- `src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx` (banner + sheet)
+- `src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx` (banner + sheet)
+- `src-vnext/features/shots/components/RenumberShotsDialog.tsx` (scene mode toggle + grouped preview)
+- `src-vnext/features/shots/components/BulkActionBar.tsx` (button label rename)
+- `src-vnext/features/export/lib/blockDataResolvers.ts` (localeCompare sort)
+- `src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx` (no padStart)
+- `src-vnext/features/export/lib/pdf/blocks/ShotDetailBlockPdf.tsx` (no padStart)
+- `src-vnext/features/export/components/blocks/ShotGridBlockView.tsx` (no padStart)
+- `src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx` (no padStart)
+- `src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx` (test adjustment)
+- `firestore.rules` (lanes size validation)
+
+## Next Steps
+
+1. **Visual smoke test with live data** — Requires logged-in Firebase user. User should verify: (a) table view scene grouping, (b) scene detail sheet editing flow, (c) scene context banner on shot detail, (d) renumber by scene, (e) scene assign popover from table cell.
+2. **Deploy Firestore rules** — `firebase deploy --only firestore:rules` (adds lane size validation)
+3. **Commit + PR** — Suggested title: `feat: S29 scene enhancement — table grouping, notes, letter-suffix numbering`. Include test/lint/build status in PR description.
+4. **Follow-up items (not blocking merge):**
+   - M1: Scene group sort by `sceneNumber` instead of `sortOrder` (strategic — may want to discuss with user)
+   - M3: Lift `SceneDetailSheet` state from two panels to `ThreePanelLayout` to avoid duplicate sheet instances
+   - M7: Disable DnD reorder when shot count > 500 (perf)
+   - L9: Consider moving blanks-last in export sort (`?? "\uffff"`)
+
+## Verification Status
+
+- **Tests:** 167 files / 1975 passing (includes 39 new scene numbering + 24 new component tests)
+- **Lint:** zero warnings
+- **Build:** clean (`npm run build` ~12s)
+- **Dev server:** starts and renders shell correctly
+- **HTML mockup:** visually verified in Chrome, matches implementation design
+- **Codex CLI:** unavailable (gpt-5.4-high not supported on ChatGPT account — known limitation)

--- a/docs/_runtime/HANDOFF.md
+++ b/docs/_runtime/HANDOFF.md
@@ -139,10 +139,7 @@ Sprint S29 closes three gaps in the S28 scene system:
 2. **Deploy Firestore rules** — `firebase deploy --only firestore:rules` (adds lane size validation)
 3. **Commit + PR** — Suggested title: `feat: S29 scene enhancement — table grouping, notes, letter-suffix numbering`. Include test/lint/build status in PR description.
 4. **Follow-up items (not blocking merge):**
-   - M1: Scene group sort by `sceneNumber` instead of `sortOrder` (strategic — may want to discuss with user)
-   - M3: Lift `SceneDetailSheet` state from two panels to `ThreePanelLayout` to avoid duplicate sheet instances
-   - M7: Disable DnD reorder when shot count > 500 (perf)
-   - L9: Consider moving blanks-last in export sort (`?? "\uffff"`)
+   - (All M-level follow-ups from initial review have been resolved per CLAUDE.md rule 6b.)
 
 ## Verification Status
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -726,6 +726,30 @@ service cloud.firestore {
           (isAdmin() || isProducer());
       }
 
+      // Lanes (Scenes) — explicit rule with size validation on direction and notes.
+      // Must come BEFORE the wildcard catch-all so it takes precedence.
+      match /lanes/{laneId} {
+        allow read: if clientMatches(clientId) &&
+          (isAdmin() || producerCanAccessProject(clientId, projectId) ||
+           hasProjectRole(projectId, ['producer', 'crew', 'warehouse', 'viewer']));
+        allow create, update: if clientMatches(clientId) &&
+          (isAdmin() || producerCanAccessProject(clientId, projectId) ||
+           hasProjectRole(projectId, ['producer', 'warehouse'])) &&
+          (
+            !('direction' in request.resource.data) ||
+            request.resource.data.direction == null ||
+            (request.resource.data.direction is string && request.resource.data.direction.size() <= 500)
+          ) &&
+          (
+            !('notes' in request.resource.data) ||
+            request.resource.data.notes == null ||
+            (request.resource.data.notes is string && request.resource.data.notes.size() <= 5000)
+          );
+        allow delete: if clientMatches(clientId) &&
+          (isAdmin() || producerCanAccessProject(clientId, projectId) ||
+           hasProjectRole(projectId, ['producer', 'warehouse']));
+      }
+
       // Wildcard catch-all for any other project sub-collections
       // Includes 'crew' for consistency with explicit sub-resource rules above.
       match /{collectionId}/{docId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -749,7 +749,11 @@ service cloud.firestore {
           (
             !('sceneNumber' in request.resource.data) ||
             request.resource.data.sceneNumber == null ||
-            (request.resource.data.sceneNumber is int && request.resource.data.sceneNumber >= 1)
+            (
+              request.resource.data.sceneNumber is int &&
+              request.resource.data.sceneNumber >= 1 &&
+              request.resource.data.sceneNumber <= 9999
+            )
           );
         allow delete: if clientMatches(clientId) &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||

--- a/firestore.rules
+++ b/firestore.rules
@@ -726,8 +726,9 @@ service cloud.firestore {
           (isAdmin() || isProducer());
       }
 
-      // Lanes (Scenes) — explicit rule with size validation on direction and notes.
-      // Must come BEFORE the wildcard catch-all so it takes precedence.
+      // Lanes (Scenes) — explicit rule with size validation on direction/notes
+      // and positive-integer validation on sceneNumber. Must come BEFORE the
+      // wildcard catch-all so it takes precedence.
       match /lanes/{laneId} {
         allow read: if clientMatches(clientId) &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||
@@ -744,6 +745,11 @@ service cloud.firestore {
             !('notes' in request.resource.data) ||
             request.resource.data.notes == null ||
             (request.resource.data.notes is string && request.resource.data.notes.size() <= 5000)
+          ) &&
+          (
+            !('sceneNumber' in request.resource.data) ||
+            request.resource.data.sceneNumber == null ||
+            (request.resource.data.sceneNumber is int && request.resource.data.sceneNumber >= 1)
           );
         allow delete: if clientMatches(clientId) &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||

--- a/mockups/s29-scene-enhancements.html
+++ b/mockups/s29-scene-enhancements.html
@@ -1,0 +1,1719 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>S29 — Scene Enhancements · Production Hub Mockup</title>
+  <script>
+    (function() {
+      var stored = localStorage.getItem('sb:theme');
+      if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.documentElement.classList.add('dark');
+      }
+    })();
+  </script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    /* ============================================
+     * DESIGN TOKENS — Light Mode (default)
+     * ============================================ */
+    :root {
+      --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+
+      /* Surfaces */
+      --color-bg: #fafafa;
+      --color-surface: #ffffff;
+      --color-surface-subtle: #f4f4f5;
+
+      /* Text */
+      --color-text: #18181b;
+      --color-text-secondary: #52525b;
+      --color-text-muted: #71717a;
+      --color-text-subtle: #a1a1aa;
+
+      /* Borders */
+      --color-border: #e4e4e7;
+      --color-border-strong: #d4d4d8;
+
+      /* Primary */
+      --color-primary: #18181b;
+      --color-primary-text: #ffffff;
+
+      /* Status */
+      --color-status-gray-bg: #f4f4f5;
+      --color-status-gray-text: #3f3f46;
+      --color-status-blue-bg: #eff6ff;
+      --color-status-blue-text: #1d4ed8;
+      --color-status-green-bg: #ecfdf5;
+      --color-status-green-text: #047857;
+      --color-status-amber-bg: #fffbeb;
+      --color-status-amber-text: #b45309;
+
+      /* Table */
+      --color-table-header-border: #d4d4d8;
+      --color-table-row-border: rgba(212, 212, 216, 0.44);
+      --color-table-row-hover: #fafafa;
+
+      /* Shadows */
+      --shadow-sm: 0 1px 2px 0 rgba(0,0,0,0.04);
+      --shadow-md: 0 2px 4px -1px rgba(0,0,0,0.07), 0 1px 2px -1px rgba(0,0,0,0.04);
+      --shadow-lg: 0 4px 12px -2px rgba(0,0,0,0.10), 0 2px 4px -2px rgba(0,0,0,0.05);
+      --shadow-xl: 0 8px 24px -4px rgba(0,0,0,0.12), 0 4px 8px -4px rgba(0,0,0,0.06);
+      --shadow-sheet: 0 16px 48px -8px rgba(0,0,0,0.16), 0 8px 16px -4px rgba(0,0,0,0.08);
+
+      /* Overlay */
+      --color-overlay: rgba(0, 0, 0, 0.3);
+
+      /* Radius */
+      --radius-sm: 4px;
+      --radius-md: 6px;
+      --radius-lg: 8px;
+
+      /* Scene Colors */
+      --scene-teal: #14b8a6;
+      --scene-purple: #a78bfa;
+      --scene-green: #22c55e;
+      --scene-orange: #fb923c;
+      --scene-pink: #fb7185;
+      --scene-blue: #3b82f6;
+    }
+
+    /* ============================================
+     * DARK MODE
+     * ============================================ */
+    .dark {
+      --color-bg: #09090b;
+      --color-surface: #18181b;
+      --color-surface-subtle: #1c1c1f;
+
+      --color-text: #fafafa;
+      --color-text-secondary: #d4d4d8;
+      --color-text-muted: #a1a1aa;
+      --color-text-subtle: #71717a;
+
+      --color-border: #3f3f46;
+      --color-border-strong: #52525b;
+
+      --color-primary: #fafafa;
+      --color-primary-text: #18181b;
+
+      --color-status-gray-bg: #27272a;
+      --color-status-gray-text: #d4d4d8;
+      --color-status-blue-bg: #172554;
+      --color-status-blue-text: #93c5fd;
+      --color-status-green-bg: #052e16;
+      --color-status-green-text: #6ee7b7;
+      --color-status-amber-bg: #451a03;
+      --color-status-amber-text: #fcd34d;
+
+      --color-table-header-border: #52525b;
+      --color-table-row-border: rgba(63, 63, 70, 0.44);
+      --color-table-row-hover: #27272a;
+
+      --shadow-sm: 0 1px 2px 0 rgba(0,0,0,0.2);
+      --shadow-md: 0 2px 4px -1px rgba(0,0,0,0.3), 0 1px 2px -1px rgba(0,0,0,0.2);
+      --shadow-lg: 0 4px 12px -2px rgba(0,0,0,0.4), 0 2px 4px -2px rgba(0,0,0,0.25);
+      --shadow-xl: 0 8px 24px -4px rgba(0,0,0,0.5), 0 4px 8px -4px rgba(0,0,0,0.3);
+      --shadow-sheet: 0 16px 48px -8px rgba(0,0,0,0.6), 0 8px 16px -4px rgba(0,0,0,0.4);
+
+      --color-overlay: rgba(0, 0, 0, 0.6);
+    }
+
+    /* ============================================
+     * RESET & BASE
+     * ============================================ */
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    html { font-size: 14px; scroll-behavior: smooth; }
+    body {
+      font-family: var(--font-sans);
+      font-size: 14px;
+      line-height: 1.5;
+      color: var(--color-text);
+      background: var(--color-bg);
+      -webkit-font-smoothing: antialiased;
+      -moz-osx-font-smoothing: grayscale;
+      transition: background 200ms, color 200ms;
+    }
+
+    /* ============================================
+     * TYPOGRAPHY
+     * ============================================ */
+    .heading-page {
+      font-size: 1.25rem;
+      font-weight: 300;
+      letter-spacing: -0.02em;
+      line-height: 1.2;
+      color: var(--color-text);
+    }
+    .heading-section {
+      font-size: 0.875rem;
+      font-weight: 600;
+      color: var(--color-text);
+      letter-spacing: -0.01em;
+    }
+    .heading-subsection {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+    .label-meta {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--color-text-muted);
+    }
+    .label-sprint {
+      font-size: 0.5625rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.14em;
+      color: var(--scene-blue);
+    }
+
+    /* ============================================
+     * MOCKUP LAYOUT
+     * ============================================ */
+    .mockup-container {
+      max-width: 1280px;
+      margin: 0 auto;
+      padding: 0 1.5rem;
+    }
+
+    .mockup-hero {
+      padding: 3.5rem 0 2.5rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .mockup-hero h1 {
+      font-size: 2rem;
+      font-weight: 300;
+      letter-spacing: -0.035em;
+      line-height: 1.2;
+      color: var(--color-text);
+    }
+    .mockup-hero p {
+      font-size: 0.875rem;
+      color: var(--color-text-muted);
+      max-width: 640px;
+      line-height: 1.6;
+    }
+
+    /* Section container */
+    .mockup-section {
+      padding: 3rem 0;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .mockup-section:last-child {
+      border-bottom: none;
+    }
+
+    .section-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .section-num {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 28px;
+      height: 28px;
+      border-radius: 9999px;
+      background: var(--color-surface-subtle);
+      border: 1px solid var(--color-border);
+      font-size: 0.75rem;
+      font-weight: 700;
+      color: var(--color-text-muted);
+      flex-shrink: 0;
+    }
+
+    /* ============================================
+     * THEME TOGGLE
+     * ============================================ */
+    .theme-toggle {
+      position: fixed;
+      top: 1rem;
+      right: 1rem;
+      z-index: 1000;
+      display: flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      font-size: 0.75rem;
+      font-weight: 500;
+      color: var(--color-text-muted);
+      cursor: pointer;
+      box-shadow: var(--shadow-md);
+      transition: all 150ms;
+    }
+    .theme-toggle:hover {
+      color: var(--color-text);
+      border-color: var(--color-border-strong);
+    }
+
+    /* ============================================
+     * FRAME — simulates the app chrome
+     * ============================================ */
+    .mockup-frame {
+      background: var(--color-surface-subtle);
+      border: 1px solid var(--color-border);
+      border-radius: 0.625rem;
+      overflow: hidden;
+    }
+    .frame-chrome {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.625rem 1rem;
+      background: var(--color-surface);
+      border-bottom: 1px solid var(--color-border);
+    }
+    .frame-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 9999px;
+      background: var(--color-border);
+    }
+    .frame-breadcrumb {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      font-size: 0.6875rem;
+      color: var(--color-text-subtle);
+      gap: 0.25rem;
+    }
+    .frame-breadcrumb span:last-child {
+      color: var(--color-text-muted);
+    }
+
+    /* ============================================
+     * BADGE
+     * ============================================ */
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.125rem 0.5rem;
+      border-radius: 9999px;
+      font-size: 0.6875rem;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+    .badge-gray {
+      background: var(--color-status-gray-bg);
+      color: var(--color-status-gray-text);
+    }
+    .badge-blue {
+      background: var(--color-status-blue-bg);
+      color: var(--color-status-blue-text);
+    }
+    .badge-green {
+      background: var(--color-status-green-bg);
+      color: var(--color-status-green-text);
+    }
+    .badge-amber {
+      background: var(--color-status-amber-bg);
+      color: var(--color-status-amber-text);
+    }
+
+    /* Count badge (small pill) */
+    .count-badge {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 20px;
+      height: 18px;
+      padding: 0 0.375rem;
+      border-radius: 9999px;
+      font-size: 0.625rem;
+      font-weight: 600;
+      background: var(--color-surface-subtle);
+      color: var(--color-text-muted);
+      border: 1px solid var(--color-border);
+    }
+
+    /* Scene badge (colored dot + name) */
+    .scene-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.125rem 0.5rem 0.125rem 0.375rem;
+      border-radius: var(--radius-sm);
+      font-size: 0.6875rem;
+      font-weight: 500;
+      background: var(--color-surface-subtle);
+      color: var(--color-text-secondary);
+    }
+    .scene-dot {
+      width: 8px;
+      height: 8px;
+      border-radius: 9999px;
+      flex-shrink: 0;
+    }
+    .scene-dot-sm {
+      width: 6px;
+      height: 6px;
+      border-radius: 9999px;
+      flex-shrink: 0;
+    }
+
+    /* ============================================
+     * TABLE — Shots
+     * ============================================ */
+    .shots-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .shots-table thead th {
+      padding: 0.5rem 0.75rem;
+      text-align: left;
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--color-text-muted);
+      border-bottom: 1px solid var(--color-table-header-border);
+      white-space: nowrap;
+      background: var(--color-surface);
+    }
+    .shots-table tbody tr {
+      border-bottom: 1px solid var(--color-table-row-border);
+      transition: background 100ms;
+    }
+    .shots-table tbody tr:hover {
+      background: var(--color-table-row-hover);
+    }
+    .shots-table tbody td {
+      padding: 0.625rem 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--color-text);
+      vertical-align: middle;
+    }
+
+    /* Checkbox */
+    .checkbox {
+      width: 14px;
+      height: 14px;
+      border: 1.5px solid var(--color-border-strong);
+      border-radius: 3px;
+      flex-shrink: 0;
+      cursor: pointer;
+    }
+
+    /* ============================================
+     * SCENE HEADER ROW
+     * ============================================ */
+    .scene-header-row td {
+      padding: 0 !important;
+    }
+    .scene-header-bar {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      background: var(--color-surface-subtle);
+      cursor: pointer;
+      transition: background 100ms;
+      position: relative;
+    }
+    .scene-header-bar:hover {
+      background: var(--color-table-row-hover);
+    }
+    .scene-header-bar::before {
+      content: '';
+      position: absolute;
+      left: 0;
+      top: 0;
+      bottom: 0;
+      width: 3px;
+      border-radius: 0 2px 2px 0;
+    }
+    .scene-header-bar .chevron {
+      width: 16px;
+      height: 16px;
+      color: var(--color-text-subtle);
+      transition: transform 200ms;
+      flex-shrink: 0;
+    }
+    .scene-header-bar .chevron.collapsed {
+      transform: rotate(-90deg);
+    }
+    .scene-header-bar .scene-name {
+      font-size: 0.8125rem;
+      font-weight: 600;
+      color: var(--color-text);
+      flex: 1;
+    }
+    .scene-header-bar .scene-count {
+      font-size: 0.6875rem;
+      color: var(--color-text-muted);
+    }
+    .scene-header-bar .kebab {
+      width: 16px;
+      height: 16px;
+      color: var(--color-text-subtle);
+      cursor: pointer;
+      opacity: 0;
+      transition: opacity 150ms;
+    }
+    .scene-header-bar:hover .kebab {
+      opacity: 1;
+    }
+
+    /* ============================================
+     * SHEET (slide-over panel)
+     * ============================================ */
+    .sheet-overlay {
+      position: relative;
+      display: flex;
+      height: 560px;
+      overflow: hidden;
+      border-radius: 0.625rem;
+      border: 1px solid var(--color-border);
+    }
+    .sheet-backdrop {
+      flex: 1;
+      background: var(--color-bg);
+      opacity: 0.6;
+    }
+    .sheet-panel {
+      width: 420px;
+      background: var(--color-surface);
+      border-left: 1px solid var(--color-border);
+      box-shadow: var(--shadow-sheet);
+      display: flex;
+      flex-direction: column;
+      overflow-y: auto;
+    }
+    .sheet-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .sheet-close {
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      border-radius: var(--radius-sm);
+      color: var(--color-text-muted);
+      cursor: pointer;
+      transition: all 120ms;
+      border: none;
+      background: transparent;
+    }
+    .sheet-close:hover {
+      background: var(--color-surface-subtle);
+      color: var(--color-text);
+    }
+    .sheet-body {
+      padding: 1.25rem;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 1.25rem;
+    }
+
+    /* Field group */
+    .field-group {
+      display: flex;
+      flex-direction: column;
+      gap: 0.375rem;
+    }
+    .field-label {
+      font-size: 0.6875rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--color-text-muted);
+    }
+    .field-input {
+      width: 100%;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.875rem;
+      color: var(--color-text);
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      outline: none;
+      font-family: var(--font-sans);
+      transition: border-color 150ms;
+    }
+    .field-input:focus {
+      border-color: var(--color-border-strong);
+    }
+    .field-input::placeholder {
+      color: var(--color-text-subtle);
+    }
+    .field-hint {
+      font-size: 0.6875rem;
+      color: var(--color-text-subtle);
+    }
+    textarea.field-input {
+      resize: vertical;
+      line-height: 1.5;
+    }
+
+    /* Color swatches */
+    .color-swatches {
+      display: flex;
+      gap: 0.5rem;
+    }
+    .color-swatch {
+      width: 28px;
+      height: 28px;
+      border-radius: 9999px;
+      cursor: pointer;
+      border: 2px solid transparent;
+      transition: all 150ms;
+      position: relative;
+    }
+    .color-swatch:hover {
+      transform: scale(1.1);
+    }
+    .color-swatch.active {
+      border-color: var(--color-text);
+      box-shadow: 0 0 0 2px var(--color-bg);
+    }
+    .color-swatch.active::after {
+      content: '';
+      position: absolute;
+      inset: 4px;
+      border-radius: 9999px;
+      border: 2px solid rgba(255,255,255,0.4);
+    }
+
+    /* ============================================
+     * CONTEXT BANNER
+     * ============================================ */
+    .context-banner {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.5rem 0.75rem;
+      background: var(--color-surface-subtle);
+      border-bottom: 1px solid var(--color-border);
+      cursor: pointer;
+      transition: background 120ms;
+    }
+    .context-banner:hover {
+      background: var(--color-table-row-hover);
+    }
+    .context-banner .direction-preview {
+      font-size: 0.75rem;
+      color: var(--color-text-muted);
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      flex: 1;
+    }
+    .context-banner .view-link {
+      font-size: 0.6875rem;
+      font-weight: 500;
+      color: var(--scene-blue);
+      white-space: nowrap;
+      flex-shrink: 0;
+    }
+
+    /* Shot detail header */
+    .shot-detail-header {
+      padding: 1.25rem 1.5rem;
+      border-bottom: 1px solid var(--color-border);
+      background: var(--color-surface);
+    }
+    .shot-title {
+      font-size: 1.125rem;
+      font-weight: 300;
+      letter-spacing: -0.015em;
+      color: var(--color-text);
+    }
+
+    /* ============================================
+     * DIALOG
+     * ============================================ */
+    .dialog-frame {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: 0.75rem;
+      box-shadow: var(--shadow-xl);
+      width: 480px;
+      max-width: 100%;
+      overflow: hidden;
+    }
+    .dialog-header {
+      padding: 1rem 1.25rem;
+      border-bottom: 1px solid var(--color-border);
+    }
+    .dialog-header h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--color-text);
+      letter-spacing: -0.01em;
+    }
+    .dialog-body {
+      padding: 1rem 1.25rem;
+      max-height: 400px;
+      overflow-y: auto;
+    }
+    .dialog-footer {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.75rem 1.25rem;
+      border-top: 1px solid var(--color-border);
+      background: var(--color-surface-subtle);
+    }
+    .dialog-footer-info {
+      font-size: 0.75rem;
+      color: var(--color-text-muted);
+    }
+
+    /* Buttons */
+    .btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.375rem;
+      padding: 0.5rem 1rem;
+      border-radius: var(--radius-md);
+      font-size: 0.8125rem;
+      font-weight: 500;
+      cursor: pointer;
+      border: none;
+      transition: all 120ms;
+      white-space: nowrap;
+      font-family: var(--font-sans);
+    }
+    .btn-primary {
+      background: var(--color-primary);
+      color: var(--color-primary-text);
+    }
+    .btn-primary:hover {
+      opacity: 0.9;
+    }
+    .btn-ghost {
+      background: transparent;
+      color: var(--color-text-muted);
+      border: 1px solid var(--color-border);
+    }
+    .btn-ghost:hover {
+      color: var(--color-text);
+      border-color: var(--color-border-strong);
+      background: var(--color-surface-subtle);
+    }
+
+    /* Toggle tabs */
+    .toggle-group {
+      display: inline-flex;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      overflow: hidden;
+    }
+    .toggle-tab {
+      padding: 0.375rem 0.875rem;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--color-text-muted);
+      cursor: pointer;
+      border: none;
+      background: transparent;
+      transition: all 120ms;
+      font-family: var(--font-sans);
+    }
+    .toggle-tab:not(:last-child) {
+      border-right: 1px solid var(--color-border);
+    }
+    .toggle-tab:hover {
+      color: var(--color-text);
+    }
+    .toggle-tab.active {
+      background: var(--color-primary);
+      color: var(--color-primary-text);
+    }
+
+    /* Renumber preview table */
+    .renumber-table {
+      width: 100%;
+      border-collapse: collapse;
+    }
+    .renumber-table .group-header td {
+      padding: 0.625rem 0;
+      font-size: 0.75rem;
+      font-weight: 600;
+      color: var(--color-text);
+    }
+    .renumber-table .group-header:not(:first-child) td {
+      padding-top: 1rem;
+    }
+    .renumber-table .renumber-row td {
+      padding: 0.375rem 0;
+      font-size: 0.8125rem;
+      color: var(--color-text-secondary);
+    }
+    .renumber-arrow {
+      color: var(--color-text-subtle);
+      padding: 0 0.5rem;
+    }
+    .renumber-new {
+      font-weight: 600;
+      color: var(--color-text);
+    }
+
+    /* ============================================
+     * POPOVER
+     * ============================================ */
+    .popover {
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: 0.5rem;
+      box-shadow: var(--shadow-xl);
+      min-width: 240px;
+      overflow: hidden;
+    }
+    .popover-item {
+      display: flex;
+      align-items: center;
+      gap: 0.625rem;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--color-text);
+      cursor: pointer;
+      transition: background 100ms;
+    }
+    .popover-item:hover {
+      background: var(--color-table-row-hover);
+    }
+    .popover-item.muted {
+      color: var(--color-text-muted);
+    }
+    .popover-item.accent {
+      color: var(--scene-blue);
+      font-weight: 500;
+    }
+    .popover-divider {
+      height: 1px;
+      background: var(--color-border);
+      margin: 0.25rem 0;
+    }
+
+    /* ============================================
+     * NAV CHIPS
+     * ============================================ */
+    .nav-chips {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-top: 1.5rem;
+    }
+    .nav-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.75rem;
+      border-radius: 9999px;
+      font-size: 0.75rem;
+      font-weight: 500;
+      cursor: pointer;
+      text-decoration: none;
+      transition: opacity 150ms;
+      border: none;
+      font-family: var(--font-sans);
+    }
+    .nav-chip:hover { opacity: 0.85; }
+
+    /* Chip variants with scene colors */
+    .chip-teal { background: rgba(20,184,166,0.12); color: #14b8a6; border: 1px solid rgba(20,184,166,0.2); }
+    .chip-purple { background: rgba(167,139,250,0.12); color: #a78bfa; border: 1px solid rgba(167,139,250,0.2); }
+    .chip-green { background: rgba(34,197,94,0.12); color: #22c55e; border: 1px solid rgba(34,197,94,0.2); }
+    .chip-orange { background: rgba(251,146,60,0.12); color: #fb923c; border: 1px solid rgba(251,146,60,0.2); }
+    .chip-pink { background: rgba(251,113,133,0.12); color: #fb7185; border: 1px solid rgba(251,113,133,0.2); }
+
+    /* ============================================
+     * SCROLLBAR
+     * ============================================ */
+    ::-webkit-scrollbar { width: 6px; height: 6px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--color-border); border-radius: 3px; }
+
+    /* ============================================
+     * TOOLBAR BUTTON
+     * ============================================ */
+    .toolbar-btn {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.375rem;
+      padding: 0.375rem 0.625rem;
+      background: transparent;
+      border: 1px solid var(--color-border);
+      border-radius: var(--radius-md);
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--color-text-muted);
+      cursor: pointer;
+      white-space: nowrap;
+      transition: all 120ms;
+      font-family: var(--font-sans);
+    }
+    .toolbar-btn:hover {
+      color: var(--color-text);
+      border-color: var(--color-border-strong);
+      background: var(--color-surface-subtle);
+    }
+
+    /* ============================================
+     * SVG ICONS — inline helpers
+     * ============================================ */
+    .icon-sm { width: 14px; height: 14px; flex-shrink: 0; }
+    .icon-xs { width: 12px; height: 12px; flex-shrink: 0; }
+
+    /* ============================================
+     * UTILITIES
+     * ============================================ */
+    .flex { display: flex; }
+    .flex-col { flex-direction: column; }
+    .items-center { align-items: center; }
+    .items-start { align-items: flex-start; }
+    .justify-between { justify-content: space-between; }
+    .justify-center { justify-content: center; }
+    .gap-1 { gap: 0.25rem; }
+    .gap-2 { gap: 0.5rem; }
+    .gap-3 { gap: 0.75rem; }
+    .gap-4 { gap: 1rem; }
+    .gap-5 { gap: 1.25rem; }
+    .flex-1 { flex: 1; }
+    .w-full { width: 100%; }
+    .mt-1 { margin-top: 0.25rem; }
+    .mt-2 { margin-top: 0.5rem; }
+    .mt-3 { margin-top: 0.75rem; }
+    .mt-4 { margin-top: 1rem; }
+    .mb-1 { margin-bottom: 0.25rem; }
+    .mb-2 { margin-bottom: 0.5rem; }
+    .ml-auto { margin-left: auto; }
+    .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .opacity-50 { opacity: 0.5; }
+    .text-center { text-align: center; }
+    .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); border: 0; }
+  </style>
+</head>
+<body>
+
+  <!-- THEME TOGGLE -->
+  <button class="theme-toggle" onclick="toggleTheme()" id="themeToggle">
+    <svg id="sunIcon" class="icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="display:none"><circle cx="12" cy="12" r="5" stroke-width="2"/><path stroke-linecap="round" stroke-width="2" d="M12 1v2m0 18v2M4.22 4.22l1.42 1.42m12.72 12.72l1.42 1.42M1 12h2m18 0h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/></svg>
+    <svg id="moonIcon" class="icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"/></svg>
+    <span id="themeLabel">Dark</span>
+  </button>
+
+  <!-- ============================================================ -->
+  <!-- HERO                                                          -->
+  <!-- ============================================================ -->
+  <div class="mockup-container">
+    <div class="mockup-hero">
+      <p class="label-sprint" style="margin-bottom:0.75rem">Sprint S29</p>
+      <h1>Scene Enhancements</h1>
+      <p style="margin-top:0.75rem;">
+        Scene grouping in table view, detail sheet for editing scene metadata, context banners in shot detail, renumbering by scene with letter suffixes, and a scene assignment popover. Five interconnected surfaces that make scenes a first-class organizational unit.
+      </p>
+      <div class="nav-chips">
+        <a href="#section-1" class="nav-chip chip-teal">1. Table Grouping</a>
+        <a href="#section-2" class="nav-chip chip-purple">2. Detail Sheet</a>
+        <a href="#section-3" class="nav-chip chip-green">3. Context Banner</a>
+        <a href="#section-4" class="nav-chip chip-orange">4. Renumber Dialog</a>
+        <a href="#section-5" class="nav-chip chip-pink">5. Assign Popover</a>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 1: TABLE VIEW WITH SCENE GROUPING                     -->
+    <!-- ============================================================ -->
+    <div class="mockup-section" id="section-1">
+      <div class="section-header">
+        <div class="section-num">1</div>
+        <div>
+          <p class="label-meta">Table View</p>
+          <h2 class="heading-page" style="margin-top:0.125rem">Scene-Grouped Shot Table</h2>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.375rem;max-width:560px;">
+            Scenes appear as collapsible header rows between shot rows. Each header has a colored left bar, chevron toggle, shot count, and kebab menu. Shot numbers use letter suffixes within scenes. The "Ungrouped" section shows flat-numbered shots at the bottom.
+          </p>
+        </div>
+      </div>
+
+      <div class="mockup-frame">
+        <!-- Chrome bar -->
+        <div class="frame-chrome">
+          <div class="frame-dot"></div>
+          <div class="frame-dot"></div>
+          <div class="frame-dot"></div>
+          <div class="frame-breadcrumb">
+            <span>Spring 2026</span>
+            <span>/</span>
+            <span>Shots</span>
+          </div>
+        </div>
+
+        <!-- Page header -->
+        <div style="display:flex;align-items:center;justify-content:space-between;padding:0.875rem 1.25rem;border-bottom:1px solid var(--color-border);background:var(--color-surface);">
+          <div>
+            <p style="font-size:0.625rem;color:var(--color-text-subtle);margin-bottom:0.125rem;">Spring 2026</p>
+            <h1 class="heading-page">Shots</h1>
+          </div>
+          <button class="btn btn-primary" style="font-size:0.8125rem;padding:0.375rem 0.75rem;">
+            <svg class="icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M12 4v16m8-8H4"/></svg>
+            Add Shot
+          </button>
+        </div>
+
+        <!-- Toolbar -->
+        <div style="display:flex;align-items:center;gap:0.5rem;padding:0.5rem 1.25rem;border-bottom:1px solid var(--color-border);background:var(--color-surface);flex-wrap:wrap;">
+          <!-- Search -->
+          <div style="position:relative;flex-shrink:0;">
+            <svg style="position:absolute;left:0.625rem;top:50%;transform:translateY(-50%);" class="icon-sm" fill="none" stroke="var(--color-text-subtle)" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"/></svg>
+            <input type="text" placeholder="Search shots..." class="field-input" style="padding-left:2rem;max-width:200px;font-size:0.8125rem;padding-top:0.375rem;padding-bottom:0.375rem;" readonly>
+          </div>
+
+          <div style="width:1px;height:20px;background:var(--color-border);flex-shrink:0;"></div>
+
+          <button class="toolbar-btn">
+            <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7h18M6 12h12M9 17h6"/></svg>
+            Sort: Shot #
+          </button>
+          <button class="toolbar-btn" style="background:var(--color-surface-subtle);">
+            <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+            Group: Scene
+          </button>
+          <button class="toolbar-btn">
+            <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"/></svg>
+            Filter
+          </button>
+
+          <div style="flex:1;"></div>
+
+          <button class="toolbar-btn">
+            <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17V7m0 10a2 2 0 01-2 2H5a2 2 0 01-2-2V7a2 2 0 012-2h2a2 2 0 012 2m0 10a2 2 0 002 2h2a2 2 0 002-2M9 7a2 2 0 012-2h2a2 2 0 012 2m0 10V7"/></svg>
+            Columns
+          </button>
+        </div>
+
+        <!-- TABLE -->
+        <div style="background:var(--color-surface);overflow-x:auto;">
+          <table class="shots-table">
+            <thead>
+              <tr>
+                <th style="width:40px;"><div class="checkbox"></div></th>
+                <th style="width:48px;">#</th>
+                <th style="min-width:220px;">Shot</th>
+                <th style="width:90px;">Date</th>
+                <th style="width:140px;">Notes</th>
+                <th style="width:160px;">Scene</th>
+                <th style="width:140px;">Products</th>
+                <th style="width:100px;">Talent</th>
+                <th style="width:100px;">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              <!-- SCENE 1: Outdoor Men's Collection (TEAL) -->
+              <tr class="scene-header-row">
+                <td colspan="9">
+                  <div class="scene-header-bar" style="padding-left:calc(0.75rem + 3px);" onclick="toggleScene('scene1')">
+                    <div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--scene-teal);border-radius:0 2px 2px 0;"></div>
+                    <svg class="chevron" id="scene1-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    <span class="scene-dot" style="background:var(--scene-teal);"></span>
+                    <span class="scene-name">#1 Outdoor Men's Collection</span>
+                    <span class="count-badge">4 shots</span>
+                    <div style="flex:1;"></div>
+                    <svg class="kebab" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01"/></svg>
+                  </div>
+                </td>
+              </tr>
+              <tr id="scene1-row-1">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">1A</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Hero Laydown</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Navy polo centered on marble, overhead angle</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 12</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Iron before shoot</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-teal);"></span>Outdoor Men's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">Navy Polo</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-gray">Draft</span></td>
+              </tr>
+              <tr id="scene1-row-2">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">1B</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Model Walk</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Full body, walking toward camera, urban park</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 12</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Golden hour only</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-teal);"></span>Outdoor Men's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">Navy Polo</span>
+                    <span class="badge badge-gray" style="opacity:0.7;">+1</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;">Marcus R.</td>
+                <td><span class="badge badge-blue">In Progress</span></td>
+              </tr>
+              <tr id="scene1-row-3">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">1C</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Detail Close-up</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Collar and button detail, shallow DoF</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 12</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-teal);"></span>Outdoor Men's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">Navy Polo</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-gray">Draft</span></td>
+              </tr>
+              <tr id="scene1-row-4">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">1D</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Lifestyle Group</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Three models, cafe terrace, relaxed conversation</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 13</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Need permit for cafe</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-teal);"></span>Outdoor Men's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">White Tee</span>
+                    <span class="badge badge-gray" style="opacity:0.7;">+2</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;">Marcus R.</td>
+                <td><span class="badge badge-green">Shot</span></td>
+              </tr>
+
+              <!-- SCENE 2: Studio Women's (PURPLE) — COLLAPSED -->
+              <tr class="scene-header-row">
+                <td colspan="9">
+                  <div class="scene-header-bar" style="padding-left:calc(0.75rem + 3px);" onclick="toggleScene('scene2')">
+                    <div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--scene-purple);border-radius:0 2px 2px 0;"></div>
+                    <svg class="chevron collapsed" id="scene2-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    <span class="scene-dot" style="background:var(--scene-purple);"></span>
+                    <span class="scene-name">#2 Studio Women's</span>
+                    <span class="count-badge">3 shots</span>
+                    <div style="flex:1;"></div>
+                    <svg class="kebab" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01"/></svg>
+                  </div>
+                </td>
+              </tr>
+              <!-- Scene 2 rows hidden (collapsed) -->
+              <tr id="scene2-row-1" style="display:none;">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">2A</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Full Body Standing</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Seamless white backdrop, neutral pose</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 14</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-purple);"></span>Studio Women's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1"><span class="badge badge-gray">Silk Blouse</span></div>
+                </td>
+                <td style="font-size:0.8125rem;">Elena K.</td>
+                <td><span class="badge badge-blue">In Progress</span></td>
+              </tr>
+              <tr id="scene2-row-2" style="display:none;">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">2B</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Seated Pose</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Mid-century chair, three-quarter angle</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 14</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Chair arrives morning of</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-purple);"></span>Studio Women's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1"><span class="badge badge-gray">Linen Trousers</span></div>
+                </td>
+                <td style="font-size:0.8125rem;">Elena K.</td>
+                <td><span class="badge badge-amber">On Hold</span></td>
+              </tr>
+              <tr id="scene2-row-3" style="display:none;">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">2C</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Detail Neckline</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Close crop on blouse collar and buttons</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 14</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-purple);"></span>Studio Women's</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1"><span class="badge badge-gray">Silk Blouse</span></div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-gray">Draft</span></td>
+              </tr>
+
+              <!-- SCENE 3: Accessories Flatlay (GREEN) -->
+              <tr class="scene-header-row">
+                <td colspan="9">
+                  <div class="scene-header-bar" style="padding-left:calc(0.75rem + 3px);" onclick="toggleScene('scene3')">
+                    <div style="position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--scene-green);border-radius:0 2px 2px 0;"></div>
+                    <svg class="chevron" id="scene3-chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    <span class="scene-dot" style="background:var(--scene-green);"></span>
+                    <span class="scene-name">#3 Accessories Flatlay</span>
+                    <span class="count-badge">3 shots</span>
+                    <div style="flex:1;"></div>
+                    <svg class="kebab" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 5v.01M12 12v.01M12 19v.01"/></svg>
+                  </div>
+                </td>
+              </tr>
+              <tr id="scene3-row-1">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">3A</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Watch + Belt Pair</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Overhead, dark slate surface, diagonal composition</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 15</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Clean slate surface</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-green);"></span>Accessories</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">Leather Belt</span>
+                    <span class="badge badge-gray" style="opacity:0.7;">+1</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-gray">Draft</span></td>
+              </tr>
+              <tr id="scene3-row-2">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">3B</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Sunglasses Hero</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Single pair, angled reflection, soft shadow</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 15</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-green);"></span>Accessories</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1"><span class="badge badge-gray">Aviator Shades</span></div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-green">Shot</span></td>
+              </tr>
+              <tr id="scene3-row-3">
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">3C</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Full Collection Grid</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">All accessories in a 3x3 grid arrangement</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 15</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Needs styling assist</td>
+                <td>
+                  <span class="scene-badge"><span class="scene-dot-sm" style="background:var(--scene-green);"></span>Accessories</span>
+                </td>
+                <td>
+                  <div class="flex items-center gap-1">
+                    <span class="badge badge-gray">Mixed</span>
+                    <span class="badge badge-gray" style="opacity:0.7;">+4</span>
+                  </div>
+                </td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-blue">In Progress</span></td>
+              </tr>
+
+              <!-- UNGROUPED -->
+              <tr class="scene-header-row">
+                <td colspan="9">
+                  <div class="scene-header-bar" style="padding-left:calc(0.75rem + 3px);">
+                    <svg class="chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                    <span class="scene-name" style="color:var(--color-text-muted);font-weight:500;">Ungrouped</span>
+                    <span class="count-badge">2 shots</span>
+                  </div>
+                </td>
+              </tr>
+              <tr>
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">4</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">BTS Reel Captures</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Handheld, candid behind-the-scenes moments</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 12</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Video team handles</td>
+                <td style="font-size:0.75rem;color:var(--color-text-subtle);">--</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td style="font-size:0.8125rem;color:var(--color-text-muted);">--</td>
+                <td><span class="badge badge-gray">Draft</span></td>
+              </tr>
+              <tr>
+                <td><div class="checkbox"></div></td>
+                <td style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);">5</td>
+                <td>
+                  <div style="font-weight:500;color:var(--color-text);">Location Scouting Ref</div>
+                  <div style="font-size:0.75rem;color:var(--color-text-muted);margin-top:0.125rem;">Reference shots for approved exterior locations</div>
+                </td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Apr 10</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">Pre-visit required</td>
+                <td style="font-size:0.75rem;color:var(--color-text-subtle);">--</td>
+                <td style="font-size:0.75rem;color:var(--color-text-muted);">--</td>
+                <td style="font-size:0.8125rem;">Ted G.</td>
+                <td><span class="badge badge-green">Shot</span></td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 2: SCENE DETAIL SHEET                                 -->
+    <!-- ============================================================ -->
+    <div class="mockup-section" id="section-2">
+      <div class="section-header">
+        <div class="section-num">2</div>
+        <div>
+          <p class="label-meta">Right Slide-Over</p>
+          <h2 class="heading-page" style="margin-top:0.125rem">Scene Detail Sheet</h2>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.375rem;max-width:560px;">
+            Clicking a scene header opens a right-side sheet with editable name, number, color, creative direction, and production notes. The sheet provides full scene metadata editing without leaving the shots view.
+          </p>
+        </div>
+      </div>
+
+      <div class="sheet-overlay">
+        <!-- Background (faded table) -->
+        <div class="sheet-backdrop" style="display:flex;flex-direction:column;">
+          <div style="padding:1rem 1.25rem;border-bottom:1px solid var(--color-border);opacity:0.4;">
+            <h1 class="heading-page">Shots</h1>
+          </div>
+          <div style="flex:1;display:flex;align-items:center;justify-content:center;opacity:0.3;">
+            <p style="font-size:0.8125rem;color:var(--color-text-muted);">Shot table content (dimmed)</p>
+          </div>
+        </div>
+
+        <!-- Sheet panel -->
+        <div class="sheet-panel">
+          <div class="sheet-header">
+            <div class="flex items-center gap-3">
+              <span class="scene-dot" style="background:var(--scene-teal);width:10px;height:10px;"></span>
+              <span class="heading-section">Scene Details</span>
+            </div>
+            <button class="sheet-close">
+              <svg class="icon-sm" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
+          </div>
+
+          <div class="sheet-body">
+            <!-- Scene Name -->
+            <div class="field-group">
+              <label class="field-label">Scene Name</label>
+              <input type="text" class="field-input" value="Outdoor Men's Collection" style="font-size:1rem;font-weight:500;">
+            </div>
+
+            <!-- Scene Number -->
+            <div class="field-group">
+              <label class="field-label">Scene Number</label>
+              <div class="flex items-center gap-2">
+                <input type="number" class="field-input" value="1" style="width:80px;text-align:center;">
+                <span class="field-hint">Auto-suggest: next available is 4</span>
+              </div>
+            </div>
+
+            <!-- Color -->
+            <div class="field-group">
+              <label class="field-label">Color</label>
+              <div class="color-swatches">
+                <div class="color-swatch active" style="background:var(--scene-teal);"></div>
+                <div class="color-swatch" style="background:var(--scene-purple);"></div>
+                <div class="color-swatch" style="background:var(--scene-green);"></div>
+                <div class="color-swatch" style="background:var(--scene-orange);"></div>
+                <div class="color-swatch" style="background:var(--scene-pink);"></div>
+                <div class="color-swatch" style="background:var(--scene-blue);"></div>
+              </div>
+            </div>
+
+            <!-- Creative Direction -->
+            <div class="field-group">
+              <label class="field-label">Creative Direction</label>
+              <textarea class="field-input" rows="3" placeholder="Describe the visual tone, lighting, mood, and styling direction for this scene...">Natural light. Relaxed, editorial poses. Earth tones only. Client wants aspirational but approachable.</textarea>
+            </div>
+
+            <!-- Production Notes -->
+            <div class="field-group">
+              <label class="field-label">Production Notes</label>
+              <textarea class="field-input" rows="5">Setup requires 2 C-stands for bounce, 1 diffusion panel. Cafe terrace reserved 7am-1pm (permit #4821). Talent call time 6:30am for wardrobe. Backup indoor location: Studio B mezzanine. Weather contingency: move to Day 3 afternoon slot.</textarea>
+            </div>
+
+            <!-- Shot count -->
+            <div style="display:flex;align-items:center;gap:0.5rem;padding:0.75rem;background:var(--color-surface-subtle);border-radius:var(--radius-md);border:1px solid var(--color-border);">
+              <svg class="icon-sm" fill="none" stroke="var(--color-text-muted)" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 10h16M4 14h16M4 18h16"/></svg>
+              <span style="font-size:0.8125rem;color:var(--color-text-secondary);">6 shots in this scene</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 3: SCENE CONTEXT BANNER                               -->
+    <!-- ============================================================ -->
+    <div class="mockup-section" id="section-3">
+      <div class="section-header">
+        <div class="section-num">3</div>
+        <div>
+          <p class="label-meta">Shot Detail Page</p>
+          <h2 class="heading-page" style="margin-top:0.125rem">Scene Context Banner</h2>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.375rem;max-width:560px;">
+            When viewing a shot that belongs to a scene, a thin context banner sits above the shot header showing the scene name, color, and a preview of the creative direction. Clicking it opens the scene detail sheet.
+          </p>
+        </div>
+      </div>
+
+      <div class="mockup-frame">
+        <!-- Chrome -->
+        <div class="frame-chrome">
+          <div class="frame-dot"></div>
+          <div class="frame-dot"></div>
+          <div class="frame-dot"></div>
+          <div class="frame-breadcrumb">
+            <span>Spring 2026</span>
+            <span>/</span>
+            <span>Shots</span>
+            <span>/</span>
+            <span>1A</span>
+          </div>
+        </div>
+
+        <!-- Context Banner -->
+        <div class="context-banner">
+          <span class="scene-dot" style="background:var(--scene-teal);"></span>
+          <span style="font-size:0.8125rem;font-weight:600;color:var(--color-text);white-space:nowrap;">#1 Outdoor Men's Collection</span>
+          <span style="width:1px;height:14px;background:var(--color-border);flex-shrink:0;margin:0 0.25rem;"></span>
+          <span class="direction-preview">Natural light. Relaxed, editorial poses. Earth tones only. Client wants aspirational but approachable.</span>
+          <span class="view-link">View scene</span>
+          <svg style="width:12px;height:12px;color:var(--color-text-subtle);flex-shrink:0;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+        </div>
+
+        <!-- Shot Detail Header -->
+        <div class="shot-detail-header">
+          <div class="flex items-center gap-3" style="margin-bottom:0.5rem;">
+            <span style="font-size:0.8125rem;font-weight:600;color:var(--color-text-muted);">1A</span>
+            <span style="width:1px;height:14px;background:var(--color-border);"></span>
+            <span class="badge badge-gray">Draft</span>
+          </div>
+          <h1 class="shot-title">Hero Laydown — Navy Polo</h1>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.25rem;">Navy polo centered on marble, overhead angle</p>
+        </div>
+
+        <!-- Shot detail body placeholder -->
+        <div style="padding:2rem;display:flex;flex-direction:column;gap:1rem;background:var(--color-surface);">
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+            <div style="padding:1rem;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-subtle);">
+              <p class="field-label" style="margin-bottom:0.5rem;">Products</p>
+              <div class="flex items-center gap-2">
+                <div style="width:36px;height:36px;border-radius:var(--radius-sm);background:var(--color-border);display:flex;align-items:center;justify-content:center;">
+                  <svg style="width:16px;height:16px;color:var(--color-text-subtle);" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/></svg>
+                </div>
+                <div>
+                  <p style="font-size:0.8125rem;font-weight:500;color:var(--color-text);">Navy Polo</p>
+                  <p style="font-size:0.6875rem;color:var(--color-text-muted);">S - XL</p>
+                </div>
+              </div>
+            </div>
+            <div style="padding:1rem;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-subtle);">
+              <p class="field-label" style="margin-bottom:0.5rem;">Talent</p>
+              <p style="font-size:0.8125rem;color:var(--color-text-muted);">No talent assigned</p>
+            </div>
+          </div>
+          <div style="padding:1rem;border:1px solid var(--color-border);border-radius:var(--radius-md);background:var(--color-surface-subtle);">
+            <p class="field-label" style="margin-bottom:0.5rem;">Notes</p>
+            <p style="font-size:0.8125rem;color:var(--color-text-secondary);">Iron before shoot. Check marble slab for scuffs and clean thoroughly.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 4: RENUMBER DIALOG — "BY SCENE" MODE                  -->
+    <!-- ============================================================ -->
+    <div class="mockup-section" id="section-4">
+      <div class="section-header">
+        <div class="section-num">4</div>
+        <div>
+          <p class="label-meta">Renumber Dialog</p>
+          <h2 class="heading-page" style="margin-top:0.125rem">Renumber Shots — By Scene Mode</h2>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.375rem;max-width:560px;">
+            The renumber dialog adds a "By Scene" toggle that numbers shots with letter suffixes within each scene. The preview table shows before/after values grouped by scene, with ungrouped shots at the bottom receiving flat sequential numbers.
+          </p>
+        </div>
+      </div>
+
+      <div style="display:flex;justify-content:center;">
+        <div class="dialog-frame">
+          <div class="dialog-header">
+            <h3>Renumber Shots</h3>
+          </div>
+
+          <div class="dialog-body">
+            <!-- Toggle: Sequential | By Scene -->
+            <div class="flex items-center gap-3" style="margin-bottom:1rem;">
+              <span class="field-label" style="text-transform:none;font-size:0.8125rem;font-weight:500;letter-spacing:0;">Mode</span>
+              <div class="toggle-group">
+                <button class="toggle-tab">Sequential</button>
+                <button class="toggle-tab active">By Scene</button>
+              </div>
+            </div>
+
+            <!-- Start number -->
+            <div class="flex items-center gap-3" style="margin-bottom:1.25rem;">
+              <span style="font-size:0.8125rem;color:var(--color-text-secondary);white-space:nowrap;">Start number</span>
+              <input type="number" class="field-input" value="1" style="width:72px;text-align:center;font-size:0.875rem;">
+            </div>
+
+            <!-- Preview table -->
+            <div style="border:1px solid var(--color-border);border-radius:var(--radius-md);padding:0.75rem;background:var(--color-surface-subtle);">
+              <p class="field-label" style="margin-bottom:0.75rem;">Preview</p>
+
+              <table class="renumber-table">
+                <tbody>
+                  <!-- Scene 1 -->
+                  <tr class="group-header">
+                    <td colspan="3">
+                      <div class="flex items-center gap-2">
+                        <span class="scene-dot-sm" style="background:var(--scene-teal);"></span>
+                        <span>Scene 1 — Outdoor Men's</span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="width:50px;padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">03</td>
+                    <td style="width:30px;text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">1A</span></td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">07</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">1B</span></td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">12</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">1C</span></td>
+                  </tr>
+
+                  <!-- Scene 2 -->
+                  <tr class="group-header">
+                    <td colspan="3">
+                      <div class="flex items-center gap-2">
+                        <span class="scene-dot-sm" style="background:var(--scene-purple);"></span>
+                        <span>Scene 2 — Studio Women's</span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">15</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">2A</span></td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">18</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">2B</span></td>
+                  </tr>
+
+                  <!-- Ungrouped -->
+                  <tr class="group-header">
+                    <td colspan="3">
+                      <div class="flex items-center gap-2">
+                        <span style="font-style:italic;color:var(--color-text-muted);">Ungrouped</span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">21</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">3</span></td>
+                  </tr>
+                  <tr class="renumber-row">
+                    <td style="padding-left:1.25rem;color:var(--color-text-subtle);font-family:monospace;font-size:0.8125rem;">22</td>
+                    <td style="text-align:center;"><span class="renumber-arrow">&rarr;</span></td>
+                    <td><span class="renumber-new">4</span></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="dialog-footer">
+            <span class="dialog-footer-info">7 shots will be renumbered &middot; 0 unchanged</span>
+            <div class="flex gap-2">
+              <button class="btn btn-ghost">Cancel</button>
+              <button class="btn btn-primary">Renumber 7 Shots</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- SECTION 5: SCENE ASSIGN POPOVER                               -->
+    <!-- ============================================================ -->
+    <div class="mockup-section" id="section-5">
+      <div class="section-header">
+        <div class="section-num">5</div>
+        <div>
+          <p class="label-meta">Scene Assignment</p>
+          <h2 class="heading-page" style="margin-top:0.125rem">Scene Assign Popover</h2>
+          <p style="font-size:0.8125rem;color:var(--color-text-muted);margin-top:0.375rem;max-width:560px;">
+            A lightweight popover for assigning shots to scenes. Triggered from the shot detail properties panel or the "Scene" column in the table. Lists existing scenes with color dots, an ungrouped option, and a shortcut to create a new scene.
+          </p>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:3rem;flex-wrap:wrap;">
+        <!-- Popover standalone -->
+        <div>
+          <p class="label-meta" style="margin-bottom:0.75rem;">Popover (standalone)</p>
+          <div class="popover">
+            <div class="popover-item muted">
+              <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24" style="opacity:0.5"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636"/></svg>
+              None (ungrouped)
+            </div>
+            <div class="popover-divider"></div>
+            <div class="popover-item" style="background:var(--color-table-row-hover);">
+              <span class="scene-dot" style="background:var(--scene-teal);"></span>
+              <span>#1 Outdoor Men's</span>
+              <svg class="icon-xs ml-auto" fill="none" stroke="var(--color-text-subtle)" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5" d="M5 13l4 4L19 7"/></svg>
+            </div>
+            <div class="popover-item">
+              <span class="scene-dot" style="background:var(--scene-purple);"></span>
+              <span>#2 Studio Women's</span>
+            </div>
+            <div class="popover-item">
+              <span class="scene-dot" style="background:var(--scene-green);"></span>
+              <span>#3 Accessories Flatlay</span>
+            </div>
+            <div class="popover-divider"></div>
+            <div class="popover-item accent">
+              <svg class="icon-xs" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+              New Scene...
+            </div>
+          </div>
+        </div>
+
+        <!-- Context: in-table trigger -->
+        <div>
+          <p class="label-meta" style="margin-bottom:0.75rem;">In-table context (trigger shown)</p>
+          <div style="border:1px solid var(--color-border);border-radius:var(--radius-md);overflow:hidden;width:400px;">
+            <!-- Mini table row -->
+            <div style="display:flex;align-items:center;gap:0.75rem;padding:0.625rem 0.75rem;background:var(--color-surface);border-bottom:1px solid var(--color-table-row-border);">
+              <div class="checkbox"></div>
+              <span style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);width:28px;">1A</span>
+              <span style="font-size:0.8125rem;font-weight:500;color:var(--color-text);flex:1;">Hero Laydown</span>
+              <div style="position:relative;">
+                <span class="scene-badge" style="cursor:pointer;border:1px solid var(--color-border-strong);">
+                  <span class="scene-dot-sm" style="background:var(--scene-teal);"></span>
+                  Outdoor Men's
+                  <svg style="width:10px;height:10px;color:var(--color-text-subtle);margin-left:0.125rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </span>
+              </div>
+            </div>
+            <!-- Another row -->
+            <div style="display:flex;align-items:center;gap:0.75rem;padding:0.625rem 0.75rem;background:var(--color-surface);">
+              <div class="checkbox"></div>
+              <span style="font-weight:600;font-size:0.8125rem;color:var(--color-text-muted);width:28px;">4</span>
+              <span style="font-size:0.8125rem;font-weight:500;color:var(--color-text);flex:1;">BTS Reel Captures</span>
+              <div>
+                <span class="scene-badge" style="cursor:pointer;border:1px solid transparent;color:var(--color-text-subtle);">
+                  <svg style="width:10px;height:10px;opacity:0.5;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"/></svg>
+                  Add scene
+                  <svg style="width:10px;height:10px;color:var(--color-text-subtle);margin-left:0.125rem;" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /mockup-container -->
+
+  <!-- ============================================================ -->
+  <!-- SCRIPTS                                                        -->
+  <!-- ============================================================ -->
+  <script>
+    // Theme toggle
+    function toggleTheme() {
+      var html = document.documentElement;
+      var isDark = html.classList.toggle('dark');
+      localStorage.setItem('sb:theme', isDark ? 'dark' : 'light');
+      updateThemeUI();
+    }
+
+    function updateThemeUI() {
+      var isDark = document.documentElement.classList.contains('dark');
+      document.getElementById('sunIcon').style.display = isDark ? 'block' : 'none';
+      document.getElementById('moonIcon').style.display = isDark ? 'none' : 'block';
+      document.getElementById('themeLabel').textContent = isDark ? 'Light' : 'Dark';
+    }
+    updateThemeUI();
+
+    // Scene toggle (collapse/expand)
+    function toggleScene(sceneId) {
+      var chevron = document.getElementById(sceneId + '-chevron');
+      var isCollapsed = chevron.classList.toggle('collapsed');
+
+      // Find all rows for this scene
+      var i = 1;
+      while (true) {
+        var row = document.getElementById(sceneId + '-row-' + i);
+        if (!row) break;
+        row.style.display = isCollapsed ? 'none' : 'table-row';
+        i++;
+      }
+    }
+  </script>
+
+</body>
+</html>

--- a/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
+++ b/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
@@ -139,14 +139,14 @@ describe("ShotGridBlockView", () => {
     expect(screen.queryByText("Description")).not.toBeInTheDocument()
   })
 
-  it("renders all 5 shot rows with padded shot numbers", () => {
+  it("renders all 5 shot rows with shot numbers", () => {
     render(<ShotGridBlockView block={buildBlock()} />)
 
-    expect(screen.getByText("001")).toBeInTheDocument()
-    expect(screen.getByText("002")).toBeInTheDocument()
-    expect(screen.getByText("003")).toBeInTheDocument()
-    expect(screen.getByText("004")).toBeInTheDocument()
-    expect(screen.getByText("005")).toBeInTheDocument()
+    expect(screen.getByText("1")).toBeInTheDocument()
+    expect(screen.getByText("2")).toBeInTheDocument()
+    expect(screen.getByText("3")).toBeInTheDocument()
+    expect(screen.getByText("4")).toBeInTheDocument()
+    expect(screen.getByText("5")).toBeInTheDocument()
   })
 
   it("renders status badges with correct labels", () => {

--- a/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
@@ -65,7 +65,7 @@ export function ShotDetailBlockView({ block }: ShotDetailBlockViewProps) {
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <div className="flex items-center gap-2">
           <span className="text-sm font-semibold text-[var(--color-text)]">
-            #{String(shot.shotNumber ?? "0").padStart(3, "0")} {shot.title}
+            #{shot.shotNumber || "\u2014"} {shot.title}
           </span>
           <span className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${statusClasses}`}>
             {statusLabel}

--- a/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
@@ -30,7 +30,7 @@ function getCellValue(
 ): React.ReactNode {
   switch (columnKey) {
     case "shotNumber":
-      return String(shot.shotNumber ?? "0").padStart(3, "0")
+      return shot.shotNumber || "\u2014"
     case "thumbnail":
       return <div className="h-8 w-12 rounded bg-[var(--color-surface-muted)]" />
     case "title":

--- a/src-vnext/features/export/lib/blockDataResolvers.ts
+++ b/src-vnext/features/export/lib/blockDataResolvers.ts
@@ -90,8 +90,16 @@ export function sortShots(
 
   return [...shots].sort((a, b) => {
     switch (sortBy) {
-      case "shotNumber":
-        return (a.shotNumber ?? "").localeCompare(b.shotNumber ?? "", undefined, { numeric: true, sensitivity: "base" }) * dir
+      case "shotNumber": {
+        // Nulls/empty last in both directions, then natural sort (numeric: true
+        // so "1A" < "1B" < "2A" < "10A").
+        const aNum = a.shotNumber ?? ""
+        const bNum = b.shotNumber ?? ""
+        if (!aNum && !bNum) return 0
+        if (!aNum) return 1
+        if (!bNum) return -1
+        return aNum.localeCompare(bNum, undefined, { numeric: true, sensitivity: "base" }) * dir
+      }
       case "title":
         return a.title.localeCompare(b.title) * dir
       case "status":

--- a/src-vnext/features/export/lib/blockDataResolvers.ts
+++ b/src-vnext/features/export/lib/blockDataResolvers.ts
@@ -90,11 +90,8 @@ export function sortShots(
 
   return [...shots].sort((a, b) => {
     switch (sortBy) {
-      case "shotNumber": {
-        const numA = Number(a.shotNumber ?? 0)
-        const numB = Number(b.shotNumber ?? 0)
-        return (numA - numB) * dir
-      }
+      case "shotNumber":
+        return (a.shotNumber ?? "").localeCompare(b.shotNumber ?? "", undefined, { numeric: true, sensitivity: "base" }) * dir
       case "title":
         return a.title.localeCompare(b.title) * dir
       case "status":

--- a/src-vnext/features/export/lib/pdf/blocks/ShotDetailBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotDetailBlockPdf.tsx
@@ -35,7 +35,7 @@ export function ShotDetailBlockPdf({ block, data, imageMap }: ShotDetailBlockPdf
       <View style={{ flex: 1 }}>
         <View style={{ flexDirection: "row", alignItems: "center", gap: 6, marginBottom: 3 }}>
           <Text style={{ fontFamily: "Helvetica-Bold", fontSize: 11, color: "#111827" }}>
-            #{String(shot.shotNumber ?? "0").padStart(3, "0")} {shot.title}
+            #{shot.shotNumber || "\u2014"} {shot.title}
           </Text>
           <Text style={{ ...styles.badge, backgroundColor: sc.bg, color: sc.text }}>
             {statusLabel}

--- a/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
@@ -23,7 +23,7 @@ interface ShotGridBlockPdfProps {
 
 function cellText(shot: Shot, key: string, data: ExportData): string {
   switch (key) {
-    case "shotNumber": return shot.shotNumber ? String(shot.shotNumber).padStart(3, "0") : "\u2014"
+    case "shotNumber": return shot.shotNumber || "\u2014"
     case "title": return shot.title
     case "products": return resolveProductNamesString(shot)
     case "talent": return resolveTalentNames(shot, data.talent)

--- a/src-vnext/features/shots/components/BulkActionBar.tsx
+++ b/src-vnext/features/shots/components/BulkActionBar.tsx
@@ -295,7 +295,7 @@ export function BulkActionBar({
             onClick={onGroupSceneOpen}
           >
             <Layers className="mr-1.5 h-3.5 w-3.5" />
-            Group into Scene
+            Set Scene
           </Button>
         )}
         {canManageShots(role) && (

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/ui/dialog"
 import {
+  MAX_SHOTS_PER_SCENE,
   parseSceneShotNumber,
   previewRenumber,
   previewRenumberWithScenes,
@@ -62,6 +63,19 @@ export function RenumberShotsDialog({
     () => shots.filter((s) => s.shotNumber && parseSceneShotNumber(s.shotNumber).suffix != null).length,
     [shots],
   )
+
+  // Detect scenes that exceed the A..ZZ letter capacity — these would fail in
+  // renumberShotsWithScenes' overflow guard. Surface a preview warning so users
+  // see the problem before clicking Renumber.
+  const overflowScenes = useMemo(() => {
+    if (!lanes) return [] as ReadonlyArray<{ name: string; count: number }>
+    return lanes
+      .map((lane) => ({
+        name: lane.name,
+        count: shots.filter((s) => s.laneId === lane.id).length,
+      }))
+      .filter((g) => g.count > MAX_SHOTS_PER_SCENE)
+  }, [lanes, shots])
 
   // Auto-compute suggested start number and set mode when dialog opens
   const prevOpen = useRef(false)
@@ -208,6 +222,15 @@ export function RenumberShotsDialog({
           {mode === "sequential" && sceneNumberedCount > 0 && (
             <div className="rounded-md border-l-2 border-l-[var(--color-status-amber-border)] bg-[var(--color-status-amber-bg)] px-3 py-2 text-xs text-[var(--color-status-amber-text)]">
               {sceneNumberedCount} shot{sceneNumberedCount === 1 ? " has" : "s have"} scene letter suffixes (e.g., 1A, 2B). Sequential mode will replace them with flat numbers.
+            </div>
+          )}
+
+          {mode === "byScene" && overflowScenes.length > 0 && (
+            <div className="rounded-md border-l-2 border-l-[var(--color-status-red-border)] bg-[var(--color-status-red-bg)] px-3 py-2 text-xs text-[var(--color-status-red-text)]">
+              {overflowScenes.length === 1
+                ? `Scene "${overflowScenes[0]!.name}" has ${overflowScenes[0]!.count} shots, exceeding the per-scene limit of ${MAX_SHOTS_PER_SCENE} (A..ZZ).`
+                : `${overflowScenes.length} scenes exceed the per-scene limit of ${MAX_SHOTS_PER_SCENE} shots (A..ZZ).`}
+              {" "}Renumbering will fail until you split or shrink these scenes.
             </div>
           )}
 

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -9,12 +9,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/ui/dialog"
-import { previewRenumber, renumberShots, suggestStartNumber } from "@/features/shots/lib/shotNumbering"
-import { SORT_LABELS, type SortKey } from "@/features/shots/lib/shotListFilters"
+import {
+  parseSceneShotNumber,
+  previewRenumber,
+  previewRenumberWithScenes,
+  renumberShots,
+  renumberShotsWithScenes,
+  suggestStartNumber,
+} from "@/features/shots/lib/shotNumbering"
+import { SORT_LABELS, type SortKey, type GroupKey } from "@/features/shots/lib/shotListFilters"
+import { getSceneColor } from "@/features/shots/components/SceneHeader"
 import { toast } from "sonner"
-import type { Shot } from "@/shared/types"
+import type { Shot, Lane } from "@/shared/types"
 
 const PREVIEW_LIMIT = 10
+
+type RenumberMode = "sequential" | "byScene"
 
 interface RenumberShotsDialogProps {
   readonly open: boolean
@@ -25,6 +35,8 @@ interface RenumberShotsDialogProps {
   readonly sortDir: "asc" | "desc"
   readonly totalShotCount: number
   readonly allShots: ReadonlyArray<Shot>
+  readonly lanes?: ReadonlyArray<Lane>
+  readonly groupKey?: GroupKey
 }
 
 export function RenumberShotsDialog({
@@ -36,32 +48,76 @@ export function RenumberShotsDialog({
   sortDir,
   totalShotCount,
   allShots,
+  lanes,
+  groupKey,
 }: RenumberShotsDialogProps) {
   const [busy, setBusy] = useState(false)
   const [startNumber, setStartNumber] = useState(1)
+  const [mode, setMode] = useState<RenumberMode>("sequential")
 
-  // Auto-compute suggested start number only when dialog opens (not on re-renders)
+  const hasScenes = (lanes?.length ?? 0) > 0
+
+  // Detect shots currently using scene letter suffixes — sequential renumber would destroy these
+  const sceneNumberedCount = useMemo(
+    () => shots.filter((s) => s.shotNumber && parseSceneShotNumber(s.shotNumber).suffix != null).length,
+    [shots],
+  )
+
+  // Auto-compute suggested start number and set mode when dialog opens
   const prevOpen = useRef(false)
   useEffect(() => {
     if (open && !prevOpen.current) {
       setStartNumber(suggestStartNumber(allShots, shots))
+      setMode(hasScenes && groupKey === "scene" ? "byScene" : "sequential")
     }
     prevOpen.current = open
-  }, [open, allShots, shots])
+  }, [open, allShots, shots, hasScenes, groupKey])
 
-  const { changes, unchangedCount } = useMemo(
-    () => (open ? previewRenumber(shots, startNumber) : { changes: [], unchangedCount: 0 }),
-    [open, shots, startNumber],
-  )
+  // Build scene groups for preview/execution
+  const { sceneGroups, ungroupedShots } = useMemo(() => {
+    if (!lanes || lanes.length === 0) return { sceneGroups: [], ungroupedShots: [] as readonly Shot[] }
 
-  const preview = changes.slice(0, PREVIEW_LIMIT)
-  const remaining = changes.length - preview.length
+    const groups = lanes
+      .filter((l) => l.sceneNumber != null)
+      .sort((a, b) => (a.sceneNumber ?? 0) - (b.sceneNumber ?? 0))
+      .map((lane) => ({
+        sceneNumber: lane.sceneNumber!,
+        sceneName: lane.name,
+        color: lane.color,
+        shots: shots.filter((s) => s.laneId === lane.id),
+      }))
+      .filter((g) => g.shots.length > 0)
+
+    const laneIds = new Set(lanes.map((l) => l.id))
+    const ungrouped = shots.filter((s) => !s.laneId || !laneIds.has(s.laneId))
+
+    return { sceneGroups: groups, ungroupedShots: ungrouped }
+  }, [lanes, shots])
+
+  // Preview: sequential or by-scene
+  const { changes, unchangedCount } = useMemo(() => {
+    if (!open) return { changes: [] as readonly { shotId: string; title: string; currentNumber: string; newNumber: string; sceneName: string }[], unchangedCount: 0 }
+    if (mode === "byScene" && sceneGroups.length > 0) {
+      return previewRenumberWithScenes(sceneGroups, ungroupedShots)
+    }
+    // Sequential mode — wrap changes to include empty sceneName for type consistency
+    const seq = previewRenumber(shots, startNumber)
+    return {
+      changes: seq.changes.map((c) => ({ ...c, sceneName: "" })),
+      unchangedCount: seq.unchangedCount,
+    }
+  }, [open, mode, shots, startNumber, sceneGroups, ungroupedShots])
 
   const handleRenumber = async () => {
     if (!clientId || changes.length === 0) return
     setBusy(true)
     try {
-      const count = await renumberShots(shots, clientId, startNumber)
+      let count: number
+      if (mode === "byScene" && sceneGroups.length > 0) {
+        count = await renumberShotsWithScenes(sceneGroups, ungroupedShots, clientId)
+      } else {
+        count = await renumberShots(shots, clientId, startNumber)
+      }
       toast.success(`Renumbered ${count} shot${count === 1 ? "" : "s"}`)
       onOpenChange(false)
     } catch (err) {
@@ -81,7 +137,9 @@ export function RenumberShotsDialog({
         <DialogHeader>
           <DialogTitle>Renumber Shots</DialogTitle>
           <DialogDescription>
-            Reassign sequential shot numbers based on the current display order.
+            {mode === "byScene"
+              ? "Assign scene-based shot numbers (1A, 1B\u2026) using scene order."
+              : "Reassign sequential shot numbers based on the current display order."}
           </DialogDescription>
         </DialogHeader>
 
@@ -90,34 +148,72 @@ export function RenumberShotsDialog({
             Sorted by: {sortLabel}
           </div>
 
+          {hasScenes && (
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-[var(--color-text)]">Mode</span>
+              <div className="flex rounded-md border border-[var(--color-border)] overflow-hidden">
+                <button
+                  type="button"
+                  className={`px-3 py-1 text-xs font-medium transition-colors ${
+                    mode === "sequential"
+                      ? "bg-[var(--color-primary)] text-[var(--color-primary-text)]"
+                      : "bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                  }`}
+                  onClick={() => setMode("sequential")}
+                >
+                  Sequential
+                </button>
+                <button
+                  type="button"
+                  className={`px-3 py-1 text-xs font-medium transition-colors border-l border-[var(--color-border)] ${
+                    mode === "byScene"
+                      ? "bg-[var(--color-primary)] text-[var(--color-primary-text)]"
+                      : "bg-[var(--color-surface)] text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+                  }`}
+                  onClick={() => setMode("byScene")}
+                >
+                  By Scene
+                </button>
+              </div>
+            </div>
+          )}
+
           {shots.length < totalShotCount && (
             <div className="rounded-md border-l-2 border-l-[var(--color-status-amber-border)] bg-[var(--color-status-amber-bg)] px-3 py-2 text-xs text-[var(--color-status-amber-text)]">
               Renumbering {shots.length} of {totalShotCount} shots. Hidden shots will keep their current numbers.
             </div>
           )}
 
-          <div className="flex items-center gap-2">
-            <label htmlFor="renumber-start" className="text-sm text-[var(--color-text)]">
-              Start from:
-            </label>
-            <Input
-              id="renumber-start"
-              type="number"
-              min={1}
-              value={startNumber}
-              onChange={(e) => {
-                const val = parseInt(e.target.value, 10)
-                if (!Number.isNaN(val) && val >= 1) {
-                  setStartNumber(val)
-                }
-              }}
-              className="w-20 tabular-nums"
-            />
-          </div>
+          {mode === "sequential" && sceneNumberedCount > 0 && (
+            <div className="rounded-md border-l-2 border-l-[var(--color-status-amber-border)] bg-[var(--color-status-amber-bg)] px-3 py-2 text-xs text-[var(--color-status-amber-text)]">
+              {sceneNumberedCount} shot{sceneNumberedCount === 1 ? " has" : "s have"} scene letter suffixes (e.g., 1A, 2B). Sequential mode will replace them with flat numbers.
+            </div>
+          )}
+
+          {mode === "sequential" && (
+            <div className="flex items-center gap-2">
+              <label htmlFor="renumber-start" className="text-sm text-[var(--color-text)]">
+                Start from:
+              </label>
+              <Input
+                id="renumber-start"
+                type="number"
+                min={1}
+                value={startNumber}
+                onChange={(e) => {
+                  const val = parseInt(e.target.value, 10)
+                  if (!Number.isNaN(val) && val >= 1) {
+                    setStartNumber(val)
+                  }
+                }}
+                className="w-20 tabular-nums"
+              />
+            </div>
+          )}
 
           {changes.length === 0 ? (
             <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3 text-sm text-[var(--color-text-muted)]">
-              All shot numbers are already sequential. Nothing to change.
+              All shot numbers are already {mode === "byScene" ? "scene-aligned" : "sequential"}. Nothing to change.
             </div>
           ) : (
             <>
@@ -131,20 +227,29 @@ export function RenumberShotsDialog({
                     </tr>
                   </thead>
                   <tbody>
-                    {preview.map((c) => (
-                      <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
-                        <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
-                        <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
-                        <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
-                      </tr>
-                    ))}
+                    {mode === "byScene" ? (
+                      <ScenePreviewRows
+                        changes={changes}
+                        sceneGroups={sceneGroups}
+                        ungroupedShots={ungroupedShots}
+                        previewLimit={PREVIEW_LIMIT}
+                      />
+                    ) : (
+                      changes.slice(0, PREVIEW_LIMIT).map((c) => (
+                        <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
+                          <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
+                          <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
+                          <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
+                        </tr>
+                      ))
+                    )}
                   </tbody>
                 </table>
               </div>
 
-              {remaining > 0 && (
+              {mode === "sequential" && changes.length > PREVIEW_LIMIT && (
                 <div className="text-xs text-[var(--color-text-muted)]">
-                  {"\u2026"} and {remaining} more
+                  {"\u2026"} and {changes.length - PREVIEW_LIMIT} more
                 </div>
               )}
 
@@ -171,4 +276,112 @@ export function RenumberShotsDialog({
       </DialogContent>
     </Dialog>
   )
+}
+
+// ---------------------------------------------------------------------------
+// Scene preview rows — grouped by scene with headers
+// ---------------------------------------------------------------------------
+
+interface ScenePreviewRowsProps {
+  readonly changes: ReadonlyArray<{
+    readonly shotId: string
+    readonly currentNumber: string
+    readonly newNumber: string
+    readonly sceneName: string
+  }>
+  readonly sceneGroups: ReadonlyArray<{
+    readonly sceneNumber: number
+    readonly sceneName: string
+    readonly color?: string
+  }>
+  readonly ungroupedShots: ReadonlyArray<Shot>
+  readonly previewLimit: number
+}
+
+function ScenePreviewRows({ changes, sceneGroups, ungroupedShots, previewLimit }: ScenePreviewRowsProps) {
+  // Group changes by sceneName for rendering with headers
+  let rendered = 0
+  const rows: JSX.Element[] = []
+
+  for (const group of sceneGroups) {
+    if (rendered >= previewLimit) break
+
+    const groupChanges = changes.filter((c) => c.sceneName === group.sceneName)
+    if (groupChanges.length === 0) continue
+
+    rows.push(
+      <tr key={`header-${group.sceneNumber}`} className="bg-[var(--color-surface-subtle)]">
+        <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text)]">
+          <span
+            className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle"
+            style={{ backgroundColor: getSceneColor(group.color) }}
+          />
+          {"Scene "}
+          {group.sceneNumber}
+          {" \u2014 "}
+          {group.sceneName}
+        </td>
+      </tr>,
+    )
+
+    const visible = groupChanges.slice(0, previewLimit - rendered)
+    for (const c of visible) {
+      rows.push(
+        <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
+          <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
+          <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
+          <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
+        </tr>,
+      )
+      rendered++
+    }
+
+    if (groupChanges.length > visible.length) {
+      rows.push(
+        <tr key={`more-${group.sceneNumber}`}>
+          <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
+            {"\u2026"} and {groupChanges.length - visible.length} more in this scene
+          </td>
+        </tr>,
+      )
+    }
+  }
+
+  // Ungrouped shots
+  if (rendered < previewLimit && ungroupedShots.length > 0) {
+    const ungroupedChanges = changes.filter((c) => c.sceneName === "")
+    if (ungroupedChanges.length > 0) {
+      rows.push(
+        <tr key="header-ungrouped" className="bg-[var(--color-surface-subtle)]">
+          <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)]">
+            Ungrouped
+          </td>
+        </tr>,
+      )
+
+      const visible = ungroupedChanges.slice(0, previewLimit - rendered)
+      for (const c of visible) {
+        rows.push(
+          <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
+            <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
+            <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
+            <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
+          </tr>,
+        )
+        rendered++
+      }
+
+      if (ungroupedChanges.length > visible.length) {
+        rows.push(
+          <tr key="more-ungrouped">
+            <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
+              {"\u2026"} and {ungroupedChanges.length - visible.length} more ungrouped
+            </td>
+          </tr>,
+        )
+      }
+    }
+  }
+
+  return <>{rows}</>
 }

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from "react"
+import { useState, useMemo, useEffect, useRef, type ReactElement } from "react"
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import {
@@ -81,6 +81,7 @@ export function RenumberShotsDialog({
       .filter((l) => l.sceneNumber != null)
       .sort((a, b) => (a.sceneNumber ?? 0) - (b.sceneNumber ?? 0))
       .map((lane) => ({
+        sceneId: lane.id,
         sceneNumber: lane.sceneNumber!,
         sceneName: lane.name,
         color: lane.color,
@@ -96,14 +97,14 @@ export function RenumberShotsDialog({
 
   // Preview: sequential or by-scene
   const { changes, unchangedCount } = useMemo(() => {
-    if (!open) return { changes: [] as readonly { shotId: string; title: string; currentNumber: string; newNumber: string; sceneName: string }[], unchangedCount: 0 }
+    if (!open) return { changes: [] as readonly { shotId: string; title: string; currentNumber: string; newNumber: string; sceneName: string; sceneId: string }[], unchangedCount: 0 }
     if (mode === "byScene" && sceneGroups.length > 0) {
       return previewRenumberWithScenes(sceneGroups, ungroupedShots)
     }
-    // Sequential mode — wrap changes to include empty sceneName for type consistency
+    // Sequential mode — wrap changes to include empty sceneName/sceneId for type consistency
     const seq = previewRenumber(shots, startNumber)
     return {
-      changes: seq.changes.map((c) => ({ ...c, sceneName: "" })),
+      changes: seq.changes.map((c) => ({ ...c, sceneName: "", sceneId: "" })),
       unchangedCount: seq.unchangedCount,
     }
   }, [open, mode, shots, startNumber, sceneGroups, ungroupedShots])
@@ -288,8 +289,10 @@ interface ScenePreviewRowsProps {
     readonly currentNumber: string
     readonly newNumber: string
     readonly sceneName: string
+    readonly sceneId: string
   }>
   readonly sceneGroups: ReadonlyArray<{
+    readonly sceneId: string
     readonly sceneNumber: number
     readonly sceneName: string
     readonly color?: string
@@ -298,90 +301,101 @@ interface ScenePreviewRowsProps {
   readonly previewLimit: number
 }
 
-function ScenePreviewRows({ changes, sceneGroups, ungroupedShots, previewLimit }: ScenePreviewRowsProps) {
-  // Group changes by sceneName for rendering with headers
-  let rendered = 0
-  const rows: JSX.Element[] = []
+type PreviewRow = ReactElement
 
-  for (const group of sceneGroups) {
-    if (rendered >= previewLimit) break
+function buildScenePreviewRowsState(
+  changes: ScenePreviewRowsProps["changes"],
+  sceneGroups: ScenePreviewRowsProps["sceneGroups"],
+  ungroupedShots: ReadonlyArray<Shot>,
+  previewLimit: number,
+): ReadonlyArray<PreviewRow> {
+  // Phase 1: scene groups. Track running count via reduce, building rows immutably.
+  const scenePhase = sceneGroups.reduce<{ rows: ReadonlyArray<PreviewRow>; rendered: number }>(
+    (acc, group) => {
+      if (acc.rendered >= previewLimit) return acc
+      // Filter by stable sceneId to avoid name-collision bugs.
+      const groupChanges = changes.filter((c) => c.sceneId === group.sceneId)
+      if (groupChanges.length === 0) return acc
 
-    const groupChanges = changes.filter((c) => c.sceneName === group.sceneName)
-    if (groupChanges.length === 0) continue
-
-    rows.push(
-      <tr key={`header-${group.sceneNumber}`} className="bg-[var(--color-surface-subtle)]">
-        <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text)]">
-          <span
-            className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle"
-            style={{ backgroundColor: getSceneColor(group.color) }}
-          />
-          {"Scene "}
-          {group.sceneNumber}
-          {" \u2014 "}
-          {group.sceneName}
-        </td>
-      </tr>,
-    )
-
-    const visible = groupChanges.slice(0, previewLimit - rendered)
-    for (const c of visible) {
-      rows.push(
+      const visible = groupChanges.slice(0, previewLimit - acc.rendered)
+      const header: PreviewRow = (
+        <tr key={`header-${group.sceneId}`} className="bg-[var(--color-surface-subtle)]">
+          <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text)]">
+            <span
+              className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle"
+              style={{ backgroundColor: getSceneColor(group.color) }}
+            />
+            {"Scene "}
+            {group.sceneNumber}
+            {" \u2014 "}
+            {group.sceneName}
+          </td>
+        </tr>
+      )
+      const changeRows: ReadonlyArray<PreviewRow> = visible.map((c) => (
         <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
           <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
           <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
           <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
-        </tr>,
-      )
-      rendered++
-    }
+        </tr>
+      ))
+      const moreRow: ReadonlyArray<PreviewRow> =
+        groupChanges.length > visible.length
+          ? [
+              <tr key={`more-${group.sceneId}`}>
+                <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
+                  {"\u2026"} and {groupChanges.length - visible.length} more in this scene
+                </td>
+              </tr>,
+            ]
+          : []
 
-    if (groupChanges.length > visible.length) {
-      rows.push(
-        <tr key={`more-${group.sceneNumber}`}>
-          <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
-            {"\u2026"} and {groupChanges.length - visible.length} more in this scene
-          </td>
-        </tr>,
-      )
-    }
-  }
-
-  // Ungrouped shots
-  if (rendered < previewLimit && ungroupedShots.length > 0) {
-    const ungroupedChanges = changes.filter((c) => c.sceneName === "")
-    if (ungroupedChanges.length > 0) {
-      rows.push(
-        <tr key="header-ungrouped" className="bg-[var(--color-surface-subtle)]">
-          <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)]">
-            Ungrouped
-          </td>
-        </tr>,
-      )
-
-      const visible = ungroupedChanges.slice(0, previewLimit - rendered)
-      for (const c of visible) {
-        rows.push(
-          <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
-            <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
-            <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
-            <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
-          </tr>,
-        )
-        rendered++
+      return {
+        rendered: acc.rendered + visible.length,
+        rows: [...acc.rows, header, ...changeRows, ...moreRow],
       }
+    },
+    { rows: [], rendered: 0 },
+  )
 
-      if (ungroupedChanges.length > visible.length) {
-        rows.push(
+  // Phase 2: ungrouped shots
+  if (scenePhase.rendered >= previewLimit || ungroupedShots.length === 0) {
+    return scenePhase.rows
+  }
+  const ungroupedChanges = changes.filter((c) => c.sceneId === "")
+  if (ungroupedChanges.length === 0) {
+    return scenePhase.rows
+  }
+  const visible = ungroupedChanges.slice(0, previewLimit - scenePhase.rendered)
+  const ungroupedHeader: PreviewRow = (
+    <tr key="header-ungrouped" className="bg-[var(--color-surface-subtle)]">
+      <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)]">
+        Ungrouped
+      </td>
+    </tr>
+  )
+  const ungroupedChangeRows: ReadonlyArray<PreviewRow> = visible.map((c) => (
+    <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
+      <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
+      <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
+      <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
+    </tr>
+  ))
+  const ungroupedMoreRow: ReadonlyArray<PreviewRow> =
+    ungroupedChanges.length > visible.length
+      ? [
           <tr key="more-ungrouped">
             <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
               {"\u2026"} and {ungroupedChanges.length - visible.length} more ungrouped
             </td>
           </tr>,
-        )
-      }
-    }
-  }
+        ]
+      : []
 
+  return [...scenePhase.rows, ungroupedHeader, ...ungroupedChangeRows, ...ungroupedMoreRow]
+}
+
+function ScenePreviewRows({ changes, sceneGroups, ungroupedShots, previewLimit }: ScenePreviewRowsProps) {
+  const rows = buildScenePreviewRowsState(changes, sceneGroups, ungroupedShots, previewLimit)
   return <>{rows}</>
 }

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -74,8 +74,14 @@ export function RenumberShotsDialog({
   }, [open, allShots, shots, hasScenes, groupKey])
 
   // Build scene groups for preview/execution
-  const { sceneGroups, ungroupedShots } = useMemo(() => {
-    if (!lanes || lanes.length === 0) return { sceneGroups: [], ungroupedShots: [] as readonly Shot[] }
+  const { sceneGroups, ungroupedShots, maxSceneNumberAcrossProject } = useMemo(() => {
+    if (!lanes || lanes.length === 0) {
+      return {
+        sceneGroups: [],
+        ungroupedShots: [] as readonly Shot[],
+        maxSceneNumberAcrossProject: 0,
+      }
+    }
 
     const groups = lanes
       .filter((l) => l.sceneNumber != null)
@@ -92,14 +98,23 @@ export function RenumberShotsDialog({
     const laneIds = new Set(lanes.map((l) => l.id))
     const ungrouped = shots.filter((s) => !s.laneId || !laneIds.has(s.laneId))
 
-    return { sceneGroups: groups, ungroupedShots: ungrouped }
+    // Compute max across ALL lanes (not just visible). This guards against
+    // cross-filter collisions: if a filter hides scene 5 entirely, the visible
+    // scenes' max would drop and ungrouped numbering would collide with the
+    // still-stored "5A", "5B" shot numbers from the hidden scene.
+    const maxSceneNumberAcrossProject = lanes.reduce(
+      (max, l) => (l.sceneNumber != null && l.sceneNumber > max ? l.sceneNumber : max),
+      0,
+    )
+
+    return { sceneGroups: groups, ungroupedShots: ungrouped, maxSceneNumberAcrossProject }
   }, [lanes, shots])
 
   // Preview: sequential or by-scene
   const { changes, unchangedCount } = useMemo(() => {
     if (!open) return { changes: [] as readonly { shotId: string; title: string; currentNumber: string; newNumber: string; sceneName: string; sceneId: string }[], unchangedCount: 0 }
     if (mode === "byScene" && sceneGroups.length > 0) {
-      return previewRenumberWithScenes(sceneGroups, ungroupedShots)
+      return previewRenumberWithScenes(sceneGroups, ungroupedShots, maxSceneNumberAcrossProject)
     }
     // Sequential mode — wrap changes to include empty sceneName/sceneId for type consistency
     const seq = previewRenumber(shots, startNumber)
@@ -107,7 +122,7 @@ export function RenumberShotsDialog({
       changes: seq.changes.map((c) => ({ ...c, sceneName: "", sceneId: "" })),
       unchangedCount: seq.unchangedCount,
     }
-  }, [open, mode, shots, startNumber, sceneGroups, ungroupedShots])
+  }, [open, mode, shots, startNumber, sceneGroups, ungroupedShots, maxSceneNumberAcrossProject])
 
   const handleRenumber = async () => {
     if (!clientId || changes.length === 0) return
@@ -115,7 +130,12 @@ export function RenumberShotsDialog({
     try {
       let count: number
       if (mode === "byScene" && sceneGroups.length > 0) {
-        count = await renumberShotsWithScenes(sceneGroups, ungroupedShots, clientId)
+        count = await renumberShotsWithScenes(
+          sceneGroups,
+          ungroupedShots,
+          clientId,
+          maxSceneNumberAcrossProject,
+        )
       } else {
         count = await renumberShots(shots, clientId, startNumber)
       }

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -128,7 +128,16 @@ export function RenumberShotsDialog({
   const { changes, unchangedCount } = useMemo(() => {
     if (!open) return { changes: [] as readonly { shotId: string; title: string; currentNumber: string; newNumber: string; sceneName: string; sceneId: string }[], unchangedCount: 0 }
     if (mode === "byScene" && sceneGroups.length > 0) {
-      return previewRenumberWithScenes(sceneGroups, ungroupedShots, maxSceneNumberAcrossProject)
+      // previewRenumberWithScenes also returns overflowScenes — we compute our
+      // own via the overflowScenes useMemo above so the UI can react immediately
+      // on filter changes without re-running the expensive projection. Drop the
+      // preview function's overflow list here.
+      const { overflowScenes: _unused, ...rest } = previewRenumberWithScenes(
+        sceneGroups,
+        ungroupedShots,
+        maxSceneNumberAcrossProject,
+      )
+      return rest
     }
     // Sequential mode — wrap changes to include empty sceneName/sceneId for type consistency
     const seq = previewRenumber(shots, startNumber)
@@ -185,10 +194,16 @@ export function RenumberShotsDialog({
 
           {hasScenes && (
             <div className="flex items-center gap-2">
-              <span className="text-sm text-[var(--color-text)]">Mode</span>
-              <div className="flex rounded-md border border-[var(--color-border)] overflow-hidden">
+              <span id="renumber-mode-label" className="text-sm text-[var(--color-text)]">Mode</span>
+              <div
+                className="flex rounded-md border border-[var(--color-border)] overflow-hidden"
+                role="radiogroup"
+                aria-labelledby="renumber-mode-label"
+              >
                 <button
                   type="button"
+                  role="radio"
+                  aria-checked={mode === "sequential"}
                   className={`px-3 py-1 text-xs font-medium transition-colors ${
                     mode === "sequential"
                       ? "bg-[var(--color-primary)] text-[var(--color-primary-text)]"
@@ -200,6 +215,8 @@ export function RenumberShotsDialog({
                 </button>
                 <button
                   type="button"
+                  role="radio"
+                  aria-checked={mode === "byScene"}
                   className={`px-3 py-1 text-xs font-medium transition-colors border-l border-[var(--color-border)] ${
                     mode === "byScene"
                       ? "bg-[var(--color-primary)] text-[var(--color-primary-text)]"
@@ -313,7 +330,14 @@ export function RenumberShotsDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)} disabled={busy}>
             Cancel
           </Button>
-          <Button onClick={handleRenumber} disabled={busy || changes.length === 0}>
+          <Button
+            onClick={handleRenumber}
+            disabled={
+              busy ||
+              changes.length === 0 ||
+              (mode === "byScene" && overflowScenes.length > 0)
+            }
+          >
             {busy ? "Renumbering\u2026" : `Renumber ${changes.length} Shot${changes.length === 1 ? "" : "s"}`}
           </Button>
         </DialogFooter>
@@ -352,90 +376,88 @@ function buildScenePreviewRowsState(
   ungroupedShots: ReadonlyArray<Shot>,
   previewLimit: number,
 ): ReadonlyArray<PreviewRow> {
-  // Phase 1: scene groups. Track running count via reduce, building rows immutably.
-  const scenePhase = sceneGroups.reduce<{ rows: ReadonlyArray<PreviewRow>; rendered: number }>(
-    (acc, group) => {
-      if (acc.rendered >= previewLimit) return acc
-      // Filter by stable sceneId to avoid name-collision bugs.
-      const groupChanges = changes.filter((c) => c.sceneId === group.sceneId)
-      if (groupChanges.length === 0) return acc
+  // Local scratch builder: rows array never escapes the function. Matches the
+  // pattern used in shotNumbering.previewRenumberWithScenes — avoids O(n²)
+  // spread-in-reduce while keeping the public API returning a ReadonlyArray.
+  const rows: PreviewRow[] = []
+  let rendered = 0
 
-      const visible = groupChanges.slice(0, previewLimit - acc.rendered)
-      const header: PreviewRow = (
-        <tr key={`header-${group.sceneId}`} className="bg-[var(--color-surface-subtle)]">
-          <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text)]">
-            <span
-              className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle"
-              style={{ backgroundColor: getSceneColor(group.color) }}
-            />
-            {"Scene "}
-            {group.sceneNumber}
-            {" \u2014 "}
-            {group.sceneName}
-          </td>
-        </tr>
-      )
-      const changeRows: ReadonlyArray<PreviewRow> = visible.map((c) => (
+  // Phase 1: scene groups
+  for (const group of sceneGroups) {
+    if (rendered >= previewLimit) break
+    // Filter by stable sceneId to avoid name-collision bugs.
+    const groupChanges = changes.filter((c) => c.sceneId === group.sceneId)
+    if (groupChanges.length === 0) continue
+
+    const visible = groupChanges.slice(0, previewLimit - rendered)
+    rows.push(
+      <tr key={`header-${group.sceneId}`} className="bg-[var(--color-surface-subtle)]">
+        <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text)]">
+          <span
+            className="mr-1.5 inline-block h-2 w-2 rounded-full align-middle"
+            style={{ backgroundColor: getSceneColor(group.color) }}
+          />
+          {"Scene "}
+          {group.sceneNumber}
+          {" \u2014 "}
+          {group.sceneName}
+        </td>
+      </tr>,
+    )
+    for (const c of visible) {
+      rows.push(
         <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
           <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
           <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
           <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
-        </tr>
-      ))
-      const moreRow: ReadonlyArray<PreviewRow> =
-        groupChanges.length > visible.length
-          ? [
-              <tr key={`more-${group.sceneId}`}>
-                <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
-                  {"\u2026"} and {groupChanges.length - visible.length} more in this scene
-                </td>
-              </tr>,
-            ]
-          : []
-
-      return {
-        rendered: acc.rendered + visible.length,
-        rows: [...acc.rows, header, ...changeRows, ...moreRow],
-      }
-    },
-    { rows: [], rendered: 0 },
-  )
+        </tr>,
+      )
+    }
+    if (groupChanges.length > visible.length) {
+      rows.push(
+        <tr key={`more-${group.sceneId}`}>
+          <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
+            {"\u2026"} and {groupChanges.length - visible.length} more in this scene
+          </td>
+        </tr>,
+      )
+    }
+    rendered += visible.length
+  }
 
   // Phase 2: ungrouped shots
-  if (scenePhase.rendered >= previewLimit || ungroupedShots.length === 0) {
-    return scenePhase.rows
-  }
+  if (rendered >= previewLimit || ungroupedShots.length === 0) return rows
   const ungroupedChanges = changes.filter((c) => c.sceneId === "")
-  if (ungroupedChanges.length === 0) {
-    return scenePhase.rows
-  }
-  const visible = ungroupedChanges.slice(0, previewLimit - scenePhase.rendered)
-  const ungroupedHeader: PreviewRow = (
+  if (ungroupedChanges.length === 0) return rows
+
+  const visible = ungroupedChanges.slice(0, previewLimit - rendered)
+  rows.push(
     <tr key="header-ungrouped" className="bg-[var(--color-surface-subtle)]">
       <td colSpan={3} className="px-3 py-1.5 text-xs font-medium text-[var(--color-text-muted)]">
         Ungrouped
       </td>
-    </tr>
+    </tr>,
   )
-  const ungroupedChangeRows: ReadonlyArray<PreviewRow> = visible.map((c) => (
-    <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
-      <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
-      <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
-      <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
-    </tr>
-  ))
-  const ungroupedMoreRow: ReadonlyArray<PreviewRow> =
-    ungroupedChanges.length > visible.length
-      ? [
-          <tr key="more-ungrouped">
-            <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
-              {"\u2026"} and {ungroupedChanges.length - visible.length} more ungrouped
-            </td>
-          </tr>,
-        ]
-      : []
+  for (const c of visible) {
+    rows.push(
+      <tr key={c.shotId} className="border-b border-[var(--color-border)] last:border-0">
+        <td className="px-3 py-1.5 text-[var(--color-text-muted)]">{c.currentNumber}</td>
+        <td className="px-3 py-1.5 text-center text-[var(--color-text-subtle)]">{"\u2192"}</td>
+        <td className="px-3 py-1.5 font-medium text-[var(--color-status-blue-text)]">{c.newNumber}</td>
+      </tr>,
+    )
+  }
+  if (ungroupedChanges.length > visible.length) {
+    rows.push(
+      <tr key="more-ungrouped">
+        <td colSpan={3} className="px-3 py-1 text-2xs text-[var(--color-text-muted)]">
+          {"\u2026"} and {ungroupedChanges.length - visible.length} more ungrouped
+        </td>
+      </tr>,
+    )
+  }
 
-  return [...scenePhase.rows, ungroupedHeader, ...ungroupedChangeRows, ...ungroupedMoreRow]
+  return rows
 }
 
 function ScenePreviewRows({ changes, sceneGroups, ungroupedShots, previewLimit }: ScenePreviewRowsProps) {

--- a/src-vnext/features/shots/components/RenumberShotsDialog.tsx
+++ b/src-vnext/features/shots/components/RenumberShotsDialog.tsx
@@ -18,7 +18,7 @@ import {
   suggestStartNumber,
 } from "@/features/shots/lib/shotNumbering"
 import { SORT_LABELS, type SortKey, type GroupKey } from "@/features/shots/lib/shotListFilters"
-import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import { getSceneColor } from "@/features/shots/lib/sceneColors"
 import { toast } from "sonner"
 import type { Shot, Lane } from "@/shared/types"
 

--- a/src-vnext/features/shots/components/SceneAssignPopover.test.tsx
+++ b/src-vnext/features/shots/components/SceneAssignPopover.test.tsx
@@ -1,0 +1,115 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { SceneAssignPopover } from "./SceneAssignPopover"
+import type { Lane } from "@/shared/types"
+import type { Timestamp } from "firebase/firestore"
+
+const MOCK_TIMESTAMP = { toMillis: () => 0, toDate: () => new Date(0) } as unknown as Timestamp
+
+function makeLane(overrides: Partial<Lane> = {}): Lane {
+  return {
+    id: overrides.id ?? "lane-1",
+    name: overrides.name ?? "Kitchen Scene",
+    projectId: "proj-1",
+    clientId: "client-1",
+    sortOrder: overrides.sortOrder ?? 0,
+    color: overrides.color ?? "teal",
+    sceneNumber: overrides.sceneNumber ?? 1,
+    direction: overrides.direction,
+    notes: overrides.notes,
+    createdAt: MOCK_TIMESTAMP,
+    updatedAt: MOCK_TIMESTAMP,
+    createdBy: "user-1",
+  }
+}
+
+describe("SceneAssignPopover", () => {
+  it("renders the trigger children", () => {
+    render(
+      <SceneAssignPopover
+        shot={{ id: "shot-1", laneId: null }}
+        lanes={[]}
+        onAssign={vi.fn()}
+      >
+        <button>Click me</button>
+      </SceneAssignPopover>,
+    )
+    expect(screen.getByRole("button", { name: "Click me" })).toBeInTheDocument()
+  })
+
+  it("shows lane options and ungrouped option when opened", () => {
+    const lanes = [
+      makeLane({ id: "lane-1", name: "Kitchen Scene", sceneNumber: 1 }),
+      makeLane({ id: "lane-2", name: "Living Room", sceneNumber: 2, color: "purple" }),
+    ]
+    render(
+      <SceneAssignPopover
+        shot={{ id: "shot-1", laneId: null }}
+        lanes={lanes}
+        onAssign={vi.fn()}
+      >
+        <button>Trigger</button>
+      </SceneAssignPopover>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(screen.getByText("None (ungrouped)")).toBeInTheDocument()
+    expect(screen.getByText(/Kitchen Scene/)).toBeInTheDocument()
+    expect(screen.getByText(/Living Room/)).toBeInTheDocument()
+  })
+
+  it("calls onAssign with laneId when a lane is selected", () => {
+    const onAssign = vi.fn()
+    const lanes = [makeLane({ id: "lane-1", name: "Kitchen", sceneNumber: 1 })]
+    render(
+      <SceneAssignPopover
+        shot={{ id: "shot-1", laneId: null }}
+        lanes={lanes}
+        onAssign={onAssign}
+      >
+        <button>Trigger</button>
+      </SceneAssignPopover>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger" }))
+    fireEvent.click(screen.getByText(/Kitchen/))
+
+    expect(onAssign).toHaveBeenCalledWith("shot-1", "lane-1")
+  })
+
+  it("calls onAssign with null when 'None (ungrouped)' is selected", () => {
+    const onAssign = vi.fn()
+    const lanes = [makeLane({ id: "lane-1", name: "Kitchen", sceneNumber: 1 })]
+    render(
+      <SceneAssignPopover
+        shot={{ id: "shot-1", laneId: "lane-1" }}
+        lanes={lanes}
+        onAssign={onAssign}
+      >
+        <button>Trigger</button>
+      </SceneAssignPopover>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger" }))
+    fireEvent.click(screen.getByText("None (ungrouped)"))
+
+    expect(onAssign).toHaveBeenCalledWith("shot-1", null)
+  })
+
+  it("shows empty state when no lanes exist", () => {
+    render(
+      <SceneAssignPopover
+        shot={{ id: "shot-1", laneId: null }}
+        lanes={[]}
+        onAssign={vi.fn()}
+      >
+        <button>Trigger</button>
+      </SceneAssignPopover>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "Trigger" }))
+    expect(screen.getByText("No scenes created yet")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/SceneAssignPopover.tsx
+++ b/src-vnext/features/shots/components/SceneAssignPopover.tsx
@@ -5,7 +5,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/ui/popover"
-import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import { getSceneColor } from "@/features/shots/lib/sceneColors"
 import type { Lane } from "@/shared/types"
 
 interface SceneAssignPopoverProps {

--- a/src-vnext/features/shots/components/SceneAssignPopover.tsx
+++ b/src-vnext/features/shots/components/SceneAssignPopover.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react"
+import { Check } from "lucide-react"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/ui/popover"
+import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import type { Lane } from "@/shared/types"
+
+interface SceneAssignPopoverProps {
+  readonly shot: { readonly id: string; readonly laneId?: string | null }
+  readonly lanes: ReadonlyArray<Lane>
+  readonly onAssign: (shotId: string, laneId: string | null) => void
+  readonly children: React.ReactNode
+}
+
+export function SceneAssignPopover({
+  shot,
+  lanes,
+  onAssign,
+  children,
+}: SceneAssignPopoverProps) {
+  const [open, setOpen] = useState(false)
+  const currentLaneId = shot.laneId ?? null
+
+  const handleSelect = (laneId: string | null) => {
+    onAssign(shot.id, laneId)
+    setOpen(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent
+        className="w-52 p-1"
+        align="start"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-[var(--color-surface-subtle)]"
+          onClick={() => handleSelect(null)}
+        >
+          <span className="inline-block h-2 w-2 rounded-full flex-shrink-0 bg-[var(--color-text-subtle)]" />
+          <span className="flex-1 text-left text-[var(--color-text-muted)]">
+            None (ungrouped)
+          </span>
+          {currentLaneId === null && (
+            <Check className="h-3.5 w-3.5 text-[var(--color-text-subtle)]" />
+          )}
+        </button>
+
+        {lanes.map((lane) => (
+          <button
+            key={lane.id}
+            type="button"
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-xs hover:bg-[var(--color-surface-subtle)]"
+            onClick={() => handleSelect(lane.id)}
+          >
+            <span
+              className="inline-block h-2 w-2 rounded-full flex-shrink-0"
+              style={{ backgroundColor: getSceneColor(lane.color) }}
+            />
+            <span className="flex-1 truncate text-left text-[var(--color-text)]">
+              {lane.sceneNumber != null ? `#${lane.sceneNumber} ` : ""}
+              {lane.name}
+            </span>
+            {currentLaneId === lane.id && (
+              <Check className="h-3.5 w-3.5 text-[var(--color-text-subtle)]" />
+            )}
+          </button>
+        ))}
+
+        {lanes.length === 0 && (
+          <div className="px-2 py-3 text-center text-2xs text-[var(--color-text-muted)]">
+            No scenes created yet
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src-vnext/features/shots/components/SceneContextBanner.tsx
+++ b/src-vnext/features/shots/components/SceneContextBanner.tsx
@@ -1,4 +1,4 @@
-import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import { getSceneColor } from "@/features/shots/lib/sceneColors"
 import type { Lane } from "@/shared/types"
 
 // ---------------------------------------------------------------------------

--- a/src-vnext/features/shots/components/SceneContextBanner.tsx
+++ b/src-vnext/features/shots/components/SceneContextBanner.tsx
@@ -1,0 +1,78 @@
+import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import type { Lane } from "@/shared/types"
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface SceneContextBannerProps {
+  readonly laneId: string | undefined | null
+  readonly laneById: ReadonlyMap<string, Lane>
+  readonly onViewScene?: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_DIRECTION_PREVIEW = 100
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SceneContextBanner({
+  laneId,
+  laneById,
+  onViewScene,
+}: SceneContextBannerProps) {
+  if (!laneId) return null
+
+  const lane = laneById.get(laneId)
+  if (!lane) return null
+
+  const resolvedColor = getSceneColor(lane.color)
+  const directionPreview =
+    lane.direction && lane.direction.length > MAX_DIRECTION_PREVIEW
+      ? `${lane.direction.slice(0, MAX_DIRECTION_PREVIEW)}\u2026`
+      : lane.direction
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md px-3 py-1.5 bg-[var(--color-surface-subtle)]"
+      style={{ borderLeft: `3px solid ${resolvedColor}` }}
+      data-testid="scene-context-banner"
+    >
+      <span
+        className="h-2 w-2 rounded-full flex-shrink-0"
+        style={{ background: resolvedColor }}
+      />
+
+      <span className="text-sm font-medium text-[var(--color-text)] truncate">
+        {lane.sceneNumber != null && (
+          <span className="text-[var(--color-text-subtle)] mr-1">
+            #{lane.sceneNumber}
+          </span>
+        )}
+        {lane.name}
+      </span>
+
+      {directionPreview && (
+        <span className="hidden sm:inline text-xs text-[var(--color-text-muted)] truncate flex-1 min-w-0">
+          {directionPreview}
+        </span>
+      )}
+
+      {onViewScene && (
+        <button
+          type="button"
+          onClick={onViewScene}
+          className="flex-shrink-0 text-xs text-[var(--color-text-muted)] hover:text-[var(--color-text)] transition-colors ml-auto"
+          data-testid="scene-view-link"
+        >
+          View scene &rsaquo;
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -1,0 +1,299 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/ui/sheet"
+import { Input } from "@/ui/input"
+import { Textarea } from "@/ui/textarea"
+import { SCENE_COLORS, getSceneColor } from "@/features/shots/components/SceneHeader"
+import { updateLane, type LanePatch } from "@/features/shots/lib/laneActions"
+import { toast } from "sonner"
+import type { Lane } from "@/shared/types"
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface SceneDetailSheetProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly lane: Lane | null
+  readonly projectId: string
+  readonly clientId: string | null
+  readonly shotCount?: number
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_DIRECTION_CHARS = 500
+const MAX_NOTES_CHARS = 5000
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function SceneDetailSheet({
+  open,
+  onOpenChange,
+  lane,
+  projectId,
+  clientId,
+  shotCount,
+}: SceneDetailSheetProps) {
+  // Local state for form fields
+  const [name, setName] = useState("")
+  const [sceneNumber, setSceneNumber] = useState("")
+  const [direction, setDirection] = useState("")
+  const [notes, setNotes] = useState("")
+
+  // Sync local state when sheet opens for a DIFFERENT lane.
+  // Gate via initKey so Firestore snapshot echoes (same lane.id, new object ref) don't
+  // clobber in-progress edits. Resets when sheet closes so next open re-initializes.
+  const initKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!open) {
+      initKeyRef.current = null
+      return
+    }
+    if (lane && initKeyRef.current !== lane.id) {
+      initKeyRef.current = lane.id
+      setName(lane.name)
+      setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
+      setDirection(lane.direction ?? "")
+      setNotes(lane.notes ?? "")
+    }
+  }, [lane, open])
+
+  const savePatch = useCallback(
+    async (patch: LanePatch) => {
+      if (!lane || !clientId) return
+      try {
+        await updateLane({
+          laneId: lane.id,
+          projectId,
+          clientId,
+          patch,
+        })
+        toast.success("Scene updated")
+      } catch {
+        toast.error("Failed to update scene")
+      }
+    },
+    [lane, projectId, clientId],
+  )
+
+  const handleNameBlur = useCallback(() => {
+    if (!lane) return
+    const trimmed = name.trim()
+    if (trimmed && trimmed !== lane.name) {
+      savePatch({ name: trimmed })
+    }
+  }, [name, lane, savePatch])
+
+  const handleNameKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        ;(e.target as HTMLInputElement).blur()
+      }
+    },
+    [],
+  )
+
+  const handleSceneNumberBlur = useCallback(() => {
+    if (!lane) return
+    const trimmed = sceneNumber.trim()
+    if (!trimmed) {
+      if (lane.sceneNumber !== undefined) {
+        savePatch({ sceneNumber: null })
+      }
+      return
+    }
+    const parsed = parseInt(trimmed, 10)
+    if (!Number.isFinite(parsed) || parsed < 0 || String(parsed) !== trimmed) {
+      toast.error("Scene number must be a non-negative integer")
+      setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
+      return
+    }
+    if (parsed !== lane.sceneNumber) {
+      savePatch({ sceneNumber: parsed })
+    }
+  }, [sceneNumber, lane, savePatch])
+
+  const handleSceneNumberKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        ;(e.target as HTMLInputElement).blur()
+      }
+    },
+    [],
+  )
+
+  const handleColorSelect = useCallback(
+    (colorKey: string) => {
+      savePatch({ color: colorKey })
+    },
+    [savePatch],
+  )
+
+  const handleDirectionChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setDirection(e.target.value.slice(0, MAX_DIRECTION_CHARS))
+    },
+    [],
+  )
+
+  const handleDirectionBlur = useCallback(() => {
+    if (!lane) return
+    const current = lane.direction ?? ""
+    if (direction !== current) {
+      savePatch({ direction: direction || null })
+    }
+  }, [direction, lane, savePatch])
+
+  const handleNotesBlur = useCallback(() => {
+    if (!lane) return
+    const current = lane.notes ?? ""
+    if (notes !== current) {
+      savePatch({ notes: notes || null })
+    }
+  }, [notes, lane, savePatch])
+
+  if (!lane) return null
+
+  const resolvedColor = getSceneColor(lane.color)
+  const displayShotCount = shotCount ?? 0
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="w-[380px] sm:max-w-[380px] overflow-y-auto">
+        <SheetHeader>
+          <SheetTitle className="flex items-center gap-2">
+            <span
+              className="h-3 w-3 rounded-full flex-shrink-0"
+              style={{ background: resolvedColor }}
+            />
+            Scene Details
+          </SheetTitle>
+          <SheetDescription className="sr-only">
+            Edit scene properties including name, number, color, direction, and notes.
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="flex flex-col gap-5 mt-4">
+          {/* Scene Name */}
+          <div>
+            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+              Scene Name
+            </label>
+            <Input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              onBlur={handleNameBlur}
+              onKeyDown={handleNameKeyDown}
+              placeholder="e.g., Beach Lifestyle"
+              data-testid="scene-name-input"
+            />
+          </div>
+
+          {/* Scene Number */}
+          <div>
+            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+              Scene Number
+            </label>
+            <Input
+              type="number"
+              value={sceneNumber}
+              onChange={(e) => setSceneNumber(e.target.value)}
+              onBlur={handleSceneNumberBlur}
+              onKeyDown={handleSceneNumberKeyDown}
+              placeholder="e.g., 1"
+              min={0}
+              data-testid="scene-number-input"
+            />
+          </div>
+
+          {/* Color Picker */}
+          <div>
+            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+              Color
+            </label>
+            <div className="flex gap-2" data-testid="scene-color-picker">
+              {SCENE_COLORS.map((c) => (
+                <button
+                  key={c.key}
+                  type="button"
+                  onClick={() => handleColorSelect(c.key)}
+                  className={`h-7 w-7 rounded-full transition-all ${
+                    lane.color === c.key
+                      ? "ring-2 ring-white ring-offset-2 ring-offset-[var(--color-surface)]"
+                      : "hover:scale-110"
+                  }`}
+                  style={{ background: c.hex }}
+                  aria-label={`Color ${c.key}`}
+                  data-testid={`scene-color-${c.key}`}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Creative Direction */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                Creative Direction
+              </label>
+              <span className="text-3xs text-[var(--color-text-subtle)]">
+                {direction.length}/{MAX_DIRECTION_CHARS}
+              </span>
+            </div>
+            <Textarea
+              value={direction}
+              onChange={handleDirectionChange}
+              onBlur={handleDirectionBlur}
+              rows={3}
+              maxLength={MAX_DIRECTION_CHARS}
+              placeholder="Mood, lighting, style notes..."
+              className="resize-none text-sm"
+              data-testid="scene-direction-textarea"
+            />
+          </div>
+
+          {/* Production Notes */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                Production Notes
+              </label>
+              <span className="text-3xs text-[var(--color-text-subtle)]">
+                {notes.length}/{MAX_NOTES_CHARS}
+              </span>
+            </div>
+            <Textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value.slice(0, MAX_NOTES_CHARS))}
+              onBlur={handleNotesBlur}
+              rows={5}
+              maxLength={MAX_NOTES_CHARS}
+              placeholder="Setup, timing, special requirements..."
+              className="resize-none text-sm"
+              data-testid="scene-notes-textarea"
+            />
+          </div>
+
+          {/* Shot count */}
+          <div className="flex items-center gap-1.5 text-xs text-[var(--color-text-muted)] pt-1 border-t border-[var(--color-border)]">
+            <span className="font-medium">{displayShotCount}</span>
+            <span>{displayShotCount === 1 ? "shot" : "shots"} in this scene</span>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -108,10 +108,11 @@ export function SceneDetailSheet({
   const handleSceneNumberBlur = useCallback(() => {
     if (!lane) return
     const trimmed = sceneNumber.trim()
+    // Scene number cannot be cleared — every lane has one (auto-incremented at
+    // creation, backfilled at read time for legacy lanes). If the user empties
+    // the field, revert to the stored value.
     if (!trimmed) {
-      if (lane.sceneNumber !== undefined) {
-        savePatch({ sceneNumber: null })
-      }
+      setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
       return
     }
     const parsed = Number(trimmed)
@@ -151,6 +152,14 @@ export function SceneDetailSheet({
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
       // maxLength on the textarea enforces the limit at the browser boundary.
       setDirection(e.target.value)
+    },
+    [],
+  )
+
+  const handleNotesChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      // maxLength on the textarea enforces the limit at the browser boundary.
+      setNotes(e.target.value)
     },
     [],
   )
@@ -195,10 +204,14 @@ export function SceneDetailSheet({
         <div className="flex flex-col gap-5 mt-4">
           {/* Scene Name */}
           <div>
-            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+            <label
+              htmlFor="scene-detail-name"
+              className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block"
+            >
               Scene Name
             </label>
             <Input
+              id="scene-detail-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
               onBlur={handleNameBlur}
@@ -210,10 +223,14 @@ export function SceneDetailSheet({
 
           {/* Scene Number */}
           <div>
-            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+            <label
+              htmlFor="scene-detail-number"
+              className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block"
+            >
               Scene Number
             </label>
             <Input
+              id="scene-detail-number"
               type="number"
               value={sceneNumber}
               onChange={(e) => setSceneNumber(e.target.value)}
@@ -225,11 +242,11 @@ export function SceneDetailSheet({
             />
           </div>
 
-          {/* Color Picker */}
-          <div>
-            <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
+          {/* Color Picker — fieldset/legend for an accessible group label */}
+          <fieldset>
+            <legend className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
               Color
-            </label>
+            </legend>
             <div className="flex gap-2" data-testid="scene-color-picker">
               {SCENE_COLORS.map((c) => (
                 <button
@@ -243,16 +260,20 @@ export function SceneDetailSheet({
                   }`}
                   style={{ background: c.hex }}
                   aria-label={`Color ${c.key}`}
+                  aria-pressed={lane.color === c.key}
                   data-testid={`scene-color-${c.key}`}
                 />
               ))}
             </div>
-          </div>
+          </fieldset>
 
           {/* Creative Direction */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+              <label
+                htmlFor="scene-detail-direction"
+                className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]"
+              >
                 Creative Direction
               </label>
               <span className="text-3xs text-[var(--color-text-subtle)]">
@@ -260,6 +281,7 @@ export function SceneDetailSheet({
               </span>
             </div>
             <Textarea
+              id="scene-detail-direction"
               value={direction}
               onChange={handleDirectionChange}
               onBlur={handleDirectionBlur}
@@ -274,7 +296,10 @@ export function SceneDetailSheet({
           {/* Production Notes */}
           <div>
             <div className="flex items-center justify-between mb-1.5">
-              <label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+              <label
+                htmlFor="scene-detail-notes"
+                className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]"
+              >
                 Production Notes
               </label>
               <span className="text-3xs text-[var(--color-text-subtle)]">
@@ -282,8 +307,9 @@ export function SceneDetailSheet({
               </span>
             </div>
             <Textarea
+              id="scene-detail-notes"
               value={notes}
-              onChange={(e) => setNotes(e.target.value)}
+              onChange={handleNotesChange}
               onBlur={handleNotesBlur}
               rows={5}
               maxLength={MAX_NOTES_CHARS}

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -80,9 +80,12 @@ export function SceneDetailSheet({
           clientId,
           patch,
         })
-        toast.success("Scene updated")
+        // Use a stable toast id keyed to this sheet instance so tabbing through
+        // multiple fields in rapid succession replaces the previous toast instead
+        // of stacking (avoids the "toast storm" on multi-field edit).
+        toast.success("Scene updated", { id: `scene-update:${lane.id}` })
       } catch {
-        toast.error("Failed to update scene")
+        toast.error("Failed to update scene", { id: `scene-update:${lane.id}` })
       }
     },
     [lane, projectId, clientId],

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/ui/sheet"
 import { Input } from "@/ui/input"
 import { Textarea } from "@/ui/textarea"
-import { SCENE_COLORS, getSceneColor } from "@/features/shots/components/SceneHeader"
+import { SCENE_COLORS, getSceneColor } from "@/features/shots/lib/sceneColors"
 import { updateLane, type LanePatch } from "@/features/shots/lib/laneActions"
 import { toast } from "sonner"
 import type { Lane } from "@/shared/types"
@@ -115,9 +115,11 @@ export function SceneDetailSheet({
       return
     }
     const parsed = Number(trimmed)
-    // Accept any non-negative integer; "01" is fine (parseInt normalizes to 1 on display).
-    if (!Number.isInteger(parsed) || parsed < 0) {
-      toast.error("Scene number must be a whole number (0 or greater)")
+    // Scene numbers must be positive integers (>= 1). Scene 0 would produce shot
+    // numbers like "0A", "0B" which sort before Scene 1 and look odd. Auto-increment
+    // also starts at 1, so 0 is never produced by the system — reject manual override.
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      toast.error("Scene number must be a whole number (1 or greater)")
       setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
       return
     }
@@ -147,7 +149,8 @@ export function SceneDetailSheet({
 
   const handleDirectionChange = useCallback(
     (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setDirection(e.target.value.slice(0, MAX_DIRECTION_CHARS))
+      // maxLength on the textarea enforces the limit at the browser boundary.
+      setDirection(e.target.value)
     },
     [],
   )
@@ -217,7 +220,7 @@ export function SceneDetailSheet({
               onBlur={handleSceneNumberBlur}
               onKeyDown={handleSceneNumberKeyDown}
               placeholder="e.g., 1"
-              min={0}
+              min={1}
               data-testid="scene-number-input"
             />
           </div>
@@ -280,7 +283,7 @@ export function SceneDetailSheet({
             </div>
             <Textarea
               value={notes}
-              onChange={(e) => setNotes(e.target.value.slice(0, MAX_NOTES_CHARS))}
+              onChange={(e) => setNotes(e.target.value)}
               onBlur={handleNotesBlur}
               rows={5}
               maxLength={MAX_NOTES_CHARS}

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -32,6 +32,7 @@ interface SceneDetailSheetProps {
 
 const MAX_DIRECTION_CHARS = 500
 const MAX_NOTES_CHARS = 5000
+const MAX_SCENE_NUMBER = 9999
 
 // ---------------------------------------------------------------------------
 // Component
@@ -116,11 +117,11 @@ export function SceneDetailSheet({
       return
     }
     const parsed = Number(trimmed)
-    // Scene numbers must be positive integers (>= 1). Scene 0 would produce shot
-    // numbers like "0A", "0B" which sort before Scene 1 and look odd. Auto-increment
-    // also starts at 1, so 0 is never produced by the system — reject manual override.
-    if (!Number.isInteger(parsed) || parsed < 1) {
-      toast.error("Scene number must be a whole number (1 or greater)")
+    // Scene numbers must be positive integers (1..9999). Scene 0 would produce shot
+    // numbers like "0A", "0B" which sort before Scene 1. An upper bound prevents
+    // absurd values like "99999A" that would overflow table columns and PDFs.
+    if (!Number.isInteger(parsed) || parsed < 1 || parsed > MAX_SCENE_NUMBER) {
+      toast.error(`Scene number must be a whole number between 1 and ${MAX_SCENE_NUMBER}`)
       setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
       return
     }
@@ -238,6 +239,7 @@ export function SceneDetailSheet({
               onKeyDown={handleSceneNumberKeyDown}
               placeholder="e.g., 1"
               min={1}
+              max={MAX_SCENE_NUMBER}
               data-testid="scene-number-input"
             />
           </div>

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -114,14 +114,17 @@ export function SceneDetailSheet({
       }
       return
     }
-    const parsed = parseInt(trimmed, 10)
-    if (!Number.isFinite(parsed) || parsed < 0 || String(parsed) !== trimmed) {
-      toast.error("Scene number must be a non-negative integer")
+    const parsed = Number(trimmed)
+    // Accept any non-negative integer; "01" is fine (parseInt normalizes to 1 on display).
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      toast.error("Scene number must be a whole number (0 or greater)")
       setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
       return
     }
     if (parsed !== lane.sceneNumber) {
       savePatch({ sceneNumber: parsed })
+      // Reflect the normalized value back into the input (e.g., "01" → "1")
+      setSceneNumber(String(parsed))
     }
   }, [sceneNumber, lane, savePatch])
 

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -184,13 +184,15 @@ export function SceneDetailSheet({
     }
   }, [notes, lane, savePatch])
 
-  if (!lane) return null
-
-  const resolvedColor = getSceneColor(lane.color)
+  // Keep the Sheet mounted even when lane is null so that a deletion-while-open
+  // scenario still plays Radix's close animation. When lane is null we render
+  // an empty shell inside SheetContent instead of returning null at the component
+  // boundary.
+  const resolvedColor = lane ? getSceneColor(lane.color) : getSceneColor(null)
   const displayShotCount = shotCount ?? 0
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange}>
+    <Sheet open={open && lane !== null} onOpenChange={onOpenChange}>
       <SheetContent side="right" className="w-[380px] sm:max-w-[380px] overflow-y-auto">
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
@@ -205,6 +207,14 @@ export function SceneDetailSheet({
           </SheetDescription>
         </SheetHeader>
 
+        {!lane ? (
+          // Lane was deleted while the sheet was open — show a brief empty state
+          // until Radix finishes the close animation (parent clears editSceneId
+          // via onOpenChange).
+          <div className="flex items-center justify-center py-10 text-sm text-[var(--color-text-muted)]">
+            Scene no longer available
+          </div>
+        ) : (
         <div className="flex flex-col gap-5 mt-4">
           {/* Scene Name */}
           <div>
@@ -330,6 +340,7 @@ export function SceneDetailSheet({
             <span>{displayShotCount === 1 ? "shot" : "shots"} in this scene</span>
           </div>
         </div>
+        )}
       </SheetContent>
     </Sheet>
   )

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -24,6 +24,11 @@ interface SceneDetailSheetProps {
   readonly projectId: string
   readonly clientId: string | null
   readonly shotCount?: number
+  /**
+   * All other lanes in the project — used to validate that the user doesn't
+   * enter a duplicate sceneNumber. Excludes the currently-edited lane.
+   */
+  readonly siblingLanes?: ReadonlyArray<Lane>
 }
 
 // ---------------------------------------------------------------------------
@@ -45,6 +50,7 @@ export function SceneDetailSheet({
   projectId,
   clientId,
   shotCount,
+  siblingLanes,
 }: SceneDetailSheetProps) {
   // Local state for form fields
   const [name, setName] = useState("")
@@ -128,12 +134,24 @@ export function SceneDetailSheet({
       setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
       return
     }
+    // Duplicate check: two scenes with the same sceneNumber would produce
+    // colliding shot numbers (e.g., both scenes numbering their first shot "3A").
+    const duplicate = siblingLanes?.find(
+      (l) => l.id !== lane.id && l.sceneNumber === parsed,
+    )
+    if (duplicate) {
+      toast.error(
+        `Scene number ${parsed} is already used by "${duplicate.name}". Pick a different number.`,
+      )
+      setSceneNumber(lane.sceneNumber != null ? String(lane.sceneNumber) : "")
+      return
+    }
     if (parsed !== lane.sceneNumber) {
       savePatch({ sceneNumber: parsed })
       // Reflect the normalized value back into the input (e.g., "01" → "1")
       setSceneNumber(String(parsed))
     }
-  }, [sceneNumber, lane, savePatch])
+  }, [sceneNumber, lane, savePatch, siblingLanes])
 
   const handleSceneNumberKeyDown = useCallback(
     (e: React.KeyboardEvent) => {

--- a/src-vnext/features/shots/components/SceneHeader.tsx
+++ b/src-vnext/features/shots/components/SceneHeader.tsx
@@ -76,7 +76,10 @@ export function SceneHeader({
           {name}
         </span>
         {trimmedDirection && !isUngrouped && (
-          <span className="text-2xs text-[var(--color-text-muted)] truncate">
+          <span
+            className="text-2xs text-[var(--color-text-muted)] truncate"
+            title={direction && direction.length > 60 ? direction : undefined}
+          >
             {trimmedDirection}{direction && direction.length > 60 ? "\u2026" : ""}
           </span>
         )}

--- a/src-vnext/features/shots/components/SceneHeader.tsx
+++ b/src-vnext/features/shots/components/SceneHeader.tsx
@@ -24,9 +24,11 @@ interface SceneHeaderProps {
   /** @deprecated Use onEdit instead */
   readonly onRename?: () => void
   readonly onEdit?: () => void
-  readonly onUngroupAll: () => void
-  readonly onDelete: () => void
+  readonly onUngroupAll?: () => void
+  readonly onDelete?: () => void
   readonly isUngrouped?: boolean
+  /** When false, hides the kebab menu entirely (crew-level read access). */
+  readonly canManageLanes?: boolean
 }
 
 export function SceneHeader({
@@ -42,6 +44,7 @@ export function SceneHeader({
   onUngroupAll,
   onDelete,
   isUngrouped,
+  canManageLanes = true,
 }: SceneHeaderProps) {
   const ChevronIcon = collapsed ? ChevronRight : ChevronDown
   const trimmedDirection = direction ? direction.slice(0, 60) : null
@@ -89,7 +92,7 @@ export function SceneHeader({
         {shotCount}
       </span>
 
-      {!isUngrouped && (
+      {!isUngrouped && canManageLanes && (
         <DropdownMenu>
           <DropdownMenuTrigger
             onClick={(e) => e.stopPropagation()}
@@ -106,15 +109,19 @@ export function SceneHeader({
               </DropdownMenuItem>
             )}
             <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={onUngroupAll}>
-              Ungroup All
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              className="text-[var(--color-error)]"
-              onClick={onDelete}
-            >
-              Delete Scene
-            </DropdownMenuItem>
+            {onUngroupAll && (
+              <DropdownMenuItem onClick={onUngroupAll}>
+                Ungroup All
+              </DropdownMenuItem>
+            )}
+            {onDelete && (
+              <DropdownMenuItem
+                className="text-[var(--color-error)]"
+                onClick={onDelete}
+              >
+                Delete Scene
+              </DropdownMenuItem>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       )}

--- a/src-vnext/features/shots/components/SceneHeader.tsx
+++ b/src-vnext/features/shots/components/SceneHeader.tsx
@@ -28,9 +28,13 @@ interface SceneHeaderProps {
   readonly name: string
   readonly shotCount: number
   readonly color?: string | null
+  readonly sceneNumber?: number
+  readonly direction?: string
   readonly collapsed: boolean
   readonly onToggleCollapse: () => void
-  readonly onRename: () => void
+  /** @deprecated Use onEdit instead */
+  readonly onRename?: () => void
+  readonly onEdit?: () => void
   readonly onUngroupAll: () => void
   readonly onDelete: () => void
   readonly isUngrouped?: boolean
@@ -40,14 +44,19 @@ export function SceneHeader({
   name,
   shotCount,
   color,
+  sceneNumber,
+  direction,
   collapsed,
   onToggleCollapse,
   onRename,
+  onEdit,
   onUngroupAll,
   onDelete,
   isUngrouped,
 }: SceneHeaderProps) {
   const ChevronIcon = collapsed ? ChevronRight : ChevronDown
+  const trimmedDirection = direction ? direction.slice(0, 60) : null
+  const handleEditOrRename = onEdit ?? onRename
 
   return (
     <button
@@ -62,15 +71,27 @@ export function SceneHeader({
 
       <ChevronIcon className="h-3.5 w-3.5 text-[var(--color-text-muted)]" />
 
-      <span
-        className={`text-sm font-semibold flex-1 ${
-          isUngrouped
-            ? "text-[var(--color-text-muted)]"
-            : "text-[var(--color-text)]"
-        }`}
-      >
-        {name}
-      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={`text-sm font-semibold truncate ${
+            isUngrouped
+              ? "text-[var(--color-text-muted)]"
+              : "text-[var(--color-text)]"
+          }`}
+        >
+          {sceneNumber != null && !isUngrouped && (
+            <span className="text-[var(--color-text-subtle)] font-normal mr-1">
+              #{sceneNumber}
+            </span>
+          )}
+          {name}
+        </span>
+        {trimmedDirection && !isUngrouped && (
+          <span className="text-2xs text-[var(--color-text-muted)] truncate">
+            {trimmedDirection}{direction && direction.length > 60 ? "\u2026" : ""}
+          </span>
+        )}
+      </div>
 
       <span className="text-2xs text-[var(--color-text-muted)] bg-[var(--color-surface-subtle)] px-1.5 py-0.5 rounded-full">
         {shotCount}
@@ -87,7 +108,11 @@ export function SceneHeader({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuItem onClick={onRename}>Rename</DropdownMenuItem>
+            {handleEditOrRename && (
+              <DropdownMenuItem onClick={handleEditOrRename}>
+                Edit Scene
+              </DropdownMenuItem>
+            )}
             <DropdownMenuSeparator />
             <DropdownMenuItem onClick={onUngroupAll}>
               Ungroup All

--- a/src-vnext/features/shots/components/SceneHeader.tsx
+++ b/src-vnext/features/shots/components/SceneHeader.tsx
@@ -6,23 +6,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
+import { SCENE_COLORS, getSceneColor, type SceneColorKey } from "@/features/shots/lib/sceneColors"
 
-export const SCENE_COLORS = [
-  { key: "teal", hex: "#14b8a6" },
-  { key: "purple", hex: "#a78bfa" },
-  { key: "green", hex: "#22c55e" },
-  { key: "orange", hex: "#fb923c" },
-  { key: "pink", hex: "#fb7185" },
-  { key: "blue", hex: "#3b82f6" },
-] as const
-
-export type SceneColorKey = (typeof SCENE_COLORS)[number]["key"]
-
-export function getSceneColor(color?: string | null): string {
-  if (!color) return "var(--color-text-subtle)"
-  const found = SCENE_COLORS.find((c) => c.key === color)
-  return found?.hex ?? color
-}
+// Re-exports for backward compatibility — new code should import directly from
+// `@/features/shots/lib/sceneColors`.
+export { SCENE_COLORS, getSceneColor }
+export type { SceneColorKey }
 
 interface SceneHeaderProps {
   readonly name: string

--- a/src-vnext/features/shots/components/SceneHeader.tsx
+++ b/src-vnext/features/shots/components/SceneHeader.tsx
@@ -21,8 +21,6 @@ interface SceneHeaderProps {
   readonly direction?: string
   readonly collapsed: boolean
   readonly onToggleCollapse: () => void
-  /** @deprecated Use onEdit instead */
-  readonly onRename?: () => void
   readonly onEdit?: () => void
   readonly onUngroupAll?: () => void
   readonly onDelete?: () => void
@@ -39,7 +37,6 @@ export function SceneHeader({
   direction,
   collapsed,
   onToggleCollapse,
-  onRename,
   onEdit,
   onUngroupAll,
   onDelete,
@@ -48,7 +45,6 @@ export function SceneHeader({
 }: SceneHeaderProps) {
   const ChevronIcon = collapsed ? ChevronRight : ChevronDown
   const trimmedDirection = direction ? direction.slice(0, 60) : null
-  const handleEditOrRename = onEdit ?? onRename
 
   return (
     <button
@@ -103,8 +99,8 @@ export function SceneHeader({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            {handleEditOrRename && (
-              <DropdownMenuItem onClick={handleEditOrRename}>
+            {onEdit && (
+              <DropdownMenuItem onClick={onEdit}>
                 Edit Scene
               </DropdownMenuItem>
             )}

--- a/src-vnext/features/shots/components/SceneTableRow.tsx
+++ b/src-vnext/features/shots/components/SceneTableRow.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
-import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import { getSceneColor } from "@/features/shots/lib/sceneColors"
 
 interface SceneTableRowProps {
   readonly label: string
@@ -42,10 +42,7 @@ export function SceneTableRow({
   const trimmedDirection = direction ? direction.slice(0, 60) : null
 
   return (
-    <tr
-      className="border-b border-[var(--color-border)] bg-[var(--color-surface-subtle)]"
-      role="row"
-    >
+    <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface-subtle)]">
       <td colSpan={colSpan} className="p-0">
         <div
           className="flex w-full items-center gap-2 px-3 py-2 hover:bg-[var(--color-surface-subtle)]"

--- a/src-vnext/features/shots/components/SceneTableRow.tsx
+++ b/src-vnext/features/shots/components/SceneTableRow.tsx
@@ -16,11 +16,13 @@ interface SceneTableRowProps {
   readonly direction?: string
   readonly collapsed: boolean
   readonly onToggleCollapse: () => void
-  readonly onEdit: () => void
-  readonly onUngroupAll: () => void
-  readonly onDelete: () => void
+  readonly onEdit?: () => void
+  readonly onUngroupAll?: () => void
+  readonly onDelete?: () => void
   readonly isUngrouped: boolean
   readonly colSpan: number
+  /** When false, hides the kebab menu entirely (crew-level read access). */
+  readonly canManageLanes?: boolean
 }
 
 export function SceneTableRow({
@@ -36,6 +38,7 @@ export function SceneTableRow({
   onDelete,
   isUngrouped,
   colSpan,
+  canManageLanes = true,
 }: SceneTableRowProps) {
   const ChevronIcon = collapsed ? ChevronRight : ChevronDown
   const resolvedColor = getSceneColor(isUngrouped ? null : color)
@@ -88,7 +91,7 @@ export function SceneTableRow({
             {shotCount}
           </span>
 
-          {!isUngrouped && (
+          {!isUngrouped && canManageLanes && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -100,19 +103,25 @@ export function SceneTableRow({
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={onEdit}>
-                  Edit Scene
-                </DropdownMenuItem>
+                {onEdit && (
+                  <DropdownMenuItem onClick={onEdit}>
+                    Edit Scene
+                  </DropdownMenuItem>
+                )}
                 <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={onUngroupAll}>
-                  Ungroup All
-                </DropdownMenuItem>
-                <DropdownMenuItem
-                  className="text-[var(--color-error)]"
-                  onClick={onDelete}
-                >
-                  Delete Scene
-                </DropdownMenuItem>
+                {onUngroupAll && (
+                  <DropdownMenuItem onClick={onUngroupAll}>
+                    Ungroup All
+                  </DropdownMenuItem>
+                )}
+                {onDelete && (
+                  <DropdownMenuItem
+                    className="text-[var(--color-error)]"
+                    onClick={onDelete}
+                  >
+                    Delete Scene
+                  </DropdownMenuItem>
+                )}
               </DropdownMenuContent>
             </DropdownMenu>
           )}

--- a/src-vnext/features/shots/components/SceneTableRow.tsx
+++ b/src-vnext/features/shots/components/SceneTableRow.tsx
@@ -1,0 +1,123 @@
+import { ChevronDown, ChevronRight, MoreHorizontal } from "lucide-react"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu"
+import { getSceneColor } from "@/features/shots/components/SceneHeader"
+
+interface SceneTableRowProps {
+  readonly label: string
+  readonly sceneNumber?: number
+  readonly shotCount: number
+  readonly color?: string
+  readonly direction?: string
+  readonly collapsed: boolean
+  readonly onToggleCollapse: () => void
+  readonly onEdit: () => void
+  readonly onUngroupAll: () => void
+  readonly onDelete: () => void
+  readonly isUngrouped: boolean
+  readonly colSpan: number
+}
+
+export function SceneTableRow({
+  label,
+  sceneNumber,
+  shotCount,
+  color,
+  direction,
+  collapsed,
+  onToggleCollapse,
+  onEdit,
+  onUngroupAll,
+  onDelete,
+  isUngrouped,
+  colSpan,
+}: SceneTableRowProps) {
+  const ChevronIcon = collapsed ? ChevronRight : ChevronDown
+  const resolvedColor = getSceneColor(isUngrouped ? null : color)
+  const trimmedDirection = direction ? direction.slice(0, 60) : null
+
+  return (
+    <tr
+      className="border-b border-[var(--color-border)] bg-[var(--color-surface-subtle)]"
+      role="row"
+    >
+      <td colSpan={colSpan} className="p-0">
+        <div
+          className="flex w-full items-center gap-2 px-3 py-2 hover:bg-[var(--color-surface-subtle)]"
+          style={{ borderLeft: `3px solid ${resolvedColor}` }}
+        >
+          {/* Collapse toggle — a dedicated button that doesn't wrap other interactive elements */}
+          <button
+            type="button"
+            className="flex min-w-0 flex-1 items-center gap-2 text-left"
+            onClick={onToggleCollapse}
+            aria-expanded={!collapsed}
+            aria-label={`${collapsed ? "Expand" : "Collapse"} scene ${label}`}
+          >
+            <ChevronIcon className="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-muted)]" />
+
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+              <span
+                className={`text-sm font-semibold truncate ${
+                  isUngrouped
+                    ? "text-[var(--color-text-muted)]"
+                    : "text-[var(--color-text)]"
+                }`}
+              >
+                {sceneNumber != null && !isUngrouped && (
+                  <span className="text-[var(--color-text-subtle)] font-normal mr-1">
+                    #{sceneNumber}
+                  </span>
+                )}
+                {label}
+              </span>
+              {trimmedDirection && (
+                <span className="text-2xs text-[var(--color-text-subtle)] truncate">
+                  {trimmedDirection}{direction && direction.length > 60 ? "\u2026" : ""}
+                </span>
+              )}
+            </div>
+          </button>
+
+          <span className="flex-shrink-0 rounded-full bg-[var(--color-surface)] px-1.5 py-0.5 text-2xs text-[var(--color-text-muted)]">
+            {shotCount}
+          </span>
+
+          {!isUngrouped && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex-shrink-0 rounded p-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface)]"
+                  aria-label="Scene actions"
+                >
+                  <MoreHorizontal className="h-3.5 w-3.5" />
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={onEdit}>
+                  Edit Scene
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={onUngroupAll}>
+                  Ungroup All
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  className="text-[var(--color-error)]"
+                  onClick={onDelete}
+                >
+                  Delete Scene
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/src-vnext/features/shots/components/SceneTableRow.tsx
+++ b/src-vnext/features/shots/components/SceneTableRow.tsx
@@ -74,7 +74,10 @@ export function SceneTableRow({
                 {label}
               </span>
               {trimmedDirection && (
-                <span className="text-2xs text-[var(--color-text-subtle)] truncate">
+                <span
+                  className="text-2xs text-[var(--color-text-subtle)] truncate"
+                  title={direction && direction.length > 60 ? direction : undefined}
+                >
                   {trimmedDirection}{direction && direction.length > 60 ? "\u2026" : ""}
                 </span>
               )}

--- a/src-vnext/features/shots/components/SceneTableRow.tsx
+++ b/src-vnext/features/shots/components/SceneTableRow.tsx
@@ -45,7 +45,7 @@ export function SceneTableRow({
     <tr className="border-b border-[var(--color-border)] bg-[var(--color-surface-subtle)]">
       <td colSpan={colSpan} className="p-0">
         <div
-          className="flex w-full items-center gap-2 px-3 py-2 hover:bg-[var(--color-surface-subtle)]"
+          className="flex w-full items-center gap-2 px-3 py-2 transition-colors hover:bg-[var(--color-surface-muted)]"
           style={{ borderLeft: `3px solid ${resolvedColor}` }}
         >
           {/* Collapse toggle — a dedicated button that doesn't wrap other interactive elements */}

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { useShot } from "@/features/shots/hooks/useShot"
 import { useShots } from "@/features/shots/hooks/useShots"
+import { useLanes } from "@/features/shots/hooks/useLanes"
 import { ShotStatusSelect } from "@/features/shots/components/ShotStatusSelect"
 import { ShotStatusTapRow } from "@/features/shots/components/ShotStatusTapRow"
 import { TalentPicker } from "@/features/shots/components/TalentPicker"
@@ -19,6 +20,8 @@ import { TagEditor } from "@/features/shots/components/TagEditor"
 import { ShotLifecycleActionsMenu } from "@/features/shots/components/ShotLifecycleActionsMenu"
 import { ShotReferenceLinksSection } from "@/features/shots/components/ShotReferenceLinksSection"
 import { ProductSummaryStrip } from "@/features/shots/components/ProductSummaryStrip"
+import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
 import { formatDateOnly, parseDateOnly } from "@/features/shots/lib/dateOnly"
 import { useAuth } from "@/app/providers/AuthProvider"
@@ -58,7 +61,9 @@ export default function ShotDetailPage() {
   const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
   const canShare = role === "admin" || role === "producer"
   const [shareOpen, setShareOpen] = useState(false)
+  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
   const canExport = !isMobile
+  const { data: lanes, laneById } = useLanes()
 
   // -- FAB integration: ?status_picker=1 and ?focus=notes --
   const [searchParams, setSearchParamsFab] = useSearchParams()
@@ -162,6 +167,13 @@ export default function ShotDetailPage() {
           <span className="mx-1">/</span>
           <span>#{shot.shotNumber || "—"}</span>
         </div>
+
+        {/* ── Scene context banner ── */}
+        <SceneContextBanner
+          laneId={shot.laneId}
+          laneById={laneById}
+          onViewScene={() => setSceneSheetOpen(true)}
+        />
 
         {/* ── Header: back, title, shot number, status ── */}
         <div className="flex items-center gap-3">
@@ -377,6 +389,15 @@ export default function ShotDetailPage() {
             selectedShotIds={[shot.id]}
           />
         )}
+
+        <SceneDetailSheet
+          open={sceneSheetOpen}
+          onOpenChange={setSceneSheetOpen}
+          lane={shot.laneId ? laneById.get(shot.laneId) ?? null : null}
+          projectId={shot.projectId}
+          clientId={clientId}
+          shotCount={shot.laneId ? projectShots.filter((s) => s.laneId === shot.laneId).length : 0}
+        />
 
       </div>
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -102,6 +102,13 @@ export default function ShotListPage() {
   const [editSceneId, setEditSceneId] = useState<string | null>(null)
   const [collapsedScenes, setCollapsedScenes] = useState<ReadonlySet<string>>(new Set())
 
+  // Scene shot count for the open SceneDetailSheet — memoized so we don't re-filter
+  // the shots array on every render while the sheet is open.
+  const editSceneShotCount = useMemo(
+    () => (editSceneId ? shots.filter((s) => s.laneId === editSceneId).length : 0),
+    [editSceneId, shots],
+  )
+
   const toggleSceneCollapse = useCallback((key: string) => {
     setCollapsedScenes((prev) => {
       const next = new Set(prev)
@@ -119,6 +126,10 @@ export default function ShotListPage() {
   const canShare = role === "admin" || role === "producer"
   const canExport = !isMobile
   const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
+  // Scene/lane writes (edit, delete, ungroup) are gated to admin/producer/warehouse
+  // to match the Firestore rule on /lanes. Crew users see the scene grouping UI
+  // read-only — no kebab menu, no edit sheet access from the table header.
+  const canManageLanes = role === "admin" || role === "producer" || role === "warehouse"
 
   // -- Lookup maps (computed from picker data, passed to list state hook) --
   const talentNameById = useMemo(() => new Map(talentRecords.map((t) => [t.id, t.name])), [talentRecords])
@@ -600,25 +611,30 @@ export default function ShotListPage() {
               if (!clientId) return
               void assignShotsToLane({ shotIds: [shotId], laneId, projectId, clientId })
                 .then(() => {
-                  const laneName = laneId ? (laneNameById.get(laneId) ?? "scene") : "None"
-                  toast.success(`Shot assigned to ${laneName}`)
+                  if (laneId) {
+                    const laneName = laneNameById.get(laneId) ?? "scene"
+                    toast.success(`Shot moved to ${laneName}`)
+                  } else {
+                    toast.success("Shot removed from scene")
+                  }
                 })
                 .catch(() => toast.error("Failed to assign scene"))
             }}
             groups={hasActiveGrouping ? shotGroups : null}
             collapsedScenes={collapsedScenes}
             onToggleSceneCollapse={toggleSceneCollapse}
-            onEditScene={(key) => setEditSceneId(key)}
-            onDeleteScene={(key, name) => {
+            canManageLanes={canManageLanes}
+            onEditScene={canManageLanes ? (key) => setEditSceneId(key) : undefined}
+            onDeleteScene={canManageLanes ? (key, name) => {
               setDeleteSceneTarget({ id: key, name })
-            }}
-            onUngroupScene={(key) => {
+            } : undefined}
+            onUngroupScene={canManageLanes ? (key) => {
               if (clientId) {
                 void ungroupAllShotsFromLane({ shots, laneId: key, projectId, clientId })
                   .then((n) => toast.success(`${n} shots ungrouped`))
                   .catch(() => toast.error("Failed to ungroup scene"))
               }
-            }}
+            } : undefined}
           />
       ) : (
         hasActiveGrouping && shotGroups ? (
@@ -640,17 +656,18 @@ export default function ShotListPage() {
                       direction={lane?.direction}
                       collapsed={isCollapsed}
                       onToggleCollapse={() => toggleSceneCollapse(group.key)}
-                      onEdit={() => setEditSceneId(group.key)}
-                      onUngroupAll={() => {
+                      canManageLanes={canManageLanes}
+                      onEdit={canManageLanes ? () => setEditSceneId(group.key) : undefined}
+                      onUngroupAll={canManageLanes ? () => {
                         if (clientId) {
                           void ungroupAllShotsFromLane({ shots, laneId: group.key, projectId, clientId })
                             .then((n) => toast.success(`${n} shots ungrouped`))
                             .catch(() => toast.error("Failed to ungroup scene"))
                         }
-                      }}
-                      onDelete={() => {
+                      } : undefined}
+                      onDelete={canManageLanes ? () => {
                         setDeleteSceneTarget({ id: group.key, name: group.label })
-                      }}
+                      } : undefined}
                       isUngrouped={isUngrouped}
                     />
                   ) : (
@@ -887,10 +904,7 @@ export default function ShotListPage() {
         lane={editSceneId ? laneById.get(editSceneId) ?? null : null}
         projectId={projectId}
         clientId={clientId}
-        // Use the unfiltered `shots` array so the count reflects the true scene
-        // population — displayShots is post-filter and would under-report when
-        // the user has active status/talent/product filters.
-        shotCount={editSceneId ? shots.filter((s) => s.laneId === editSceneId).length : 0}
+        shotCount={editSceneShotCount}
       />
 
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -616,6 +616,7 @@ export default function ShotListPage() {
               if (clientId) {
                 void ungroupAllShotsFromLane({ shots, laneId: key, projectId, clientId })
                   .then((n) => toast.success(`${n} shots ungrouped`))
+                  .catch(() => toast.error("Failed to ungroup scene"))
               }
             }}
           />
@@ -644,6 +645,7 @@ export default function ShotListPage() {
                         if (clientId) {
                           void ungroupAllShotsFromLane({ shots, laneId: group.key, projectId, clientId })
                             .then((n) => toast.success(`${n} shots ungrouped`))
+                            .catch(() => toast.error("Failed to ungroup scene"))
                         }
                       }}
                       onDelete={() => {

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -311,6 +311,8 @@ export default function ShotListPage() {
           }}
           projects={projects}
           existingTitles={existingShotTitles}
+          lanes={lanes}
+          laneById={laneById}
         />
       </ErrorBoundary>
     )
@@ -905,6 +907,7 @@ export default function ShotListPage() {
         projectId={projectId}
         clientId={clientId}
         shotCount={editSceneShotCount}
+        siblingLanes={lanes}
       />
 
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -887,7 +887,10 @@ export default function ShotListPage() {
         lane={editSceneId ? laneById.get(editSceneId) ?? null : null}
         projectId={projectId}
         clientId={clientId}
-        shotCount={editSceneId ? displayShots.filter((s) => s.laneId === editSceneId).length : 0}
+        // Use the unfiltered `shots` array so the count reflects the true scene
+        // population — displayShots is post-filter and would under-report when
+        // the user has active status/talent/product filters.
+        shotCount={editSceneId ? shots.filter((s) => s.laneId === editSceneId).length : 0}
       />
 
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -39,8 +39,9 @@ import { RenumberShotsDialog } from "@/features/shots/components/RenumberShotsDi
 import { useHeroProductData } from "@/features/shots/hooks/useHeroProductData"
 import { useLanes } from "@/features/shots/hooks/useLanes"
 import { SceneHeader } from "@/features/shots/components/SceneHeader"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { GroupIntoSceneDialog } from "@/features/shots/components/GroupIntoSceneDialog"
-import { createLane, assignShotsToLane, ungroupAllShotsFromLane, deleteLane, updateLane } from "@/features/shots/lib/laneActions"
+import { createLane, assignShotsToLane, ungroupAllShotsFromLane, deleteLane } from "@/features/shots/lib/laneActions"
 import { Skeleton } from "@/ui/skeleton"
 import { useStuckLoading } from "@/shared/hooks/useStuckLoading"
 import { ThreePanelLayout } from "@/features/shots/components/ThreePanelLayout"
@@ -98,6 +99,7 @@ export default function ShotListPage() {
   const [renumberOpen, setRenumberOpen] = useState(false)
   const [groupSceneOpen, setGroupSceneOpen] = useState(false)
   const [deleteSceneTarget, setDeleteSceneTarget] = useState<{ id: string; name: string } | null>(null)
+  const [editSceneId, setEditSceneId] = useState<string | null>(null)
   const [collapsedScenes, setCollapsedScenes] = useState<ReadonlySet<string>>(new Set())
 
   const toggleSceneCollapse = useCallback((key: string) => {
@@ -124,7 +126,7 @@ export default function ShotListPage() {
   const productNameById = useMemo(() => new Map(productFamilies.map((p) => [p.id, p.styleName])), [productFamilies])
   const familyById = useMemo(() => new Map(productFamilies.map((p) => [p.id, p])), [productFamilies])
   const { skuById, samplesByFamily } = useHeroProductData(shots, clientId)
-  const { data: lanes, laneNameById } = useLanes()
+  const { data: lanes, laneNameById, laneById } = useLanes()
   const laneOrder = useMemo(() => new Map(lanes.map((l) => [l.id, l.sortOrder])), [lanes])
 
   // -- All filter / sort / view state --
@@ -143,7 +145,7 @@ export default function ShotListPage() {
     shotGroups, activeFilterBadges, tagOptions,
     storageKeyBase,
   } = useShotListState({
-    shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder,
+    shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById,
   })
 
   // -- Extra (advanced) filter count: conditions beyond status/missing inline filters --
@@ -568,21 +570,6 @@ export default function ShotListPage() {
           ))}
         </div>
       ) : viewMode === "table" ? (
-        <>
-          {hasActiveGrouping && (
-            <div className="mb-3 flex items-center gap-2 rounded-md bg-[var(--color-surface-subtle)] px-3 py-2 text-xs text-[var(--color-text-subtle)]">
-              <Info className="h-3.5 w-3.5 flex-shrink-0" />
-              <span>
-                Grouping is available in Card view.{" "}
-                <button
-                  className="underline hover:text-[var(--color-text)]"
-                  onClick={() => setViewMode("card")}
-                >
-                  Switch to cards
-                </button>
-              </span>
-            </div>
-          )}
           <ShotsTable
             clientId={clientId}
             projectId={projectId}
@@ -607,8 +594,31 @@ export default function ShotListPage() {
                 .catch(() => toast.error("Failed to save shot order."))
                 .finally(() => setMobileOptimistic(null))
             }}
+            laneById={laneById}
+            lanes={lanes}
+            onAssignScene={(shotId, laneId) => {
+              if (!clientId) return
+              void assignShotsToLane({ shotIds: [shotId], laneId, projectId, clientId })
+                .then(() => {
+                  const laneName = laneId ? (laneNameById.get(laneId) ?? "scene") : "None"
+                  toast.success(`Shot assigned to ${laneName}`)
+                })
+                .catch(() => toast.error("Failed to assign scene"))
+            }}
+            groups={hasActiveGrouping ? shotGroups : null}
+            collapsedScenes={collapsedScenes}
+            onToggleSceneCollapse={toggleSceneCollapse}
+            onEditScene={(key) => setEditSceneId(key)}
+            onDeleteScene={(key, name) => {
+              setDeleteSceneTarget({ id: key, name })
+            }}
+            onUngroupScene={(key) => {
+              if (clientId) {
+                void ungroupAllShotsFromLane({ shots, laneId: key, projectId, clientId })
+                  .then((n) => toast.success(`${n} shots ungrouped`))
+              }
+            }}
           />
-        </>
       ) : (
         hasActiveGrouping && shotGroups ? (
           <div className="space-y-4">
@@ -625,14 +635,11 @@ export default function ShotListPage() {
                       name={group.label}
                       shotCount={group.shots.length}
                       color={lane?.color}
+                      sceneNumber={lane?.sceneNumber}
+                      direction={lane?.direction}
                       collapsed={isCollapsed}
                       onToggleCollapse={() => toggleSceneCollapse(group.key)}
-                      onRename={() => {
-                        const newName = window.prompt("Rename scene:", group.label)
-                        if (newName && newName.trim() && clientId) {
-                          void updateLane({ laneId: group.key, projectId, clientId, patch: { name: newName.trim() } })
-                        }
-                      }}
+                      onEdit={() => setEditSceneId(group.key)}
                       onUngroupAll={() => {
                         if (clientId) {
                           void ungroupAllShotsFromLane({ shots, laneId: group.key, projectId, clientId })
@@ -811,6 +818,8 @@ export default function ShotListPage() {
         sortDir={sortDir}
         totalShotCount={shots.length}
         allShots={shots}
+        lanes={lanes}
+        groupKey={groupKey}
       />
 
       {canShare && (
@@ -854,7 +863,7 @@ export default function ShotListPage() {
         }))}
         onCreateAndAssign={async (name, color) => {
           if (!clientId) return
-          const laneId = await createLane({ name, projectId, clientId, sortOrder: lanes.length, color, user })
+          const laneId = await createLane({ name, projectId, clientId, sortOrder: lanes.length, color, user, existingLanes: lanes })
           await assignShotsToLane({ shotIds: Array.from(selectedIds), laneId, projectId, clientId })
           toast.success(`Scene "${name}" created with ${selectedIds.size} shots`)
           clearSelection()
@@ -868,6 +877,15 @@ export default function ShotListPage() {
           clearSelection()
           setGroupKey("scene")
         }}
+      />
+
+      <SceneDetailSheet
+        open={editSceneId !== null}
+        onOpenChange={(open) => { if (!open) setEditSceneId(null) }}
+        lane={editSceneId ? laneById.get(editSceneId) ?? null : null}
+        projectId={projectId}
+        clientId={clientId}
+        shotCount={editSceneId ? displayShots.filter((s) => s.laneId === editSceneId).length : 0}
       />
 
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -97,6 +97,8 @@ type ShotsTableProps = {
   readonly onEditScene?: (key: string) => void
   readonly onDeleteScene?: (key: string, name: string) => void
   readonly onUngroupScene?: (key: string) => void
+  /** When false, scene header kebab menus are hidden (crew-level read access). */
+  readonly canManageLanes?: boolean
   readonly laneById?: ReadonlyMap<string, Lane>
   readonly lanes?: ReadonlyArray<Lane>
   readonly onAssignScene?: (shotId: string, laneId: string | null) => void
@@ -297,9 +299,10 @@ type GroupRowsProps = {
   readonly onOpenShot: (shotId: string) => void
   readonly stopPropagation: (e: React.MouseEvent) => void
   readonly onToggleCollapse: () => void
-  readonly onEdit: () => void
-  readonly onUngroupAll: () => void
-  readonly onDelete: () => void
+  readonly canManageLanes: boolean
+  readonly onEdit?: () => void
+  readonly onUngroupAll?: () => void
+  readonly onDelete?: () => void
   readonly lanes?: ReadonlyArray<Lane>
   readonly onAssignScene?: (shotId: string, laneId: string | null) => void
 }
@@ -318,6 +321,7 @@ function GroupRows({
   onOpenShot,
   stopPropagation,
   onToggleCollapse,
+  canManageLanes,
   onEdit,
   onUngroupAll,
   onDelete,
@@ -334,6 +338,7 @@ function GroupRows({
         direction={group.direction}
         collapsed={isCollapsed}
         onToggleCollapse={onToggleCollapse}
+        canManageLanes={canManageLanes}
         onEdit={onEdit}
         onUngroupAll={onUngroupAll}
         onDelete={onDelete}
@@ -399,6 +404,7 @@ export function ShotsTable({
   onEditScene,
   onDeleteScene,
   onUngroupScene,
+  canManageLanes = true,
   laneById,
   lanes,
   onAssignScene,
@@ -604,9 +610,10 @@ export function ShotsTable({
                       onOpenShot={onOpenShot}
                       stopPropagation={stopPropagation}
                       onToggleCollapse={() => onToggleSceneCollapse?.(group.key)}
-                      onEdit={() => onEditScene?.(group.key)}
-                      onUngroupAll={() => onUngroupScene?.(group.key)}
-                      onDelete={() => onDeleteScene?.(group.key, group.label)}
+                      canManageLanes={canManageLanes}
+                      onEdit={onEditScene ? () => onEditScene(group.key) : undefined}
+                      onUngroupAll={onUngroupScene ? () => onUngroupScene(group.key) : undefined}
+                      onDelete={onDeleteScene ? () => onDeleteScene(group.key, group.label) : undefined}
                       lanes={lanes}
                       onAssignScene={onAssignScene}
                     />

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -469,11 +469,16 @@ export function ShotsTable({
   }, [shots, rowContexts])
 
   // -- Compute colSpan for scene header rows --
+  // Scene header <tr> must span every column the data rows render. This mirrors the
+  // <colgroup>/<thead> structure below:
+  //   [optional drag handle] + [optional selection] + visibleColumns + [optional lifecycle] + status
+  // The trailing `+ 1` accounts for the pinned status column which is NOT part of
+  // `visibleColumns` (it's always rendered at the end of every row).
   const sceneColSpan = useMemo(() => {
-    let count = visibleColumns.length + 1 // visible columns + status column
-    if (reorderEnabled) count += 1
-    if (selectionEnabled) count += 1
-    if (showLifecycleActions) count += 1
+    let count = visibleColumns.length + 1 // visibleColumns + pinned status column
+    if (reorderEnabled) count += 1 // drag handle column
+    if (selectionEnabled) count += 1 // selection checkbox column
+    if (showLifecycleActions) count += 1 // lifecycle actions column
     return count
   }, [visibleColumns.length, reorderEnabled, selectionEnabled, showLifecycleActions])
 

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -389,7 +389,7 @@ export function ShotsTable({
   familyById,
   skuById,
   samplesByFamily,
-  reorderEnabled = false,
+  reorderEnabled: reorderEnabledProp = false,
   onReorder,
   groups,
   collapsedScenes,
@@ -402,6 +402,12 @@ export function ShotsTable({
   onAssignScene,
 }: ShotsTableProps) {
   const selectionEnabled = selection?.enabled === true
+
+  // Auto-disable DnD reorder for large projects — @dnd-kit's sortable overhead
+  // becomes noticeable past ~500 sortable items. Users can still reorder via
+  // the custom sort + renumber flow.
+  const REORDER_SHOT_LIMIT = 500
+  const reorderEnabled = reorderEnabledProp && shots.length <= REORDER_SHOT_LIMIT
 
   const allSelected =
     selectionEnabled && shots.length > 0 && shots.every((s) => selection!.selectedIds.has(s.id))

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -25,6 +25,7 @@ import { useTableColumns } from "@/shared/hooks/useTableColumns"
 import { ResizableHeader } from "@/shared/components/ResizableHeader"
 import { ColumnSettingsPopover } from "@/shared/components/ColumnSettingsPopover"
 import { ShotStatusSelect } from "@/features/shots/components/ShotStatusSelect"
+import { SceneTableRow } from "@/features/shots/components/SceneTableRow"
 import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
 import {
   computeShotRowContext,
@@ -34,8 +35,10 @@ import {
   cellTitle,
   isInteractiveCell,
 } from "@/features/shots/lib/shotColumnRenderers"
+import { SceneAssignPopover } from "@/features/shots/components/SceneAssignPopover"
 import type { TableColumnConfig } from "@/shared/types/table"
-import type { Shot, ProductFamily, ProductSku, ProductSample } from "@/shared/types"
+import type { Shot, ProductFamily, ProductSku, ProductSample, Lane } from "@/shared/types"
+import type { ShotGroup } from "@/features/shots/lib/shotListFilters"
 
 // ---------------------------------------------------------------------------
 // Migration from old localStorage key format
@@ -84,6 +87,15 @@ type ShotsTableProps = {
   readonly samplesByFamily?: ReadonlyMap<string, ReadonlyArray<ProductSample>>
   readonly reorderEnabled?: boolean
   readonly onReorder?: (reordered: ReadonlyArray<Shot>, affectedRange: { from: number; to: number }) => void
+  readonly groups?: ReadonlyArray<ShotGroup> | null
+  readonly collapsedScenes?: ReadonlySet<string>
+  readonly onToggleSceneCollapse?: (key: string) => void
+  readonly onEditScene?: (key: string) => void
+  readonly onDeleteScene?: (key: string, name: string) => void
+  readonly onUngroupScene?: (key: string) => void
+  readonly laneById?: ReadonlyMap<string, Lane>
+  readonly lanes?: ReadonlyArray<Lane>
+  readonly onAssignScene?: (shotId: string, laneId: string | null) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -102,6 +114,8 @@ type RowCellsProps = {
   readonly ctx: ReturnType<typeof computeShotRowContext>
   readonly stopPropagation: (e: React.MouseEvent) => void
   readonly reorderDragHandle?: ReactNode
+  readonly lanes?: ReadonlyArray<Lane>
+  readonly onAssignScene?: (shotId: string, laneId: string | null) => void
 }
 
 function RowCells({
@@ -115,6 +129,8 @@ function RowCells({
   ctx,
   stopPropagation,
   reorderDragHandle,
+  lanes,
+  onAssignScene,
 }: RowCellsProps) {
   return (
     <>
@@ -145,6 +161,27 @@ function RowCells({
           ) : (
             renderShotCell(shot, col.key, ctx)
           )
+
+        if (col.key === "scene" && lanes && onAssignScene) {
+          return (
+            <td
+              key={col.key}
+              className={cellClassName(col.key)}
+              title={cellTitle(col.key, ctx)}
+              onClick={stopPropagation}
+            >
+              <SceneAssignPopover
+                shot={shot}
+                lanes={lanes}
+                onAssign={onAssignScene}
+              >
+                <button type="button" className="w-full text-left">
+                  {content}
+                </button>
+              </SceneAssignPopover>
+            </td>
+          )
+        }
 
         return (
           <td
@@ -240,6 +277,102 @@ function DndWrapper({
 }
 
 // ---------------------------------------------------------------------------
+// Group rows (scene header + shot rows)
+// ---------------------------------------------------------------------------
+
+type GroupRowsProps = {
+  readonly group: ShotGroup
+  readonly isCollapsed: boolean
+  readonly isUngrouped: boolean
+  readonly colSpan: number
+  readonly contextById: ReadonlyMap<string, ReturnType<typeof computeShotRowContext>>
+  readonly visibleColumns: readonly TableColumnConfig[]
+  readonly selectionEnabled: boolean
+  readonly selection?: ShotsTableProps["selection"]
+  readonly showLifecycleActions: boolean
+  readonly renderLifecycleAction?: (shot: Shot) => ReactNode
+  readonly onOpenShot: (shotId: string) => void
+  readonly stopPropagation: (e: React.MouseEvent) => void
+  readonly onToggleCollapse: () => void
+  readonly onEdit: () => void
+  readonly onUngroupAll: () => void
+  readonly onDelete: () => void
+  readonly lanes?: ReadonlyArray<Lane>
+  readonly onAssignScene?: (shotId: string, laneId: string | null) => void
+}
+
+function GroupRows({
+  group,
+  isCollapsed,
+  isUngrouped,
+  colSpan,
+  contextById,
+  visibleColumns,
+  selectionEnabled,
+  selection,
+  showLifecycleActions,
+  renderLifecycleAction,
+  onOpenShot,
+  stopPropagation,
+  onToggleCollapse,
+  onEdit,
+  onUngroupAll,
+  onDelete,
+  lanes,
+  onAssignScene,
+}: GroupRowsProps) {
+  return (
+    <>
+      <SceneTableRow
+        label={group.label}
+        sceneNumber={group.sceneNumber}
+        shotCount={group.shots.length}
+        color={group.color}
+        direction={group.direction}
+        collapsed={isCollapsed}
+        onToggleCollapse={onToggleCollapse}
+        onEdit={onEdit}
+        onUngroupAll={onUngroupAll}
+        onDelete={onDelete}
+        isUngrouped={isUngrouped}
+        colSpan={colSpan}
+      />
+      {!isCollapsed &&
+        group.shots.map((shot) => {
+          const ctx = contextById.get(shot.id)
+          if (!ctx) return null
+          const isSelected = selectionEnabled ? selection!.selectedIds.has(shot.id) : false
+          const onToggle = selectionEnabled ? () => selection!.onToggle(shot.id) : undefined
+
+          return (
+            <tr
+              key={shot.id}
+              className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5"
+              onClick={() => onOpenShot(shot.id)}
+              role="row"
+            >
+              <RowCells
+                shot={shot}
+                visibleColumns={visibleColumns}
+                selectionEnabled={selectionEnabled}
+                isSelected={isSelected}
+                onToggle={onToggle}
+                showLifecycleActions={showLifecycleActions}
+                renderLifecycleAction={renderLifecycleAction}
+                onOpenShot={onOpenShot}
+                ctx={ctx}
+                stopPropagation={stopPropagation}
+                lanes={lanes}
+                onAssignScene={onAssignScene}
+              />
+            </tr>
+          )
+        })}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Main component
 // ---------------------------------------------------------------------------
 
@@ -258,6 +391,15 @@ export function ShotsTable({
   samplesByFamily,
   reorderEnabled = false,
   onReorder,
+  groups,
+  collapsedScenes,
+  onToggleSceneCollapse,
+  onEditScene,
+  onDeleteScene,
+  onUngroupScene,
+  laneById,
+  lanes,
+  onAssignScene,
 }: ShotsTableProps) {
   const selectionEnabled = selection?.enabled === true
 
@@ -312,10 +454,30 @@ export function ShotsTable({
   const rowContexts = useMemo(
     () =>
       shots.map((shot) =>
-        computeShotRowContext(shot, familyById, skuById, samplesByFamily, talentNameById, locationNameById),
+        computeShotRowContext(shot, familyById, skuById, samplesByFamily, talentNameById, locationNameById, laneById),
       ),
-    [shots, familyById, skuById, samplesByFamily, talentNameById, locationNameById],
+    [shots, familyById, skuById, samplesByFamily, talentNameById, locationNameById, laneById],
   )
+
+  // -- Context lookup by shot id (for grouped rendering) --
+  const contextById = useMemo(() => {
+    const map = new Map<string, ReturnType<typeof computeShotRowContext>>()
+    for (let i = 0; i < shots.length; i++) {
+      map.set(shots[i]!.id, rowContexts[i]!)
+    }
+    return map
+  }, [shots, rowContexts])
+
+  // -- Compute colSpan for scene header rows --
+  const sceneColSpan = useMemo(() => {
+    let count = visibleColumns.length + 1 // visible columns + status column
+    if (reorderEnabled) count += 1
+    if (selectionEnabled) count += 1
+    if (showLifecycleActions) count += 1
+    return count
+  }, [visibleColumns.length, reorderEnabled, selectionEnabled, showLifecycleActions])
+
+  const hasGroups = groups != null && groups.length > 0
 
   const stopPropagation = useCallback((e: React.MouseEvent) => e.stopPropagation(), [])
 
@@ -409,44 +571,77 @@ export function ShotsTable({
             </thead>
 
             <tbody>
-              {shots.map((shot, index) => {
-                const ctx = rowContexts[index]!
-                const isSelected = selectionEnabled ? selection!.selectedIds.has(shot.id) : false
-                const onToggle = selectionEnabled ? () => selection!.onToggle(shot.id) : undefined
+              {hasGroups ? (
+                groups!.map((group) => {
+                  const isCollapsed = collapsedScenes?.has(group.key) ?? false
+                  const isUngrouped = group.key === "__ungrouped"
 
-                const commonCellProps = {
-                  shot,
-                  visibleColumns,
-                  selectionEnabled,
-                  isSelected,
-                  onToggle,
-                  showLifecycleActions,
-                  renderLifecycleAction,
-                  onOpenShot,
-                  ctx,
-                  stopPropagation,
-                }
-
-                if (reorderEnabled) {
                   return (
-                    <SortableRow
-                      key={shot.id}
-                      {...commonCellProps}
+                    <GroupRows
+                      key={group.key}
+                      group={group}
+                      isCollapsed={isCollapsed}
+                      isUngrouped={isUngrouped}
+                      colSpan={sceneColSpan}
+                      contextById={contextById}
+                      visibleColumns={visibleColumns}
+                      selectionEnabled={selectionEnabled}
+                      selection={selection}
+                      showLifecycleActions={showLifecycleActions}
+                      renderLifecycleAction={renderLifecycleAction}
+                      onOpenShot={onOpenShot}
+                      stopPropagation={stopPropagation}
+                      onToggleCollapse={() => onToggleSceneCollapse?.(group.key)}
+                      onEdit={() => onEditScene?.(group.key)}
+                      onUngroupAll={() => onUngroupScene?.(group.key)}
+                      onDelete={() => onDeleteScene?.(group.key, group.label)}
+                      lanes={lanes}
+                      onAssignScene={onAssignScene}
                     />
                   )
-                }
+                })
+              ) : (
+                shots.map((shot, index) => {
+                  const ctx = rowContexts[index]!
+                  const isSelected = selectionEnabled ? selection!.selectedIds.has(shot.id) : false
+                  const onToggle = selectionEnabled ? () => selection!.onToggle(shot.id) : undefined
 
-                return (
-                  <tr
-                    key={shot.id}
-                    className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5"
-                    onClick={() => onOpenShot(shot.id)}
-                    role="row"
-                  >
-                    <RowCells {...commonCellProps} />
-                  </tr>
-                )
-              })}
+                  const commonCellProps = {
+                    shot,
+                    visibleColumns,
+                    selectionEnabled,
+                    isSelected,
+                    onToggle,
+                    showLifecycleActions,
+                    renderLifecycleAction,
+                    onOpenShot,
+                    ctx,
+                    stopPropagation,
+                    lanes,
+                    onAssignScene,
+                  }
+
+                  if (reorderEnabled) {
+                    return (
+                      <SortableRow
+                        key={shot.id}
+                        {...commonCellProps}
+                      />
+                    )
+                  }
+
+                  return (
+                    <tr
+                      key={shot.id}
+                      className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5"
+                      onClick={() => onOpenShot(shot.id)}
+                      role="row"
+                    >
+                      <RowCells {...commonCellProps} />
+                    </tr>
+                  )
+                })
+              )}
             </tbody>
           </table>
         </div>

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -242,7 +242,6 @@ function SortableRow(props: SortableRowProps) {
       style={{ transform: CSS.Transform.toString(transform), transition }}
       className={`border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5${isDragging ? " opacity-30" : ""}`}
       onClick={() => props.onOpenShot(props.shot.id)}
-      role="row"
     >
       <RowCells {...props} reorderDragHandle={dragHandle} />
     </tr>
@@ -349,7 +348,6 @@ function GroupRows({
               key={shot.id}
               className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5"
               onClick={() => onOpenShot(shot.id)}
-              role="row"
             >
               <RowCells
                 shot={shot}
@@ -646,7 +644,6 @@ export function ShotsTable({
                       key={shot.id}
                       className="border-b border-[var(--color-border)] hover:bg-[var(--color-surface-subtle)] data-[active-row]:bg-[var(--color-primary)]/5"
                       onClick={() => onOpenShot(shot.id)}
-                      role="row"
                     >
                       <RowCells {...commonCellProps} />
                     </tr>

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -40,6 +40,10 @@ import type { TableColumnConfig } from "@/shared/types/table"
 import type { Shot, ProductFamily, ProductSku, ProductSample, Lane } from "@/shared/types"
 import type { ShotGroup } from "@/features/shots/lib/shotListFilters"
 
+// Threshold above which DnD reorder is automatically disabled — @dnd-kit's
+// sortable overhead becomes noticeable past ~500 items. Exported for tests.
+export const REORDER_SHOT_LIMIT = 500
+
 // ---------------------------------------------------------------------------
 // Migration from old localStorage key format
 // ---------------------------------------------------------------------------
@@ -402,9 +406,8 @@ export function ShotsTable({
   const selectionEnabled = selection?.enabled === true
 
   // Auto-disable DnD reorder for large projects — @dnd-kit's sortable overhead
-  // becomes noticeable past ~500 sortable items. Users can still reorder via
-  // the custom sort + renumber flow.
-  const REORDER_SHOT_LIMIT = 500
+  // becomes noticeable past this threshold. Users can still reorder via the
+  // custom sort + renumber flow.
   const reorderEnabled = reorderEnabledProp && shots.length <= REORDER_SHOT_LIMIT
 
   const allSelected =

--- a/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
@@ -98,7 +98,12 @@ export function ThreePanelCanvasPanel({
         <SceneContextBanner
           laneId={shot.laneId}
           laneById={resolvedLaneById}
-          onViewScene={shot.laneId ? () => onOpenSceneSheet?.(shot.laneId!) : undefined}
+          onViewScene={(() => {
+            // Capture the lane id once so TypeScript doesn't require a non-null
+            // assertion inside the closure.
+            const laneId = shot.laneId
+            return laneId ? () => onOpenSceneSheet?.(laneId) : undefined
+          })()}
         />
 
         {/* Header: title + shot number */}

--- a/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { ChevronLeft, Share2 } from "lucide-react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { HeroImageSection } from "@/features/shots/components/HeroImageSection"
@@ -5,6 +6,8 @@ import { ActiveLookCoverReferencesPanel } from "@/features/shots/components/Acti
 import { NotesSection } from "@/features/shots/components/NotesSection"
 import { ShotReferenceLinksSection } from "@/features/shots/components/ShotReferenceLinksSection"
 import { ProductSummaryStrip } from "@/features/shots/components/ProductSummaryStrip"
+import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { CompactActiveEditors } from "@/features/shots/components/ActiveEditorsBar"
 import { ShotLifecycleActionsMenu } from "@/features/shots/components/ShotLifecycleActionsMenu"
 import {
@@ -15,7 +18,7 @@ import {
 import { textPreview } from "@/shared/lib/textPreview"
 import { useAuth } from "@/app/providers/AuthProvider"
 import type { SaveState } from "@/shared/hooks/useAutoSave"
-import type { Shot, Project } from "@/shared/types"
+import type { Shot, Project, Lane } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Props
@@ -30,6 +33,8 @@ interface ThreePanelCanvasPanelProps {
   readonly onShareClick?: () => void
   readonly projects: ReadonlyArray<Project>
   readonly existingTitles: ReadonlySet<string>
+  readonly laneById?: ReadonlyMap<string, Lane>
+  readonly allShots?: ReadonlyArray<Shot>
 }
 
 // ---------------------------------------------------------------------------
@@ -45,9 +50,13 @@ export function ThreePanelCanvasPanel({
   onShareClick,
   projects,
   existingTitles,
+  laneById,
+  allShots,
 }: ThreePanelCanvasPanelProps) {
   const { clientId } = useAuth()
   const safeDescription = textPreview(shot.description, Number.POSITIVE_INFINITY)
+  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
+  const resolvedLaneById = laneById ?? new Map<string, Lane>()
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -89,6 +98,13 @@ export function ThreePanelCanvasPanel({
       </div>
 
       <div className="flex flex-col gap-4 p-4">
+        {/* Scene context banner */}
+        <SceneContextBanner
+          laneId={shot.laneId}
+          laneById={resolvedLaneById}
+          onViewScene={() => setSceneSheetOpen(true)}
+        />
+
         {/* Header: title + shot number */}
         <div className="flex items-baseline gap-3">
           {canEdit ? (
@@ -184,6 +200,15 @@ export function ThreePanelCanvasPanel({
           }}
         />
       </div>
+
+      <SceneDetailSheet
+        open={sceneSheetOpen}
+        onOpenChange={setSceneSheetOpen}
+        lane={shot.laneId ? resolvedLaneById.get(shot.laneId) ?? null : null}
+        projectId={shot.projectId}
+        clientId={clientId}
+        shotCount={shot.laneId && allShots ? allShots.filter((s) => s.laneId === shot.laneId).length : 0}
+      />
     </div>
   )
 }

--- a/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelCanvasPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import { ChevronLeft, Share2 } from "lucide-react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { HeroImageSection } from "@/features/shots/components/HeroImageSection"
@@ -7,7 +6,6 @@ import { NotesSection } from "@/features/shots/components/NotesSection"
 import { ShotReferenceLinksSection } from "@/features/shots/components/ShotReferenceLinksSection"
 import { ProductSummaryStrip } from "@/features/shots/components/ProductSummaryStrip"
 import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
-import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { CompactActiveEditors } from "@/features/shots/components/ActiveEditorsBar"
 import { ShotLifecycleActionsMenu } from "@/features/shots/components/ShotLifecycleActionsMenu"
 import {
@@ -16,7 +14,6 @@ import {
   SaveIndicator,
 } from "@/features/shots/components/ShotDetailShared"
 import { textPreview } from "@/shared/lib/textPreview"
-import { useAuth } from "@/app/providers/AuthProvider"
 import type { SaveState } from "@/shared/hooks/useAutoSave"
 import type { Shot, Project, Lane } from "@/shared/types"
 
@@ -34,7 +31,8 @@ interface ThreePanelCanvasPanelProps {
   readonly projects: ReadonlyArray<Project>
   readonly existingTitles: ReadonlySet<string>
   readonly laneById?: ReadonlyMap<string, Lane>
-  readonly allShots?: ReadonlyArray<Shot>
+  /** Opens the SceneDetailSheet for the given lane id — owned by ThreePanelLayout. */
+  readonly onOpenSceneSheet?: (laneId: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -51,11 +49,9 @@ export function ThreePanelCanvasPanel({
   projects,
   existingTitles,
   laneById,
-  allShots,
+  onOpenSceneSheet,
 }: ThreePanelCanvasPanelProps) {
-  const { clientId } = useAuth()
   const safeDescription = textPreview(shot.description, Number.POSITIVE_INFINITY)
-  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
   const resolvedLaneById = laneById ?? new Map<string, Lane>()
 
   return (
@@ -102,7 +98,7 @@ export function ThreePanelCanvasPanel({
         <SceneContextBanner
           laneId={shot.laneId}
           laneById={resolvedLaneById}
-          onViewScene={() => setSceneSheetOpen(true)}
+          onViewScene={shot.laneId ? () => onOpenSceneSheet?.(shot.laneId!) : undefined}
         />
 
         {/* Header: title + shot number */}
@@ -201,14 +197,6 @@ export function ThreePanelCanvasPanel({
         />
       </div>
 
-      <SceneDetailSheet
-        open={sceneSheetOpen}
-        onOpenChange={setSceneSheetOpen}
-        lane={shot.laneId ? resolvedLaneById.get(shot.laneId) ?? null : null}
-        projectId={shot.projectId}
-        clientId={clientId}
-        shotCount={shot.laneId && allShots ? allShots.filter((s) => s.laneId === shot.laneId).length : 0}
-      />
     </div>
   )
 }

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels"
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
 import { useShot } from "@/features/shots/hooks/useShot"
+import { useLanes } from "@/features/shots/hooks/useLanes"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
@@ -76,6 +77,7 @@ export function ThreePanelLayout({
   existingTitles,
 }: ThreePanelLayoutProps) {
   const { data: shot, loading, error } = useShot(selectedShotId)
+  const { laneById } = useLanes()
   const { role, clientId, user } = useAuth()
   const { projectName } = useProjectScope()
   const isMobile = useIsMobile()
@@ -224,6 +226,8 @@ export function ThreePanelLayout({
         onShareClick={canShare ? () => setShareOpen(true) : undefined}
         projects={projects}
         existingTitles={existingTitles}
+        laneById={laneById}
+        allShots={allShots}
       />
     )
   }
@@ -275,6 +279,9 @@ export function ThreePanelLayout({
               save={save}
               canEdit={canEdit}
               canDoOperational={canDoOperational}
+              laneById={laneById}
+              allShots={allShots}
+              clientId={clientId}
             />
           ) : (
             <div className="flex h-full items-center justify-center p-4">

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels"
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
 import { useShot } from "@/features/shots/hooks/useShot"
-import { useLanes } from "@/features/shots/hooks/useLanes"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
@@ -17,13 +16,17 @@ import { ThreePanelPropertiesPanel } from "@/features/shots/components/ThreePane
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
 import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { toast } from "sonner"
-import type { Shot, ShotFirestoreStatus, Project } from "@/shared/types"
+import type { Shot, ShotFirestoreStatus, Project, Lane } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
 const STORAGE_KEY = "sb:three-panel:sizes"
+
+// Stable empty fallbacks — prevents re-render when lane props are undefined.
+const EMPTY_LANES: ReadonlyArray<Lane> = []
+const EMPTY_LANE_BY_ID: ReadonlyMap<string, Lane> = new Map()
 
 const STATUS_CYCLE: ReadonlyArray<ShotFirestoreStatus> = [
   "todo",
@@ -60,6 +63,13 @@ interface ThreePanelLayoutProps {
   readonly onShotCreated?: (shotId: string, title: string) => void
   readonly projects: ReadonlyArray<Project>
   readonly existingTitles: ReadonlySet<string>
+  /**
+   * Lane data from the parent ShotListPage's useLanes subscription. Passed
+   * through instead of re-subscribing here to avoid a duplicate onSnapshot
+   * listener when three-panel mode is active.
+   */
+  readonly lanes?: ReadonlyArray<Lane>
+  readonly laneById?: ReadonlyMap<string, Lane>
 }
 
 // ---------------------------------------------------------------------------
@@ -76,9 +86,15 @@ export function ThreePanelLayout({
   onShotCreated,
   projects,
   existingTitles,
+  lanes: lanesProp,
+  laneById: laneByIdProp,
 }: ThreePanelLayoutProps) {
   const { data: shot, loading, error } = useShot(selectedShotId)
-  const { laneById } = useLanes()
+  // Default to empty lane data when the parent hasn't wired the props yet.
+  // Using empty fallbacks keeps the layout functional for any caller that
+  // hasn't migrated; the scene banner simply won't render.
+  const lanes = lanesProp ?? (EMPTY_LANES as ReadonlyArray<Lane>)
+  const laneById = laneByIdProp ?? EMPTY_LANE_BY_ID
   const { role, clientId, user } = useAuth()
   const { projectName } = useProjectScope()
   const isMobile = useIsMobile()
@@ -323,6 +339,7 @@ export function ThreePanelLayout({
         projectId={shot?.projectId ?? ""}
         clientId={clientId}
         shotCount={sceneSheetShotCount}
+        siblingLanes={lanes}
       />
     </div>
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -15,6 +15,7 @@ import { ThreePanelListPanel } from "@/features/shots/components/ThreePanelListP
 import { ThreePanelCanvasPanel } from "@/features/shots/components/ThreePanelCanvasPanel"
 import { ThreePanelPropertiesPanel } from "@/features/shots/components/ThreePanelPropertiesPanel"
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { toast } from "sonner"
 import type { Shot, ShotFirestoreStatus, Project } from "@/shared/types"
 
@@ -86,6 +87,16 @@ export function ThreePanelLayout({
   const canDoOperational = canManageShots(role)
   const canShare = role === "admin" || role === "producer"
   const [shareOpen, setShareOpen] = useState(false)
+
+  // -- Scene sheet state (lifted from canvas + properties panels to avoid duplicates) --
+  const [sceneSheetLaneId, setSceneSheetLaneId] = useState<string | null>(null)
+  const handleOpenSceneSheet = useCallback((laneId: string) => {
+    setSceneSheetLaneId(laneId)
+  }, [])
+  const sceneSheetLane = sceneSheetLaneId ? laneById.get(sceneSheetLaneId) ?? null : null
+  const sceneSheetShotCount = sceneSheetLaneId
+    ? allShots.filter((s) => s.laneId === sceneSheetLaneId).length
+    : 0
 
   // -- Save function (same pattern as ShotDetailPage) --
   const save = useCallback(
@@ -227,7 +238,7 @@ export function ThreePanelLayout({
         projects={projects}
         existingTitles={existingTitles}
         laneById={laneById}
-        allShots={allShots}
+        onOpenSceneSheet={handleOpenSceneSheet}
       />
     )
   }
@@ -280,8 +291,7 @@ export function ThreePanelLayout({
               canEdit={canEdit}
               canDoOperational={canDoOperational}
               laneById={laneById}
-              allShots={allShots}
-              clientId={clientId}
+              onOpenSceneSheet={handleOpenSceneSheet}
             />
           ) : (
             <div className="flex h-full items-center justify-center p-4">
@@ -304,6 +314,16 @@ export function ThreePanelLayout({
           selectedShotIds={[shot.id]}
         />
       )}
+
+      {/* Single SceneDetailSheet lifted from canvas + properties panels (M3 fix). */}
+      <SceneDetailSheet
+        open={sceneSheetLaneId !== null}
+        onOpenChange={(open) => { if (!open) setSceneSheetLaneId(null) }}
+        lane={sceneSheetLane}
+        projectId={shot?.projectId ?? ""}
+        clientId={clientId}
+        shotCount={sceneSheetShotCount}
+      />
     </div>
     </ErrorBoundary>
   )

--- a/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
@@ -66,11 +66,14 @@ export function ThreePanelPropertiesPanel({
           />
         </div>
 
-        {/* Scene context banner */}
+        {/* Scene context banner — capture laneId so the closure avoids a non-null assertion */}
         <SceneContextBanner
           laneId={shot.laneId}
           laneById={resolvedLaneById}
-          onViewScene={shot.laneId ? () => onOpenSceneSheet?.(shot.laneId!) : undefined}
+          onViewScene={(() => {
+            const laneId = shot.laneId
+            return laneId ? () => onOpenSceneSheet?.(laneId) : undefined
+          })()}
         />
 
         {/* Shot number */}

--- a/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { ShotStatusSelect } from "@/features/shots/components/ShotStatusSelect"
 import { TalentPicker } from "@/features/shots/components/TalentPicker"
@@ -6,6 +7,8 @@ import { TagEditor } from "@/features/shots/components/TagEditor"
 import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
 import { ShotCommentsSection } from "@/features/shots/components/ShotCommentsSection"
 import { ShotVersionHistorySection } from "@/features/shots/components/ShotVersionHistorySection"
+import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import {
   SectionLabel,
   MetaEditorCard,
@@ -14,7 +17,7 @@ import {
 } from "@/features/shots/components/ShotDetailShared"
 import { formatDateOnly, parseDateOnly } from "@/features/shots/lib/dateOnly"
 import { toast } from "sonner"
-import type { Shot } from "@/shared/types"
+import type { Shot, Lane } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Props
@@ -25,6 +28,9 @@ interface ThreePanelPropertiesPanelProps {
   readonly save: (fields: Record<string, unknown>) => Promise<boolean>
   readonly canEdit: boolean
   readonly canDoOperational: boolean
+  readonly laneById?: ReadonlyMap<string, Lane>
+  readonly allShots?: ReadonlyArray<Shot>
+  readonly clientId?: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -36,8 +42,13 @@ export function ThreePanelPropertiesPanel({
   save,
   canEdit,
   canDoOperational,
+  laneById,
+  allShots,
+  clientId,
 }: ThreePanelPropertiesPanelProps) {
   const talentCount = (shot.talentIds ?? shot.talent ?? []).length
+  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
+  const resolvedLaneById = laneById ?? new Map<string, Lane>()
 
   return (
     <div className="flex h-full flex-col overflow-y-auto">
@@ -58,6 +69,13 @@ export function ThreePanelPropertiesPanel({
             disabled={!canDoOperational}
           />
         </div>
+
+        {/* Scene context banner */}
+        <SceneContextBanner
+          laneId={shot.laneId}
+          laneById={resolvedLaneById}
+          onViewScene={() => setSceneSheetOpen(true)}
+        />
 
         {/* Shot number */}
         <MetaEditorCard label="Shot #">
@@ -154,6 +172,15 @@ export function ThreePanelPropertiesPanel({
 
         <ShotVersionHistorySection shot={shot} />
       </div>
+
+      <SceneDetailSheet
+        open={sceneSheetOpen}
+        onOpenChange={setSceneSheetOpen}
+        lane={shot.laneId ? resolvedLaneById.get(shot.laneId) ?? null : null}
+        projectId={shot.projectId}
+        clientId={clientId ?? null}
+        shotCount={shot.laneId && allShots ? allShots.filter((s) => s.laneId === shot.laneId).length : 0}
+      />
     </div>
   )
 }

--- a/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
+++ b/src-vnext/features/shots/components/ThreePanelPropertiesPanel.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { ShotStatusSelect } from "@/features/shots/components/ShotStatusSelect"
 import { TalentPicker } from "@/features/shots/components/TalentPicker"
@@ -8,7 +7,6 @@ import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
 import { ShotCommentsSection } from "@/features/shots/components/ShotCommentsSection"
 import { ShotVersionHistorySection } from "@/features/shots/components/ShotVersionHistorySection"
 import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
-import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import {
   SectionLabel,
   MetaEditorCard,
@@ -29,8 +27,8 @@ interface ThreePanelPropertiesPanelProps {
   readonly canEdit: boolean
   readonly canDoOperational: boolean
   readonly laneById?: ReadonlyMap<string, Lane>
-  readonly allShots?: ReadonlyArray<Shot>
-  readonly clientId?: string | null
+  /** Opens the SceneDetailSheet for the given lane id — owned by ThreePanelLayout. */
+  readonly onOpenSceneSheet?: (laneId: string) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -43,11 +41,9 @@ export function ThreePanelPropertiesPanel({
   canEdit,
   canDoOperational,
   laneById,
-  allShots,
-  clientId,
+  onOpenSceneSheet,
 }: ThreePanelPropertiesPanelProps) {
   const talentCount = (shot.talentIds ?? shot.talent ?? []).length
-  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
   const resolvedLaneById = laneById ?? new Map<string, Lane>()
 
   return (
@@ -74,7 +70,7 @@ export function ThreePanelPropertiesPanel({
         <SceneContextBanner
           laneId={shot.laneId}
           laneById={resolvedLaneById}
-          onViewScene={() => setSceneSheetOpen(true)}
+          onViewScene={shot.laneId ? () => onOpenSceneSheet?.(shot.laneId!) : undefined}
         />
 
         {/* Shot number */}
@@ -173,14 +169,6 @@ export function ThreePanelPropertiesPanel({
         <ShotVersionHistorySection shot={shot} />
       </div>
 
-      <SceneDetailSheet
-        open={sceneSheetOpen}
-        onOpenChange={setSceneSheetOpen}
-        lane={shot.laneId ? resolvedLaneById.get(shot.laneId) ?? null : null}
-        projectId={shot.projectId}
-        clientId={clientId ?? null}
-        shotCount={shot.laneId && allShots ? allShots.filter((s) => s.laneId === shot.laneId).length : 0}
-      />
     </div>
   )
 }

--- a/src-vnext/features/shots/components/__tests__/SceneContextBanner.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/SceneContextBanner.test.tsx
@@ -1,0 +1,132 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
+import type { Lane } from "@/shared/types"
+
+const mkLane = (overrides: Partial<Lane> = {}): Lane => ({
+  id: "lane-1",
+  name: "Beach Lifestyle",
+  projectId: "p1",
+  clientId: "c1",
+  sortOrder: 0,
+  color: "teal",
+  sceneNumber: 2,
+  direction: "Warm tones, golden hour",
+  notes: "",
+  createdAt: { toDate: () => new Date() } as unknown as Lane["createdAt"],
+  updatedAt: { toDate: () => new Date() } as unknown as Lane["updatedAt"],
+  createdBy: "u1",
+  ...overrides,
+})
+
+describe("SceneContextBanner", () => {
+  it("renders nothing when laneId is null", () => {
+    const { container } = render(
+      <SceneContextBanner
+        laneId={null}
+        laneById={new Map()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when laneId is undefined", () => {
+    const { container } = render(
+      <SceneContextBanner
+        laneId={undefined}
+        laneById={new Map()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders nothing when lane is not found in laneById", () => {
+    const { container } = render(
+      <SceneContextBanner
+        laneId="missing-lane"
+        laneById={new Map()}
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders scene name and number when lane is present", () => {
+    const lane = mkLane()
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    expect(screen.getByTestId("scene-context-banner")).toBeInTheDocument()
+    expect(screen.getByText("#2")).toBeInTheDocument()
+    expect(screen.getByText("Beach Lifestyle")).toBeInTheDocument()
+  })
+
+  it("renders scene name without number when sceneNumber is missing", () => {
+    const lane = mkLane({ sceneNumber: undefined })
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    expect(screen.getByText("Beach Lifestyle")).toBeInTheDocument()
+    expect(screen.queryByText(/^#/)).toBeNull()
+  })
+
+  it("renders direction preview when direction exists", () => {
+    const lane = mkLane({ direction: "Short direction" })
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    expect(screen.getByText("Short direction")).toBeInTheDocument()
+  })
+
+  it("truncates direction longer than 100 characters with ellipsis", () => {
+    const longDirection = "a".repeat(150)
+    const lane = mkLane({ direction: longDirection })
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    const expected = `${"a".repeat(100)}\u2026`
+    expect(screen.getByText(expected)).toBeInTheDocument()
+  })
+
+  it("renders banner without direction text when direction is missing", () => {
+    const lane = mkLane({ direction: undefined })
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    expect(screen.getByTestId("scene-context-banner")).toBeInTheDocument()
+    expect(screen.getByText("Beach Lifestyle")).toBeInTheDocument()
+  })
+
+  it("renders 'View scene' link when onViewScene is provided", () => {
+    const lane = mkLane()
+    const laneById = new Map([[lane.id, lane]])
+    const onViewScene = vi.fn()
+
+    render(
+      <SceneContextBanner
+        laneId={lane.id}
+        laneById={laneById}
+        onViewScene={onViewScene}
+      />,
+    )
+
+    const link = screen.getByTestId("scene-view-link")
+    expect(link).toBeInTheDocument()
+    fireEvent.click(link)
+    expect(onViewScene).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not render 'View scene' link when onViewScene is undefined", () => {
+    const lane = mkLane()
+    const laneById = new Map([[lane.id, lane]])
+
+    render(<SceneContextBanner laneId={lane.id} laneById={laneById} />)
+
+    expect(screen.queryByTestId("scene-view-link")).toBeNull()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
@@ -1,0 +1,344 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import type { Lane } from "@/shared/types"
+
+vi.mock("@/features/shots/lib/laneActions", () => ({
+  updateLane: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+import { updateLane } from "@/features/shots/lib/laneActions"
+import { toast } from "sonner"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
+
+const baseLane: Lane = {
+  id: "lane-1",
+  name: "Beach Lifestyle",
+  projectId: "p1",
+  clientId: "c1",
+  sortOrder: 0,
+  color: "teal",
+  sceneNumber: 3,
+  direction: "Golden hour, warm tones",
+  notes: "Bring reflector",
+  createdAt: { toDate: () => new Date() } as unknown as Lane["createdAt"],
+  updatedAt: { toDate: () => new Date() } as unknown as Lane["updatedAt"],
+  createdBy: "u1",
+}
+
+describe("SceneDetailSheet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders nothing when lane is null", () => {
+    const { container } = render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={null}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it("renders scene name, number, direction, and notes from the lane", () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+        shotCount={4}
+      />,
+    )
+
+    expect(screen.getByTestId("scene-name-input")).toHaveValue("Beach Lifestyle")
+    expect(screen.getByTestId("scene-number-input")).toHaveValue(3)
+    expect(screen.getByTestId("scene-direction-textarea")).toHaveValue(
+      "Golden hour, warm tones",
+    )
+    expect(screen.getByTestId("scene-notes-textarea")).toHaveValue("Bring reflector")
+    expect(screen.getByText("4")).toBeInTheDocument()
+    expect(screen.getByText("shots in this scene")).toBeInTheDocument()
+  })
+
+  it("renders all 6 scene color swatches", () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+    expect(screen.getByTestId("scene-color-teal")).toBeInTheDocument()
+    expect(screen.getByTestId("scene-color-purple")).toBeInTheDocument()
+    expect(screen.getByTestId("scene-color-green")).toBeInTheDocument()
+    expect(screen.getByTestId("scene-color-orange")).toBeInTheDocument()
+    expect(screen.getByTestId("scene-color-pink")).toBeInTheDocument()
+    expect(screen.getByTestId("scene-color-blue")).toBeInTheDocument()
+  })
+
+  it("calls updateLane with new name on blur when name changes", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    const nameInput = screen.getByTestId("scene-name-input")
+    fireEvent.change(nameInput, { target: { value: "Mountain Vista" } })
+    fireEvent.blur(nameInput)
+
+    await waitFor(() => {
+      expect(updateLane).toHaveBeenCalledWith({
+        laneId: "lane-1",
+        projectId: "p1",
+        clientId: "c1",
+        patch: { name: "Mountain Vista" },
+      })
+    })
+  })
+
+  it("does not call updateLane when name is unchanged on blur", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    const nameInput = screen.getByTestId("scene-name-input")
+    fireEvent.blur(nameInput)
+
+    // Flush any pending microtasks
+    await Promise.resolve()
+    expect(updateLane).not.toHaveBeenCalled()
+  })
+
+  it("calls updateLane with new sceneNumber on blur", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    const numberInput = screen.getByTestId("scene-number-input")
+    fireEvent.change(numberInput, { target: { value: "7" } })
+    fireEvent.blur(numberInput)
+
+    await waitFor(() => {
+      expect(updateLane).toHaveBeenCalledWith({
+        laneId: "lane-1",
+        projectId: "p1",
+        clientId: "c1",
+        patch: { sceneNumber: 7 },
+      })
+    })
+  })
+
+  it("calls updateLane with new color when a swatch is clicked", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("scene-color-purple"))
+
+    await waitFor(() => {
+      expect(updateLane).toHaveBeenCalledWith({
+        laneId: "lane-1",
+        projectId: "p1",
+        clientId: "c1",
+        patch: { color: "purple" },
+      })
+    })
+  })
+
+  it("calls updateLane with notes on blur", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    const notesTextarea = screen.getByTestId("scene-notes-textarea")
+    fireEvent.change(notesTextarea, { target: { value: "New production notes" } })
+    fireEvent.blur(notesTextarea)
+
+    await waitFor(() => {
+      expect(updateLane).toHaveBeenCalledWith({
+        laneId: "lane-1",
+        projectId: "p1",
+        clientId: "c1",
+        patch: { notes: "New production notes" },
+      })
+    })
+  })
+
+  it("shows toast.success after successful update", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("scene-color-pink"))
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Scene updated")
+    })
+  })
+
+  it("shows toast.error when updateLane throws", async () => {
+    ;(updateLane as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("boom"),
+    )
+
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("scene-color-pink"))
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to update scene")
+    })
+  })
+
+  it("does not call updateLane when clientId is null", async () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId={null}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId("scene-color-pink"))
+
+    await Promise.resolve()
+    expect(updateLane).not.toHaveBeenCalled()
+  })
+
+  it("displays singular 'shot' label when count is 1", () => {
+    render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+        shotCount={1}
+      />,
+    )
+    expect(screen.getByText("shot in this scene")).toBeInTheDocument()
+  })
+
+  it("does NOT clobber in-progress edits when parent re-renders with new lane reference (same id)", async () => {
+    // Simulates a Firestore onSnapshot echo: lane.id stays the same but the object ref changes.
+    // Without the useRef init gate, the effect would re-sync local state and wipe typing.
+    const { rerender } = render(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={baseLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    // User types in the direction textarea
+    const directionTextarea = screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement
+    fireEvent.change(directionTextarea, { target: { value: "User typed this mid-edit" } })
+    expect(directionTextarea.value).toBe("User typed this mid-edit")
+
+    // Simulate snapshot echo: parent passes a new lane object with the same id
+    const echoedLane: Lane = { ...baseLane, direction: "Old value from Firestore" }
+    rerender(
+      <SceneDetailSheet
+        open
+        onOpenChange={vi.fn()}
+        lane={echoedLane}
+        projectId="p1"
+        clientId="c1"
+      />,
+    )
+
+    // User's in-progress text must still be there — NOT reset to "Old value from Firestore"
+    expect((screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement).value).toBe(
+      "User typed this mid-edit",
+    )
+  })
+
+  it("re-initializes when sheet closes and re-opens for a different lane", () => {
+    const laneA: Lane = { ...baseLane, id: "lane-a", name: "Lane A", direction: "direction A" }
+    const laneB: Lane = { ...baseLane, id: "lane-b", name: "Lane B", direction: "direction B" }
+
+    const onOpenChange = vi.fn()
+    const { rerender } = render(
+      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" />,
+    )
+    expect((screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement).value).toBe(
+      "direction A",
+    )
+
+    // Close the sheet
+    rerender(
+      <SceneDetailSheet open={false} onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" />,
+    )
+
+    // Re-open for a different lane
+    rerender(
+      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneB} projectId="p1" clientId="c1" />,
+    )
+
+    expect((screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement).value).toBe(
+      "direction B",
+    )
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
@@ -222,7 +222,7 @@ describe("SceneDetailSheet", () => {
     fireEvent.click(screen.getByTestId("scene-color-pink"))
 
     await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("Scene updated")
+      expect(toast.success).toHaveBeenCalledWith("Scene updated", { id: `scene-update:${baseLane.id}` })
     })
   })
 
@@ -244,7 +244,7 @@ describe("SceneDetailSheet", () => {
     fireEvent.click(screen.getByTestId("scene-color-pink"))
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("Failed to update scene")
+      expect(toast.error).toHaveBeenCalledWith("Failed to update scene", { id: `scene-update:${baseLane.id}` })
     })
   })
 

--- a/src-vnext/features/shots/hooks/useLanes.ts
+++ b/src-vnext/features/shots/hooks/useLanes.ts
@@ -8,13 +8,21 @@ import type { Lane } from "@/shared/types"
 import type { Timestamp } from "firebase/firestore"
 
 function mapLane(id: string, data: Record<string, unknown>): Lane {
+  const sortOrder = (data["sortOrder"] as number) ?? 0
+  const storedSceneNumber = data["sceneNumber"] as number | null | undefined
+  // Legacy lanes (pre-S29) have no sceneNumber — fall back to sortOrder + 1 so the
+  // UI never shows "undefined" and scene-aware renumbering can still address them.
+  const sceneNumber = storedSceneNumber != null ? storedSceneNumber : sortOrder + 1
   return {
     id,
     name: (data["name"] as string) ?? "",
     projectId: (data["projectId"] as string) ?? "",
     clientId: (data["clientId"] as string) ?? "",
-    sortOrder: (data["sortOrder"] as number) ?? 0,
+    sortOrder,
     color: (data["color"] as string | null) ?? undefined,
+    sceneNumber,
+    direction: (data["direction"] as string | null) ?? undefined,
+    notes: (data["notes"] as string | null) ?? undefined,
     createdAt: data["createdAt"] as Timestamp,
     updatedAt: data["updatedAt"] as Timestamp,
     createdBy: (data["createdBy"] as string) ?? "",
@@ -39,5 +47,13 @@ export function useLanes() {
     return map
   }, [data])
 
-  return { data, loading, error, laneNameById }
+  const laneById = useMemo(() => {
+    const map = new Map<string, Lane>()
+    for (const lane of data) {
+      map.set(lane.id, lane)
+    }
+    return map
+  }, [data])
+
+  return { data, loading, error, laneNameById, laneById }
 }

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
-import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku } from "@/shared/types"
+import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku, Lane } from "@/shared/types"
 import {
   type SortKey,
   type SortDir,
@@ -122,8 +122,9 @@ export function useShotListState(params: {
   readonly skuById?: ReadonlyMap<string, ProductSku>
   readonly laneNameById?: ReadonlyMap<string, string>
   readonly laneOrder?: ReadonlyMap<string, number>
+  readonly laneById?: ReadonlyMap<string, Lane>
 }): ShotListState {
-  const { shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder } = params
+  const { shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById } = params
 
   const isMobile = useIsMobile()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -472,8 +473,8 @@ export function useShotListState(params: {
   const insights = useMemo(() => computeInsights(displayShots), [displayShots])
 
   const shotGroups = useMemo(
-    () => groupShots(displayShots, groupKey, { talentNameById, locationNameById, laneNameById, laneOrder }),
-    [displayShots, groupKey, locationNameById, talentNameById, laneNameById, laneOrder],
+    () => groupShots(displayShots, groupKey, { talentNameById, locationNameById, laneNameById, laneOrder, laneById }),
+    [displayShots, groupKey, locationNameById, talentNameById, laneNameById, laneOrder, laneById],
   )
 
   const tagLabelById = useMemo(() => {

--- a/src-vnext/features/shots/lib/__tests__/sceneGrouping.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/sceneGrouping.test.ts
@@ -142,4 +142,38 @@ describe("groupShots — scene grouping", () => {
     // groupShots doesn't re-sort within groups — the input is pre-sorted
     expect(groups![0]!.shots.map((s) => s.id)).toEqual(["s1", "s2", "s3"])
   })
+
+  it("treats shots with orphaned laneId as ungrouped when laneById is provided", () => {
+    const shots = [
+      makeShot({ id: "s1", laneId: "lane-a" }),
+      makeShot({ id: "s2", laneId: "deleted-lane" }), // references deleted lane
+      makeShot({ id: "s3" }), // truly ungrouped
+    ]
+    const laneNameById = new Map([["lane-a", "Beach"]])
+    // laneById only contains the existing lane
+    const laneById = new Map<string, import("@/shared/types").Lane>([
+      [
+        "lane-a",
+        {
+          id: "lane-a",
+          name: "Beach",
+          projectId: "proj-1",
+          clientId: "client-1",
+          sortOrder: 0,
+          sceneNumber: 1,
+          createdAt: null,
+          updatedAt: null,
+          createdBy: "user-1",
+        } as import("@/shared/types").Lane,
+      ],
+    ])
+    const groups = groupShots(shots, "scene", { ...EMPTY_LOOKUPS, laneNameById, laneById })
+    expect(groups).not.toBeNull()
+    expect(groups!).toHaveLength(2)
+    // Beach has s1, Ungrouped has orphan (s2) + s3
+    const beach = groups!.find((g) => g.key === "lane-a")
+    const ungrouped = groups!.find((g) => g.key === "__ungrouped")
+    expect(beach!.shots.map((s) => s.id)).toEqual(["s1"])
+    expect(ungrouped!.shots.map((s) => s.id).sort()).toEqual(["s2", "s3"])
+  })
 })

--- a/src-vnext/features/shots/lib/laneActions.ts
+++ b/src-vnext/features/shots/lib/laneActions.ts
@@ -9,16 +9,19 @@ import {
   getFirestore,
 } from "firebase/firestore"
 import { lanesPath, laneDocPath, shotsPath } from "@/shared/lib/paths"
-import type { Shot } from "@/shared/types"
+import type { Lane, Shot } from "@/shared/types"
 import type { User } from "firebase/auth"
 
 const BATCH_CHUNK_SIZE = 250
 const MAX_BULK_OPS = 500
 
-type LanePatch = {
+export type LanePatch = {
   readonly name?: string
   readonly sortOrder?: number
   readonly color?: string | null
+  readonly direction?: string | null
+  readonly notes?: string | null
+  readonly sceneNumber?: number | null
 }
 
 export async function createLane(params: {
@@ -27,11 +30,18 @@ export async function createLane(params: {
   readonly clientId: string
   readonly sortOrder: number
   readonly color?: string
+  readonly sceneNumber?: number
+  readonly existingLanes?: ReadonlyArray<Lane>
   readonly user: User | null
 }): Promise<string> {
-  const { name, projectId, clientId, sortOrder, color, user } = params
+  const { name, projectId, clientId, sortOrder, color, user, existingLanes } = params
   const trimmedName = name.trim()
   if (!trimmedName) throw new Error("Lane name cannot be empty")
+
+  const resolvedSceneNumber =
+    params.sceneNumber ??
+    Math.max(0, ...(existingLanes ?? []).map((l) => l.sceneNumber ?? 0)) + 1
+
   const db = getFirestore()
   const ref = doc(collection(db, ...lanesPath(projectId, clientId)))
   await setDoc(ref, {
@@ -40,6 +50,9 @@ export async function createLane(params: {
     clientId,
     sortOrder,
     color: color ?? null,
+    sceneNumber: resolvedSceneNumber,
+    direction: null,
+    notes: null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     createdBy: user?.uid ?? "",

--- a/src-vnext/features/shots/lib/sceneColors.ts
+++ b/src-vnext/features/shots/lib/sceneColors.ts
@@ -1,0 +1,28 @@
+/**
+ * Scene color palette — the 6 accent colors users can assign to scenes.
+ * Extracted from SceneHeader.tsx so non-component code (column renderers,
+ * numbering dialogs, etc.) can resolve colors without pulling in a component
+ * file.
+ */
+
+export const SCENE_COLORS = [
+  { key: "teal", hex: "#14b8a6" },
+  { key: "purple", hex: "#a78bfa" },
+  { key: "green", hex: "#22c55e" },
+  { key: "orange", hex: "#fb923c" },
+  { key: "pink", hex: "#fb7185" },
+  { key: "blue", hex: "#3b82f6" },
+] as const
+
+export type SceneColorKey = (typeof SCENE_COLORS)[number]["key"]
+
+/**
+ * Resolves a scene color key to a CSS color value.
+ * Returns a subtle fallback when no color is set, or the raw value if the key
+ * isn't recognized (future-proofs against legacy colors stored in Firestore).
+ */
+export function getSceneColor(color?: string | null): string {
+  if (!color) return "var(--color-text-subtle)"
+  const found = SCENE_COLORS.find((c) => c.key === color)
+  return found?.hex ?? color
+}

--- a/src-vnext/features/shots/lib/shotColumnRenderers.tsx
+++ b/src-vnext/features/shots/lib/shotColumnRenderers.tsx
@@ -12,8 +12,9 @@ import {
 } from "@/features/shots/lib/shotListSummaries"
 import { computeShotReadiness, formatLaunchDateShort, launchUrgencyClass } from "@/features/shots/lib/shotProductReadiness"
 import { formatUpdatedAt } from "@/features/shots/lib/shotListFilters"
+import { getSceneColor } from "@/features/shots/components/SceneHeader"
 import { ASSET_TYPE_SHORT_LABELS } from "@/features/products/lib/assetRequirements"
-import type { Shot, ShotReferenceLinkType, ProductFamily, ProductSku, ProductSample } from "@/shared/types"
+import type { Shot, ShotReferenceLinkType, ProductFamily, ProductSku, ProductSample, Lane } from "@/shared/types"
 import type { ShotReadiness } from "@/features/shots/lib/shotProductReadiness"
 import type React from "react"
 
@@ -38,6 +39,8 @@ export interface ShotRowContext {
   readonly title: string
   readonly hasTalent: boolean
   readonly talentTitle: string
+  readonly sceneName: string | null
+  readonly sceneColor: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +54,7 @@ export function computeShotRowContext(
   samplesByFamily: ReadonlyMap<string, ReadonlyArray<ProductSample>> | undefined,
   talentNameById: ReadonlyMap<string, string> | null | undefined,
   locationNameById: ReadonlyMap<string, string> | null | undefined,
+  laneById?: ReadonlyMap<string, Lane> | null,
 ): ShotRowContext {
   const title = shot.title || "Untitled Shot"
   const readiness = familyById ? computeShotReadiness(shot, familyById, skuById, samplesByFamily) : null
@@ -73,6 +77,10 @@ export function computeShotRowContext(
     shot.locationName ??
     (shot.locationId ? locationNameById?.get(shot.locationId) ?? undefined : undefined)
 
+  const lane = shot.laneId ? laneById?.get(shot.laneId) ?? null : null
+  const sceneName = lane?.name ?? null
+  const sceneColor = lane?.color ?? null
+
   return {
     readiness,
     talentNames,
@@ -84,6 +92,8 @@ export function computeShotRowContext(
     title,
     hasTalent,
     talentTitle,
+    sceneName,
+    sceneColor,
   }
 }
 
@@ -344,6 +354,19 @@ export function renderShotCell(
     case "updated":
       return <>{formatUpdatedAt(shot)}</>
 
+    case "scene":
+      return ctx.sceneName ? (
+        <div className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2 w-2 rounded-full flex-shrink-0"
+            style={{ backgroundColor: getSceneColor(ctx.sceneColor) }}
+          />
+          <span className="text-xs truncate">{ctx.sceneName}</span>
+        </div>
+      ) : (
+        <span className="text-[var(--color-text-subtle)]">{"\u2014"}</span>
+      )
+
     default:
       return null
   }
@@ -365,6 +388,8 @@ export function cellClassName(columnKey: string): string {
       return "px-3 py-2 text-[var(--color-text-secondary)]"
     case "tags":
       return "px-3 py-2"
+    case "scene":
+      return "px-3 py-2 cursor-pointer"
     case "launch":
       return "px-3 py-2 text-[var(--color-text-secondary)]"
     case "reqs":
@@ -383,7 +408,7 @@ export function cellClassName(columnKey: string): string {
 // ---------------------------------------------------------------------------
 
 export function isInteractiveCell(columnKey: string): boolean {
-  return columnKey === "tags" || columnKey === "links" || columnKey === "notes"
+  return columnKey === "tags" || columnKey === "links" || columnKey === "notes" || columnKey === "scene"
 }
 
 // ---------------------------------------------------------------------------

--- a/src-vnext/features/shots/lib/shotColumnRenderers.tsx
+++ b/src-vnext/features/shots/lib/shotColumnRenderers.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/features/shots/lib/shotListSummaries"
 import { computeShotReadiness, formatLaunchDateShort, launchUrgencyClass } from "@/features/shots/lib/shotProductReadiness"
 import { formatUpdatedAt } from "@/features/shots/lib/shotListFilters"
-import { getSceneColor } from "@/features/shots/components/SceneHeader"
+import { getSceneColor } from "@/features/shots/lib/sceneColors"
 import { ASSET_TYPE_SHORT_LABELS } from "@/features/products/lib/assetRequirements"
 import type { Shot, ShotReferenceLinkType, ProductFamily, ProductSku, ProductSample, Lane } from "@/shared/types"
 import type { ShotReadiness } from "@/features/shots/lib/shotProductReadiness"

--- a/src-vnext/features/shots/lib/shotListFilters.ts
+++ b/src-vnext/features/shots/lib/shotListFilters.ts
@@ -505,7 +505,9 @@ export function groupShots(
         shots: value.shots as ReadonlyArray<Shot>,
         color: lane?.color,
         sceneNumber: lane?.sceneNumber,
-        direction: lane?.direction?.slice(0, 100) || undefined,
+        // Presentation-layer renderers (SceneHeader, SceneTableRow, SceneContextBanner)
+        // own their own truncation. Pass the raw direction through.
+        direction: lane?.direction || undefined,
       }
     })
 

--- a/src-vnext/features/shots/lib/shotListFilters.ts
+++ b/src-vnext/features/shots/lib/shotListFilters.ts
@@ -1,4 +1,4 @@
-import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku } from "@/shared/types"
+import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku, Lane } from "@/shared/types"
 import { extractShotAssignedProducts } from "@/shared/lib/shotProducts"
 import { formatDateOnly } from "@/features/shots/lib/dateOnly"
 import { shotLaunchDateMs, shotRequirementsCount } from "@/features/shots/lib/shotProductReadiness"
@@ -29,6 +29,7 @@ export type ShotsListFields = {
   readonly reqs: boolean
   readonly samples: boolean
   readonly updated: boolean
+  readonly scene: boolean
 }
 
 export const DEFAULT_FIELDS: ShotsListFields = {
@@ -47,6 +48,7 @@ export const DEFAULT_FIELDS: ShotsListFields = {
   reqs: false,
   samples: false,
   updated: false,
+  scene: false,
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +342,9 @@ export type ShotGroup = {
   readonly key: string
   readonly label: string
   readonly shots: ReadonlyArray<Shot>
+  readonly color?: string
+  readonly sceneNumber?: number
+  readonly direction?: string
 }
 
 export function groupShots(
@@ -350,6 +355,7 @@ export function groupShots(
     readonly locationNameById: ReadonlyMap<string, string>
     readonly laneNameById?: ReadonlyMap<string, string>
     readonly laneOrder?: ReadonlyMap<string, number>
+    readonly laneById?: ReadonlyMap<string, Lane>
   },
 ): ReadonlyArray<ShotGroup> | null {
   if (groupKey === "none") return null
@@ -473,25 +479,35 @@ export function groupShots(
     const NONE = "__ungrouped"
     const laneNames = lookups.laneNameById ?? new Map<string, string>()
     const laneOrders = lookups.laneOrder ?? new Map<string, number>()
+    const lanes = lookups.laneById
     const byKey = new Map<string, { readonly label: string; readonly shots: Shot[] }>()
 
     for (const shot of shots) {
-      const key = shot.laneId ?? NONE
-      const label =
-        key === NONE
-          ? "Ungrouped"
-          : laneNames.get(key) ?? "Unnamed Scene"
+      // Treat orphaned laneId (references a deleted lane) as ungrouped so users
+      // can see and reassign these shots instead of landing in a phantom group.
+      // Guard: only check orphan status when lanes have actually loaded (size > 0),
+      // otherwise shots would flicker to ungrouped on initial snapshot race.
+      const isOrphan =
+        lanes != null && lanes.size > 0 && shot.laneId != null && !lanes.has(shot.laneId)
+      const key = shot.laneId == null || isOrphan ? NONE : shot.laneId
+      const label = key === NONE ? "Ungrouped" : laneNames.get(key) ?? "Unnamed Scene"
 
       const existing = byKey.get(key)
       if (existing) existing.shots.push(shot)
       else byKey.set(key, { label, shots: [shot] })
     }
 
-    const groups = Array.from(byKey.entries()).map(([key, value]) => ({
-      key,
-      label: value.label,
-      shots: value.shots as ReadonlyArray<Shot>,
-    }))
+    const groups = Array.from(byKey.entries()).map(([key, value]) => {
+      const lane = lanes?.get(key)
+      return {
+        key,
+        label: value.label,
+        shots: value.shots as ReadonlyArray<Shot>,
+        color: lane?.color,
+        sceneNumber: lane?.sceneNumber,
+        direction: lane?.direction?.slice(0, 100) || undefined,
+      }
+    })
 
     groups.sort((a, b) => {
       if (a.key === NONE) return 1

--- a/src-vnext/features/shots/lib/shotListFilters.ts
+++ b/src-vnext/features/shots/lib/shotListFilters.ts
@@ -506,8 +506,9 @@ export function groupShots(
         color: lane?.color,
         sceneNumber: lane?.sceneNumber,
         // Presentation-layer renderers (SceneHeader, SceneTableRow, SceneContextBanner)
-        // own their own truncation. Pass the raw direction through.
-        direction: lane?.direction || undefined,
+        // own their own truncation. Pass the raw direction through; trim whitespace-only
+        // strings to undefined so renderers see a clean "absent" signal.
+        direction: lane?.direction?.trim() || undefined,
       }
     })
 

--- a/src-vnext/features/shots/lib/shotListFilters.ts
+++ b/src-vnext/features/shots/lib/shotListFilters.ts
@@ -509,9 +509,18 @@ export function groupShots(
       }
     })
 
+    // Sort order for scene groups:
+    //   1. Ungrouped always last
+    //   2. Stable sceneNumber (the identifier used for shot numbering — 51A, 51B…)
+    //   3. Fall back to laneOrder for legacy lanes that haven't been assigned a
+    //      sceneNumber yet (should be rare post-backfill)
+    //   4. Finally, alphabetical on label for ties
     groups.sort((a, b) => {
       if (a.key === NONE) return 1
       if (b.key === NONE) return -1
+      const aScene = a.sceneNumber ?? Number.POSITIVE_INFINITY
+      const bScene = b.sceneNumber ?? Number.POSITIVE_INFINITY
+      if (aScene !== bScene) return aScene - bScene
       const aOrder = laneOrders.get(a.key) ?? 0
       const bOrder = laneOrders.get(b.key) ?? 0
       if (aOrder !== bOrder) return aOrder - bOrder

--- a/src-vnext/features/shots/lib/shotNumbering.test.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.test.ts
@@ -381,9 +381,9 @@ describe("previewRenumberWithScenes", () => {
     // Scene 2: 2A, 2B
     expect(result.changes.find((c) => c.shotId === "s2a")?.newNumber).toBe("2A")
     expect(result.changes.find((c) => c.shotId === "s2b")?.newNumber).toBe("2B")
-    // Ungrouped: sequential from max scene number + 1 = 3, 4
-    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("03")
-    expect(result.changes.find((c) => c.shotId === "u2")?.newNumber).toBe("04")
+    // Ungrouped: raw unpadded sequential from max scene number + 1 = 3, 4
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("3")
+    expect(result.changes.find((c) => c.shotId === "u2")?.newNumber).toBe("4")
   })
 
   it("includes sceneName in change entries", () => {
@@ -457,9 +457,9 @@ describe("previewRenumberWithScenes", () => {
       [{ sceneNumber: 5, sceneName: "Late Scene", shots: scene5Shots }],
       ungrouped,
     )
-    // Scene 5: 5A. Ungrouped starts at 6.
+    // Scene 5: 5A. Ungrouped starts at 6 (raw, unpadded to match scene mode style).
     expect(result.changes.find((c) => c.shotId === "s5a")?.newNumber).toBe("5A")
-    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("06")
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("6")
   })
 
   it("respects maxSceneNumberOverride for cross-filter safety", () => {
@@ -473,7 +473,7 @@ describe("previewRenumberWithScenes", () => {
       5, // override — user has scene 5 hidden by filter
     )
     expect(result.changes.find((c) => c.shotId === "s2a")?.newNumber).toBe("2A")
-    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("06")
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("6")
   })
 
   it("propagates sceneId through to changes for stable grouping in preview UI", () => {
@@ -554,11 +554,10 @@ describe("buildSceneRenumberUpdates", () => {
       [{ sceneNumber: 1, shots: sceneShots }],
       ungrouped,
     )
-    // s1/s2 already correct → no update. u1 needs "02" with sortOrder 2 (matches — no update)
-    // but shotNumber is missing so it IS an update
+    // s1/s2 already correct → no update. u1 gets raw unpadded "2" (scene-mode style).
     const ungroupedUpdate = updates.find((u) => u.shotId === "u1")
     expect(ungroupedUpdate?.newSortOrder).toBe(2)
-    expect(ungroupedUpdate?.newNumber).toBe("02")
+    expect(ungroupedUpdate?.newNumber).toBe("2")
   })
 
   it("skips already-correct shots but updates incorrect ones", () => {
@@ -581,5 +580,27 @@ describe("buildSceneRenumberUpdates", () => {
     const ungrouped = [makeShot({ id: "u1", sortOrder: 0 })]
     const updates = buildSceneRenumberUpdates([], ungrouped, 10)
     expect(updates[0]?.newNumber).toBe("11")
+  })
+
+  it("produces raw unpadded numbers for ungrouped shots in scene-aware mode", () => {
+    // Single-digit ungrouped numbers should NOT be zero-padded when they appear
+    // alongside scene letter suffixes like "1A", "2B". This matches the scene-mode
+    // visual style and avoids "1A, 2B, 06, 07" jarring mixes.
+    const sceneShots = [makeShot({ id: "s1", sortOrder: 0 })]
+    const ungrouped = [
+      makeShot({ id: "u1", sortOrder: 1 }),
+      makeShot({ id: "u2", sortOrder: 2 }),
+      makeShot({ id: "u3", sortOrder: 3 }),
+    ]
+    const updates = buildSceneRenumberUpdates(
+      [{ sceneNumber: 1, shots: sceneShots }],
+      ungrouped,
+    )
+    const u1 = updates.find((u) => u.shotId === "u1")
+    const u2 = updates.find((u) => u.shotId === "u2")
+    const u3 = updates.find((u) => u.shotId === "u3")
+    expect(u1?.newNumber).toBe("2")
+    expect(u2?.newNumber).toBe("3")
+    expect(u3?.newNumber).toBe("4")
   })
 })

--- a/src-vnext/features/shots/lib/shotNumbering.test.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.test.ts
@@ -4,6 +4,12 @@ import {
   formatShotNumber,
   nextShotNumber,
   previewRenumber,
+  indexToLetterSuffix,
+  formatSceneShotNumber,
+  parseSceneShotNumber,
+  computeMaxBaseNumber,
+  previewRenumberWithScenes,
+  buildSceneRenumberUpdates,
 } from "./shotNumbering"
 import type { Shot } from "@/shared/types"
 
@@ -201,5 +207,341 @@ describe("previewRenumber", () => {
     expect(result.changes[0]!.newNumber).toBe("02")
     expect(result.changes[1]!.shotId).toBe("c")
     expect(result.changes[1]!.newNumber).toBe("03")
+  })
+})
+
+// ========================================================================
+// Scene-aware numbering
+// ========================================================================
+
+describe("indexToLetterSuffix", () => {
+  it("converts 0 to A", () => {
+    expect(indexToLetterSuffix(0)).toBe("A")
+  })
+
+  it("converts 1 to B", () => {
+    expect(indexToLetterSuffix(1)).toBe("B")
+  })
+
+  it("converts 25 to Z", () => {
+    expect(indexToLetterSuffix(25)).toBe("Z")
+  })
+
+  it("converts 26 to AA", () => {
+    expect(indexToLetterSuffix(26)).toBe("AA")
+  })
+
+  it("converts 27 to AB", () => {
+    expect(indexToLetterSuffix(27)).toBe("AB")
+  })
+
+  it("converts 51 to AZ", () => {
+    expect(indexToLetterSuffix(51)).toBe("AZ")
+  })
+
+  it("converts 52 to BA", () => {
+    expect(indexToLetterSuffix(52)).toBe("BA")
+  })
+
+  it("clamps negative to A", () => {
+    expect(indexToLetterSuffix(-1)).toBe("A")
+    expect(indexToLetterSuffix(-100)).toBe("A")
+  })
+
+  it("handles boundary at 701 (ZZ) and clamps beyond", () => {
+    expect(indexToLetterSuffix(701)).toBe("ZZ")
+    expect(indexToLetterSuffix(702)).toBe("ZZ") // clamped to max
+    expect(indexToLetterSuffix(9999)).toBe("ZZ") // clamped to max
+  })
+})
+
+describe("formatSceneShotNumber", () => {
+  it("formats scene 1, index 0 as 1A", () => {
+    expect(formatSceneShotNumber(1, 0)).toBe("1A")
+  })
+
+  it("formats scene 1, index 2 as 1C", () => {
+    expect(formatSceneShotNumber(1, 2)).toBe("1C")
+  })
+
+  it("formats scene 51, index 0 as 51A", () => {
+    expect(formatSceneShotNumber(51, 0)).toBe("51A")
+  })
+
+  it("formats scene 10, index 25 as 10Z", () => {
+    expect(formatSceneShotNumber(10, 25)).toBe("10Z")
+  })
+
+  it("formats scene 10, index 26 as 10AA", () => {
+    expect(formatSceneShotNumber(10, 26)).toBe("10AA")
+  })
+})
+
+describe("parseSceneShotNumber", () => {
+  it("parses 51A into base 51 suffix A", () => {
+    expect(parseSceneShotNumber("51A")).toEqual({ base: 51, suffix: "A" })
+  })
+
+  it("parses 1C into base 1 suffix C", () => {
+    expect(parseSceneShotNumber("1C")).toEqual({ base: 1, suffix: "C" })
+  })
+
+  it("parses 10AA into base 10 suffix AA", () => {
+    expect(parseSceneShotNumber("10AA")).toEqual({ base: 10, suffix: "AA" })
+  })
+
+  it("parses flat number 03 into base 3 suffix null", () => {
+    expect(parseSceneShotNumber("03")).toEqual({ base: 3, suffix: null })
+  })
+
+  it("parses empty string into base 0 suffix null", () => {
+    expect(parseSceneShotNumber("")).toEqual({ base: 0, suffix: null })
+  })
+
+  it("parses legacy SH-005 into base 5 suffix null", () => {
+    expect(parseSceneShotNumber("SH-005")).toEqual({ base: 5, suffix: null })
+  })
+
+  it("handles lowercase letters by normalizing to uppercase", () => {
+    expect(parseSceneShotNumber("10a")).toEqual({ base: 10, suffix: "A" })
+    expect(parseSceneShotNumber("5bc")).toEqual({ base: 5, suffix: "BC" })
+  })
+})
+
+describe("computeMaxBaseNumber", () => {
+  it("returns 0 for empty array", () => {
+    expect(computeMaxBaseNumber([])).toBe(0)
+  })
+
+  it("finds max base from scene-numbered shots", () => {
+    const shots = [
+      makeShot({ id: "a", shotNumber: "51A" }),
+      makeShot({ id: "b", shotNumber: "51C" }),
+      makeShot({ id: "c", shotNumber: "52B" }),
+    ]
+    expect(computeMaxBaseNumber(shots)).toBe(52)
+  })
+
+  it("finds max base from flat-numbered shots", () => {
+    const shots = [
+      makeShot({ id: "a", shotNumber: "03" }),
+      makeShot({ id: "b", shotNumber: "07" }),
+      makeShot({ id: "c", shotNumber: "12" }),
+    ]
+    expect(computeMaxBaseNumber(shots)).toBe(12)
+  })
+
+  it("handles mixed scene and flat numbers", () => {
+    const shots = [
+      makeShot({ id: "a", shotNumber: "51A" }),
+      makeShot({ id: "b", shotNumber: "03" }),
+      makeShot({ id: "c", shotNumber: "52B" }),
+    ]
+    expect(computeMaxBaseNumber(shots)).toBe(52)
+  })
+
+  it("ignores shots without numbers", () => {
+    const shots = [
+      makeShot({ id: "a", shotNumber: "10A" }),
+      makeShot({ id: "b", shotNumber: null }),
+      makeShot({ id: "c", shotNumber: undefined }),
+    ]
+    expect(computeMaxBaseNumber(shots)).toBe(10)
+  })
+})
+
+describe("previewRenumberWithScenes", () => {
+  it("assigns letter suffixes to scene shots and sequential to ungrouped", () => {
+    const scene1Shots = [
+      makeShot({ id: "s1a", title: "Scene 1 Shot A", shotNumber: "01", sortOrder: 0 }),
+      makeShot({ id: "s1b", title: "Scene 1 Shot B", shotNumber: "02", sortOrder: 1 }),
+      makeShot({ id: "s1c", title: "Scene 1 Shot C", shotNumber: "03", sortOrder: 2 }),
+    ]
+    const scene2Shots = [
+      makeShot({ id: "s2a", title: "Scene 2 Shot A", shotNumber: "04", sortOrder: 3 }),
+      makeShot({ id: "s2b", title: "Scene 2 Shot B", shotNumber: "05", sortOrder: 4 }),
+    ]
+    const ungrouped = [
+      makeShot({ id: "u1", title: "Ungrouped 1", shotNumber: "06", sortOrder: 5 }),
+      makeShot({ id: "u2", title: "Ungrouped 2", shotNumber: "07", sortOrder: 6 }),
+    ]
+
+    const result = previewRenumberWithScenes(
+      [
+        { sceneNumber: 1, sceneName: "Scene 1", shots: scene1Shots },
+        { sceneNumber: 2, sceneName: "Scene 2", shots: scene2Shots },
+      ],
+      ungrouped,
+    )
+
+    // Scene 1: 1A, 1B, 1C
+    expect(result.changes.find((c) => c.shotId === "s1a")?.newNumber).toBe("1A")
+    expect(result.changes.find((c) => c.shotId === "s1b")?.newNumber).toBe("1B")
+    expect(result.changes.find((c) => c.shotId === "s1c")?.newNumber).toBe("1C")
+    // Scene 2: 2A, 2B
+    expect(result.changes.find((c) => c.shotId === "s2a")?.newNumber).toBe("2A")
+    expect(result.changes.find((c) => c.shotId === "s2b")?.newNumber).toBe("2B")
+    // Ungrouped: sequential from max scene number + 1 = 3, 4
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("03")
+    expect(result.changes.find((c) => c.shotId === "u2")?.newNumber).toBe("04")
+  })
+
+  it("includes sceneName in change entries", () => {
+    const sceneShots = [
+      makeShot({ id: "s1", shotNumber: "01", sortOrder: 0 }),
+    ]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Hero Shots", shots: sceneShots }],
+      [],
+    )
+    expect(result.changes[0]!.sceneName).toBe("Hero Shots")
+  })
+
+  it("labels ungrouped shots with empty sceneName", () => {
+    const ungrouped = [
+      makeShot({ id: "u1", shotNumber: "99", sortOrder: 0 }),
+    ]
+    const result = previewRenumberWithScenes([], ungrouped)
+    expect(result.changes[0]!.sceneName).toBe("")
+  })
+
+  it("counts already-correct shots as unchanged", () => {
+    const sceneShots = [
+      makeShot({ id: "s1a", shotNumber: "1A", sortOrder: 0 }),
+      makeShot({ id: "s1b", shotNumber: "1B", sortOrder: 1 }),
+    ]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Scene 1", shots: sceneShots }],
+      [],
+    )
+    expect(result.unchangedCount).toBe(2)
+    expect(result.changes).toHaveLength(0)
+  })
+
+  it("handles empty scene groups and empty ungrouped", () => {
+    const result = previewRenumberWithScenes([], [])
+    expect(result.changes).toHaveLength(0)
+    expect(result.unchangedCount).toBe(0)
+  })
+
+  it("uses Untitled for shots without a title", () => {
+    const shots = [
+      makeShot({ id: "s1", title: "", shotNumber: "05", sortOrder: 0 }),
+    ]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Scene 1", shots }],
+      [],
+    )
+    expect(result.changes[0]!.title).toBe("Untitled")
+  })
+
+  it("shows em-dash for shots without a current number", () => {
+    const shots = [
+      makeShot({ id: "s1", shotNumber: null, sortOrder: 0 }),
+    ]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Scene 1", shots }],
+      [],
+    )
+    expect(result.changes[0]!.currentNumber).toBe("\u2014")
+  })
+
+  it("ungrouped numbering starts after highest scene number", () => {
+    const scene5Shots = [
+      makeShot({ id: "s5a", shotNumber: "01", sortOrder: 0 }),
+    ]
+    const ungrouped = [
+      makeShot({ id: "u1", shotNumber: "02", sortOrder: 1 }),
+    ]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 5, sceneName: "Late Scene", shots: scene5Shots }],
+      ungrouped,
+    )
+    // Scene 5: 5A. Ungrouped starts at 6.
+    expect(result.changes.find((c) => c.shotId === "s5a")?.newNumber).toBe("5A")
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("06")
+  })
+
+  it("respects maxSceneNumberOverride for cross-filter safety", () => {
+    // User has scenes 1, 2, 5 in project but only scene 2 + ungrouped visible.
+    // Ungrouped numbering must start at 6, not 3, to avoid colliding with scene 5 shots.
+    const scene2Shots = [makeShot({ id: "s2a", sortOrder: 0 })]
+    const ungrouped = [makeShot({ id: "u1", sortOrder: 1 })]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 2, sceneName: "Visible", shots: scene2Shots }],
+      ungrouped,
+      5, // override — user has scene 5 hidden by filter
+    )
+    expect(result.changes.find((c) => c.shotId === "s2a")?.newNumber).toBe("2A")
+    expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("06")
+  })
+})
+
+describe("buildSceneRenumberUpdates", () => {
+  it("returns empty array when all shots already have correct numbers and sortOrder", () => {
+    const shots = [
+      makeShot({ id: "s1", shotNumber: "1A", sortOrder: 0 }),
+      makeShot({ id: "s2", shotNumber: "1B", sortOrder: 1 }),
+    ]
+    const updates = buildSceneRenumberUpdates(
+      [{ sceneNumber: 1, shots }],
+      [],
+    )
+    expect(updates).toHaveLength(0)
+  })
+
+  it("produces updates for scene shots with letter suffixes", () => {
+    const shots = [
+      makeShot({ id: "s1", shotNumber: "03", sortOrder: 5 }),
+      makeShot({ id: "s2", shotNumber: "07", sortOrder: 9 }),
+    ]
+    const updates = buildSceneRenumberUpdates(
+      [{ sceneNumber: 1, shots }],
+      [],
+    )
+    expect(updates).toHaveLength(2)
+    expect(updates[0]).toEqual({ shotId: "s1", newNumber: "1A", newSortOrder: 0 })
+    expect(updates[1]).toEqual({ shotId: "s2", newNumber: "1B", newSortOrder: 1 })
+  })
+
+  it("continues ungrouped sortOrder from where scene shots left off", () => {
+    const sceneShots = [
+      makeShot({ id: "s1", sortOrder: 0 }),
+      makeShot({ id: "s2", sortOrder: 1 }),
+    ]
+    const ungrouped = [
+      makeShot({ id: "u1", sortOrder: 2 }),
+    ]
+    const updates = buildSceneRenumberUpdates(
+      [{ sceneNumber: 1, shots: sceneShots }],
+      ungrouped,
+    )
+    // s1/s2 already correct → no update. u1 needs "02" with sortOrder 2 (matches — no update)
+    // but shotNumber is missing so it IS an update
+    const ungroupedUpdate = updates.find((u) => u.shotId === "u1")
+    expect(ungroupedUpdate?.newSortOrder).toBe(2)
+    expect(ungroupedUpdate?.newNumber).toBe("02")
+  })
+
+  it("skips already-correct shots but updates incorrect ones", () => {
+    const shots = [
+      makeShot({ id: "s1", shotNumber: "1A", sortOrder: 0 }), // correct
+      makeShot({ id: "s2", shotNumber: "WRONG", sortOrder: 1 }), // wrong number
+      makeShot({ id: "s3", shotNumber: "1C", sortOrder: 99 }), // wrong sortOrder
+    ]
+    const updates = buildSceneRenumberUpdates(
+      [{ sceneNumber: 1, shots }],
+      [],
+    )
+    expect(updates).toHaveLength(2)
+    expect(updates.find((u) => u.shotId === "s2")).toBeDefined()
+    expect(updates.find((u) => u.shotId === "s3")).toBeDefined()
+    expect(updates.find((u) => u.shotId === "s1")).toBeUndefined()
+  })
+
+  it("applies maxSceneNumberOverride to ungrouped start", () => {
+    const ungrouped = [makeShot({ id: "u1", sortOrder: 0 })]
+    const updates = buildSceneRenumberUpdates([], ungrouped, 10)
+    expect(updates[0]?.newNumber).toBe("11")
   })
 })

--- a/src-vnext/features/shots/lib/shotNumbering.test.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.test.ts
@@ -513,6 +513,31 @@ describe("previewRenumberWithScenes", () => {
     const result = previewRenumberWithScenes([], ungrouped)
     expect(result.changes[0]?.sceneId).toBe("")
   })
+
+  it("reports empty overflowScenes when all scenes are within capacity", () => {
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Small", shots: [makeShot({ id: "s1" })] }],
+      [],
+    )
+    expect(result.overflowScenes).toHaveLength(0)
+  })
+
+  it("flags scenes that exceed MAX_SHOTS_PER_SCENE in overflowScenes", () => {
+    // Create 703 shots in a single scene (exceeds A..ZZ = 702)
+    const manyShots = Array.from({ length: 703 }, (_, i) =>
+      makeShot({ id: `s${i}`, sortOrder: i }),
+    )
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "Mega Scene", shots: manyShots }],
+      [],
+    )
+    expect(result.overflowScenes).toHaveLength(1)
+    expect(result.overflowScenes[0]).toEqual({
+      sceneNumber: 1,
+      sceneName: "Mega Scene",
+      count: 703,
+    })
+  })
 })
 
 describe("buildSceneRenumberUpdates", () => {

--- a/src-vnext/features/shots/lib/shotNumbering.test.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.test.ts
@@ -475,6 +475,44 @@ describe("previewRenumberWithScenes", () => {
     expect(result.changes.find((c) => c.shotId === "s2a")?.newNumber).toBe("2A")
     expect(result.changes.find((c) => c.shotId === "u1")?.newNumber).toBe("06")
   })
+
+  it("propagates sceneId through to changes for stable grouping in preview UI", () => {
+    // Regression: two scenes with the same name should not collide in preview grouping.
+    // The preview UI filters by sceneId, not sceneName, so different lane ids must be preserved.
+    const sceneA = [makeShot({ id: "a1", sortOrder: 0 })]
+    const sceneB = [makeShot({ id: "b1", sortOrder: 1 })]
+    const result = previewRenumberWithScenes(
+      [
+        { sceneId: "lane-A", sceneNumber: 1, sceneName: "Duplicate Name", shots: sceneA },
+        { sceneId: "lane-B", sceneNumber: 2, sceneName: "Duplicate Name", shots: sceneB },
+      ],
+      [],
+    )
+    // Both changes must have their respective laneId preserved
+    const aChange = result.changes.find((c) => c.shotId === "a1")
+    const bChange = result.changes.find((c) => c.shotId === "b1")
+    expect(aChange?.sceneId).toBe("lane-A")
+    expect(bChange?.sceneId).toBe("lane-B")
+    // sceneName is still populated (for display) but may collide — that's fine, sceneId disambiguates
+    expect(aChange?.sceneName).toBe("Duplicate Name")
+    expect(bChange?.sceneName).toBe("Duplicate Name")
+  })
+
+  it("defaults sceneId to empty string when caller omits it", () => {
+    // Backward compat: callers that don't pass sceneId should still work.
+    const shots = [makeShot({ id: "s1", sortOrder: 0 })]
+    const result = previewRenumberWithScenes(
+      [{ sceneNumber: 1, sceneName: "No ID", shots }],
+      [],
+    )
+    expect(result.changes[0]?.sceneId).toBe("")
+  })
+
+  it("tags ungrouped changes with empty sceneId", () => {
+    const ungrouped = [makeShot({ id: "u1", sortOrder: 0 })]
+    const result = previewRenumberWithScenes([], ungrouped)
+    expect(result.changes[0]?.sceneId).toBe("")
+  })
 })
 
 describe("buildSceneRenumberUpdates", () => {

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -141,3 +141,228 @@ export function suggestStartNumber(
   const maxHidden = computeMaxShotNumber(hiddenShots)
   return maxHidden > 0 ? maxHidden + 1 : 1
 }
+
+// ========================================================================
+// Scene-aware numbering
+// ========================================================================
+
+/**
+ * Converts a zero-based index to a letter suffix: 0→A, 1→B, ... 25→Z, 26→AA, 27→AB, ... 701→ZZ.
+ * Negative indices are clamped to 0 (returns "A").
+ * Maximum supported index is 701 (ZZ = 26 + 26*26 - 1).
+ */
+export function indexToLetterSuffix(index: number): string {
+  const clamped = Math.max(0, Math.min(index, 701))
+  if (clamped < 26) {
+    return String.fromCharCode(65 + clamped)
+  }
+  const first = Math.floor((clamped - 26) / 26)
+  const second = (clamped - 26) % 26
+  return String.fromCharCode(65 + first) + String.fromCharCode(65 + second)
+}
+
+/**
+ * Formats a scene shot number: sceneNumber + letterSuffix.
+ * e.g. (1, 0) → "1A", (10, 26) → "10AA"
+ */
+export function formatSceneShotNumber(sceneNumber: number, indexInScene: number): string {
+  return `${sceneNumber}${indexToLetterSuffix(indexInScene)}`
+}
+
+/**
+ * Parses a shot number into its base number and optional letter suffix.
+ * Scene numbers: "51A" → { base: 51, suffix: "A" }
+ * Flat numbers: "03" → { base: 3, suffix: null }
+ * Legacy: "SH-005" → { base: 5, suffix: null }
+ * Empty: "" → { base: 0, suffix: null }
+ */
+export function parseSceneShotNumber(shotNumber: string): { base: number; suffix: string | null } {
+  if (!shotNumber) return { base: 0, suffix: null }
+
+  // Try scene format: digits followed by letters
+  const sceneMatch = shotNumber.match(/^(\d+)([A-Za-z]+)$/)
+  if (sceneMatch) {
+    return {
+      base: parseInt(sceneMatch[1]!, 10),
+      suffix: sceneMatch[2]!.toUpperCase(),
+    }
+  }
+
+  // Fall back to flat/legacy: extract trailing digits
+  const flatMatch = shotNumber.match(/(\d+)$/)
+  if (flatMatch) {
+    return { base: parseInt(flatMatch[1]!, 10), suffix: null }
+  }
+
+  return { base: 0, suffix: null }
+}
+
+/**
+ * Returns the highest base number found among all shots.
+ * Works with both scene numbers (51A → base 51) and flat numbers (03 → base 3).
+ */
+export function computeMaxBaseNumber(shots: ReadonlyArray<Shot>): number {
+  let max = 0
+  for (const shot of shots) {
+    const num = shot.shotNumber
+    if (!num) continue
+    const parsed = parseSceneShotNumber(num)
+    if (parsed.base > max) max = parsed.base
+  }
+  return max
+}
+
+/**
+ * Preview what scene-aware renumbering would change.
+ * Scene shots get letter suffixes (1A, 1B, ...), ungrouped get flat sequential numbers
+ * starting after the highest scene number.
+ */
+type SceneChange = {
+  readonly shotId: string
+  readonly title: string
+  readonly currentNumber: string
+  readonly newNumber: string
+  readonly sceneName: string
+}
+
+type SceneUpdate = {
+  readonly shotId: string
+  readonly newNumber: string
+  readonly newSortOrder: number
+}
+
+/**
+ * Pure helper: project scene groups and ungrouped shots onto the list of numbering
+ * targets (shot + expected newNumber + global sort order). Shared by preview and write.
+ * The `maxSceneNumber` param allows callers to continue ungrouped numbering beyond the
+ * scenes that happen to have visible shots (avoids cross-filter number collisions).
+ */
+function projectSceneTargets(
+  sceneGroups: ReadonlyArray<{ readonly sceneNumber: number; readonly shots: ReadonlyArray<Shot>; readonly sceneName?: string }>,
+  ungroupedShots: ReadonlyArray<Shot>,
+  maxSceneNumberOverride?: number,
+): ReadonlyArray<{ readonly shot: Shot; readonly newNumber: string; readonly newSortOrder: number; readonly sceneName: string }> {
+  const scenePart = sceneGroups.reduce<ReadonlyArray<{ shot: Shot; newNumber: string; newSortOrder: number; sceneName: string }>>(
+    (acc, group) => [
+      ...acc,
+      ...group.shots.map((shot, i) => ({
+        shot,
+        newNumber: formatSceneShotNumber(group.sceneNumber, i),
+        newSortOrder: acc.length + i,
+        sceneName: group.sceneName ?? "",
+      })),
+    ],
+    [],
+  )
+
+  const computedMaxScene = sceneGroups.reduce((m, g) => (g.sceneNumber > m ? g.sceneNumber : m), 0)
+  const maxSceneNumber = Math.max(computedMaxScene, maxSceneNumberOverride ?? 0)
+  const ungroupedStart = maxSceneNumber + 1
+
+  const ungroupedPart = ungroupedShots.map((shot, i) => ({
+    shot,
+    newNumber: formatShotNumber(i + ungroupedStart),
+    newSortOrder: scenePart.length + i,
+    sceneName: "",
+  }))
+
+  return [...scenePart, ...ungroupedPart]
+}
+
+export function previewRenumberWithScenes(
+  sceneGroups: ReadonlyArray<{
+    readonly sceneNumber: number
+    readonly sceneName: string
+    readonly shots: ReadonlyArray<Shot>
+  }>,
+  ungroupedShots: ReadonlyArray<Shot>,
+  maxSceneNumberOverride?: number,
+): {
+  readonly changes: ReadonlyArray<SceneChange>
+  readonly unchangedCount: number
+} {
+  const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
+
+  const result = targets.reduce<{ changes: ReadonlyArray<SceneChange>; unchangedCount: number }>(
+    (acc, { shot, newNumber, newSortOrder, sceneName }) => {
+      if (shot.shotNumber === newNumber && shot.sortOrder === newSortOrder) {
+        return { ...acc, unchangedCount: acc.unchangedCount + 1 }
+      }
+      return {
+        ...acc,
+        changes: [
+          ...acc.changes,
+          {
+            shotId: shot.id,
+            title: shot.title || "Untitled",
+            currentNumber: shot.shotNumber ?? "\u2014",
+            newNumber,
+            sceneName,
+          },
+        ],
+      }
+    },
+    { changes: [], unchangedCount: 0 },
+  )
+
+  return result
+}
+
+/**
+ * Renumber shots with scene-aware numbering and write to Firestore.
+ * Scene shots get letter suffixes, ungrouped get flat sequential numbers.
+ * Returns the count of shots actually updated.
+ */
+/**
+ * Builds the Firestore update list for scene-aware renumbering. Pure function —
+ * exported for unit testing without Firestore mocks.
+ */
+export function buildSceneRenumberUpdates(
+  sceneGroups: ReadonlyArray<{ readonly sceneNumber: number; readonly shots: ReadonlyArray<Shot> }>,
+  ungroupedShots: ReadonlyArray<Shot>,
+  maxSceneNumberOverride?: number,
+): ReadonlyArray<SceneUpdate> {
+  const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
+  return targets.reduce<ReadonlyArray<SceneUpdate>>(
+    (acc, { shot, newNumber, newSortOrder }) =>
+      shot.shotNumber === newNumber && shot.sortOrder === newSortOrder
+        ? acc
+        : [...acc, { shotId: shot.id, newNumber, newSortOrder }],
+    [],
+  )
+}
+
+export async function renumberShotsWithScenes(
+  sceneGroups: ReadonlyArray<{
+    readonly sceneNumber: number
+    readonly shots: ReadonlyArray<Shot>
+  }>,
+  ungroupedShots: ReadonlyArray<Shot>,
+  clientId: string,
+  maxSceneNumberOverride?: number,
+): Promise<number> {
+  const totalShots = sceneGroups.reduce((sum, g) => sum + g.shots.length, 0) + ungroupedShots.length
+  if (totalShots > MAX_RENUMBER_SHOTS) {
+    throw new Error(`Cannot renumber more than ${MAX_RENUMBER_SHOTS} shots at once.`)
+  }
+
+  const updates = buildSceneRenumberUpdates(sceneGroups, ungroupedShots, maxSceneNumberOverride)
+  if (updates.length === 0) return 0
+
+  for (let start = 0; start < updates.length; start += BATCH_CHUNK_SIZE) {
+    const chunk = updates.slice(start, start + BATCH_CHUNK_SIZE)
+    const batch = writeBatch(db)
+    for (const { shotId, newNumber, newSortOrder } of chunk) {
+      const path = shotPath(shotId, clientId)
+      const ref = doc(db, path[0]!, ...path.slice(1))
+      batch.update(ref, {
+        shotNumber: newNumber,
+        sortOrder: newSortOrder,
+        updatedAt: serverTimestamp(),
+      })
+    }
+    await batch.commit()
+  }
+
+  return updates.length
+}

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -358,6 +358,9 @@ export function buildSceneRenumberUpdates(
   return updates
 }
 
+/** Maximum shots per scene — bounded by indexToLetterSuffix capacity (A..ZZ = 702). */
+export const MAX_SHOTS_PER_SCENE = 702
+
 export async function renumberShotsWithScenes(
   sceneGroups: ReadonlyArray<{
     readonly sceneNumber: number
@@ -370,6 +373,15 @@ export async function renumberShotsWithScenes(
   const totalShots = sceneGroups.reduce((sum, g) => sum + g.shots.length, 0) + ungroupedShots.length
   if (totalShots > MAX_RENUMBER_SHOTS) {
     throw new Error(`Cannot renumber more than ${MAX_RENUMBER_SHOTS} shots at once.`)
+  }
+  // Guard per-scene capacity: indexToLetterSuffix clamps at "ZZ" (index 701), so a
+  // scene with 703+ shots would produce duplicate "ZZ" numbers. Surface a clear
+  // error before the write instead of silently corrupting data.
+  const overflowScene = sceneGroups.find((g) => g.shots.length > MAX_SHOTS_PER_SCENE)
+  if (overflowScene) {
+    throw new Error(
+      `Scene ${overflowScene.sceneNumber} has ${overflowScene.shots.length} shots, which exceeds the maximum of ${MAX_SHOTS_PER_SCENE} shots per scene (A..ZZ).`,
+    )
   }
 
   const updates = buildSceneRenumberUpdates(sceneGroups, ungroupedShots, maxSceneNumberOverride)

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -300,6 +300,11 @@ function projectSceneTargets(
  * starting after the highest scene number. Caller can optionally pass `sceneId` on
  * each group — it flows through to `SceneChange.sceneId` so preview UI can group by
  * stable id instead of the display name (which may collide between scenes).
+ *
+ * Returns `overflowScenes` listing any scenes that exceed MAX_SHOTS_PER_SCENE so
+ * callers can surface a warning before executing. The preview still produces
+ * (clamped-at-ZZ) change entries for overflowing scenes — callers are expected
+ * to gate the execute action on `overflowScenes.length === 0`.
  */
 export function previewRenumberWithScenes(
   sceneGroups: ReadonlyArray<{
@@ -313,8 +318,12 @@ export function previewRenumberWithScenes(
 ): {
   readonly changes: ReadonlyArray<SceneChange>
   readonly unchangedCount: number
+  readonly overflowScenes: ReadonlyArray<{ sceneNumber: number; sceneName: string; count: number }>
 } {
   const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
+  const overflowScenes = sceneGroups
+    .filter((g) => g.shots.length > MAX_SHOTS_PER_SCENE)
+    .map((g) => ({ sceneNumber: g.sceneNumber, sceneName: g.sceneName, count: g.shots.length }))
 
   // Local scratch builder: push into a const array that never escapes this function.
   // Avoids O(n²) spread-in-reduce for the up-to-2000-shot cap. Return type is
@@ -336,7 +345,7 @@ export function previewRenumberWithScenes(
     })
   }
 
-  return { changes, unchangedCount }
+  return { changes, unchangedCount, overflowScenes }
 }
 
 /**

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -212,17 +212,14 @@ export function computeMaxBaseNumber(shots: ReadonlyArray<Shot>): number {
   return max
 }
 
-/**
- * Preview what scene-aware renumbering would change.
- * Scene shots get letter suffixes (1A, 1B, ...), ungrouped get flat sequential numbers
- * starting after the highest scene number.
- */
 type SceneChange = {
   readonly shotId: string
   readonly title: string
   readonly currentNumber: string
   readonly newNumber: string
   readonly sceneName: string
+  /** Stable lane id — used by preview UI to group by scene without name collisions. Empty string for ungrouped. */
+  readonly sceneId: string
 }
 
 type SceneUpdate = {
@@ -231,49 +228,78 @@ type SceneUpdate = {
   readonly newSortOrder: number
 }
 
+type SceneTarget = {
+  readonly shot: Shot
+  readonly newNumber: string
+  readonly newSortOrder: number
+  readonly sceneName: string
+  readonly sceneId: string
+}
+
 /**
  * Pure helper: project scene groups and ungrouped shots onto the list of numbering
  * targets (shot + expected newNumber + global sort order). Shared by preview and write.
- * The `maxSceneNumber` param allows callers to continue ungrouped numbering beyond the
- * scenes that happen to have visible shots (avoids cross-filter number collisions).
+ * The `maxSceneNumberOverride` param allows callers to continue ungrouped numbering
+ * beyond the scenes that happen to have visible shots (avoids cross-filter number
+ * collisions).
  */
 function projectSceneTargets(
-  sceneGroups: ReadonlyArray<{ readonly sceneNumber: number; readonly shots: ReadonlyArray<Shot>; readonly sceneName?: string }>,
+  sceneGroups: ReadonlyArray<{
+    readonly sceneNumber: number
+    readonly shots: ReadonlyArray<Shot>
+    readonly sceneName?: string
+    readonly sceneId?: string
+  }>,
   ungroupedShots: ReadonlyArray<Shot>,
   maxSceneNumberOverride?: number,
-): ReadonlyArray<{ readonly shot: Shot; readonly newNumber: string; readonly newSortOrder: number; readonly sceneName: string }> {
-  const scenePart = sceneGroups.reduce<ReadonlyArray<{ shot: Shot; newNumber: string; newSortOrder: number; sceneName: string }>>(
-    (acc, group) => [
-      ...acc,
-      ...group.shots.map((shot, i) => ({
-        shot,
-        newNumber: formatSceneShotNumber(group.sceneNumber, i),
-        newSortOrder: acc.length + i,
-        sceneName: group.sceneName ?? "",
-      })),
-    ],
-    [],
+): ReadonlyArray<SceneTarget> {
+  // Compute running sort-order offsets in one pass, then flatMap to build scene targets.
+  // Avoids O(n²) spread-in-reduce while staying immutable at the outer level.
+  const offsets: number[] = []
+  let runningOffset = 0
+  for (const group of sceneGroups) {
+    offsets.push(runningOffset)
+    runningOffset += group.shots.length
+  }
+  const scenePart: ReadonlyArray<SceneTarget> = sceneGroups.flatMap((group, gIdx) =>
+    group.shots.map((shot, i) => ({
+      shot,
+      newNumber: formatSceneShotNumber(group.sceneNumber, i),
+      newSortOrder: offsets[gIdx]! + i,
+      sceneName: group.sceneName ?? "",
+      sceneId: group.sceneId ?? "",
+    })),
   )
 
   const computedMaxScene = sceneGroups.reduce((m, g) => (g.sceneNumber > m ? g.sceneNumber : m), 0)
   const maxSceneNumber = Math.max(computedMaxScene, maxSceneNumberOverride ?? 0)
   const ungroupedStart = maxSceneNumber + 1
+  const ungroupedOffset = runningOffset
 
-  const ungroupedPart = ungroupedShots.map((shot, i) => ({
+  const ungroupedPart: ReadonlyArray<SceneTarget> = ungroupedShots.map((shot, i) => ({
     shot,
     newNumber: formatShotNumber(i + ungroupedStart),
-    newSortOrder: scenePart.length + i,
+    newSortOrder: ungroupedOffset + i,
     sceneName: "",
+    sceneId: "",
   }))
 
   return [...scenePart, ...ungroupedPart]
 }
 
+/**
+ * Preview what scene-aware renumbering would change.
+ * Scene shots get letter suffixes (1A, 1B, ...), ungrouped get flat sequential numbers
+ * starting after the highest scene number. Caller can optionally pass `sceneId` on
+ * each group — it flows through to `SceneChange.sceneId` so preview UI can group by
+ * stable id instead of the display name (which may collide between scenes).
+ */
 export function previewRenumberWithScenes(
   sceneGroups: ReadonlyArray<{
     readonly sceneNumber: number
     readonly sceneName: string
     readonly shots: ReadonlyArray<Shot>
+    readonly sceneId?: string
   }>,
   ungroupedShots: ReadonlyArray<Shot>,
   maxSceneNumberOverride?: number,
@@ -284,7 +310,7 @@ export function previewRenumberWithScenes(
   const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
 
   const result = targets.reduce<{ changes: ReadonlyArray<SceneChange>; unchangedCount: number }>(
-    (acc, { shot, newNumber, newSortOrder, sceneName }) => {
+    (acc, { shot, newNumber, newSortOrder, sceneName, sceneId }) => {
       if (shot.shotNumber === newNumber && shot.sortOrder === newSortOrder) {
         return { ...acc, unchangedCount: acc.unchangedCount + 1 }
       }
@@ -298,6 +324,7 @@ export function previewRenumberWithScenes(
             currentNumber: shot.shotNumber ?? "\u2014",
             newNumber,
             sceneName,
+            sceneId,
           },
         ],
       }
@@ -308,11 +335,6 @@ export function previewRenumberWithScenes(
   return result
 }
 
-/**
- * Renumber shots with scene-aware numbering and write to Firestore.
- * Scene shots get letter suffixes, ungrouped get flat sequential numbers.
- * Returns the count of shots actually updated.
- */
 /**
  * Builds the Firestore update list for scene-aware renumbering. Pure function —
  * exported for unit testing without Firestore mocks.

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -149,7 +149,11 @@ export function suggestStartNumber(
 /**
  * Converts a zero-based index to a letter suffix: 0→A, 1→B, ... 25→Z, 26→AA, 27→AB, ... 701→ZZ.
  * Negative indices are clamped to 0 (returns "A").
- * Maximum supported index is 701 (ZZ = 26 + 26*26 - 1).
+ * Maximum supported index is 701 (ZZ = 26 + 26*26 - 1). Indices >= 702 are
+ * intentionally clamped to "ZZ" — if a single scene has more than 702 shots the
+ * project has bigger problems than duplicate letter suffixes, but the clamp
+ * prevents invalid characters (e.g., `[A`) from being emitted. Callers that need
+ * to detect overflow should validate shot counts before numbering.
  */
 export function indexToLetterSuffix(index: number): string {
   const clamped = Math.max(0, Math.min(index, 701))
@@ -276,9 +280,12 @@ function projectSceneTargets(
   const ungroupedStart = maxSceneNumber + 1
   const ungroupedOffset = runningOffset
 
+  // Ungrouped shots in scene-aware mode use raw unpadded numbers to match the
+  // unpadded scene numbers used in scene shots (e.g., "1A", "2B", then "6", "7").
+  // Using formatShotNumber here would produce "06" next to "1A" — visually jarring.
   const ungroupedPart: ReadonlyArray<SceneTarget> = ungroupedShots.map((shot, i) => ({
     shot,
-    newNumber: formatShotNumber(i + ungroupedStart),
+    newNumber: String(i + ungroupedStart),
     newSortOrder: ungroupedOffset + i,
     sceneName: "",
     sceneId: "",

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -358,7 +358,13 @@ export function buildSceneRenumberUpdates(
   return updates
 }
 
-/** Maximum shots per scene — bounded by indexToLetterSuffix capacity (A..ZZ = 702). */
+/**
+ * Maximum shots per scene — bounded by indexToLetterSuffix's letter capacity.
+ * The base-26 encoding A..Z plus AA..ZZ gives 26 + 26*26 = 702 distinct values
+ * (indices 0..701, where 0 → "A" and 701 → "ZZ"). A scene with more than 702
+ * shots would force renumberShotsWithScenes to emit duplicate "ZZ" suffixes,
+ * which we surface as an explicit error rather than silently corrupting.
+ */
 export const MAX_SHOTS_PER_SCENE = 702
 
 export async function renumberShotsWithScenes(

--- a/src-vnext/features/shots/lib/shotNumbering.ts
+++ b/src-vnext/features/shots/lib/shotNumbering.ts
@@ -309,30 +309,27 @@ export function previewRenumberWithScenes(
 } {
   const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
 
-  const result = targets.reduce<{ changes: ReadonlyArray<SceneChange>; unchangedCount: number }>(
-    (acc, { shot, newNumber, newSortOrder, sceneName, sceneId }) => {
-      if (shot.shotNumber === newNumber && shot.sortOrder === newSortOrder) {
-        return { ...acc, unchangedCount: acc.unchangedCount + 1 }
-      }
-      return {
-        ...acc,
-        changes: [
-          ...acc.changes,
-          {
-            shotId: shot.id,
-            title: shot.title || "Untitled",
-            currentNumber: shot.shotNumber ?? "\u2014",
-            newNumber,
-            sceneName,
-            sceneId,
-          },
-        ],
-      }
-    },
-    { changes: [], unchangedCount: 0 },
-  )
+  // Local scratch builder: push into a const array that never escapes this function.
+  // Avoids O(n²) spread-in-reduce for the up-to-2000-shot cap. Return type is
+  // ReadonlyArray so callers can't mutate.
+  const changes: SceneChange[] = []
+  let unchangedCount = 0
+  for (const { shot, newNumber, newSortOrder, sceneName, sceneId } of targets) {
+    if (shot.shotNumber === newNumber && shot.sortOrder === newSortOrder) {
+      unchangedCount++
+      continue
+    }
+    changes.push({
+      shotId: shot.id,
+      title: shot.title || "Untitled",
+      currentNumber: shot.shotNumber ?? "\u2014",
+      newNumber,
+      sceneName,
+      sceneId,
+    })
+  }
 
-  return result
+  return { changes, unchangedCount }
 }
 
 /**
@@ -345,13 +342,13 @@ export function buildSceneRenumberUpdates(
   maxSceneNumberOverride?: number,
 ): ReadonlyArray<SceneUpdate> {
   const targets = projectSceneTargets(sceneGroups, ungroupedShots, maxSceneNumberOverride)
-  return targets.reduce<ReadonlyArray<SceneUpdate>>(
-    (acc, { shot, newNumber, newSortOrder }) =>
-      shot.shotNumber === newNumber && shot.sortOrder === newSortOrder
-        ? acc
-        : [...acc, { shotId: shot.id, newNumber, newSortOrder }],
-    [],
-  )
+  // Local scratch builder (see previewRenumberWithScenes note).
+  const updates: SceneUpdate[] = []
+  for (const { shot, newNumber, newSortOrder } of targets) {
+    if (shot.shotNumber === newNumber && shot.sortOrder === newSortOrder) continue
+    updates.push({ shotId: shot.id, newNumber, newSortOrder })
+  }
+  return updates
 }
 
 export async function renumberShotsWithScenes(

--- a/src-vnext/features/shots/lib/shotTableColumns.test.ts
+++ b/src-vnext/features/shots/lib/shotTableColumns.test.ts
@@ -7,10 +7,10 @@ import {
 import { DEFAULT_FIELDS, type ShotsListFields } from "./shotListFilters"
 
 describe("SHOT_TABLE_COLUMNS", () => {
-  it("defines 14 columns with unique keys", () => {
-    expect(SHOT_TABLE_COLUMNS).toHaveLength(14)
+  it("defines 15 columns with unique keys", () => {
+    expect(SHOT_TABLE_COLUMNS).toHaveLength(15)
     const keys = SHOT_TABLE_COLUMNS.map((c) => c.key)
-    expect(new Set(keys).size).toBe(14)
+    expect(new Set(keys).size).toBe(15)
   })
 
   it("marks 'shot' and 'shotNumber' columns as pinned", () => {

--- a/src-vnext/features/shots/lib/shotTableColumns.ts
+++ b/src-vnext/features/shots/lib/shotTableColumns.ts
@@ -21,6 +21,7 @@ export const SHOT_TABLE_COLUMNS: readonly TableColumnConfig[] = [
   { key: "reqs", label: "Reqs", defaultLabel: "Reqs", visible: false, width: 120, order: 11 },
   { key: "samples", label: "Samples", defaultLabel: "Samples", visible: false, width: 100, order: 12 },
   { key: "updated", label: "Updated", defaultLabel: "Updated", visible: true, width: 110, order: 13 },
+  { key: "scene", label: "Scene", defaultLabel: "Scene", visible: false, width: 140, order: 14 },
 ]
 
 // ---------------------------------------------------------------------------
@@ -43,6 +44,7 @@ const COLUMN_TO_FIELD: Record<string, keyof ShotsListFields | null> = {
   reqs: "reqs",
   samples: "samples",
   updated: "updated",
+  scene: "scene",
 }
 
 // ---------------------------------------------------------------------------

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -119,6 +119,9 @@ export interface Lane {
   readonly clientId: string
   readonly sortOrder: number
   readonly color?: string
+  readonly sceneNumber?: number
+  readonly direction?: string
+  readonly notes?: string
   readonly createdAt: Timestamp
   readonly updatedAt: Timestamp
   readonly createdBy: string


### PR DESCRIPTION
## Summary

Closes three gaps in the S28 scene system:
- **Scene grouping in table view** — previously card-only; table view showed a dismissive "switch to cards" banner
- **Scene-level creative direction + production notes** — scenes had only a name and color; producers now have an umbrella context field for shots within
- **Letter-suffix sub-numbering** — shots in scenes get `51A`, `51B`, `51C` format relative to the scene number (industry-standard from film/TV production)

All 4 implementation phases complete across 37 files (+4524/-278). Zero migration needed — legacy S28 lanes auto-backfill `sceneNumber = sortOrder + 1` at read time.

## What shipped

**Phase 1 — data model + scene UI**
- Extended `Lane` type with optional `sceneNumber`, `direction`, `notes`
- `useLanes` returns `laneById` map + auto-backfills legacy lanes
- `createLane` accepts `existingLanes` and auto-increments `sceneNumber`
- New `SceneDetailSheet` (right slide-over, blur-only saves, `useRef` init gate against snapshot echo)
- New `SceneContextBanner` in `ShotDetailPage` + `ThreePanelCanvasPanel` + `ThreePanelPropertiesPanel` (three-panel parity)
- `SceneHeader` shows `#sceneNumber` prefix + direction preview + "Edit Scene" menu (replaces `window.prompt`)

**Phase 2 — table grouping**
- New `SceneTableRow` (refactored to `<div>` + sibling `<button>` to avoid nested interactive elements)
- `ShotsTable` accepts `groups`, `collapsedScenes`, and scene action callbacks
- `ShotListPage` removes the "switch to cards" banner
- Orphan `laneId` guard in `groupShots` (gated on `lanes.size > 0` to prevent load-race flicker)

**Phase 3 — scene-aware sub-numbering**
- 6 new pure functions in `shotNumbering.ts` (`indexToLetterSuffix`, `formatSceneShotNumber`, `parseSceneShotNumber`, `computeMaxBaseNumber`, `projectSceneTargets`, `buildSceneRenumberUpdates`, `previewRenumberWithScenes`, `renumberShotsWithScenes`)
- `MAX_RENUMBER_SHOTS` guard + `maxSceneNumberOverride` param for cross-filter safety
- `RenumberShotsDialog` adds Sequential / By Scene toggle with grouped preview and warning when sequential would destroy scene letters

**Phase 4 — scene assignment**
- New `scene` column in `SHOT_TABLE_COLUMNS` (default hidden)
- Scene cell renderer with colored dot + badge
- New `SceneAssignPopover` (None / scene list / checkmark on active)
- `BulkActionBar` button renamed to "Set Scene"

**Export fixes** (discovered during pre-impl audit)
- `blockDataResolvers` sort: `Number("51A")` returns `NaN` → switched to `localeCompare` with `{ numeric: true, sensitivity: "base" }`
- Four export files: removed `padStart(3, "0")` which produced `"05A"` from `"5A"`

**Firestore rules**
- Added explicit `match /lanes/{laneId}` rule before the wildcard with `direction.size() <= 500` and `notes.size() <= 5000` validation

## Review cycle

Four internal review passes; **all CRITICAL and HIGH findings fixed before commit**:

1. **Pre-implementation audit** — caught the export `Number()` NaN sort bug and 4× `padStart` issues
2. **Data model + numbering review** — caught `previewRenumberWithScenes` sortOrder divergence from write path, missing `MAX_RENUMBER_SHOTS` guard, missing boundary clamping on `indexToLetterSuffix`
3. **Architecture review** (13 findings) — caught missing `existingLanes` in `createLane` call (would have collided every new scene to `sceneNumber=1`), debounced direction write causing multi-user conflict, legacy lane backfill strategy, orphan `laneId` phantom groups
4. **Full sprint code review** (23 findings) — caught dead code (Phase 3 UI unreachable because `lanes`/`groupKey` not passed to dialog), `SceneDetailSheet` re-render trap (snapshot echoes clobbered in-progress edits), push-mutation violations, nested interactive HTML in `SceneTableRow`, missing Firestore size validation, missing tests for `renumberShotsWithScenes`

Codex CLI independent review attempted; `gpt-5.4-high` not available on ChatGPT accounts (known limitation). The two-tier internal review was the practical substitute.

## Test status

- **167 test files / 1975 tests passing** (was 1905, +70 new)
- Lint: zero warnings (`--max-warnings=0`)
- Production build: clean (~12s)
- Test coverage:
  - `shotNumbering`: +39 tests (boundary clamping, parser edge cases, grouping projections, pure `buildSceneRenumberUpdates` logic with `maxSceneNumberOverride`)
  - `SceneDetailSheet`: 14 tests including explicit regression for the re-render trap
  - `SceneContextBanner`: 10 tests
  - `SceneAssignPopover`: 5 tests
  - `sceneGrouping`: +1 orphan test
  - `shotTableColumns`: column count updated
  - `ShotGridBlockView`: updated expectations for non-padded shot numbers

## Test plan

- [ ] Verify scene grouping appears in table view when "Group by: Scene" is active
- [ ] Create a new scene from `GroupIntoSceneDialog` and confirm `sceneNumber` auto-increments
- [ ] Open Edit Scene from the scene header kebab menu and verify direction + notes save on blur
- [ ] Verify direction preview appears in the scene header and shot detail banner
- [ ] Open a shot that belongs to a scene and confirm the SceneContextBanner appears at the top
- [ ] Repeat the above in three-panel view (canvas + properties panels)
- [ ] Open Renumber dialog with scenes — verify By Scene mode is auto-selected when grouped, preview shows grouped rows, and execute produces `51A`, `51B`, etc.
- [ ] Test sequential mode warning banner with existing scene-numbered shots
- [ ] Enable the Scene column via Columns settings; click a cell and assign a scene from the popover
- [ ] Verify legacy S28 lanes (no stored `sceneNumber`) participate correctly in scene-aware renumber
- [ ] Deploy Firestore rules (`firebase deploy --only firestore:rules`) and verify lane writes still succeed
- [ ] Generate a PDF export with scene-numbered shots and confirm `51A` displays correctly (no padding artifacts)

## Deployment notes

- Firestore rules need to be deployed after merge (`firebase deploy --only firestore:rules`)
- No migration script needed — all new fields are optional
- Legacy lanes without `sceneNumber` backfill at read time (no breakage)