### PR TITLE
Phase 1: call sheet builder completion

### DIFF
--- a/CALL_SHEET_BUILDER_SPEC.md
+++ b/CALL_SHEET_BUILDER_SPEC.md
@@ -642,6 +642,20 @@ Optimistic updates are permitted only for idempotent toggles (section visibility
 
 An earlier draft of this spec suggested Zustand or React Context for a `CallSheetBuilderState` store — **that suggestion is rejected**; it contradicts the hard architectural rule in `CLAUDE.md` §5. Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 1.
 
+### Autosave semantics
+
+Call sheet field edits save on blur (input leaves focus) via dirty-field `updateDoc` writes to Firestore. Re-renders flow through `onSnapshot` subscribers per `CLAUDE.md` §5. Three rules govern the save path:
+
+1. **Idempotent toggles** (section visibility, `is_visible`, `is_key_contact`, `showName` / `showPhone` on locations) apply optimistically client-side and converge on the next snapshot tick. These never need a confirmation gesture; the toggle IS the confirmation.
+2. **Free-text and numeric fields** save on blur via dirty-field `updateDoc`. No debounce on text input — only the on-blur write is dispatched. The user's draft state lives in component-local `useState`; the snapshot listener is the single source of truth and re-syncs after the write lands.
+3. **Destructive actions** (section hide, row delete, section reorder, location remove, track collapse, timeline entry delete) require an explicit confirmation OR a 5-second `sonner` undo toast (the `destructiveActionWithUndo` helper in `src-vnext/shared/lib/`). The undo window prevents the silent-loss hazard SetHero exhibits with its fail-silent autosave.
+
+Every section header renders an unobtrusive "Saved Xs ago" pill (green dot + relative timestamp, ticking every ~5 seconds) so the producer never has to wonder whether their last keystroke landed. Implementation lives in `src-vnext/shared/components/SaveIndicator.tsx` and a sibling `useLastSaved` hook.
+
+There is **no client-side cache layer**, **no custom sync engine**, **no offline mutation queue**. Firestore's default IndexedDB persistence handles offline reads; a failed write surfaces a `sonner` error toast and the user re-tries manually. This is the deliberate inverse of SetHero's "PUT and forget" pattern, which loses changes silently when the network drops mid-edit.
+
+Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 6 (corrected: the spec delta originally referenced `react-hot-toast`; the codebase uses `sonner`, which has native action-button support and is the established toast layer).
+
 ### Drag and Drop
 Use `@dnd-kit/core` for:
 - Section reordering in layout panel

--- a/CALL_SHEET_BUILDER_SPEC.md
+++ b/CALL_SHEET_BUILDER_SPEC.md
@@ -28,6 +28,8 @@ Transform the Schedule page into a full-featured Call Sheet Builder with:
 
 ## 🏗️ ARCHITECTURE OVERVIEW
 
+> **Design data models for the goal, not for the current feature set.** SetHero's scene data model has `slugline` / `pageCount` (fractional, 1/8 precision) / `storyDay` / `intExt` / `dayNight` fields despite having no script parser. These are producer-entered manual fields that unlock classic 1st-AD production workflows (coverage tracking, production reports) without requiring a script-importer engineering investment. When Shot Builder adds scene support, the scene schema should include these fields from day one even if no downstream feature uses them yet — the marginal cost is trivial (a few optional fields), and the option value is large (enables a later Production Reports / Coverage Tracker sprint without a schema migration). Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 13.
+
 ### New Data Models Required
 ```typescript
 // Departments & Positions
@@ -96,25 +98,38 @@ interface CallSheetConfig {
 
 interface CallSheetSection {
   id: string;
-  type: SectionType;
+  slug: SectionSlug;
+  displayTitle: string;  // user-editable label; defaults to the canonical display name for each slug
   isVisible: boolean;
   order: number;
   config: SectionConfig;
 }
 
-type SectionType =
-  | 'header'
-  | 'day-details'
-  | 'reminders'
-  | 'schedule'
-  | 'clients'
-  | 'talent'
-  | 'extras'
-  | 'advanced-schedule'
-  | 'page-break'
-  | 'crew'
-  | 'notes-contacts'
-  | 'custom-banner';
+// Canonical section slugs — match SetHero's internal names where applicable,
+// diverge where SB is extending (custom-banner) or collapsing (schedule).
+// Slug is stable and machine-readable; the user-visible title lives on
+// `CallSheetSection.displayTitle` so rename-in-place does not mutate the slug.
+type SectionSlug =
+  | 'header'            // SH parity (display: "Header")
+  | 'day'               // SH parity slug (display: "Day Details")
+  | 'reminders'         // SH parity (display: "Reminders")
+  | 'schedule'          // SB unified — encompasses SH's today-schedule.
+                        // Tomorrow-preview is a config flag (`showNextDayPreview`),
+                        // NOT a separate section type. SH's `advanced-schedule`
+                        // is collapsed into this.
+  | 'clients'           // SH parity (display: "Clients")
+  | 'cast'              // SH parity slug (display: "Talent")
+  | 'extras'            // SH parity (display: "Extras and Dept. Notes")
+  | 'page-break'        // SH parity (display: "Page Break")
+  | 'crew'              // SH parity (display: "Crew")
+  | 'notes'             // SH parity slug (display: "Notes & Contacts")
+  | 'custom-banner';    // SB-only extension — no SH analogue. Full-width
+                        // announcement block insertable between sections.
+
+// NOTE: 'quote' (SetHero's disabled-by-default Quote of the Day) is intentionally
+// omitted from the canonical taxonomy. Low demand for commercial/fashion producers;
+// can be added later via a custom-section extension if the need emerges.
+// Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 2.
 
 interface DayDetails {
   scheduleId: string;
@@ -161,6 +176,10 @@ interface ScheduleEntry {
   unit: string; // "Main", "Motion", "Stills", etc.
 }
 ```
+
+### Patterns worth considering (speculative, not requirements)
+
+SetHero's `crew_new` modal was observed to default `add_to_previous_reports: true` — meaning when a producer adds a crew member to a project, that crew member is **retroactively back-filled onto all prior Production Reports** so historical documents rebuild themselves as the project grows. **Medium confidence** — the field default was observed in the modal template but the behavior was not directly verified with live data. If Shot Builder ever ships Production Reports (tracked separately as a v2/v3 roadmap question, out of scope for this spec), this is a pattern worth prototyping: automatically back-fill late crew additions onto historical documents rather than leaving them as partial records. Not a hard recommendation. Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 14.
 
 ---
 
@@ -343,7 +362,10 @@ interface LayoutPanelProps {
 
 // Features:
 // - Drag handles for reordering
-// - Eye icon for visibility toggle
+// - Eye icon for visibility toggle (SetHero precedent confirmed —
+//   `is_shown: false` + `.disabled` wrapper. Do NOT replace with a
+//   text "Hide" button or a kebab menu item; the eye icon is the
+//   canonical affordance. Sourced from spec-delta Item 8.)
 // - Checkmark icon for enabled/disabled
 // - Edit button to open section editor
 // - "+" menu between sections for inserting custom banners or page breaks
@@ -482,7 +504,11 @@ Accessible via gear icon or "Settings" tab:
 - Preview mode vs Edit mode toggle
 - Generate PDF
 - Send via email (with recipient list from crew)
-- Live preview URL (shareable link)
+- Live preview URL (shareable link) — reuse the existing token-based share
+  pattern from `shotShares` (Sprint S21) and `castingShares` (Sprint S24). The
+  call sheet share is a root-level `callSheetShares/{shareToken}` collection
+  with a denormalized `resolvedSheet` so the public reader never touches
+  protected collections. Sourced from spec-delta Item 11.
 - Version history
 
 #### 5.3 File Attachments
@@ -609,18 +635,12 @@ src/
 ## 💡 IMPLEMENTATION TIPS
 
 ### State Management
-Consider using Zustand or React Context for call sheet builder state:
-```typescript
-interface CallSheetBuilderState {
-  activeSection: string | null;
-  setActiveSection: (id: string | null) => void;
-  sections: CallSheetSection[];
-  updateSection: (id: string, updates: Partial<CallSheetSection>) => void;
-  reorderSections: (newOrder: string[]) => void;
-  isPreviewMode: boolean;
-  togglePreviewMode: () => void;
-}
-```
+
+Per `CLAUDE.md` §5 (State Strategy), server state for the call sheet builder is Firestore `onSnapshot` subscriptions — **no Redux, no Zustand, no client-side cache, no custom sync engine**. Section edits flow through per-field `updateDoc` writes (dirty-field only). Re-renders are driven by snapshot observers, not a client-side store. UI-only state (which section is being edited, expanded / collapsed state of the outline sidebar, unsaved-draft flags) lives in component-local `useState` or a minimal context provider — never mirrors Firestore documents.
+
+Optimistic updates are permitted only for idempotent toggles (section visibility, `is_visible`, `is_key_contact`); optimistic **entity creation** (new section, new crew assignment) is explicitly disallowed and must await Firestore write confirmation per `CLAUDE.md` §5. The dual-PUT pattern SetHero uses on visibility writes (per the `sethero-callsheet-editor` research) maps to writing a structured Firestore document — the section shape and subcollection layout follows the existing `schedules/{scheduleId}/callSheet` / `schedules/{scheduleId}/crewCalls` / `schedules/{scheduleId}/talentCalls` paths already present in the codebase.
+
+An earlier draft of this spec suggested Zustand or React Context for a `CallSheetBuilderState` store — **that suggestion is rejected**; it contradicts the hard architectural rule in `CLAUDE.md` §5. Sourced from `outputs/sethero-callsheet-spec-delta.md` Item 1.
 
 ### Drag and Drop
 Use `@dnd-kit/core` for:

--- a/src-vnext/features/schedules/components/AdaptiveTimelineView.test.tsx
+++ b/src-vnext/features/schedules/components/AdaptiveTimelineView.test.tsx
@@ -1,0 +1,279 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { AdaptiveTimelineView } from "@/features/schedules/components/AdaptiveTimelineView"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
+import type { Schedule, ScheduleEntry } from "@/shared/types"
+
+const { toastMock, toastErrorMock, toastSuccessMock, toastInfoMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastMock, {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+    info: toastInfoMock,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    clientId: "client-1",
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({
+    projectId: "project-1",
+  }),
+  useOptionalProjectScope: () => null,
+}))
+
+const removeScheduleEntryMock = vi.fn()
+const upsertScheduleEntryMock = vi.fn()
+
+vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
+  addScheduleEntryCustom: vi.fn(),
+  addScheduleEntryShot: vi.fn(),
+  batchUpdateScheduleEntries: vi.fn().mockResolvedValue(undefined),
+  removeScheduleEntry: (...args: unknown[]) => removeScheduleEntryMock(...args),
+  updateScheduleEntryFields: vi.fn(),
+  upsertScheduleEntry: (...args: unknown[]) => upsertScheduleEntryMock(...args),
+}))
+
+// Mock the heavy visual sub-components so rendering is cheap.
+vi.mock("@/features/schedules/components/AdaptiveBannerSegment", () => ({
+  AdaptiveBannerSegment: () => <div data-testid="banner-segment" />,
+}))
+vi.mock("@/features/schedules/components/AdaptiveGapSegment", () => ({
+  AdaptiveGapSegment: () => <div data-testid="gap-segment" />,
+}))
+vi.mock("@/features/schedules/components/AdaptiveDenseBlock", () => ({
+  AdaptiveDenseBlock: () => <div data-testid="dense-block" />,
+}))
+vi.mock("@/features/schedules/components/TimelineGridView", () => ({
+  TimelineGridView: () => <div data-testid="timeline-grid-view" />,
+}))
+vi.mock("@/features/schedules/components/TimelinePropertiesDrawer", () => ({
+  TimelinePropertiesDrawer: () => <div data-testid="properties-drawer" />,
+}))
+vi.mock("@/features/schedules/components/AdaptiveTimelineHeader", () => ({
+  AdaptiveTimelineHeader: () => <div data-testid="timeline-header" />,
+  computeTrackCounts: () => new Map<string, number>(),
+}))
+
+// The unscheduled tray is the test's click surface — expose
+// onClickEntry to the user as a real button that passes the
+// target entry id.
+vi.mock("@/features/schedules/components/AdaptiveUnscheduledTray", () => ({
+  AdaptiveUnscheduledTray: ({
+    onClickEntry,
+  }: {
+    readonly onClickEntry: (entryId: string) => void
+  }) => (
+    <button
+      type="button"
+      data-testid="mock-unscheduled-row"
+      onClick={() => onClickEntry("entry-42")}
+    >
+      Open entry-42
+    </button>
+  ),
+}))
+
+vi.mock("@/features/schedules/components/AddShotToScheduleDialog", () => ({
+  AddShotToScheduleDialog: () => <div data-testid="add-shot-dialog" />,
+}))
+vi.mock("@/features/schedules/components/AddCustomEntryDialog", () => ({
+  AddCustomEntryDialog: () => <div data-testid="add-custom-dialog" />,
+}))
+
+// The edit sheet renders a Remove button when open. handleRemove is
+// wired through onRemove.
+vi.mock("@/features/schedules/components/ScheduleEntryEditSheet", () => ({
+  ScheduleEntryEditSheet: ({
+    open,
+    onRemove,
+  }: {
+    readonly open: boolean
+    readonly onRemove?: () => void | Promise<void>
+  }) =>
+    open ? (
+      <button
+        type="button"
+        data-testid="mock-edit-sheet-remove"
+        onClick={() => {
+          void onRemove?.()
+        }}
+      >
+        Remove entry
+      </button>
+    ) : null,
+}))
+
+// Stub useAdaptiveSegments so no segments render; we test via the
+// unscheduled tray click path which the mock exposes.
+vi.mock("@/features/schedules/hooks/useAdaptiveSegments", () => ({
+  useAdaptiveSegments: () => ({
+    segments: [],
+    unscheduledRows: [],
+  }),
+}))
+
+function buildFakeUndoStack(): UseUndoStackResult<UndoSnapshot> {
+  const pushMock = vi.fn((input: {
+    readonly label: string
+    readonly snapshot: UndoSnapshot
+    readonly undo: (snapshot: UndoSnapshot) => Promise<void>
+  }) => ({
+    id: "fake-action-id",
+    label: input.label,
+    snapshot: input.snapshot,
+    undo: input.undo,
+    createdAt: 123,
+  }))
+  return {
+    actions: [],
+    push: pushMock,
+    pop: vi.fn(() => null),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  }
+}
+
+const schedule: Schedule = {
+  id: "schedule-1",
+  projectId: "project-1",
+  name: "Shoot Day",
+  date: null,
+  tracks: [{ id: "primary", name: "Primary", order: 0 }],
+  settings: {
+    cascadeChanges: true,
+    dayStartTime: "06:00",
+    defaultEntryDurationMinutes: 15,
+  },
+  createdAt: { toDate: () => new Date(0) } as unknown as Schedule["createdAt"],
+  updatedAt: { toDate: () => new Date(0) } as unknown as Schedule["updatedAt"],
+}
+
+const targetEntry: ScheduleEntry = {
+  id: "entry-42",
+  type: "shot",
+  title: "Hero Shot",
+  shotId: "shot-xyz",
+  startTime: "07:30",
+  duration: 15,
+  order: 2,
+  trackId: "primary",
+  notes: "bring the good lens",
+}
+
+const entries: ReadonlyArray<ScheduleEntry> = [
+  { id: "entry-other", type: "shot", title: "Other", order: 0, trackId: "primary" },
+  targetEntry,
+]
+
+async function openAndRemove(user: ReturnType<typeof userEvent.setup>, undoStack: UseUndoStackResult<UndoSnapshot>) {
+  render(
+    <AdaptiveTimelineView
+      scheduleId="schedule-1"
+      schedule={schedule}
+      entries={entries}
+      shots={[]}
+      undoStack={undoStack}
+    />,
+  )
+
+  await user.click(screen.getByTestId("mock-unscheduled-row"))
+  await user.click(await screen.findByTestId("mock-edit-sheet-remove"))
+}
+
+describe("AdaptiveTimelineView — timeline entry delete undo", () => {
+  beforeEach(() => {
+    toastMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastInfoMock.mockReset()
+    removeScheduleEntryMock.mockReset()
+    upsertScheduleEntryMock.mockReset()
+
+    removeScheduleEntryMock.mockResolvedValue(undefined)
+    upsertScheduleEntryMock.mockResolvedValue({ id: "entry-42" })
+  })
+
+  it("calls removeScheduleEntry when the edit sheet's Remove button fires", async () => {
+    const user = userEvent.setup()
+    await openAndRemove(user, buildFakeUndoStack())
+
+    await waitFor(() => {
+      expect(removeScheduleEntryMock).toHaveBeenCalledWith(
+        "client-1",
+        "project-1",
+        "schedule-1",
+        "entry-42",
+      )
+    })
+  })
+
+  it("pushes a scheduleEntryRemoved snapshot with the full ScheduleEntry payload", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+    await openAndRemove(user, undoStack)
+
+    await waitFor(() => {
+      expect(undoStack.push).toHaveBeenCalledTimes(1)
+    })
+
+    const pushArg = (undoStack.push as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      readonly label: string
+      readonly snapshot: UndoSnapshot
+    }
+    expect(pushArg.label).toBe("Removed Hero Shot")
+    expect(pushArg.snapshot.kind).toBe("scheduleEntryRemoved")
+    if (pushArg.snapshot.kind === "scheduleEntryRemoved") {
+      expect(pushArg.snapshot.payload).toEqual(targetEntry)
+    }
+  })
+
+  it("clicking Undo fires upsertScheduleEntry with the original entry id and a patch shaped from the snapshot", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+    await openAndRemove(user, undoStack)
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    const toastOptions = toastMock.mock.calls[0]?.[1] as { action: { onClick: () => void } }
+    toastOptions.action.onClick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(upsertScheduleEntryMock).toHaveBeenCalled()
+    })
+
+    expect(upsertScheduleEntryMock).toHaveBeenCalledWith(
+      "client-1",
+      "project-1",
+      "schedule-1",
+      "entry-42",
+      expect.objectContaining({
+        type: "shot",
+        title: "Hero Shot",
+        shotId: "shot-xyz",
+        startTime: "07:30",
+        duration: 15,
+        order: 2,
+        trackId: "primary",
+        notes: "bring the good lens",
+      }),
+    )
+  })
+})

--- a/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
+++ b/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
@@ -36,8 +36,10 @@ import {
 } from "@/features/schedules/lib/cascade"
 import { buildAutoDurationFillPatches } from "@/features/schedules/lib/autoDuration"
 import { findTrackOverlapConflicts, type TrackOverlapConflict } from "@/features/schedules/lib/conflicts"
-import { parseTimeToMinutes } from "@/features/schedules/lib/time"
+import { parseTimeToMinutes, formatMinutesTo12h } from "@/features/schedules/lib/time"
+import { detectScheduleGaps, type ScheduleGap } from "@/features/schedules/lib/gapDetection"
 import type { VisibleFields } from "@/features/schedules/lib/adaptiveSegments"
+import type { ProjectedScheduleRow } from "@/features/schedules/lib/projection"
 import type {
   Schedule,
   ScheduleEntry,
@@ -85,6 +87,20 @@ function applyEntryPatches(
     if (!patch) return entry
     return { ...entry, ...patch } as ScheduleEntry
   })
+}
+
+function formatScheduleGapLabel(gap: ScheduleGap): string {
+  const hours = Math.floor(gap.durationMinutes / 60)
+  const mins = gap.durationMinutes % 60
+  const startLabel = formatMinutesTo12h(gap.startMin)
+  const endLabel = formatMinutesTo12h(gap.endMin)
+  const duration =
+    hours > 0
+      ? mins > 0
+        ? `${hours}h ${mins}m`
+        : `${hours}h`
+      : `${mins}m`
+  return `GAP \u00b7 ${duration} (${startLabel} \u2013 ${endLabel})`
 }
 
 function conflictKey(c: TrackOverlapConflict): string {
@@ -185,6 +201,19 @@ export function AdaptiveTimelineView({
     showNotes: true,
     showTags: true,
   }), [])
+
+  // Schedule gaps (idle windows > 30min per track)
+  const scheduleGaps = useMemo(() => {
+    const allRows: ProjectedScheduleRow[] = []
+    for (const seg of layout.segments) {
+      if (seg.kind === "dense") {
+        for (const trackRows of seg.rowsByTrack.values()) {
+          allRows.push(...trackRows)
+        }
+      }
+    }
+    return detectScheduleGaps(allRows)
+  }, [layout.segments])
 
   // ─── View mode ───────────────────────────────────────────────────
 
@@ -552,6 +581,30 @@ export function AdaptiveTimelineView({
                   </p>
                 </div>
               ) : null}
+
+              {/* Schedule gap indicators */}
+              {scheduleGaps.length > 0 && (
+                <div className="flex flex-col gap-1 border-t border-dashed border-[var(--color-border)] px-3 pb-2 pt-2">
+                  <span className="text-2xs font-medium text-[var(--color-text-muted)]">
+                    Schedule Gaps
+                  </span>
+                  {scheduleGaps.map((gap) => (
+                    <div
+                      key={`schedule-gap-${gap.trackId}-${gap.startMin}`}
+                      className="flex items-center gap-2 rounded border border-dashed border-[var(--color-warning)] bg-[var(--color-warning)]/5 px-2 py-1 text-2xs text-[var(--color-text-muted)]"
+                    >
+                      <span className="font-medium">
+                        {formatScheduleGapLabel(gap)}
+                      </span>
+                      {tracks.length >= 2 && (
+                        <span className="text-3xs text-[var(--color-text-subtle)]">
+                          {tracks.find((t) => t.id === gap.trackId)?.name ?? gap.trackId}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
             </div>
 
             {/* Unscheduled tray */}

--- a/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
+++ b/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
@@ -38,6 +38,7 @@ import { buildAutoDurationFillPatches } from "@/features/schedules/lib/autoDurat
 import { findTrackOverlapConflicts, type TrackOverlapConflict } from "@/features/schedules/lib/conflicts"
 import { parseTimeToMinutes, formatMinutesTo12h } from "@/features/schedules/lib/time"
 import { detectScheduleGaps, type ScheduleGap } from "@/features/schedules/lib/gapDetection"
+import { detectSharedResourceConflicts } from "@/features/schedules/lib/sharedResourceConflicts"
 import type { VisibleFields } from "@/features/schedules/lib/adaptiveSegments"
 import type { ProjectedScheduleRow } from "@/features/schedules/lib/projection"
 import type {
@@ -46,6 +47,7 @@ import type {
   ScheduleSettings,
   ScheduleTrack,
   Shot,
+  TalentCallSheet,
   TalentRecord,
 } from "@/shared/types"
 
@@ -131,6 +133,7 @@ interface AdaptiveTimelineViewProps {
   readonly entries: readonly ScheduleEntry[]
   readonly shots: readonly Shot[]
   readonly talentLookup?: readonly TalentRecord[]
+  readonly talentCalls?: readonly TalentCallSheet[]
   readonly undoStack: UseUndoStackResult<UndoSnapshot>
 }
 
@@ -158,6 +161,7 @@ export function AdaptiveTimelineView({
   entries,
   shots,
   talentLookup,
+  talentCalls,
   undoStack,
 }: AdaptiveTimelineViewProps) {
   const { clientId } = useAuth()
@@ -214,6 +218,12 @@ export function AdaptiveTimelineView({
     }
     return detectScheduleGaps(allRows)
   }, [layout.segments])
+
+  // Shared resource conflicts (talent on 2+ tracks)
+  const talentConflicts = useMemo(
+    () => detectSharedResourceConflicts(talentCalls ?? [], talentLookup ?? []),
+    [talentCalls, talentLookup],
+  )
 
   // ─── View mode ───────────────────────────────────────────────────
 
@@ -603,6 +613,33 @@ export function AdaptiveTimelineView({
                       )}
                     </div>
                   ))}
+                </div>
+              )}
+
+              {/* Shared resource conflict warnings */}
+              {talentConflicts.length > 0 && (
+                <div className="flex flex-col gap-1 border-t border-dashed border-[var(--color-border)] px-3 pb-2 pt-2">
+                  <span className="text-2xs font-medium text-[var(--color-warning)]">
+                    Shared Resource Conflicts
+                  </span>
+                  {talentConflicts.map((conflict) => {
+                    const trackNames = conflict.trackIds
+                      .map((tid) => tracks.find((t) => t.id === tid)?.name ?? tid)
+                      .join(", ")
+                    return (
+                      <div
+                        key={`conflict-${conflict.resourceId}`}
+                        className="flex items-center gap-2 rounded border border-[var(--color-warning)] bg-[var(--color-warning)]/5 px-2 py-1 text-2xs"
+                      >
+                        <span className="font-medium text-[var(--color-warning)]">
+                          {conflict.resourceName}
+                        </span>
+                        <span className="text-[var(--color-text-muted)]">
+                          appears on {trackNames}
+                        </span>
+                      </div>
+                    )
+                  })}
                 </div>
               )}
             </div>

--- a/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
+++ b/src-vnext/features/schedules/components/AdaptiveTimelineView.tsx
@@ -24,7 +24,11 @@ import {
   batchUpdateScheduleEntries,
   removeScheduleEntry,
   updateScheduleEntryFields,
+  upsertScheduleEntry,
 } from "@/features/schedules/lib/scheduleWrites"
+import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUndo"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import {
   buildCascadeMoveBetweenTracksPatches,
   buildCascadeDurationPatches,
@@ -111,9 +115,26 @@ interface AdaptiveTimelineViewProps {
   readonly entries: readonly ScheduleEntry[]
   readonly shots: readonly Shot[]
   readonly talentLookup?: readonly TalentRecord[]
+  readonly undoStack: UseUndoStackResult<UndoSnapshot>
 }
 
 // ─── Component ───────────────────────────────────────────────────────
+
+function scheduleEntryToPatch(entry: ScheduleEntry): Record<string, unknown> {
+  return {
+    type: entry.type,
+    title: entry.title,
+    shotId: entry.shotId ?? null,
+    startTime: entry.startTime ?? null,
+    time: entry.time ?? null,
+    duration: entry.duration ?? null,
+    order: entry.order,
+    trackId: entry.trackId ?? null,
+    appliesToTrackIds: entry.appliesToTrackIds ?? null,
+    highlight: entry.highlight ?? null,
+    notes: entry.notes ?? null,
+  }
+}
 
 export function AdaptiveTimelineView({
   scheduleId,
@@ -121,6 +142,7 @@ export function AdaptiveTimelineView({
   entries,
   shots,
   talentLookup,
+  undoStack,
 }: AdaptiveTimelineViewProps) {
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
@@ -263,8 +285,31 @@ export function AdaptiveTimelineView({
 
   const handleRemove = useCallback(async (entryId: string) => {
     if (!clientId) return
-    await removeScheduleEntry(clientId, projectId, scheduleId, entryId)
-  }, [clientId, projectId, scheduleId])
+    // Look up the full ScheduleEntry BEFORE the delete fires so the
+    // undo snapshot carries enough data to re-create the doc at the
+    // same path via upsertScheduleEntry.
+    const snapshotEntry = entries.find((e) => e.id === entryId)
+    if (!snapshotEntry) return
+
+    await destructiveActionWithUndo<UndoSnapshot>({
+      label: `Removed ${snapshotEntry.title || "entry"}`,
+      snapshot: { kind: "scheduleEntryRemoved", payload: snapshotEntry },
+      stack: undoStack,
+      perform: async () => {
+        await removeScheduleEntry(clientId, projectId, scheduleId, entryId)
+      },
+      undo: async (snap) => {
+        if (snap.kind !== "scheduleEntryRemoved") return
+        await upsertScheduleEntry(
+          clientId,
+          projectId,
+          scheduleId,
+          snap.payload.id,
+          scheduleEntryToPatch(snap.payload),
+        )
+      },
+    })
+  }, [clientId, entries, projectId, scheduleId, undoStack])
 
   const handleUpdateNotes = useCallback(async (entryId: string, notes: string) => {
     if (!clientId) return

--- a/src-vnext/features/schedules/components/AddCustomEntryDialog.test.tsx
+++ b/src-vnext/features/schedules/components/AddCustomEntryDialog.test.tsx
@@ -14,7 +14,7 @@ describe("AddCustomEntryDialog", () => {
         onOpenChange={() => {}}
         tracks={[
           { id: "primary", name: "Primary", order: 0 },
-          { id: "track-2", name: "Track 2", order: 1 },
+          { id: "track-2", name: "Unit 2", order: 1 },
         ]}
         defaultTrackId="primary"
         onAdd={onAdd}

--- a/src-vnext/features/schedules/components/AddCustomEntryDialog.tsx
+++ b/src-vnext/features/schedules/components/AddCustomEntryDialog.tsx
@@ -76,7 +76,7 @@ export function AddCustomEntryDialog({
 
   const trackLabel = useMemo(() => {
     if (isShared) return "Shared"
-    return tracks.find((track) => track.id === trackId)?.name ?? "Track"
+    return tracks.find((track) => track.id === trackId)?.name ?? "Unit"
   }, [isShared, trackId, tracks])
 
   function handleSubmit() {

--- a/src-vnext/features/schedules/components/AddCustomEntryDialog.tsx
+++ b/src-vnext/features/schedules/components/AddCustomEntryDialog.tsx
@@ -109,10 +109,10 @@ export function AddCustomEntryDialog({
         <div className="flex flex-col gap-4">
           {!isShared && tracks.length > 1 && (
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="custom-entry-track">Track</Label>
+              <Label htmlFor="custom-entry-track">Unit</Label>
               <Select value={trackId} onValueChange={setTrackId}>
                 <SelectTrigger id="custom-entry-track">
-                  <SelectValue placeholder="Select track" />
+                  <SelectValue placeholder="Select unit" />
                 </SelectTrigger>
                 <SelectContent>
                   {tracks.map((track) => (

--- a/src-vnext/features/schedules/components/AddShotToScheduleDialog.test.tsx
+++ b/src-vnext/features/schedules/components/AddShotToScheduleDialog.test.tsx
@@ -33,7 +33,7 @@ describe("AddShotToScheduleDialog", () => {
         onOpenChange={() => {}}
         tracks={[
           { id: "primary", name: "Primary", order: 0 },
-          { id: "track-2", name: "Track 2", order: 1 },
+          { id: "track-2", name: "Unit 2", order: 1 },
         ]}
         shots={[
           makeShot({

--- a/src-vnext/features/schedules/components/AddShotToScheduleDialog.tsx
+++ b/src-vnext/features/schedules/components/AddShotToScheduleDialog.tsx
@@ -122,11 +122,11 @@ export function AddShotToScheduleDialog({
         {tracks.length > 1 && (
           <div className="flex flex-col gap-2">
             <span className="text-xs font-medium text-[var(--color-text-muted)]">
-              Track
+              Unit
             </span>
             <Select value={trackId} onValueChange={setTrackId}>
               <SelectTrigger>
-                <SelectValue placeholder="Select track" />
+                <SelectValue placeholder="Select unit" />
               </SelectTrigger>
               <SelectContent>
                 {tracks.map((t) => (

--- a/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
@@ -47,6 +47,69 @@ vi.mock("@/features/schedules/components/TypedTimeInput", () => ({
   ),
 }))
 
+// Mock the Radix Select primitive with a trivial native <select> so that
+// jsdom-driven tests can drive onValueChange without Radix's pointer-capture
+// polyfill. The real Select is exercised in e2e.
+vi.mock("@/ui/select", async () => {
+  const React = await import("react")
+  interface SelectProps {
+    readonly children?: React.ReactNode
+    readonly value?: string
+    readonly onValueChange?: (value: string) => void
+  }
+  interface SelectItemProps {
+    readonly children?: React.ReactNode
+    readonly value: string
+  }
+  const MOCK_SELECT_ITEM_TYPE = Symbol.for("mock-select-item")
+  const Select = ({ children, value, onValueChange }: SelectProps) => {
+    const options: { value: string; label: string }[] = []
+    const visit = (node: React.ReactNode): void => {
+      React.Children.forEach(node, (child) => {
+        if (!React.isValidElement(child)) return
+        const elType = child.type as unknown
+        if (
+          typeof elType === "function" &&
+          (elType as { mockSelectItemTag?: symbol }).mockSelectItemTag === MOCK_SELECT_ITEM_TYPE
+        ) {
+          const props = child.props as SelectItemProps
+          const label = typeof props.children === "string" ? props.children : props.value
+          options.push({ value: props.value, label })
+          return
+        }
+        const props = child.props as { children?: React.ReactNode }
+        if (props?.children !== undefined) visit(props.children)
+      })
+    }
+    visit(children)
+    return React.createElement(
+      "select",
+      {
+        "data-testid": "mock-select",
+        "aria-label": "mock-select",
+        value: value ?? "",
+        onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
+          onValueChange?.(e.target.value),
+      },
+      React.createElement("option", { key: "__placeholder__", value: "" }, "placeholder"),
+      ...options.map((o) =>
+        React.createElement("option", { key: o.value, value: o.value }, o.label),
+      ),
+    )
+  }
+  const SelectItem = ({ children }: SelectItemProps) => React.createElement(React.Fragment, null, children)
+  ;(SelectItem as unknown as { mockSelectItemTag: symbol }).mockSelectItemTag = MOCK_SELECT_ITEM_TYPE
+  const Passthrough = ({ children }: { readonly children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children)
+  return {
+    Select,
+    SelectContent: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    SelectItem,
+  }
+})
+
 const removeCrewCallMock = vi.fn()
 const removeTalentCallMock = vi.fn()
 const upsertCrewCallMock = vi.fn()
@@ -224,6 +287,77 @@ describe("CallOverridesEditor — destructive undo wiring", () => {
         }),
       }),
     )
+  })
+
+  it("awaits upsertTalentCall when adding a new talent override (no optimistic creation)", async () => {
+    const user = userEvent.setup()
+
+    // Defer the upsert so we can observe that no optimistic state was
+    // applied before the write resolves.
+    let resolveWrite: (id: string) => void = () => {}
+    upsertTalentCallMock.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveWrite = resolve
+        }),
+    )
+
+    // Only render with empty talentCalls so the "Add talent" dropdown is visible.
+    renderEditor({ talentCalls: [] })
+
+    // The mocked Select renders as a native <select>. There are two
+    // selects when talentCalls is empty: the talent-add dropdown (first)
+    // and the crew-add dropdown (second). Select the talent one.
+    const selects = screen.getAllByTestId("mock-select")
+    await user.selectOptions(selects[0]!, "talent-1")
+
+    // upsertTalentCall fires with creation args (talentCallId === null)
+    await waitFor(() => {
+      expect(upsertTalentCallMock).toHaveBeenCalledWith(
+        "client-1",
+        "project-1",
+        "schedule-1",
+        null,
+        expect.objectContaining({ talentId: "talent-1" }),
+      )
+    })
+
+    // Resolve and confirm no crash or flakiness after the await
+    resolveWrite("talent-call-new")
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+
+  it("awaits upsertCrewCall when adding a new crew override (no optimistic creation)", async () => {
+    const user = userEvent.setup()
+
+    let resolveWrite: (id: string) => void = () => {}
+    upsertCrewCallMock.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveWrite = resolve
+        }),
+    )
+
+    renderEditor({ crewCalls: [] })
+
+    const selects = screen.getAllByTestId("mock-select")
+    // With empty crewCalls: first select = talent add, second select = crew add.
+    await user.selectOptions(selects[1]!, "crew-1")
+
+    await waitFor(() => {
+      expect(upsertCrewCallMock).toHaveBeenCalledWith(
+        "client-1",
+        "project-1",
+        "schedule-1",
+        null,
+        expect.objectContaining({ crewMemberId: "crew-1" }),
+      )
+    })
+
+    resolveWrite("crew-call-new")
+    await Promise.resolve()
+    await Promise.resolve()
   })
 
   it("invokes upsertCrewCall on Undo click to re-create the removed crew call", async () => {

--- a/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { CallOverridesEditor } from "@/features/schedules/components/CallOverridesEditor"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
+import type {
+  CrewCallSheet,
+  CrewRecord,
+  DayDetails,
+  TalentCallSheet,
+  TalentRecord,
+} from "@/shared/types"
+
+const { toastMock, toastErrorMock, toastSuccessMock, toastInfoMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastMock, {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+    info: toastInfoMock,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    clientId: "client-1",
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({
+    projectId: "project-1",
+  }),
+  useOptionalProjectScope: () => null,
+}))
+
+vi.mock("@/features/schedules/components/TypedTimeInput", () => ({
+  TypedTimeInput: ({ value, placeholder }: { readonly value: string; readonly placeholder: string }) => (
+    <div data-testid="typed-time-input">{value || placeholder}</div>
+  ),
+}))
+
+const removeCrewCallMock = vi.fn()
+const removeTalentCallMock = vi.fn()
+const upsertCrewCallMock = vi.fn()
+const upsertTalentCallMock = vi.fn()
+
+vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
+  removeCrewCall: (...args: unknown[]) => removeCrewCallMock(...args),
+  removeTalentCall: (...args: unknown[]) => removeTalentCallMock(...args),
+  upsertCrewCall: (...args: unknown[]) => upsertCrewCallMock(...args),
+  upsertTalentCall: (...args: unknown[]) => upsertTalentCallMock(...args),
+}))
+
+function buildFakeUndoStack(): UseUndoStackResult<UndoSnapshot> {
+  const pushMock = vi.fn((input: {
+    readonly label: string
+    readonly snapshot: UndoSnapshot
+    readonly undo: (snapshot: UndoSnapshot) => Promise<void>
+  }) => ({
+    id: "fake-action-id",
+    label: input.label,
+    snapshot: input.snapshot,
+    undo: input.undo,
+    createdAt: 123,
+  }))
+  return {
+    actions: [],
+    push: pushMock,
+    pop: vi.fn(() => null),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  }
+}
+
+const talentLibrary: readonly TalentRecord[] = [
+  { id: "talent-1", name: "Jane Doe" } as TalentRecord,
+  { id: "talent-2", name: "John Smith" } as TalentRecord,
+]
+
+const crewLibrary: readonly CrewRecord[] = [
+  { id: "crew-1", name: "Camille DP", department: "Camera", position: "DP" } as CrewRecord,
+  { id: "crew-2", name: "Sam Sound", department: "Sound", position: "Mixer" } as CrewRecord,
+]
+
+const baseTalentCall: TalentCallSheet = {
+  id: "talent-call-1",
+  talentId: "talent-1",
+  callTime: "07:00",
+  role: "Lead",
+  status: "confirmed",
+}
+
+const baseCrewCall: CrewCallSheet = {
+  id: "crew-call-1",
+  crewMemberId: "crew-1",
+  callTime: "06:30",
+  department: "Camera",
+  position: "DP",
+}
+
+const dayDetails: DayDetails = {
+  id: "day-details-1",
+  scheduleId: "schedule-1",
+  crewCallTime: "06:00",
+  shootingCallTime: "07:00",
+  estimatedWrap: "19:00",
+}
+
+function renderEditor(overrides: Partial<Parameters<typeof CallOverridesEditor>[0]> = {}) {
+  const undoStack = overrides.undoStack ?? buildFakeUndoStack()
+  const result = render(
+    <CallOverridesEditor
+      scheduleId="schedule-1"
+      dayDetails={dayDetails}
+      talentCalls={[baseTalentCall]}
+      crewCalls={[baseCrewCall]}
+      talentLibrary={talentLibrary}
+      crewLibrary={crewLibrary}
+      undoStack={undoStack}
+      {...overrides}
+    />,
+  )
+  return { ...result, undoStack }
+}
+
+describe("CallOverridesEditor — destructive undo wiring", () => {
+  beforeEach(() => {
+    toastMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastInfoMock.mockReset()
+    removeCrewCallMock.mockReset()
+    removeTalentCallMock.mockReset()
+    upsertCrewCallMock.mockReset()
+    upsertTalentCallMock.mockReset()
+
+    removeCrewCallMock.mockResolvedValue(undefined)
+    removeTalentCallMock.mockResolvedValue(undefined)
+    upsertCrewCallMock.mockResolvedValue("crew-call-1")
+    upsertTalentCallMock.mockResolvedValue("talent-call-1")
+  })
+
+  it("calls removeCrewCall when the crew row X button is clicked", async () => {
+    const user = userEvent.setup()
+    renderEditor()
+
+    await user.click(screen.getByRole("button", { name: "Remove override for Camille DP" }))
+
+    await waitFor(() => {
+      expect(removeCrewCallMock).toHaveBeenCalledWith(
+        "client-1",
+        "project-1",
+        "schedule-1",
+        "crew-call-1",
+      )
+    })
+  })
+
+  it("pushes a crewCallRemoved snapshot onto the undo stack with the full CrewCallSheet payload", async () => {
+    const user = userEvent.setup()
+    const { undoStack } = renderEditor()
+
+    await user.click(screen.getByRole("button", { name: "Remove override for Camille DP" }))
+
+    await waitFor(() => {
+      expect(undoStack.push).toHaveBeenCalledTimes(1)
+    })
+
+    const pushArg = (undoStack.push as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      readonly label: string
+      readonly snapshot: UndoSnapshot
+    }
+    expect(pushArg.snapshot.kind).toBe("crewCallRemoved")
+    if (pushArg.snapshot.kind === "crewCallRemoved") {
+      expect(pushArg.snapshot.payload).toEqual(baseCrewCall)
+    }
+  })
+
+  it("pushes a talentCallRemoved snapshot with the full TalentCallSheet payload", async () => {
+    const user = userEvent.setup()
+    const { undoStack } = renderEditor()
+
+    await user.click(screen.getByRole("button", { name: "Remove override for Jane Doe" }))
+
+    await waitFor(() => {
+      expect(undoStack.push).toHaveBeenCalledTimes(1)
+    })
+
+    const pushArg = (undoStack.push as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      readonly label: string
+      readonly snapshot: UndoSnapshot
+    }
+    expect(pushArg.snapshot.kind).toBe("talentCallRemoved")
+    if (pushArg.snapshot.kind === "talentCallRemoved") {
+      expect(pushArg.snapshot.payload).toEqual(baseTalentCall)
+    }
+  })
+
+  it("shows a toast with a 5000ms duration and a labeled Undo action button", async () => {
+    const user = userEvent.setup()
+    renderEditor()
+
+    await user.click(screen.getByRole("button", { name: "Remove override for Camille DP" }))
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "Removed Camille DP override",
+      expect.objectContaining({
+        duration: 5000,
+        action: expect.objectContaining({
+          label: "Undo",
+          onClick: expect.any(Function),
+        }),
+      }),
+    )
+  })
+
+  it("invokes upsertCrewCall on Undo click to re-create the removed crew call", async () => {
+    const user = userEvent.setup()
+    renderEditor()
+
+    await user.click(screen.getByRole("button", { name: "Remove override for Camille DP" }))
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    const lastCall = toastMock.mock.calls[toastMock.mock.calls.length - 1]
+    const onClick = (lastCall?.[1] as { action: { onClick: () => void } }).action.onClick
+    onClick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(upsertCrewCallMock).toHaveBeenCalledWith(
+        "client-1",
+        "project-1",
+        "schedule-1",
+        "crew-call-1",
+        expect.objectContaining({
+          crewMemberId: "crew-1",
+          callTime: "06:30",
+          department: "Camera",
+          position: "DP",
+        }),
+      )
+    })
+  })
+})

--- a/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
@@ -182,6 +182,7 @@ function renderEditor(overrides: Partial<Parameters<typeof CallOverridesEditor>[
   const result = render(
     <CallOverridesEditor
       scheduleId="schedule-1"
+      tracks={[]}
       dayDetails={dayDetails}
       talentCalls={[baseTalentCall]}
       crewCalls={[baseCrewCall]}

--- a/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.test.tsx
@@ -289,6 +289,32 @@ describe("CallOverridesEditor — destructive undo wiring", () => {
     )
   })
 
+  it("renders TWO SaveIndicator pills (one per section header) after a successful talent save", async () => {
+    const user = userEvent.setup()
+    renderEditor({ talentCalls: [] })
+
+    // Before any save: no pill in either section header.
+    expect(screen.queryAllByRole("status")).toHaveLength(0)
+
+    // Trigger a talent override creation via the mocked native select.
+    const selects = screen.getAllByTestId("mock-select")
+    await user.selectOptions(selects[0]!, "talent-1")
+
+    await waitFor(() => {
+      expect(upsertTalentCallMock).toHaveBeenCalled()
+    })
+
+    // Both pills should be visible, driven by the same shared lastSaved
+    // instance — the Talent header pill and the Crew header pill tick
+    // in sync, so the text content is identical.
+    await waitFor(() => {
+      const pills = screen.getAllByRole("status")
+      expect(pills).toHaveLength(2)
+      expect(pills[0]?.textContent).toBe(pills[1]?.textContent)
+      expect(pills[0]).toHaveTextContent("Saved")
+    })
+  })
+
   it("awaits upsertTalentCall when adding a new talent override (no optimistic creation)", async () => {
     const user = userEvent.setup()
 

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -21,6 +21,8 @@ import { TypedTimeInput } from "@/features/schedules/components/TypedTimeInput"
 import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUndo"
 import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
 import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
+import { useLastSaved } from "@/shared/hooks/useLastSaved"
+import { SaveIndicator } from "@/shared/components/SaveIndicator"
 import type { TalentCallSheet, CrewCallSheet, TalentRecord, CrewRecord, DayDetails } from "@/shared/types"
 
 // --- Props ---
@@ -203,6 +205,10 @@ export function CallOverridesEditor({
 }: CallOverridesEditorProps) {
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
+  // Single shared useLastSaved instance drives BOTH the Talent and
+  // Crew section headers — every successful upsert/remove bumps the
+  // same timestamp so the two pills tick in sync.
+  const lastSaved = useLastSaved()
 
   // Build lookup maps
   const talentMap = useMemo(() => {
@@ -259,11 +265,12 @@ export function CallOverridesEditor({
           talentId,
           role: talent?.notes ?? null,
         })
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to add talent override.")
       }
     },
-    [clientId, projectId, scheduleId, talentMap],
+    [clientId, lastSaved, projectId, scheduleId, talentMap],
   )
 
   const handleSaveTalentCallTime = useCallback(
@@ -284,11 +291,12 @@ export function CallOverridesEditor({
 
       try {
         await upsertTalentCall(clientId, projectId, scheduleId, talentCallId, patch)
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to save talent override.")
       }
     },
-    [clientId, projectId, scheduleId],
+    [clientId, lastSaved, projectId, scheduleId],
   )
 
   const handleRemoveTalent = useCallback(
@@ -302,6 +310,7 @@ export function CallOverridesEditor({
         stack: undoStack,
         perform: async () => {
           await removeTalentCall(clientId, projectId, scheduleId, call.id)
+          lastSaved.markSaved()
         },
         undo: async (snapshot) => {
           if (snapshot.kind !== "talentCallRemoved") return
@@ -312,12 +321,13 @@ export function CallOverridesEditor({
             snapshot.payload.id,
             talentCallToPatch(snapshot.payload),
           )
+          lastSaved.markSaved()
         },
       }).catch(() => {
         toast.error("Failed to remove talent override.")
       })
     },
-    [clientId, projectId, scheduleId, talentMap, undoStack],
+    [clientId, lastSaved, projectId, scheduleId, talentMap, undoStack],
   )
 
   // --- Crew handlers ---
@@ -332,11 +342,12 @@ export function CallOverridesEditor({
           department: crew?.department ?? null,
           position: crew?.position ?? null,
         })
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to add crew override.")
       }
     },
-    [clientId, projectId, scheduleId, crewMap],
+    [clientId, lastSaved, projectId, scheduleId, crewMap],
   )
 
   const handleSaveCrewCallTime = useCallback(
@@ -357,11 +368,12 @@ export function CallOverridesEditor({
 
       try {
         await upsertCrewCall(clientId, projectId, scheduleId, crewCallId, patch)
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to save crew override.")
       }
     },
-    [clientId, projectId, scheduleId],
+    [clientId, lastSaved, projectId, scheduleId],
   )
 
   const handleRemoveCrew = useCallback(
@@ -375,6 +387,7 @@ export function CallOverridesEditor({
         stack: undoStack,
         perform: async () => {
           await removeCrewCall(clientId, projectId, scheduleId, call.id)
+          lastSaved.markSaved()
         },
         undo: async (snapshot) => {
           if (snapshot.kind !== "crewCallRemoved") return
@@ -385,12 +398,13 @@ export function CallOverridesEditor({
             snapshot.payload.id,
             crewCallToPatch(snapshot.payload),
           )
+          lastSaved.markSaved()
         },
       }).catch(() => {
         toast.error("Failed to remove crew override.")
       })
     },
-    [clientId, projectId, scheduleId, crewMap, undoStack],
+    [clientId, lastSaved, projectId, scheduleId, crewMap, undoStack],
   )
 
   return (
@@ -402,6 +416,7 @@ export function CallOverridesEditor({
           <h3 className="label-meta text-[var(--color-text-muted)]">
             Talent Overrides
           </h3>
+          <SaveIndicator savedAt={lastSaved.savedAt} />
           {defaultShootingCall && (
             <span className="ml-auto text-2xs text-[var(--color-text-subtle)]">
               Default: {displayDefaultTime(defaultShootingCall)}
@@ -463,6 +478,7 @@ export function CallOverridesEditor({
           <h3 className="label-meta text-[var(--color-text-muted)]">
             Crew Overrides
           </h3>
+          <SaveIndicator savedAt={lastSaved.savedAt} />
           {defaultCrewCall && (
             <span className="ml-auto text-2xs text-[var(--color-text-subtle)]">
               Default: {displayDefaultTime(defaultCrewCall)}

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useMemo } from "react"
-import { UserPlus, X, Users, Clapperboard } from "lucide-react"
+import { UserPlus, X, Users, Clapperboard, Eye, EyeOff, Mail, MailX, Phone, PhoneOff } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
@@ -46,6 +46,8 @@ interface TalentOverrideRowProps {
   readonly defaultTime: string
   readonly onSaveCallTime: (value: string) => void
   readonly onRemove: () => void
+  readonly isVisible: boolean
+  readonly onToggleVisibility: () => void
 }
 
 function displayCallValue(call: { readonly callTime?: string | null; readonly callText?: string | null }): string {
@@ -66,10 +68,12 @@ function TalentOverrideRow({
   defaultTime,
   onSaveCallTime,
   onRemove,
+  isVisible,
+  onToggleVisibility,
 }: TalentOverrideRowProps) {
   const hasOverride = !!(call.callTime || call.callText)
   return (
-    <div className="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-subtle)]">
+    <div className={`flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-subtle)] ${!isVisible ? "opacity-40" : ""}`}>
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-[var(--color-text)]">
           {name}
@@ -95,6 +99,14 @@ function TalentOverrideRow({
         )}
         <button
           type="button"
+          onClick={onToggleVisibility}
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+          aria-label={isVisible ? `Hide ${name} from call sheet` : `Show ${name} on call sheet`}
+        >
+          {isVisible ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+        </button>
+        <button
+          type="button"
           onClick={onRemove}
           className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
           aria-label={`Remove override for ${name}`}
@@ -115,6 +127,12 @@ interface CrewOverrideRowProps {
   readonly defaultTime: string
   readonly onSaveCallTime: (value: string) => void
   readonly onRemove: () => void
+  readonly isVisible: boolean
+  readonly showEmail: boolean
+  readonly showPhone: boolean
+  readonly onToggleVisibility: () => void
+  readonly onToggleEmail: () => void
+  readonly onTogglePhone: () => void
 }
 
 function CrewOverrideRow({
@@ -124,10 +142,16 @@ function CrewOverrideRow({
   defaultTime,
   onSaveCallTime,
   onRemove,
+  isVisible,
+  showEmail,
+  showPhone,
+  onToggleVisibility,
+  onToggleEmail,
+  onTogglePhone,
 }: CrewOverrideRowProps) {
   const hasOverride = !!(call.callTime || call.callText)
   return (
-    <div className="flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-subtle)]">
+    <div className={`flex items-center gap-2 rounded-md px-2 py-1.5 transition-colors hover:bg-[var(--color-surface-subtle)] ${!isVisible ? "opacity-40" : ""}`}>
       <div className="flex min-w-0 flex-1 flex-col">
         <span className="truncate text-sm font-medium text-[var(--color-text)]">
           {name}
@@ -153,6 +177,30 @@ function CrewOverrideRow({
         )}
         <button
           type="button"
+          onClick={onToggleVisibility}
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+          aria-label={isVisible ? `Hide ${name} from call sheet` : `Show ${name} on call sheet`}
+        >
+          {isVisible ? <Eye className="h-3 w-3" /> : <EyeOff className="h-3 w-3" />}
+        </button>
+        <button
+          type="button"
+          onClick={onToggleEmail}
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+          aria-label={showEmail ? `Hide email for ${name}` : `Show email for ${name}`}
+        >
+          {showEmail ? <Mail className="h-3 w-3" /> : <MailX className="h-3 w-3" />}
+        </button>
+        <button
+          type="button"
+          onClick={onTogglePhone}
+          className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
+          aria-label={showPhone ? `Hide phone for ${name}` : `Show phone for ${name}`}
+        >
+          {showPhone ? <Phone className="h-3 w-3" /> : <PhoneOff className="h-3 w-3" />}
+        </button>
+        <button
+          type="button"
           onClick={onRemove}
           className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-subtle)] hover:text-[var(--color-text)]"
           aria-label={`Remove override for ${name}`}
@@ -176,6 +224,7 @@ function talentCallToPatch(call: TalentCallSheet): Record<string, unknown> {
     role: call.role ?? null,
     status: call.status ?? null,
     notes: call.notes ?? null,
+    isVisibleOverride: call.isVisibleOverride ?? null,
   }
 }
 
@@ -191,6 +240,9 @@ function crewCallToPatch(call: CrewCallSheet): Record<string, unknown> {
     department: call.department ?? null,
     position: call.position ?? null,
     notes: call.notes ?? null,
+    isVisibleOverride: call.isVisibleOverride ?? null,
+    showEmailOverride: call.showEmailOverride ?? null,
+    showPhoneOverride: call.showPhoneOverride ?? null,
   }
 }
 
@@ -407,6 +459,56 @@ export function CallOverridesEditor({
     [clientId, lastSaved, projectId, scheduleId, crewMap, undoStack],
   )
 
+  // --- Visibility toggle handlers ---
+
+  const handleToggleTalentVisibility = useCallback(
+    (call: TalentCallSheet) => () => {
+      if (!clientId) return
+      const newValue = call.isVisibleOverride === false ? null : false
+      void upsertTalentCall(clientId, projectId, scheduleId, call.id, {
+        isVisibleOverride: newValue,
+      }).then(() => lastSaved.markSaved())
+        .catch(() => toast.error("Failed to update visibility."))
+    },
+    [clientId, lastSaved, projectId, scheduleId],
+  )
+
+  const handleToggleCrewVisibility = useCallback(
+    (call: CrewCallSheet) => () => {
+      if (!clientId) return
+      const newValue = call.isVisibleOverride === false ? null : false
+      void upsertCrewCall(clientId, projectId, scheduleId, call.id, {
+        isVisibleOverride: newValue,
+      }).then(() => lastSaved.markSaved())
+        .catch(() => toast.error("Failed to update visibility."))
+    },
+    [clientId, lastSaved, projectId, scheduleId],
+  )
+
+  const handleToggleCrewEmail = useCallback(
+    (call: CrewCallSheet) => () => {
+      if (!clientId) return
+      const newValue = call.showEmailOverride === false ? null : false
+      void upsertCrewCall(clientId, projectId, scheduleId, call.id, {
+        showEmailOverride: newValue,
+      }).then(() => lastSaved.markSaved())
+        .catch(() => toast.error("Failed to update email visibility."))
+    },
+    [clientId, lastSaved, projectId, scheduleId],
+  )
+
+  const handleToggleCrewPhone = useCallback(
+    (call: CrewCallSheet) => () => {
+      if (!clientId) return
+      const newValue = call.showPhoneOverride === false ? null : false
+      void upsertCrewCall(clientId, projectId, scheduleId, call.id, {
+        showPhoneOverride: newValue,
+      }).then(() => lastSaved.markSaved())
+        .catch(() => toast.error("Failed to update phone visibility."))
+    },
+    [clientId, lastSaved, projectId, scheduleId],
+  )
+
   return (
     <div className="flex flex-col gap-4">
       {/* Talent Overrides */}
@@ -437,6 +539,8 @@ export function CallOverridesEditor({
                   defaultTime={defaultShootingCall}
                   onSaveCallTime={handleSaveTalentCallTime(tc.id)}
                   onRemove={handleRemoveTalent(tc)}
+                  isVisible={tc.isVisibleOverride !== false}
+                  onToggleVisibility={handleToggleTalentVisibility(tc)}
                 />
               )
             })}
@@ -505,6 +609,12 @@ export function CallOverridesEditor({
                   defaultTime={defaultCrewCall}
                   onSaveCallTime={handleSaveCrewCallTime(cc.id)}
                   onRemove={handleRemoveCrew(cc)}
+                  isVisible={cc.isVisibleOverride !== false}
+                  showEmail={cc.showEmailOverride !== false}
+                  showPhone={cc.showPhoneOverride !== false}
+                  onToggleVisibility={handleToggleCrewVisibility(cc)}
+                  onToggleEmail={handleToggleCrewEmail(cc)}
+                  onTogglePhone={handleToggleCrewPhone(cc)}
                 />
               )
             })}

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -225,6 +225,7 @@ function talentCallToPatch(call: TalentCallSheet): Record<string, unknown> {
     status: call.status ?? null,
     notes: call.notes ?? null,
     isVisibleOverride: call.isVisibleOverride ?? null,
+    trackId: call.trackId ?? null,
   }
 }
 
@@ -243,6 +244,7 @@ function crewCallToPatch(call: CrewCallSheet): Record<string, unknown> {
     isVisibleOverride: call.isVisibleOverride ?? null,
     showEmailOverride: call.showEmailOverride ?? null,
     showPhoneOverride: call.showPhoneOverride ?? null,
+    trackId: call.trackId ?? null,
   }
 }
 

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react"
+import { useCallback, useMemo, useState } from "react"
 import { UserPlus, X, Users, Clapperboard, Eye, EyeOff, Mail, MailX, Phone, PhoneOff } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
@@ -23,12 +23,15 @@ import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
 import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import { useLastSaved } from "@/shared/hooks/useLastSaved"
 import { SaveIndicator } from "@/shared/components/SaveIndicator"
-import type { TalentCallSheet, CrewCallSheet, TalentRecord, CrewRecord, DayDetails } from "@/shared/types"
+import { Tabs, TabsList, TabsTrigger } from "@/ui/tabs"
+import { filterCrewCallsByTrack, filterTalentCallsByTrack } from "@/features/schedules/lib/trackFiltering"
+import type { TalentCallSheet, CrewCallSheet, TalentRecord, CrewRecord, DayDetails, ScheduleTrack } from "@/shared/types"
 
 // --- Props ---
 
 interface CallOverridesEditorProps {
   readonly scheduleId: string
+  readonly tracks: readonly ScheduleTrack[]
   readonly dayDetails: DayDetails | null
   readonly talentCalls: readonly TalentCallSheet[]
   readonly crewCalls: readonly CrewCallSheet[]
@@ -250,6 +253,7 @@ function crewCallToPatch(call: CrewCallSheet): Record<string, unknown> {
 
 export function CallOverridesEditor({
   scheduleId,
+  tracks,
   dayDetails,
   talentCalls,
   crewCalls,
@@ -263,6 +267,19 @@ export function CallOverridesEditor({
   // Crew section headers — every successful upsert/remove bumps the
   // same timestamp so the two pills tick in sync.
   const lastSaved = useLastSaved()
+
+  // Unit filter state (null = "All Units")
+  const [activeTrackId, setActiveTrackId] = useState<string | null>(null)
+
+  // Filtered calls for rendering rows
+  const filteredTalentCalls = useMemo(
+    () => filterTalentCallsByTrack(talentCalls, activeTrackId),
+    [talentCalls, activeTrackId],
+  )
+  const filteredCrewCalls = useMemo(
+    () => filterCrewCallsByTrack(crewCalls, activeTrackId),
+    [crewCalls, activeTrackId],
+  )
 
   // Build lookup maps
   const talentMap = useMemo(() => {
@@ -318,13 +335,14 @@ export function CallOverridesEditor({
         await upsertTalentCall(clientId, projectId, scheduleId, null, {
           talentId,
           role: talent?.notes ?? null,
+          trackId: activeTrackId ?? null,
         })
         lastSaved.markSaved()
       } catch {
         toast.error("Failed to add talent override.")
       }
     },
-    [clientId, lastSaved, projectId, scheduleId, talentMap],
+    [activeTrackId, clientId, lastSaved, projectId, scheduleId, talentMap],
   )
 
   const handleSaveTalentCallTime = useCallback(
@@ -395,13 +413,14 @@ export function CallOverridesEditor({
           crewMemberId,
           department: crew?.department ?? null,
           position: crew?.position ?? null,
+          trackId: activeTrackId ?? null,
         })
         lastSaved.markSaved()
       } catch {
         toast.error("Failed to add crew override.")
       }
     },
-    [clientId, lastSaved, projectId, scheduleId, crewMap],
+    [activeTrackId, clientId, lastSaved, projectId, scheduleId, crewMap],
   )
 
   const handleSaveCrewCallTime = useCallback(
@@ -513,6 +532,24 @@ export function CallOverridesEditor({
 
   return (
     <div className="flex flex-col gap-4">
+      {tracks.length >= 2 && (
+        <Tabs
+          value={activeTrackId ?? "all"}
+          onValueChange={(v) => setActiveTrackId(v === "all" ? null : v)}
+        >
+          <TabsList className="h-8">
+            <TabsTrigger value="all" className="text-xs px-3">
+              All Units
+            </TabsTrigger>
+            {tracks.map((track) => (
+              <TabsTrigger key={track.id} value={track.id} className="text-xs px-3">
+                {track.name}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      )}
+
       {/* Talent Overrides */}
       <div className="flex flex-col gap-2 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
         <div className="flex items-center gap-2">
@@ -528,9 +565,9 @@ export function CallOverridesEditor({
           )}
         </div>
 
-        {talentCalls.length > 0 && (
+        {filteredTalentCalls.length > 0 && (
           <div className="flex flex-col gap-0.5">
-            {talentCalls.map((tc) => {
+            {filteredTalentCalls.map((tc) => {
               const talent = talentMap.get(tc.talentId)
               return (
                 <TalentOverrideRow
@@ -592,9 +629,9 @@ export function CallOverridesEditor({
           )}
         </div>
 
-        {crewCalls.length > 0 && (
+        {filteredCrewCalls.length > 0 && (
           <div className="flex flex-col gap-0.5">
-            {crewCalls.map((cc) => {
+            {filteredCrewCalls.map((cc) => {
               const crew = crewMap.get(cc.crewMemberId)
               const deptPosition = [
                 cc.department ?? crew?.department,

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -18,6 +18,9 @@ import {
 } from "@/ui/select"
 import { classifyTimeInput, formatHHMMTo12h } from "@/features/schedules/lib/time"
 import { TypedTimeInput } from "@/features/schedules/components/TypedTimeInput"
+import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUndo"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import type { TalentCallSheet, CrewCallSheet, TalentRecord, CrewRecord, DayDetails } from "@/shared/types"
 
 // --- Props ---
@@ -29,6 +32,7 @@ interface CallOverridesEditorProps {
   readonly crewCalls: readonly CrewCallSheet[]
   readonly talentLibrary: readonly TalentRecord[]
   readonly crewLibrary: readonly CrewRecord[]
+  readonly undoStack: UseUndoStackResult<UndoSnapshot>
 }
 
 // --- Talent override row ---
@@ -160,6 +164,34 @@ function CrewOverrideRow({
 
 // --- Main component ---
 
+function talentCallToPatch(call: TalentCallSheet): Record<string, unknown> {
+  return {
+    talentId: call.talentId,
+    callTime: call.callTime ?? null,
+    callText: call.callText ?? null,
+    setTime: call.setTime ?? null,
+    wrapTime: call.wrapTime ?? null,
+    role: call.role ?? null,
+    status: call.status ?? null,
+    notes: call.notes ?? null,
+  }
+}
+
+function crewCallToPatch(call: CrewCallSheet): Record<string, unknown> {
+  return {
+    crewMemberId: call.crewMemberId,
+    callTime: call.callTime ?? null,
+    callText: call.callText ?? null,
+    callOffsetDirection: call.callOffsetDirection ?? null,
+    callOffsetMinutes: call.callOffsetMinutes ?? null,
+    wrapTime: call.wrapTime ?? null,
+    wrapText: call.wrapText ?? null,
+    department: call.department ?? null,
+    position: call.position ?? null,
+    notes: call.notes ?? null,
+  }
+}
+
 export function CallOverridesEditor({
   scheduleId,
   dayDetails,
@@ -167,6 +199,7 @@ export function CallOverridesEditor({
   crewCalls,
   talentLibrary,
   crewLibrary,
+  undoStack,
 }: CallOverridesEditorProps) {
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
@@ -255,13 +288,32 @@ export function CallOverridesEditor({
   )
 
   const handleRemoveTalent = useCallback(
-    (talentCallId: string) => () => {
+    (call: TalentCallSheet) => () => {
       if (!clientId) return
-      void removeTalentCall(clientId, projectId, scheduleId, talentCallId).catch(() => {
+      const talent = talentMap.get(call.talentId)
+      const label = `Removed ${talent?.name ?? "talent"} override`
+      void destructiveActionWithUndo<UndoSnapshot>({
+        label,
+        snapshot: { kind: "talentCallRemoved", payload: call },
+        stack: undoStack,
+        perform: async () => {
+          await removeTalentCall(clientId, projectId, scheduleId, call.id)
+        },
+        undo: async (snapshot) => {
+          if (snapshot.kind !== "talentCallRemoved") return
+          await upsertTalentCall(
+            clientId,
+            projectId,
+            scheduleId,
+            snapshot.payload.id,
+            talentCallToPatch(snapshot.payload),
+          )
+        },
+      }).catch(() => {
         toast.error("Failed to remove talent override.")
       })
     },
-    [clientId, projectId, scheduleId],
+    [clientId, projectId, scheduleId, talentMap, undoStack],
   )
 
   // --- Crew handlers ---
@@ -305,13 +357,32 @@ export function CallOverridesEditor({
   )
 
   const handleRemoveCrew = useCallback(
-    (crewCallId: string) => () => {
+    (call: CrewCallSheet) => () => {
       if (!clientId) return
-      void removeCrewCall(clientId, projectId, scheduleId, crewCallId).catch(() => {
+      const crew = crewMap.get(call.crewMemberId)
+      const label = `Removed ${crew?.name ?? "crew"} override`
+      void destructiveActionWithUndo<UndoSnapshot>({
+        label,
+        snapshot: { kind: "crewCallRemoved", payload: call },
+        stack: undoStack,
+        perform: async () => {
+          await removeCrewCall(clientId, projectId, scheduleId, call.id)
+        },
+        undo: async (snapshot) => {
+          if (snapshot.kind !== "crewCallRemoved") return
+          await upsertCrewCall(
+            clientId,
+            projectId,
+            scheduleId,
+            snapshot.payload.id,
+            crewCallToPatch(snapshot.payload),
+          )
+        },
+      }).catch(() => {
         toast.error("Failed to remove crew override.")
       })
     },
-    [clientId, projectId, scheduleId],
+    [clientId, projectId, scheduleId, crewMap, undoStack],
   )
 
   return (
@@ -342,7 +413,7 @@ export function CallOverridesEditor({
                   role={tc.role ?? ""}
                   defaultTime={defaultShootingCall}
                   onSaveCallTime={handleSaveTalentCallTime(tc.id)}
-                  onRemove={handleRemoveTalent(tc.id)}
+                  onRemove={handleRemoveTalent(tc)}
                 />
               )
             })}
@@ -404,7 +475,7 @@ export function CallOverridesEditor({
                   deptPosition={deptPosition}
                   defaultTime={defaultCrewCall}
                   onSaveCallTime={handleSaveCrewCallTime(cc.id)}
-                  onRemove={handleRemoveCrew(cc.id)}
+                  onRemove={handleRemoveCrew(cc)}
                 />
               )
             })}

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -251,21 +251,23 @@ export function CallOverridesEditor({
   // --- Talent handlers ---
 
   const handleAddTalent = useCallback(
-    (talentId: string) => {
+    async (talentId: string): Promise<void> => {
       if (!clientId || !talentId) return
       const talent = talentMap.get(talentId)
-      void upsertTalentCall(clientId, projectId, scheduleId, null, {
-        talentId,
-        role: talent?.notes ?? null,
-      }).catch(() => {
+      try {
+        await upsertTalentCall(clientId, projectId, scheduleId, null, {
+          talentId,
+          role: talent?.notes ?? null,
+        })
+      } catch {
         toast.error("Failed to add talent override.")
-      })
+      }
     },
     [clientId, projectId, scheduleId, talentMap],
   )
 
   const handleSaveTalentCallTime = useCallback(
-    (talentCallId: string) => (value: string) => {
+    (talentCallId: string) => async (value: string): Promise<void> => {
       if (!clientId) return
       const parsed = classifyTimeInput(value, { allowText: true })
       if (parsed.kind === "invalid-time") {
@@ -280,9 +282,11 @@ export function CallOverridesEditor({
             ? { callTime: null, callText: parsed.text }
             : { callTime: null, callText: null }
 
-      void upsertTalentCall(clientId, projectId, scheduleId, talentCallId, patch).catch(() => {
+      try {
+        await upsertTalentCall(clientId, projectId, scheduleId, talentCallId, patch)
+      } catch {
         toast.error("Failed to save talent override.")
-      })
+      }
     },
     [clientId, projectId, scheduleId],
   )
@@ -319,22 +323,24 @@ export function CallOverridesEditor({
   // --- Crew handlers ---
 
   const handleAddCrew = useCallback(
-    (crewMemberId: string) => {
+    async (crewMemberId: string): Promise<void> => {
       if (!clientId || !crewMemberId) return
       const crew = crewMap.get(crewMemberId)
-      void upsertCrewCall(clientId, projectId, scheduleId, null, {
-        crewMemberId,
-        department: crew?.department ?? null,
-        position: crew?.position ?? null,
-      }).catch(() => {
+      try {
+        await upsertCrewCall(clientId, projectId, scheduleId, null, {
+          crewMemberId,
+          department: crew?.department ?? null,
+          position: crew?.position ?? null,
+        })
+      } catch {
         toast.error("Failed to add crew override.")
-      })
+      }
     },
     [clientId, projectId, scheduleId, crewMap],
   )
 
   const handleSaveCrewCallTime = useCallback(
-    (crewCallId: string) => (value: string) => {
+    (crewCallId: string) => async (value: string): Promise<void> => {
       if (!clientId) return
       const parsed = classifyTimeInput(value, { allowText: true })
       if (parsed.kind === "invalid-time") {
@@ -349,9 +355,11 @@ export function CallOverridesEditor({
             ? { callTime: null, callText: parsed.text }
             : { callTime: null, callText: null }
 
-      void upsertCrewCall(clientId, projectId, scheduleId, crewCallId, patch).catch(() => {
+      try {
+        await upsertCrewCall(clientId, projectId, scheduleId, crewCallId, patch)
+      } catch {
         toast.error("Failed to save crew override.")
-      })
+      }
     },
     [clientId, projectId, scheduleId],
   )
@@ -421,7 +429,12 @@ export function CallOverridesEditor({
         )}
 
         {availableTalent.length > 0 ? (
-          <Select onValueChange={handleAddTalent} value="">
+          <Select
+            onValueChange={(value) => {
+              void handleAddTalent(value)
+            }}
+            value=""
+          >
             <SelectTrigger className="h-8 text-xs">
               <div className="flex items-center gap-1.5 text-[var(--color-text-muted)]">
                 <UserPlus className="h-3 w-3" />
@@ -483,7 +496,12 @@ export function CallOverridesEditor({
         )}
 
         {availableCrew.length > 0 ? (
-          <Select onValueChange={handleAddCrew} value="">
+          <Select
+            onValueChange={(value) => {
+              void handleAddCrew(value)
+            }}
+            value=""
+          >
             <SelectTrigger className="h-8 text-xs">
               <div className="flex items-center gap-1.5 text-[var(--color-text-muted)]">
                 <UserPlus className="h-3 w-3" />

--- a/src-vnext/features/schedules/components/CallOverridesEditor.tsx
+++ b/src-vnext/features/schedules/components/CallOverridesEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { UserPlus, X, Users, Clapperboard, Eye, EyeOff, Mail, MailX, Phone, PhoneOff } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
@@ -270,6 +270,13 @@ export function CallOverridesEditor({
 
   // Unit filter state (null = "All Units")
   const [activeTrackId, setActiveTrackId] = useState<string | null>(null)
+
+  // Reset tab if the selected track no longer exists
+  useEffect(() => {
+    if (activeTrackId !== null && !tracks.some(t => t.id === activeTrackId)) {
+      setActiveTrackId(null)
+    }
+  }, [activeTrackId, tracks])
 
   // Filtered calls for rendering rows
   const filteredTalentCalls = useMemo(

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -286,7 +286,7 @@ export default function CallSheetBuilderPage() {
                   <InlineEdit
                     value={schedule.name}
                     placeholder={deriveDefaultCallSheetTitle(schedule)}
-                    disabled={!canManage || !clientId}
+                    disabled={!clientId}
                     showEditIcon
                     onSave={(nextName) => {
                       if (!clientId || !scheduleId) return

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -399,6 +399,7 @@ export default function CallSheetBuilderPage() {
                 scheduleName={schedule.name}
                 dateStr={dateStr}
                 dayDetails={dayDetails}
+                undoStack={undoStack}
               />
 
               <ScheduleTrackControls

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -27,6 +27,7 @@ import { DEFAULT_CALLSHEET_COLORS } from "@/features/schedules/lib/callSheetConf
 import { deriveDefaultCallSheetTitle } from "@/features/schedules/lib/callSheetTitle"
 import { updateScheduleFields } from "@/features/schedules/lib/scheduleWrites"
 import { useUndoStack } from "@/shared/hooks/useUndoStack"
+import { useLastSaved } from "@/shared/hooks/useLastSaved"
 import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { PageHeader } from "@/shared/components/PageHeader"
@@ -102,6 +103,11 @@ export default function CallSheetBuilderPage() {
   const [previewOpen, setPreviewOpen] = useState(false)
   const [printOpen, setPrintOpen] = useState(false)
   const undoStack = useUndoStack<UndoSnapshot>()
+  // Drives the "Saved Xs ago" pill on the Output controls header. The
+  // output writes are all routed through callSheetConfig setters from
+  // this component, so the useLastSaved instance lives here (not in
+  // CallSheetOutputControls).
+  const outputLastSaved = useLastSaved()
 
   const participatingTalentIds = useMemo(() => {
     if (!entries || entries.length === 0 || shots.length === 0) return [] as string[]
@@ -443,20 +449,38 @@ export default function CallSheetBuilderPage() {
                 headerLayout={rendererConfig.headerLayout ?? "legacy"}
                 castFieldConfig={rendererConfig.fieldConfigs?.cast}
                 crewFieldConfig={rendererConfig.fieldConfigs?.crew}
+                savedAt={outputLastSaved.savedAt}
                 onPatchSections={(patch) => {
-                  void callSheetConfig.setSectionVisibility(patch)
+                  void callSheetConfig
+                    .setSectionVisibility(patch)
+                    .then(() => outputLastSaved.markSaved())
+                    .catch(() => {
+                      // setSectionVisibility already surfaces its own toast
+                    })
                 }}
                 onPatchScheduleFields={(patch) => {
-                  void callSheetConfig.setScheduleBlockFields(patch)
+                  void callSheetConfig
+                    .setScheduleBlockFields(patch)
+                    .then(() => outputLastSaved.markSaved())
+                    .catch(() => {})
                 }}
                 onPatchColors={(patch) => {
-                  void callSheetConfig.setColors(patch)
+                  void callSheetConfig
+                    .setColors(patch)
+                    .then(() => outputLastSaved.markSaved())
+                    .catch(() => {})
                 }}
                 onSetHeaderLayout={(layout) => {
-                  void callSheetConfig.setHeaderLayout(layout)
+                  void callSheetConfig
+                    .setHeaderLayout(layout)
+                    .then(() => outputLastSaved.markSaved())
+                    .catch(() => {})
                 }}
                 onSaveSectionFieldConfig={(sectionKey, config) => {
-                  void callSheetConfig.setSectionFieldConfig(sectionKey, config)
+                  void callSheetConfig
+                    .setSectionFieldConfig(sectionKey, config)
+                    .then(() => outputLastSaved.markSaved())
+                    .catch(() => {})
                 }}
               />
 

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -414,6 +414,7 @@ export default function CallSheetBuilderPage() {
                 entries={entries}
                 shots={shots}
                 talentLookup={talentLibrary}
+                undoStack={undoStack}
               />
 
               <CallSheetOutputControls

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -26,6 +26,8 @@ import { OnSetViewer } from "@/features/schedules/components/OnSetViewer"
 import { DEFAULT_CALLSHEET_COLORS } from "@/features/schedules/lib/callSheetConfig"
 import { deriveDefaultCallSheetTitle } from "@/features/schedules/lib/callSheetTitle"
 import { updateScheduleFields } from "@/features/schedules/lib/scheduleWrites"
+import { useUndoStack } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { Button } from "@/ui/button"
@@ -99,6 +101,7 @@ export default function CallSheetBuilderPage() {
   const [previewScale, setPreviewScale] = useState(100)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [printOpen, setPrintOpen] = useState(false)
+  const undoStack = useUndoStack<UndoSnapshot>()
 
   const participatingTalentIds = useMemo(() => {
     if (!entries || entries.length === 0 || shots.length === 0) return [] as string[]
@@ -461,6 +464,7 @@ export default function CallSheetBuilderPage() {
                 crewCalls={crewCalls}
                 talentLibrary={talentLibrary}
                 crewLibrary={crewLibrary}
+                undoStack={undoStack}
               />
 
               <TrustChecks

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -420,6 +420,7 @@ export default function CallSheetBuilderPage() {
                 entries={entries}
                 shots={shots}
                 talentLookup={talentLibrary}
+                talentCalls={talentCalls}
                 undoStack={undoStack}
               />
 

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -28,6 +28,7 @@ import { deriveDefaultCallSheetTitle } from "@/features/schedules/lib/callSheetT
 import { updateScheduleFields } from "@/features/schedules/lib/scheduleWrites"
 import { useUndoStack } from "@/shared/hooks/useUndoStack"
 import { useLastSaved } from "@/shared/hooks/useLastSaved"
+import { filterCrewCallsByTrack, filterTalentCallsByTrack } from "@/features/schedules/lib/trackFiltering"
 import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { PageHeader } from "@/shared/components/PageHeader"
@@ -108,6 +109,19 @@ export default function CallSheetBuilderPage() {
   // this component, so the useLastSaved instance lives here (not in
   // CallSheetOutputControls).
   const outputLastSaved = useLastSaved()
+
+  // Per-unit export filtering: null = "All Units" (no filter)
+  const [activeExportTrackId, setActiveExportTrackId] = useState<string | null>(null)
+
+  // Filtered calls for the print portal
+  const exportTalentCalls = useMemo(
+    () => filterTalentCallsByTrack(talentCalls, activeExportTrackId),
+    [talentCalls, activeExportTrackId],
+  )
+  const exportCrewCalls = useMemo(
+    () => filterCrewCallsByTrack(crewCalls, activeExportTrackId),
+    [crewCalls, activeExportTrackId],
+  )
 
   const participatingTalentIds = useMemo(() => {
     if (!entries || entries.length === 0 || shots.length === 0) return [] as string[]
@@ -214,8 +228,8 @@ export default function CallSheetBuilderPage() {
           dayDetails,
           entries,
           shots,
-          talentCalls,
-          crewCalls,
+          talentCalls: exportTalentCalls,
+          crewCalls: exportCrewCalls,
           talentLibrary,
           crewLibrary,
           config: rendererConfig,
@@ -425,6 +439,9 @@ export default function CallSheetBuilderPage() {
               />
 
               <CallSheetOutputControls
+                tracks={schedule?.tracks ?? []}
+                activeTrackId={activeExportTrackId}
+                onActiveTrackChange={setActiveExportTrackId}
                 sections={{
                   header: rendererConfig.sections?.header ?? true,
                   dayDetails: rendererConfig.sections?.dayDetails ?? true,

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -24,6 +24,9 @@ import { CallSheetPrintPortal } from "@/features/schedules/components/CallSheetP
 import { TrustChecks } from "@/features/schedules/components/TrustChecks"
 import { OnSetViewer } from "@/features/schedules/components/OnSetViewer"
 import { DEFAULT_CALLSHEET_COLORS } from "@/features/schedules/lib/callSheetConfig"
+import { deriveDefaultCallSheetTitle } from "@/features/schedules/lib/callSheetTitle"
+import { updateScheduleFields } from "@/features/schedules/lib/scheduleWrites"
+import { InlineEdit } from "@/shared/components/InlineEdit"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { Button } from "@/ui/button"
 import { Sheet, SheetContent, SheetTitle } from "@/ui/sheet"
@@ -278,7 +281,28 @@ export default function CallSheetBuilderPage() {
           {/* E1: Header band */}
           <div className="mb-3 flex items-center justify-between border-b border-[var(--color-border)] bg-[var(--color-surface)] pb-3">
             <div>
-              <PageHeader title={schedule.name || "Call Sheet"} />
+              <PageHeader
+                title={
+                  <InlineEdit
+                    value={schedule.name}
+                    placeholder={deriveDefaultCallSheetTitle(schedule)}
+                    disabled={!canManage || !clientId}
+                    showEditIcon
+                    onSave={(nextName) => {
+                      if (!clientId || !scheduleId) return
+                      void updateScheduleFields(
+                        clientId,
+                        projectId,
+                        scheduleId,
+                        { name: nextName },
+                      ).catch((err) => {
+                        console.error("Failed to rename call sheet", err)
+                        toast.error("Couldn't rename call sheet — try again.")
+                      })
+                    }}
+                  />
+                }
+              />
               {dateStr && (
                 <p className="-mt-3 text-sm text-[var(--color-text-muted)]">{dateStr}</p>
               )}

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -486,6 +486,7 @@ export default function CallSheetBuilderPage() {
 
               <CallOverridesEditor
                 scheduleId={scheduleId}
+                tracks={schedule?.tracks ?? []}
                 dayDetails={dayDetails}
                 talentCalls={talentCalls}
                 crewCalls={crewCalls}

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -406,6 +406,7 @@ export default function CallSheetBuilderPage() {
                 scheduleId={scheduleId}
                 schedule={schedule}
                 entries={entries}
+                undoStack={undoStack}
               />
               <AdaptiveTimelineView
                 scheduleId={scheduleId}

--- a/src-vnext/features/schedules/components/CallSheetCastTable.tsx
+++ b/src-vnext/features/schedules/components/CallSheetCastTable.tsx
@@ -6,6 +6,7 @@ import {
   getVisibleFields,
   type CallSheetSectionFieldConfig,
 } from "@/features/schedules/lib/fieldConfig"
+import { mergeTalentWithOverride } from "@/features/schedules/lib/callSheetMerge"
 import { useColumnResize } from "@/shared/hooks/useColumnResize"
 import { useTableKeyboardNav } from "@/shared/hooks/useTableKeyboardNav"
 import { ResizableHeader } from "@/shared/components/ResizableHeader"
@@ -54,6 +55,11 @@ export function CallSheetCastTable({
   const config = fieldConfig ?? DEFAULT_CAST_SECTION
   const visibleFields = useMemo(() => getVisibleFields(config.fields), [config.fields])
 
+  const visibleTalentCalls = useMemo(
+    () => talentCalls.filter((tc) => mergeTalentWithOverride(tc).isVisible),
+    [talentCalls],
+  )
+
   // --- Container measurement for percentage → pixel conversion ---
   const containerRef = useRef<HTMLDivElement>(null)
   const [containerWidth, setContainerWidth] = useState(FALLBACK_TABLE_WIDTH)
@@ -94,10 +100,10 @@ export function CallSheetCastTable({
   const tableRef = useRef<HTMLTableElement>(null)
   const { onTableKeyDown } = useTableKeyboardNav({
     tableRef,
-    rowCount: talentCalls.length,
+    rowCount: visibleTalentCalls.length,
   })
 
-  if (talentCalls.length === 0) {
+  if (visibleTalentCalls.length === 0) {
     return (
       <p className="py-2 text-xs text-[var(--color-text-subtle)]">
         No talent call times set.
@@ -135,7 +141,7 @@ export function CallSheetCastTable({
           </tr>
         </thead>
         <tbody>
-          {talentCalls.map((tc, idx) => {
+          {visibleTalentCalls.map((tc, idx) => {
             const talent = talentMap.get(tc.talentId)
             const displayName = talent?.name ?? tc.talentId
             const callTime = tc.callTime ?? tc.callText ?? shootingCall

--- a/src-vnext/features/schedules/components/CallSheetDeptGrid.tsx
+++ b/src-vnext/features/schedules/components/CallSheetDeptGrid.tsx
@@ -7,6 +7,7 @@ import {
   type CallSheetFieldConfig,
   type CallSheetSectionFieldConfig,
 } from "@/features/schedules/lib/fieldConfig"
+import { mergeCrewWithOverride, type CrewMergeContext } from "@/features/schedules/lib/callSheetMerge"
 import type { CrewCallSheet, CrewRecord, DayDetails } from "@/shared/types"
 
 interface CallSheetDeptGridProps {
@@ -26,6 +27,10 @@ interface DeptMember {
   readonly name: string
   readonly position: string
   readonly callTime: string
+  readonly email: string | null
+  readonly phone: string | null
+  readonly showEmail: boolean
+  readonly showPhone: boolean
 }
 
 function formatTime(value: string | null | undefined): string {
@@ -37,10 +42,14 @@ function groupByDepartment(
   crewCalls: readonly CrewCallSheet[],
   crewMap: Map<string, CrewRecord>,
   defaultCallTime: string | null,
+  mergeContext: CrewMergeContext,
 ): readonly DeptGroup[] {
   const deptMap = new Map<string, DeptMember[]>()
 
   for (const cc of crewCalls) {
+    const merged = mergeCrewWithOverride(cc, mergeContext)
+    if (!merged.isVisible) continue
+
     const crew = crewMap.get(cc.crewMemberId)
     const dept = (cc.department ?? crew?.department ?? "Other").trim() || "Other"
     const position = (cc.position ?? crew?.position ?? "").trim()
@@ -50,7 +59,16 @@ function groupByDepartment(
     const existing = deptMap.get(dept) ?? []
     deptMap.set(dept, [
       ...existing,
-      { id: cc.id, name, position, callTime },
+      {
+        id: cc.id,
+        name,
+        position,
+        callTime,
+        email: crew?.email ?? null,
+        phone: crew?.phone ?? null,
+        showEmail: merged.showEmail,
+        showPhone: merged.showPhone,
+      },
     ])
   }
 
@@ -99,6 +117,16 @@ function DeptBlock({
                   {member.callTime}
                 </td>
               ),
+              email: (
+                <td key="email" className="text-2xs">
+                  {member.showEmail && member.email ? member.email : "\u2014"}
+                </td>
+              ),
+              phone: (
+                <td key="phone" className="text-2xs">
+                  {member.showPhone && member.phone ? member.phone : "\u2014"}
+                </td>
+              ),
             }
 
             return (
@@ -131,12 +159,17 @@ export function CallSheetDeptGrid({
     return m
   }, [crewLookup])
 
-  const groups = useMemo(
-    () => groupByDepartment(crewCalls, crewMap, dayDetails?.crewCallTime ?? null),
-    [crewCalls, crewMap, dayDetails],
-  )
-
   const visibleFields = useMemo(() => getVisibleFields(config.fields), [config.fields])
+
+  const mergeContext: CrewMergeContext = useMemo(() => ({
+    globalShowEmail: visibleFields.some((f) => f.key === "email"),
+    globalShowPhone: visibleFields.some((f) => f.key === "phone"),
+  }), [visibleFields])
+
+  const groups = useMemo(
+    () => groupByDepartment(crewCalls, crewMap, dayDetails?.crewCallTime ?? null, mergeContext),
+    [crewCalls, crewMap, dayDetails, mergeContext],
+  )
 
   if (groups.length === 0) {
     return (

--- a/src-vnext/features/schedules/components/CallSheetOutputControls.test.tsx
+++ b/src-vnext/features/schedules/components/CallSheetOutputControls.test.tsx
@@ -72,4 +72,47 @@ describe("CallSheetOutputControls", () => {
 
     expect(screen.queryByRole("status")).toBeNull()
   })
+
+  it("shows Export Unit selector when 2+ tracks are provided with a callback", () => {
+    const props = buildProps()
+    const onActiveTrackChange = vi.fn()
+
+    render(
+      <CallSheetOutputControls
+        {...props}
+        tracks={[
+          { id: "primary", name: "Primary", order: 0 },
+          { id: "track-2", name: "Unit 2", order: 1 },
+        ]}
+        activeTrackId={null}
+        onActiveTrackChange={onActiveTrackChange}
+      />,
+    )
+
+    expect(screen.getByText("Export Unit")).toBeInTheDocument()
+    expect(screen.getByText("All Units")).toBeInTheDocument()
+  })
+
+  it("does not show Export Unit selector for single-track schedules", () => {
+    const props = buildProps()
+
+    render(
+      <CallSheetOutputControls
+        {...props}
+        tracks={[{ id: "primary", name: "Primary", order: 0 }]}
+        activeTrackId={null}
+        onActiveTrackChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.queryByText("Export Unit")).not.toBeInTheDocument()
+  })
+
+  it("does not show Export Unit selector when no tracks prop is provided", () => {
+    const props = buildProps()
+
+    render(<CallSheetOutputControls {...props} />)
+
+    expect(screen.queryByText("Export Unit")).not.toBeInTheDocument()
+  })
 })

--- a/src-vnext/features/schedules/components/CallSheetOutputControls.test.tsx
+++ b/src-vnext/features/schedules/components/CallSheetOutputControls.test.tsx
@@ -56,4 +56,20 @@ describe("CallSheetOutputControls", () => {
 
     expect(screen.getByRole("button", { name: "Reset Defaults" })).toBeDisabled()
   })
+
+  it("renders a SaveIndicator pill in the Output header when a savedAt timestamp is passed", () => {
+    const props = buildProps()
+    render(<CallSheetOutputControls {...props} savedAt={Date.now()} />)
+
+    // Pill is mounted and shows the initial "Saved" label (within the
+    // 3s recent threshold).
+    expect(screen.getByRole("status")).toHaveTextContent("Saved")
+  })
+
+  it("does not render the SaveIndicator pill when savedAt is null", () => {
+    const props = buildProps()
+    render(<CallSheetOutputControls {...props} savedAt={null} />)
+
+    expect(screen.queryByRole("status")).toBeNull()
+  })
 })

--- a/src-vnext/features/schedules/components/CallSheetOutputControls.tsx
+++ b/src-vnext/features/schedules/components/CallSheetOutputControls.tsx
@@ -5,6 +5,13 @@ import { Switch } from "@/ui/switch"
 import { Label } from "@/ui/label"
 import { Input } from "@/ui/input"
 import { Button } from "@/ui/button"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/ui/select"
 import { DEFAULT_CALLSHEET_COLORS } from "@/features/schedules/lib/callSheetConfig"
 import { SECTION_META } from "@/features/schedules/lib/callSheetLayouts"
 import {
@@ -21,8 +28,12 @@ import type {
   CallSheetSectionVisibility,
   ScheduleBlockFields,
 } from "@/features/schedules/components/CallSheetRenderer"
+import type { ScheduleTrack } from "@/shared/types"
 
 interface CallSheetOutputControlsProps {
+  readonly tracks?: readonly ScheduleTrack[]
+  readonly activeTrackId?: string | null
+  readonly onActiveTrackChange?: (trackId: string | null) => void
   readonly sections: Required<CallSheetSectionVisibility>
   readonly scheduleBlockFields: Required<ScheduleBlockFields>
   readonly colors: Required<CallSheetColors>
@@ -48,6 +59,9 @@ interface CallSheetOutputControlsProps {
 }
 
 export function CallSheetOutputControls({
+  tracks = [],
+  activeTrackId = null,
+  onActiveTrackChange,
   sections,
   scheduleBlockFields,
   colors,
@@ -128,6 +142,30 @@ export function CallSheetOutputControls({
         </h2>
         <SaveIndicator savedAt={savedAt} />
       </div>
+
+      {tracks.length >= 2 && onActiveTrackChange && (
+        <div className="flex flex-col gap-1.5">
+          <p className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+            Export Unit
+          </p>
+          <Select
+            value={activeTrackId ?? "all"}
+            onValueChange={(v) => onActiveTrackChange(v === "all" ? null : v)}
+          >
+            <SelectTrigger className="h-8 text-xs">
+              <SelectValue placeholder="All Units" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All Units</SelectItem>
+              {tracks.map((track) => (
+                <SelectItem key={track.id} value={track.id}>
+                  {track.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
 
       <div className="flex flex-col gap-2">
         <div className="flex items-center justify-between gap-2">

--- a/src-vnext/features/schedules/components/CallSheetOutputControls.tsx
+++ b/src-vnext/features/schedules/components/CallSheetOutputControls.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/features/schedules/lib/fieldConfig"
 import { CallSheetLayoutDialog } from "@/features/schedules/components/CallSheetLayoutDialog"
 import { EditSectionFieldsDialog } from "@/features/schedules/components/EditSectionFieldsDialog"
+import { SaveIndicator } from "@/shared/components/SaveIndicator"
 import type {
   CallSheetColors,
   CallSheetHeaderLayout,
@@ -28,6 +29,10 @@ interface CallSheetOutputControlsProps {
   readonly headerLayout: CallSheetHeaderLayout
   readonly castFieldConfig?: CallSheetSectionFieldConfig
   readonly crewFieldConfig?: CallSheetSectionFieldConfig
+  // Timestamp driving the "Saved Xs ago" pill in the Output header.
+  // Owned by the parent (CallSheetBuilderPage) because all of the
+  // output-config writes are routed through parent handlers.
+  readonly savedAt?: number | null
   readonly onPatchSections: (
     patch: Partial<Required<CallSheetSectionVisibility>>,
   ) => void
@@ -49,6 +54,7 @@ export function CallSheetOutputControls({
   headerLayout,
   castFieldConfig,
   crewFieldConfig,
+  savedAt = null,
   onPatchSections,
   onPatchScheduleFields,
   onPatchColors,
@@ -120,6 +126,7 @@ export function CallSheetOutputControls({
         <h2 className="text-sm font-semibold text-[var(--color-text)]">
           Output
         </h2>
+        <SaveIndicator savedAt={savedAt} />
       </div>
 
       <div className="flex flex-col gap-2">

--- a/src-vnext/features/schedules/components/CallSheetRenderer.test.tsx
+++ b/src-vnext/features/schedules/components/CallSheetRenderer.test.tsx
@@ -150,6 +150,81 @@ describe("CallSheetRenderer", () => {
     expect(screen.queryByText("9:00 AM–11:00 AM")).not.toBeInTheDocument()
   })
 
+  it("sorts locations into canonical role order on the rendered call sheet", () => {
+    render(
+      <CallSheetRenderer
+        schedule={buildSchedule()}
+        dayDetails={{
+          id: "day-1",
+          scheduleId: "sched-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+          // Intentionally NOT in canonical order: custom, basecamp, office, parking.
+          // Expected canonical order: basecamp, parking, office, custom.
+          locations: [
+            {
+              id: "loc-studio",
+              title: "Studio A",
+              role: "custom",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "loc-basecamp",
+              title: "Basecamp",
+              role: "basecamp",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "loc-office",
+              title: "Production Office",
+              role: "office",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "loc-parking",
+              title: "Parking",
+              role: "parking",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+          ],
+        }}
+        entries={[]}
+        shots={[]}
+        talentCalls={[]}
+        crewCalls={[]}
+        talentLookup={[]}
+        crewLookup={[]}
+        config={{ sections: { header: false, dayDetails: true } }}
+      />,
+    )
+
+    // The renderer wraps each location title in a styled <span>. Query by role
+    // label text and assert their appearance order in the DOM.
+    const rendered = [
+      screen.getByText("Basecamp"),
+      screen.getByText("Parking"),
+      screen.getByText("Production Office"),
+      screen.getByText("Studio A"),
+    ]
+    // Verify DOM order matches canonical sort. Each title's
+    // compareDocumentPosition against the next should flag
+    // DOCUMENT_POSITION_FOLLOWING (0x04).
+    for (let i = 0; i < rendered.length - 1; i += 1) {
+      const current = rendered[i]!
+      const next = rendered[i + 1]!
+      expect(current.compareDocumentPosition(next) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    }
+  })
+
   it("does not render track/applicability labels in advanced schedule output", () => {
     render(
       <CallSheetRenderer

--- a/src-vnext/features/schedules/components/CallSheetRenderer.tsx
+++ b/src-vnext/features/schedules/components/CallSheetRenderer.tsx
@@ -7,6 +7,7 @@ import { CallSheetKeyTimesStrip } from "@/features/schedules/components/CallShee
 import { CallSheetCastTable } from "@/features/schedules/components/CallSheetCastTable"
 import { CallSheetDeptGrid } from "@/features/schedules/components/CallSheetDeptGrid"
 import { CallSheetPageHeader } from "@/features/schedules/components/CallSheetPageHeader"
+import { compareLocationsByRole } from "@/features/schedules/lib/locationRoles"
 import type { CallSheetSectionFieldConfig } from "@/features/schedules/lib/fieldConfig"
 import type {
   Schedule,
@@ -445,17 +446,20 @@ export function CallSheetRenderer({
           )}
           {dayDetails.locations && dayDetails.locations.length > 0 && (
             <div className="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
-              {dayDetails.locations.map((loc) => (
-                <p key={loc.id}>
-                  <span
-                    className="font-semibold uppercase tracking-wide"
-                    style={{ color: "var(--doc-accent,#2563eb)" }}
-                  >
-                    {loc.title}
-                  </span>{" "}
-                  {loc.ref?.label ?? loc.ref?.locationId ?? ""}
-                </p>
-              ))}
+              {dayDetails.locations
+                .slice()
+                .sort(compareLocationsByRole)
+                .map((loc) => (
+                  <p key={loc.id}>
+                    <span
+                      className="font-semibold uppercase tracking-wide"
+                      style={{ color: "var(--doc-accent,#2563eb)" }}
+                    >
+                      {loc.title}
+                    </span>{" "}
+                    {loc.ref?.label ?? loc.ref?.locationId ?? ""}
+                  </p>
+                ))}
             </div>
           )}
         </div>

--- a/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
@@ -424,6 +424,49 @@ describe("DayDetailsEditor location module", () => {
     expect(typedPatch.locations?.[0]?.role).toBe("basecamp")
   })
 
+  it("renders a colored role chip next to each location title (Basecamp preset + Custom fallback)", () => {
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+          locations: [
+            {
+              id: "block-basecamp",
+              title: "Basecamp",
+              role: "basecamp",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "block-custom",
+              title: "Studio A",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+          ],
+        }}
+        undoStack={buildFakeUndoStack()}
+      />,
+    )
+
+    const basecampChip = screen.getByTestId("location-role-chip-block-basecamp")
+    expect(basecampChip).toHaveTextContent("Basecamp")
+    expect(basecampChip.className).toContain("color-status-blue-bg")
+
+    const customChip = screen.getByTestId("location-role-chip-block-custom")
+    expect(customChip).toHaveTextContent("Custom")
+    expect(customChip.className).toContain("color-status-gray-bg")
+  })
+
   it("clicking Undo reinserts the block at its original index against the current dayDetails.locations", async () => {
     const user = userEvent.setup()
     const undoStack = buildFakeUndoStack()

--- a/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
@@ -135,6 +135,59 @@ describe("DayDetailsEditor location module", () => {
     expect(typedPatch.locations?.[0]?.title).toBe("Basecamp")
   })
 
+  it("awaits the Firestore write before the new location appears in local state", async () => {
+    const user = userEvent.setup()
+
+    // Defer the updateDayDetails resolution so we can observe ordering:
+    // setLocationDrafts must NOT fire until the Firestore write settles.
+    let resolveWrite: (id: string) => void = () => {}
+    updateDayDetailsMock.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveWrite = resolve
+        }),
+    )
+
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+        }}
+        undoStack={buildFakeUndoStack()}
+      />,
+    )
+
+    // Click Add Location. The async handler fires updateDayDetails but
+    // must NOT yet update local state (we control when the promise resolves).
+    await user.click(screen.getByRole("button", { name: "Add Location" }))
+
+    await waitFor(() => {
+      expect(updateDayDetailsMock).toHaveBeenCalled()
+    })
+
+    // Before the write resolves: no "Basecamp" location block in the UI.
+    // The empty-state copy still shows.
+    expect(
+      screen.getByText(/No location blocks yet/i),
+    ).toBeInTheDocument()
+
+    // Resolve the write and assert the local state caught up.
+    resolveWrite("day-details-1")
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/No location blocks yet/i),
+      ).toBeNull()
+    })
+  })
+
   it("creates a new location and links it to the target block", async () => {
     const user = userEvent.setup()
 

--- a/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
@@ -5,6 +5,20 @@ import { DayDetailsEditor } from "@/features/schedules/components/DayDetailsEdit
 import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
 import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 
+// Radix Select polyfills for JSDOM — used by the label preset combobox.
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false
+}
+if (!HTMLElement.prototype.setPointerCapture) {
+  HTMLElement.prototype.setPointerCapture = () => {}
+}
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = () => {}
+}
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {}
+}
+
 const { toastMock, toastErrorMock, toastSuccessMock, toastInfoMock } = vi.hoisted(() => ({
   toastMock: vi.fn(),
   toastErrorMock: vi.fn(),
@@ -355,6 +369,59 @@ describe("DayDetailsEditor location module", () => {
     await waitFor(() => {
       expect(screen.getByRole("status")).toHaveTextContent("Saved")
     })
+  })
+
+  it("picking the Basecamp preset writes both title and role:'basecamp' to the persisted block", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+          // Start with a custom-titled block so the Basecamp preset is a real
+          // "new selection" and not a no-op.
+          locations: [
+            {
+              id: "block-1",
+              title: "Studio A",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+          ],
+        }}
+        undoStack={buildFakeUndoStack()}
+      />,
+    )
+
+    updateDayDetailsMock.mockClear()
+
+    // Open the Label combobox (first of two — Label + From Library — in the
+    // block's form) and pick the Basecamp preset.
+    const [labelCombobox] = screen.getAllByRole("combobox")
+    await user.click(labelCombobox!)
+    await user.click(screen.getByRole("option", { name: "Basecamp" }))
+
+    await waitFor(() => {
+      expect(updateDayDetailsMock).toHaveBeenCalled()
+    })
+
+    const [, , , , patch] = updateDayDetailsMock.mock.calls.at(-1) as unknown[]
+    const typedPatch = patch as {
+      readonly locations?: readonly {
+        readonly title: string
+        readonly role?: string | null
+      }[]
+    }
+    expect(typedPatch.locations?.[0]?.title).toBe("Basecamp")
+    expect(typedPatch.locations?.[0]?.role).toBe("basecamp")
   })
 
   it("clicking Undo reinserts the block at its original index against the current dayDetails.locations", async () => {

--- a/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
@@ -321,6 +321,42 @@ describe("DayDetailsEditor location module", () => {
     }
   })
 
+  it("renders a SaveIndicator pill in the Location Details header after a successful write", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+        }}
+        undoStack={buildFakeUndoStack()}
+      />,
+    )
+
+    // Pill is absent before any save lands (savedAt === null).
+    expect(screen.queryByRole("status")).toBeNull()
+
+    // Trigger a save by adding a location block.
+    await user.click(screen.getByRole("button", { name: "Add Location" }))
+
+    await waitFor(() => {
+      expect(updateDayDetailsMock).toHaveBeenCalled()
+    })
+
+    // After the await settles, markSaved() runs and the SaveIndicator
+    // mounts. Default label within the 3s recent threshold: "Saved".
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("Saved")
+    })
+  })
+
   it("clicking Undo reinserts the block at its original index against the current dayDetails.locations", async () => {
     const user = userEvent.setup()
     const undoStack = buildFakeUndoStack()

--- a/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.test.tsx
@@ -2,6 +2,23 @@ import { describe, expect, it, vi, beforeEach } from "vitest"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { DayDetailsEditor } from "@/features/schedules/components/DayDetailsEditor"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
+
+const { toastMock, toastErrorMock, toastSuccessMock, toastInfoMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastMock, {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+    info: toastInfoMock,
+  }),
+}))
 
 const updateDayDetailsMock = vi.fn()
 const createLocationAndAssignToProjectMock = vi.fn()
@@ -47,11 +64,36 @@ vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
   ensureLocationAssignedToProject: (...args: unknown[]) => ensureLocationAssignedToProjectMock(...args),
 }))
 
+function buildFakeUndoStack(): UseUndoStackResult<UndoSnapshot> {
+  const pushMock = vi.fn((input: {
+    readonly label: string
+    readonly snapshot: UndoSnapshot
+    readonly undo: (snapshot: UndoSnapshot) => Promise<void>
+  }) => ({
+    id: "fake-action-id",
+    label: input.label,
+    snapshot: input.snapshot,
+    undo: input.undo,
+    createdAt: 123,
+  }))
+  return {
+    actions: [],
+    push: pushMock,
+    pop: vi.fn(() => null),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  }
+}
+
 describe("DayDetailsEditor location module", () => {
   beforeEach(() => {
     updateDayDetailsMock.mockReset()
     createLocationAndAssignToProjectMock.mockReset()
     ensureLocationAssignedToProjectMock.mockReset()
+    toastMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastInfoMock.mockReset()
 
     updateDayDetailsMock.mockResolvedValue("day-details-1")
     createLocationAndAssignToProjectMock.mockResolvedValue({
@@ -77,6 +119,7 @@ describe("DayDetailsEditor location module", () => {
           shootingCallTime: "07:00",
           estimatedWrap: "19:00",
         }}
+        undoStack={buildFakeUndoStack()}
       />,
     )
 
@@ -116,6 +159,7 @@ describe("DayDetailsEditor location module", () => {
             },
           ],
         }}
+        undoStack={buildFakeUndoStack()}
       />,
     )
 
@@ -149,5 +193,137 @@ describe("DayDetailsEditor location module", () => {
       expect(typedPatch.locations?.[0]?.ref?.label).toBe("New Hospital")
       expect(typedPatch.locations?.[0]?.ref?.notes).toBe("55 Health Way")
     })
+  })
+
+  it("removing a location block fires destructiveActionWithUndo and pushes a locationRemoved snapshot", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+          locations: [
+            {
+              id: "block-keep",
+              title: "Basecamp",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "block-remove",
+              title: "Hospital",
+              ref: { locationId: "loc-lib-1", label: "City Hospital", notes: "100 Main St" },
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "block-keep-2",
+              title: "Parking",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+          ],
+        }}
+        undoStack={undoStack}
+      />,
+    )
+
+    const [, removeButton] = screen.getAllByRole("button", { name: "Remove location block" })
+    await user.click(removeButton!)
+
+    await waitFor(() => {
+      expect(updateDayDetailsMock).toHaveBeenCalled()
+    })
+
+    // Assert the filtered payload was written (no longer contains Hospital)
+    const lastRemovalCall = updateDayDetailsMock.mock.calls.at(-1) as unknown[]
+    const lastPatch = lastRemovalCall[4] as { readonly locations?: ReadonlyArray<{ readonly id: string }> | null }
+    expect(lastPatch.locations).toBeTruthy()
+    expect(lastPatch.locations?.map((l) => l.id)).toEqual(["block-keep", "block-keep-2"])
+
+    // Assert the undo stack received a locationRemoved snapshot
+    await waitFor(() => {
+      expect(undoStack.push).toHaveBeenCalledTimes(1)
+    })
+    const pushArg = (undoStack.push as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      readonly label: string
+      readonly snapshot: UndoSnapshot
+    }
+    expect(pushArg.snapshot.kind).toBe("locationRemoved")
+    if (pushArg.snapshot.kind === "locationRemoved") {
+      expect(pushArg.snapshot.payload.index).toBe(1)
+      expect(pushArg.snapshot.payload.block.id).toBe("block-remove")
+      expect(pushArg.snapshot.payload.block.title).toBe("Hospital")
+      expect(pushArg.snapshot.payload.block.ref?.locationId).toBe("loc-lib-1")
+    }
+  })
+
+  it("clicking Undo reinserts the block at its original index against the current dayDetails.locations", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+
+    render(
+      <DayDetailsEditor
+        scheduleId="schedule-1"
+        scheduleName="Shoot Day"
+        dateStr="Thursday"
+        dayDetails={{
+          id: "day-details-1",
+          scheduleId: "schedule-1",
+          crewCallTime: "06:00",
+          shootingCallTime: "07:00",
+          estimatedWrap: "19:00",
+          locations: [
+            {
+              id: "block-a",
+              title: "Basecamp",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+            {
+              id: "block-b",
+              title: "Hospital",
+              ref: null,
+              showName: true,
+              showPhone: false,
+            },
+          ],
+        }}
+        undoStack={undoStack}
+      />,
+    )
+
+    const [, removeSecond] = screen.getAllByRole("button", { name: "Remove location block" })
+    await user.click(removeSecond!)
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    const toastOptions = toastMock.mock.calls[0]?.[1] as { action: { onClick: () => void } }
+    updateDayDetailsMock.mockClear()
+
+    toastOptions.action.onClick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(updateDayDetailsMock).toHaveBeenCalled()
+    })
+
+    const undoCall = updateDayDetailsMock.mock.calls.at(-1) as unknown[]
+    const undoPatch = undoCall[4] as { readonly locations?: ReadonlyArray<{ readonly id: string }> | null }
+    expect(undoPatch.locations?.map((l) => l.id)).toEqual(["block-a", "block-b"])
   })
 })

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -18,6 +18,8 @@ import {
   takeLocationRemoveSnapshot,
   type UndoSnapshot,
 } from "@/features/schedules/lib/undoSnapshots"
+import { useLastSaved } from "@/shared/hooks/useLastSaved"
+import { SaveIndicator } from "@/shared/components/SaveIndicator"
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { Textarea } from "@/ui/textarea"
@@ -186,6 +188,7 @@ export function DayDetailsEditor({
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
   const { data: locations } = useLocations(clientId)
+  const lastSaved = useLastSaved()
 
   // Ref to latest dayDetails so the undo closure can read the current
   // dayDetails id at the moment the user clicks Undo, not the stale
@@ -240,6 +243,7 @@ export function DayDetailsEditor({
           await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
             [field]: normalized,
           })
+          lastSaved.markSaved()
         } catch {
           toast.error("Failed to save details.")
         }
@@ -249,11 +253,12 @@ export function DayDetailsEditor({
         await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
           [field]: value || null,
         })
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to save details.")
       }
     },
-    [clientId, projectId, scheduleId, dayDetails?.id],
+    [clientId, projectId, scheduleId, dayDetails?.id, lastSaved],
   )
 
   const saveLocationDrafts = useCallback(
@@ -264,11 +269,12 @@ export function DayDetailsEditor({
         await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
           locations: payload.length > 0 ? payload : null,
         })
+        lastSaved.markSaved()
       } catch {
         toast.error("Failed to save location details.")
       }
     },
-    [clientId, dayDetails?.id, projectId, scheduleId],
+    [clientId, dayDetails?.id, projectId, scheduleId, lastSaved],
   )
 
   const applyLocationMutation = useCallback(
@@ -349,6 +355,7 @@ export function DayDetailsEditor({
             { locations: nextPayload.length > 0 ? nextPayload : null },
           )
           createdDayDetailsId = id
+          lastSaved.markSaved()
         },
         undo: async (snap) => {
           if (snap.kind !== "locationRemoved") return
@@ -371,13 +378,14 @@ export function DayDetailsEditor({
             dayDetailsRef.current?.id ?? createdDayDetailsId ?? null,
             { locations: restored.length > 0 ? [...restored] : null },
           )
+          lastSaved.markSaved()
         },
         })
       } catch {
         toast.error("Failed to remove location block.")
       }
     },
-    [clientId, locationDrafts, projectId, scheduleId, undoStack],
+    [clientId, lastSaved, locationDrafts, projectId, scheduleId, undoStack],
   )
 
   const handleLabelPresetChange = useCallback(
@@ -549,6 +557,7 @@ export function DayDetailsEditor({
             <h3 className="label-meta text-[var(--color-text-muted)]">
               Location Details
             </h3>
+            <SaveIndicator savedAt={lastSaved.savedAt} />
           </div>
           <Button
             type="button"

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -40,7 +40,7 @@ import {
 } from "@/ui/dialog"
 import type { DayDetails, LocationBlock, LocationRecord, LocationRole } from "@/shared/types"
 import {
-  inferLocationRole,
+  resolveLocationRole,
   roleDisplayLabel,
 } from "@/features/schedules/lib/locationRoles"
 
@@ -167,10 +167,6 @@ function normalizeLocationDrafts(
     notes: (loc.ref?.notes || "").trim(),
     role: loc.role ?? undefined,
   }))
-}
-
-function resolveDraftRole(draft: LocationDraft): LocationRole {
-  return draft.role ?? inferLocationRole(draft.title || "")
 }
 
 function toLocationBlock(draft: LocationDraft): LocationBlock {
@@ -636,7 +632,7 @@ export function DayDetailsEditor({
               const isPreset = LOCATION_LABEL_PRESETS.includes(
                 loc.title as (typeof LOCATION_LABEL_PRESETS)[number],
               )
-              const resolvedRole = resolveDraftRole(loc)
+              const resolvedRole = resolveLocationRole(loc)
               const chipLabel = roleDisplayLabel(resolvedRole)
               const chipStyles = ROLE_CHIP_STYLES[resolvedRole]
 
@@ -652,6 +648,7 @@ export function DayDetailsEditor({
                       </span>
                       <span
                         data-testid={`location-role-chip-${loc.id}`}
+                        aria-hidden="true"
                         className={`inline-flex shrink-0 items-center rounded-md border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wide ${chipStyles}`}
                       >
                         {chipLabel}

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -227,7 +227,7 @@ export function DayDetailsEditor({
   }, [remoteLocationSnapshot, remoteLocationDrafts])
 
   const saveField = useCallback(
-    (field: string) => (value: string) => {
+    (field: string) => async (value: string): Promise<void> => {
       if (!clientId) return
       if (TIME_FIELD_NAMES.has(field)) {
         const parsed = classifyTimeInput(value)
@@ -236,42 +236,48 @@ export function DayDetailsEditor({
           return
         }
         const normalized = parsed.kind === "time" ? parsed.canonical : null
-        void updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
-          [field]: normalized,
-        }).catch(() => {
+        try {
+          await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
+            [field]: normalized,
+          })
+        } catch {
           toast.error("Failed to save details.")
-        })
+        }
         return
       }
-      void updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
-        [field]: value || null,
-      }).catch(() => {
+      try {
+        await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
+          [field]: value || null,
+        })
+      } catch {
         toast.error("Failed to save details.")
-      })
+      }
     },
     [clientId, projectId, scheduleId, dayDetails?.id],
   )
 
   const saveLocationDrafts = useCallback(
-    (nextDrafts: readonly LocationDraft[]) => {
+    async (nextDrafts: readonly LocationDraft[]): Promise<void> => {
       if (!clientId) return
       const payload = nextDrafts.map(toLocationBlock)
-      void updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
-        locations: payload.length > 0 ? payload : null,
-      }).catch(() => {
+      try {
+        await updateDayDetails(clientId, projectId, scheduleId, dayDetails?.id ?? null, {
+          locations: payload.length > 0 ? payload : null,
+        })
+      } catch {
         toast.error("Failed to save location details.")
-      })
+      }
     },
     [clientId, dayDetails?.id, projectId, scheduleId],
   )
 
   const applyLocationMutation = useCallback(
-    (updater: (prev: readonly LocationDraft[]) => readonly LocationDraft[]) => {
-      setLocationDrafts((prev) => {
-        const next = updater(prev)
-        saveLocationDrafts(next)
-        return next
-      })
+    async (
+      updater: (prev: readonly LocationDraft[]) => readonly LocationDraft[],
+    ): Promise<void> => {
+      const next = updater(locationDraftsRef.current)
+      await saveLocationDrafts(next)
+      setLocationDrafts(next)
     },
     [saveLocationDrafts],
   )
@@ -285,8 +291,8 @@ export function DayDetailsEditor({
     [],
   )
 
-  const addLocationBlock = useCallback(() => {
-    applyLocationMutation((prev) => [
+  const addLocationBlock = useCallback(async (): Promise<void> => {
+    await applyLocationMutation((prev) => [
       ...prev,
       {
         id: randomId(),
@@ -299,7 +305,7 @@ export function DayDetailsEditor({
   }, [applyLocationMutation])
 
   const removeLocationBlock = useCallback(
-    (locationId: string) => {
+    async (locationId: string): Promise<void> => {
       if (!clientId) return
 
       // Capture the block being removed (from current drafts state)
@@ -325,7 +331,8 @@ export function DayDetailsEditor({
       // doc on its first write would orphan it on undo.
       let createdDayDetailsId: string | null = null
 
-      void destructiveActionWithUndo<UndoSnapshot>({
+      try {
+        await destructiveActionWithUndo<UndoSnapshot>({
         label,
         snapshot: {
           kind: "locationRemoved",
@@ -365,16 +372,17 @@ export function DayDetailsEditor({
             { locations: restored.length > 0 ? [...restored] : null },
           )
         },
-      }).catch(() => {
+        })
+      } catch {
         toast.error("Failed to remove location block.")
-      })
+      }
     },
     [clientId, locationDrafts, projectId, scheduleId, undoStack],
   )
 
   const handleLabelPresetChange = useCallback(
-    (locationId: string, value: string) => {
-      applyLocationMutation((prev) =>
+    async (locationId: string, value: string): Promise<void> => {
+      await applyLocationMutation((prev) =>
         prev.map((loc) => {
           if (loc.id !== locationId) return loc
           if (value === LOCATION_CUSTOM_VALUE) {
@@ -393,9 +401,9 @@ export function DayDetailsEditor({
   )
 
   const handleLibraryLocationChange = useCallback(
-    (locationBlockId: string, value: string) => {
+    async (locationBlockId: string, value: string): Promise<void> => {
       const selectedLocationId = value === LOCATION_NONE_VALUE ? "" : value
-      applyLocationMutation((prev) =>
+      await applyLocationMutation((prev) =>
         prev.map((loc) => {
           if (loc.id !== locationBlockId) return loc
           if (!selectedLocationId) {
@@ -415,17 +423,19 @@ export function DayDetailsEditor({
       )
 
       if (clientId && selectedLocationId) {
-        void ensureLocationAssignedToProject(clientId, projectId, selectedLocationId).catch(() => {
+        try {
+          await ensureLocationAssignedToProject(clientId, projectId, selectedLocationId)
+        } catch {
           toast.error("Failed to attach location to this project.")
-        })
+        }
       }
     },
     [applyLocationMutation, clientId, locationById, projectId],
   )
 
-  const commitLocationDrafts = useCallback(() => {
-    saveLocationDrafts(locationDrafts)
-  }, [locationDrafts, saveLocationDrafts])
+  const commitLocationDrafts = useCallback(async (): Promise<void> => {
+    await saveLocationDrafts(locationDraftsRef.current)
+  }, [saveLocationDrafts])
 
   const openCreateLocation = useCallback((targetLocationId: string) => {
     setCreateLocationTargetId(targetLocationId)
@@ -452,7 +462,7 @@ export function DayDetailsEditor({
         notes: createLocationNotes,
       })
 
-      applyLocationMutation((prev) =>
+      await applyLocationMutation((prev) =>
         prev.map((loc) => {
           if (loc.id !== createLocationTargetId) return loc
           return {
@@ -545,7 +555,9 @@ export function DayDetailsEditor({
             variant="outline"
             size="sm"
             className="h-7 gap-1 px-2 text-xs"
-            onClick={addLocationBlock}
+            onClick={() => {
+              void addLocationBlock()
+            }}
           >
             <Plus className="h-3.5 w-3.5" />
             Add Location
@@ -574,7 +586,9 @@ export function DayDetailsEditor({
                     </span>
                     <button
                       type="button"
-                      onClick={() => removeLocationBlock(loc.id)}
+                      onClick={() => {
+                        void removeLocationBlock(loc.id)
+                      }}
                       className="flex h-7 w-7 shrink-0 items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:bg-[var(--color-surface-muted)] hover:text-[var(--color-text)]"
                       aria-label="Remove location block"
                     >
@@ -589,7 +603,9 @@ export function DayDetailsEditor({
                       </Label>
                       <Select
                         value={isPreset ? loc.title : LOCATION_CUSTOM_VALUE}
-                        onValueChange={(value) => handleLabelPresetChange(loc.id, value)}
+                        onValueChange={(value) => {
+                          void handleLabelPresetChange(loc.id, value)
+                        }}
                       >
                         <SelectTrigger className="h-8">
                           <SelectValue placeholder="Select label" />
@@ -612,7 +628,9 @@ export function DayDetailsEditor({
                       <div className="flex items-center gap-2">
                         <Select
                           value={loc.locationId || LOCATION_NONE_VALUE}
-                          onValueChange={(value) => handleLibraryLocationChange(loc.id, value)}
+                          onValueChange={(value) => {
+                            void handleLibraryLocationChange(loc.id, value)
+                          }}
                         >
                           <SelectTrigger className="h-8 min-w-0 flex-1">
                             <SelectValue placeholder="Select location" />
@@ -651,7 +669,9 @@ export function DayDetailsEditor({
                       <Input
                         value={loc.title}
                         onChange={(event) => patchLocationDraft(loc.id, { title: event.target.value })}
-                        onBlur={commitLocationDrafts}
+                        onBlur={() => {
+                          void commitLocationDrafts()
+                        }}
                         placeholder="e.g. Studio Holding"
                         className="h-8 text-xs"
                       />
@@ -666,7 +686,9 @@ export function DayDetailsEditor({
                       <Input
                         value={loc.label}
                         onChange={(event) => patchLocationDraft(loc.id, { label: event.target.value })}
-                        onBlur={commitLocationDrafts}
+                        onBlur={() => {
+                          void commitLocationDrafts()
+                        }}
                         placeholder={loc.locationId ? (locationById.get(loc.locationId)?.name ?? "Location name") : "Optional"}
                         className="h-8 text-xs"
                       />
@@ -678,7 +700,9 @@ export function DayDetailsEditor({
                       <Textarea
                         value={loc.notes}
                         onChange={(event) => patchLocationDraft(loc.id, { notes: event.target.value })}
-                        onBlur={commitLocationDrafts}
+                        onBlur={() => {
+                          void commitLocationDrafts()
+                        }}
                         placeholder="Address, contact, access notes..."
                         className="min-h-[64px] text-xs"
                       />

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Clock, Utensils, Sun, Camera, MapPin, Plus, Trash2 } from "lucide-react"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
@@ -11,6 +11,13 @@ import {
 } from "@/features/schedules/lib/scheduleWrites"
 import { classifyTimeInput } from "@/features/schedules/lib/time"
 import { TypedTimeInput } from "@/features/schedules/components/TypedTimeInput"
+import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUndo"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import {
+  reinsertLocationAtIndex,
+  takeLocationRemoveSnapshot,
+  type UndoSnapshot,
+} from "@/features/schedules/lib/undoSnapshots"
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { Textarea } from "@/ui/textarea"
@@ -56,6 +63,7 @@ interface DayDetailsEditorProps {
   readonly scheduleName: string
   readonly dateStr: string
   readonly dayDetails: DayDetails | null
+  readonly undoStack: UseUndoStackResult<UndoSnapshot>
 }
 
 interface TimeAnchorProps {
@@ -173,12 +181,21 @@ export function DayDetailsEditor({
   scheduleName,
   dateStr,
   dayDetails,
+  undoStack,
 }: DayDetailsEditorProps) {
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
   const { data: locations } = useLocations(clientId)
 
+  // Ref to latest dayDetails so the undo closure can read the current
+  // dayDetails id at the moment the user clicks Undo, not the stale
+  // value captured when removeLocationBlock fired.
+  const dayDetailsRef = useRef(dayDetails)
+  dayDetailsRef.current = dayDetails
+
   const [locationDrafts, setLocationDrafts] = useState<readonly LocationDraft[]>([])
+  const locationDraftsRef = useRef<readonly LocationDraft[]>(locationDrafts)
+  locationDraftsRef.current = locationDrafts
   const [createLocationOpen, setCreateLocationOpen] = useState(false)
   const [createLocationTargetId, setCreateLocationTargetId] = useState<string | null>(null)
   const [createLocationName, setCreateLocationName] = useState("")
@@ -283,9 +300,54 @@ export function DayDetailsEditor({
 
   const removeLocationBlock = useCallback(
     (locationId: string) => {
-      applyLocationMutation((prev) => prev.filter((loc) => loc.id !== locationId))
+      if (!clientId) return
+
+      // Capture the block being removed (from current drafts state)
+      // BEFORE we mutate the drafts array. The drafts represent the
+      // user's on-screen state and include any unsaved local edits.
+      const draftIndex = locationDrafts.findIndex((loc) => loc.id === locationId)
+      if (draftIndex < 0) return
+      const draft = locationDrafts[draftIndex]!
+      const snapshotBlock = toLocationBlock(draft)
+
+      const nextDrafts = [
+        ...locationDrafts.slice(0, draftIndex),
+        ...locationDrafts.slice(draftIndex + 1),
+      ]
+      const nextPayload = nextDrafts.map(toLocationBlock)
+
+      const label = `Removed ${snapshotBlock.title || "location"} block`
+
+      void destructiveActionWithUndo<UndoSnapshot>({
+        label,
+        snapshot: {
+          kind: "locationRemoved",
+          payload: { index: draftIndex, block: snapshotBlock },
+        },
+        stack: undoStack,
+        perform: async () => {
+          setLocationDrafts(nextDrafts)
+          await updateDayDetails(clientId, projectId, scheduleId, dayDetailsRef.current?.id ?? null, {
+            locations: nextPayload.length > 0 ? nextPayload : null,
+          })
+        },
+        undo: async (snap) => {
+          if (snap.kind !== "locationRemoved") return
+          // Re-insert against the CURRENT drafts (via their ref) rather
+          // than the stale adjacent array captured at delete time. This
+          // way any edits the user made to other blocks between the
+          // delete and the undo are preserved.
+          const currentBlocks = locationDraftsRef.current.map(toLocationBlock)
+          const restored = reinsertLocationAtIndex(currentBlocks, snap.payload)
+          await updateDayDetails(clientId, projectId, scheduleId, dayDetailsRef.current?.id ?? null, {
+            locations: restored.length > 0 ? [...restored] : null,
+          })
+        },
+      }).catch(() => {
+        toast.error("Failed to remove location block.")
+      })
     },
-    [applyLocationMutation],
+    [clientId, locationDrafts, projectId, scheduleId, undoStack],
   )
 
   const handleLabelPresetChange = useCallback(

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -38,7 +38,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/ui/dialog"
-import type { DayDetails, LocationBlock, LocationRecord } from "@/shared/types"
+import type { DayDetails, LocationBlock, LocationRecord, LocationRole } from "@/shared/types"
 
 const TIME_FIELD_NAMES = new Set([
   "crewCallTime",
@@ -82,6 +82,19 @@ interface LocationDraft {
   readonly locationId: string
   readonly label: string
   readonly notes: string
+  /**
+   * Explicit canonical role for this block. Undefined if the block has never
+   * been tagged — consumers fall back to inferLocationRole(title) at display
+   * time. Persisted on the next write.
+   */
+  readonly role?: LocationRole
+}
+
+const LOCATION_PRESET_TO_ROLE: Readonly<Record<(typeof LOCATION_LABEL_PRESETS)[number], LocationRole>> = {
+  Basecamp: "basecamp",
+  Hospital: "hospital",
+  Parking: "parking",
+  "Production Office": "office",
 }
 
 function TimeAnchor({ icon, label, value, placeholder, onSave, required }: TimeAnchorProps) {
@@ -127,6 +140,7 @@ function normalizeLocationDrafts(
     locationId: (loc.ref?.locationId || "").trim(),
     label: (loc.ref?.label || "").trim(),
     notes: (loc.ref?.notes || "").trim(),
+    role: loc.role ?? undefined,
   }))
 }
 
@@ -139,6 +153,7 @@ function toLocationBlock(draft: LocationDraft): LocationBlock {
   return {
     id: draft.id,
     title: draft.title.trim() || "Location",
+    role: draft.role ?? null,
     ref: hasRef
       ? {
           locationId: locationId || null,
@@ -150,6 +165,7 @@ function toLocationBlock(draft: LocationDraft): LocationBlock {
     showPhone: false,
   }
 }
+
 
 function nextSuggestedLocationTitle(drafts: readonly LocationDraft[]): string {
   const used = new Set(drafts.map((draft) => draft.title.trim().toLowerCase()))
@@ -404,9 +420,12 @@ export function DayDetailsEditor({
               title: LOCATION_LABEL_PRESETS.includes(loc.title as (typeof LOCATION_LABEL_PRESETS)[number])
                 ? "Location"
                 : loc.title,
+              role: "custom",
             }
           }
-          return { ...loc, title: value }
+          const presetRole =
+            LOCATION_PRESET_TO_ROLE[value as (typeof LOCATION_LABEL_PRESETS)[number]]
+          return { ...loc, title: value, role: presetRole }
         }),
       )
     },

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -15,7 +15,6 @@ import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUnd
 import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
 import {
   reinsertLocationAtIndex,
-  takeLocationRemoveSnapshot,
   type UndoSnapshot,
 } from "@/features/schedules/lib/undoSnapshots"
 import { useLastSaved } from "@/shared/hooks/useLastSaved"
@@ -346,15 +345,21 @@ export function DayDetailsEditor({
         },
         stack: undoStack,
         perform: async () => {
+          // Local drafts updated BEFORE the await — destructive
+          // removals are idempotent, so optimistic state matches
+          // what the snapshot listener will eventually echo back.
+          // Asymmetric with applyLocationMutation (which awaits
+          // FIRST because creates are NOT §5-allowed to be
+          // optimistic). The undo helper handles the rollback if
+          // the write rejects.
           setLocationDrafts(nextDrafts)
-          const { id } = await updateDayDetails(
+          createdDayDetailsId = await updateDayDetails(
             clientId,
             projectId,
             scheduleId,
             dayDetailsRef.current?.id ?? null,
             { locations: nextPayload.length > 0 ? nextPayload : null },
           )
-          createdDayDetailsId = id
           lastSaved.markSaved()
         },
         undo: async (snap) => {

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -39,6 +39,10 @@ import {
   DialogTitle,
 } from "@/ui/dialog"
 import type { DayDetails, LocationBlock, LocationRecord, LocationRole } from "@/shared/types"
+import {
+  inferLocationRole,
+  roleDisplayLabel,
+} from "@/features/schedules/lib/locationRoles"
 
 const TIME_FIELD_NAMES = new Set([
   "crewCallTime",
@@ -97,6 +101,27 @@ const LOCATION_PRESET_TO_ROLE: Readonly<Record<(typeof LOCATION_LABEL_PRESETS)[n
   "Production Office": "office",
 }
 
+/**
+ * Semantic token classes for each role chip. basecamp and shoot share the
+ * blue family intentionally — they both represent "work locations" on the
+ * call sheet. Uses the existing --color-status-* token families from
+ * tokens.css; no new tokens introduced for this slice.
+ */
+const ROLE_CHIP_STYLES: Readonly<Record<LocationRole, string>> = {
+  basecamp:
+    "border-[var(--color-status-blue-border)] bg-[var(--color-status-blue-bg)] text-[var(--color-status-blue-text)]",
+  hospital:
+    "border-[var(--color-status-red-border)] bg-[var(--color-status-red-bg)] text-[var(--color-status-red-text)]",
+  parking:
+    "border-[var(--color-status-green-border)] bg-[var(--color-status-green-bg)] text-[var(--color-status-green-text)]",
+  office:
+    "border-[var(--color-status-amber-border)] bg-[var(--color-status-amber-bg)] text-[var(--color-status-amber-text)]",
+  shoot:
+    "border-[var(--color-status-blue-border)] bg-[var(--color-status-blue-bg)] text-[var(--color-status-blue-text)]",
+  custom:
+    "border-[var(--color-status-gray-border)] bg-[var(--color-status-gray-bg)] text-[var(--color-status-gray-text)]",
+}
+
 function TimeAnchor({ icon, label, value, placeholder, onSave, required }: TimeAnchorProps) {
   return (
     <div className="flex items-center gap-2.5">
@@ -142,6 +167,10 @@ function normalizeLocationDrafts(
     notes: (loc.ref?.notes || "").trim(),
     role: loc.role ?? undefined,
   }))
+}
+
+function resolveDraftRole(draft: LocationDraft): LocationRole {
+  return draft.role ?? inferLocationRole(draft.title || "")
 }
 
 function toLocationBlock(draft: LocationDraft): LocationBlock {
@@ -607,6 +636,9 @@ export function DayDetailsEditor({
               const isPreset = LOCATION_LABEL_PRESETS.includes(
                 loc.title as (typeof LOCATION_LABEL_PRESETS)[number],
               )
+              const resolvedRole = resolveDraftRole(loc)
+              const chipLabel = roleDisplayLabel(resolvedRole)
+              const chipStyles = ROLE_CHIP_STYLES[resolvedRole]
 
               return (
                 <div
@@ -614,9 +646,17 @@ export function DayDetailsEditor({
                   className="flex flex-col gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-3"
                 >
                   <div className="flex items-center justify-between gap-3">
-                    <span className="label-meta truncate text-[var(--color-text-muted)]">
-                      {loc.title || "Location"}
-                    </span>
+                    <div className="flex min-w-0 items-center gap-2">
+                      <span className="label-meta truncate text-[var(--color-text-muted)]">
+                        {loc.title || "Location"}
+                      </span>
+                      <span
+                        data-testid={`location-role-chip-${loc.id}`}
+                        className={`inline-flex shrink-0 items-center rounded-md border px-2 py-0.5 text-3xs font-semibold uppercase tracking-wide ${chipStyles}`}
+                      >
+                        {chipLabel}
+                      </span>
+                    </div>
                     <button
                       type="button"
                       onClick={() => {

--- a/src-vnext/features/schedules/components/DayDetailsEditor.tsx
+++ b/src-vnext/features/schedules/components/DayDetailsEditor.tsx
@@ -316,7 +316,14 @@ export function DayDetailsEditor({
       ]
       const nextPayload = nextDrafts.map(toLocationBlock)
 
-      const label = `Removed ${snapshotBlock.title || "location"} block`
+      const label = `Removed ${snapshotBlock.title} block`
+
+      // Captures the dayDetails doc id that updateDayDetails settled on
+      // during perform — used as a fallback when the snapshot listener
+      // hasn't yet propagated a freshly-created doc back into
+      // dayDetailsRef. Without this, a delete that creates the dayDetails
+      // doc on its first write would orphan it on undo.
+      let createdDayDetailsId: string | null = null
 
       void destructiveActionWithUndo<UndoSnapshot>({
         label,
@@ -327,9 +334,14 @@ export function DayDetailsEditor({
         stack: undoStack,
         perform: async () => {
           setLocationDrafts(nextDrafts)
-          await updateDayDetails(clientId, projectId, scheduleId, dayDetailsRef.current?.id ?? null, {
-            locations: nextPayload.length > 0 ? nextPayload : null,
-          })
+          const { id } = await updateDayDetails(
+            clientId,
+            projectId,
+            scheduleId,
+            dayDetailsRef.current?.id ?? null,
+            { locations: nextPayload.length > 0 ? nextPayload : null },
+          )
+          createdDayDetailsId = id
         },
         undo: async (snap) => {
           if (snap.kind !== "locationRemoved") return
@@ -337,11 +349,21 @@ export function DayDetailsEditor({
           // than the stale adjacent array captured at delete time. This
           // way any edits the user made to other blocks between the
           // delete and the undo are preserved.
+          //
+          // Tradeoff: locationDraftsRef holds the local drafts state,
+          // which includes any in-progress typing the user hasn't yet
+          // blurred. Undo therefore force-commits any in-flight edits
+          // to other rows alongside the reinsertion. Acceptable —
+          // committing the user's visible state is what they expect.
           const currentBlocks = locationDraftsRef.current.map(toLocationBlock)
           const restored = reinsertLocationAtIndex(currentBlocks, snap.payload)
-          await updateDayDetails(clientId, projectId, scheduleId, dayDetailsRef.current?.id ?? null, {
-            locations: restored.length > 0 ? [...restored] : null,
-          })
+          await updateDayDetails(
+            clientId,
+            projectId,
+            scheduleId,
+            dayDetailsRef.current?.id ?? createdDayDetailsId ?? null,
+            { locations: restored.length > 0 ? [...restored] : null },
+          )
         },
       }).catch(() => {
         toast.error("Failed to remove location block.")

--- a/src-vnext/features/schedules/components/ScheduleEntryCard.test.tsx
+++ b/src-vnext/features/schedules/components/ScheduleEntryCard.test.tsx
@@ -73,7 +73,7 @@ describe("ScheduleEntryCard", () => {
           value: "track-2",
           options: [
             { value: "primary", label: "Primary" },
-            { value: "track-2", label: "Track 2" },
+            { value: "track-2", label: "Unit 2" },
           ],
         }}
         onRemove={() => {}}
@@ -84,7 +84,7 @@ describe("ScheduleEntryCard", () => {
       />,
     )
 
-    expect(screen.getByText("Track 2")).toBeInTheDocument()
+    expect(screen.getByText("Unit 2")).toBeInTheDocument()
     expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
   })
 })

--- a/src-vnext/features/schedules/components/ScheduleEntryEditSheet.tsx
+++ b/src-vnext/features/schedules/components/ScheduleEntryEditSheet.tsx
@@ -311,7 +311,7 @@ export function ScheduleEntryEditSheet({
                 <Label className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
                   <span className="inline-flex items-center gap-1">
                     <Rows className="h-3 w-3" />
-                    Track
+                    Unit
                   </span>
                 </Label>
                 <Select value={trackDraft} onValueChange={(next) => void handleTrackChange(next)}>

--- a/src-vnext/features/schedules/components/ScheduleTrackControls.test.tsx
+++ b/src-vnext/features/schedules/components/ScheduleTrackControls.test.tsx
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+import { ScheduleTrackControls } from "@/features/schedules/components/ScheduleTrackControls"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import type { UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
+import type { Schedule, ScheduleEntry } from "@/shared/types"
+
+const { toastMock, toastErrorMock, toastSuccessMock, toastInfoMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  toastInfoMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastMock, {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+    info: toastInfoMock,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    clientId: "client-1",
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({
+    projectId: "project-1",
+  }),
+  useOptionalProjectScope: () => null,
+}))
+
+vi.mock("@/features/schedules/components/TypedTimeInput", () => ({
+  TypedTimeInput: ({ value, placeholder }: { readonly value: string; readonly placeholder: string }) => (
+    <div data-testid="typed-time-input">{value || placeholder}</div>
+  ),
+}))
+
+const updateScheduleFieldsMock = vi.fn()
+const batchUpdateScheduleAndEntriesMock = vi.fn()
+
+vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
+  updateScheduleFields: (...args: unknown[]) => updateScheduleFieldsMock(...args),
+  batchUpdateScheduleAndEntries: (...args: unknown[]) => batchUpdateScheduleAndEntriesMock(...args),
+}))
+
+function buildFakeUndoStack(): UseUndoStackResult<UndoSnapshot> {
+  const pushMock = vi.fn((input: {
+    readonly label: string
+    readonly snapshot: UndoSnapshot
+    readonly undo: (snapshot: UndoSnapshot) => Promise<void>
+  }) => ({
+    id: "fake-action-id",
+    label: input.label,
+    snapshot: input.snapshot,
+    undo: input.undo,
+    createdAt: 123,
+  }))
+  return {
+    actions: [],
+    push: pushMock,
+    pop: vi.fn(() => null),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  }
+}
+
+const schedule: Schedule = {
+  id: "schedule-1",
+  projectId: "project-1",
+  name: "Shoot Day",
+  date: null,
+  tracks: [
+    { id: "primary", name: "Primary", order: 0 },
+    { id: "track-b", name: "Track 2", order: 1 },
+    { id: "track-c", name: "Track 3", order: 2 },
+  ],
+  settings: {
+    cascadeChanges: true,
+    dayStartTime: "06:00",
+    defaultEntryDurationMinutes: 15,
+  },
+  createdAt: { toDate: () => new Date(0) } as unknown as Schedule["createdAt"],
+  updatedAt: { toDate: () => new Date(0) } as unknown as Schedule["updatedAt"],
+}
+
+const entries: ReadonlyArray<ScheduleEntry> = [
+  { id: "entry-1", type: "shot", title: "Shot A", order: 0, trackId: "primary", startTime: "07:00", duration: 15 },
+  { id: "entry-2", type: "shot", title: "Shot B", order: 0, trackId: "track-b", startTime: "07:30", duration: 15 },
+  { id: "entry-3", type: "shot", title: "Shot C", order: 1, trackId: "track-c", startTime: "08:00", duration: 15 },
+]
+
+describe("ScheduleTrackControls — collapse undo wiring", () => {
+  beforeEach(() => {
+    toastMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+    toastInfoMock.mockReset()
+    updateScheduleFieldsMock.mockReset()
+    batchUpdateScheduleAndEntriesMock.mockReset()
+
+    updateScheduleFieldsMock.mockResolvedValue(undefined)
+    batchUpdateScheduleAndEntriesMock.mockResolvedValue(undefined)
+  })
+
+  it("pushes a tracksCollapsed snapshot with the current tracks + per-entry trackId mapping", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+
+    render(
+      <ScheduleTrackControls
+        scheduleId="schedule-1"
+        schedule={schedule}
+        entries={entries}
+        undoStack={undoStack}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Collapse" }))
+    // ConfirmDialog confirm button label is also "Collapse"; click it.
+    const confirmButtons = screen.getAllByRole("button", { name: "Collapse" })
+    const dialogConfirm = confirmButtons[confirmButtons.length - 1]!
+    await user.click(dialogConfirm)
+
+    await waitFor(() => {
+      expect(batchUpdateScheduleAndEntriesMock).toHaveBeenCalled()
+    })
+
+    await waitFor(() => {
+      expect(undoStack.push).toHaveBeenCalledTimes(1)
+    })
+
+    const pushArg = (undoStack.push as unknown as ReturnType<typeof vi.fn>).mock.calls[0]?.[0] as {
+      readonly label: string
+      readonly snapshot: UndoSnapshot
+    }
+    expect(pushArg.snapshot.kind).toBe("tracksCollapsed")
+    if (pushArg.snapshot.kind === "tracksCollapsed") {
+      expect(pushArg.snapshot.payload.tracks.map((t) => t.id)).toEqual(["primary", "track-b", "track-c"])
+      expect(pushArg.snapshot.payload.entryTrackIds).toEqual([
+        { entryId: "entry-1", trackId: "primary" },
+        { entryId: "entry-2", trackId: "track-b" },
+        { entryId: "entry-3", trackId: "track-c" },
+      ])
+    }
+  })
+
+  it("shows a toast with a labeled Undo action button after collapse", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+
+    render(
+      <ScheduleTrackControls
+        scheduleId="schedule-1"
+        schedule={schedule}
+        entries={entries}
+        undoStack={undoStack}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Collapse" }))
+    const confirmButtons = screen.getAllByRole("button", { name: "Collapse" })
+    await user.click(confirmButtons[confirmButtons.length - 1]!)
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "Collapsed tracks to single",
+      expect.objectContaining({
+        duration: 5000,
+        action: expect.objectContaining({
+          label: "Undo",
+          onClick: expect.any(Function),
+        }),
+      }),
+    )
+  })
+
+  it("clicking Undo fires batchUpdateScheduleAndEntries with the restored tracks + per-entry patches", async () => {
+    const user = userEvent.setup()
+    const undoStack = buildFakeUndoStack()
+
+    render(
+      <ScheduleTrackControls
+        scheduleId="schedule-1"
+        schedule={schedule}
+        entries={entries}
+        undoStack={undoStack}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: "Collapse" }))
+    const confirmButtons = screen.getAllByRole("button", { name: "Collapse" })
+    await user.click(confirmButtons[confirmButtons.length - 1]!)
+
+    await waitFor(() => {
+      expect(toastMock).toHaveBeenCalledTimes(1)
+    })
+
+    batchUpdateScheduleAndEntriesMock.mockClear()
+
+    const toastOptions = toastMock.mock.calls[0]?.[1] as { action: { onClick: () => void } }
+    toastOptions.action.onClick()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await waitFor(() => {
+      expect(batchUpdateScheduleAndEntriesMock).toHaveBeenCalled()
+    })
+
+    const undoCallArgs = batchUpdateScheduleAndEntriesMock.mock.calls[0] as unknown[]
+    const [, , , payload] = undoCallArgs
+    const typedPayload = payload as {
+      readonly schedulePatch?: { readonly tracks?: ReadonlyArray<{ readonly id: string }> }
+      readonly entryUpdates?: ReadonlyArray<{ readonly entryId: string; readonly patch: { readonly trackId: string | null } }>
+    }
+    expect(typedPayload.schedulePatch?.tracks?.map((t) => t.id)).toEqual(["primary", "track-b", "track-c"])
+    expect(typedPayload.entryUpdates).toEqual([
+      { entryId: "entry-1", patch: { trackId: "primary" } },
+      { entryId: "entry-2", patch: { trackId: "track-b" } },
+      { entryId: "entry-3", patch: { trackId: "track-c" } },
+    ])
+  })
+})

--- a/src-vnext/features/schedules/components/ScheduleTrackControls.test.tsx
+++ b/src-vnext/features/schedules/components/ScheduleTrackControls.test.tsx
@@ -77,8 +77,8 @@ const schedule: Schedule = {
   date: null,
   tracks: [
     { id: "primary", name: "Primary", order: 0 },
-    { id: "track-b", name: "Track 2", order: 1 },
-    { id: "track-c", name: "Track 3", order: 2 },
+    { id: "track-b", name: "Unit 2", order: 1 },
+    { id: "track-c", name: "Unit 3", order: 2 },
   ],
   settings: {
     cascadeChanges: true,

--- a/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
+++ b/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
@@ -12,6 +12,9 @@ import { updateScheduleFields, batchUpdateScheduleAndEntries } from "@/features/
 import { buildCollapseToSingleTrack } from "@/features/schedules/lib/transforms"
 import { classifyTimeInput } from "@/features/schedules/lib/time"
 import { TypedTimeInput } from "@/features/schedules/components/TypedTimeInput"
+import { destructiveActionWithUndo } from "@/shared/lib/destructiveActionWithUndo"
+import type { UseUndoStackResult } from "@/shared/hooks/useUndoStack"
+import { takeCollapseSnapshot, type UndoSnapshot } from "@/features/schedules/lib/undoSnapshots"
 import type { Schedule, ScheduleEntry, ScheduleSettings, ScheduleTrack } from "@/shared/types"
 
 function normalizeSettings(settings: Schedule["settings"] | undefined): ScheduleSettings {
@@ -42,10 +45,12 @@ export function ScheduleTrackControls({
   scheduleId,
   schedule,
   entries,
+  undoStack,
 }: {
   readonly scheduleId: string
   readonly schedule: Schedule
   readonly entries: readonly ScheduleEntry[]
+  readonly undoStack: UseUndoStackResult<UndoSnapshot>
 }) {
   const { clientId } = useAuth()
   const { projectId } = useProjectScope()
@@ -245,18 +250,40 @@ export function ScheduleTrackControls({
         open={collapseOpen}
         onOpenChange={setCollapseOpen}
         title="Collapse to single track"
-        description="This will merge all tracks into Primary, clear shared applicability, and normalize ordering/times. This cannot be undone."
+        description="This will merge all tracks into Primary and normalize ordering/times. You can undo this for a few seconds via the toast."
         confirmLabel="Collapse"
         destructive
         onConfirm={async () => {
           if (!clientId) return
+          // Capture the snapshot BEFORE building the collapse patch so
+          // the stored state reflects what the user is collapsing away
+          // from. Both the tracks array and every entry's trackId must
+          // be preserved for a full restore.
+          const snapshotPayload = takeCollapseSnapshot(tracks, entries)
+
           try {
-            const collapse = buildCollapseToSingleTrack({ entries, settings })
-            await batchUpdateScheduleAndEntries(clientId, projectId, scheduleId, {
-              schedulePatch: { tracks: collapse.tracks },
-              entryUpdates: collapse.entryUpdates,
+            await destructiveActionWithUndo<UndoSnapshot>({
+              label: "Collapsed tracks to single",
+              snapshot: { kind: "tracksCollapsed", payload: snapshotPayload },
+              stack: undoStack,
+              perform: async () => {
+                const collapse = buildCollapseToSingleTrack({ entries, settings })
+                await batchUpdateScheduleAndEntries(clientId, projectId, scheduleId, {
+                  schedulePatch: { tracks: collapse.tracks },
+                  entryUpdates: collapse.entryUpdates,
+                })
+              },
+              undo: async (snap) => {
+                if (snap.kind !== "tracksCollapsed") return
+                await batchUpdateScheduleAndEntries(clientId, projectId, scheduleId, {
+                  schedulePatch: { tracks: snap.payload.tracks },
+                  entryUpdates: snap.payload.entryTrackIds.map(({ entryId, trackId }) => ({
+                    entryId,
+                    patch: { trackId },
+                  })),
+                })
+              },
             })
-            toast.success("Collapsed to a single track.")
           } catch (err) {
             toast.error("Failed to collapse schedule.")
             throw err

--- a/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
+++ b/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
@@ -101,7 +101,7 @@ export function ScheduleTrackControls({
         <div className="flex items-center gap-2">
           <Layers className="h-4 w-4 text-[var(--color-text-subtle)]" />
           <span className="label-meta text-[var(--color-text-muted)]">
-            Tracks
+            Units
           </span>
         </div>
 
@@ -144,7 +144,7 @@ export function ScheduleTrackControls({
                 }}
               >
                 <Plus className="mr-1.5 h-3.5 w-3.5" />
-                Add Track
+                Add Unit
               </Button>
               <Button
                 variant="destructive"

--- a/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
+++ b/src-vnext/features/schedules/components/ScheduleTrackControls.tsx
@@ -122,7 +122,7 @@ export function ScheduleTrackControls({
               onClick={() => {
                 const next: ScheduleTrack[] = [
                   { id: "primary", name: "Primary", order: 0 },
-                  { id: createTrackId(), name: "Track 2", order: 1 },
+                  { id: createTrackId(), name: "Unit 2", order: 1 },
                 ]
                 void patchTracks(next)
               }}
@@ -138,7 +138,7 @@ export function ScheduleTrackControls({
                 onClick={() => {
                   const next = [
                     ...tracks,
-                    { id: createTrackId(), name: `Track ${tracks.length + 1}`, order: tracks.length },
+                    { id: createTrackId(), name: `Unit ${tracks.length + 1}`, order: tracks.length },
                   ]
                   void patchTracks(next)
                 }}
@@ -170,7 +170,7 @@ export function ScheduleTrackControls({
               <div className="min-w-0 flex-1">
                 <InlineEdit
                   value={t.name}
-                  placeholder="Track name"
+                  placeholder="Unit name"
                   onSave={(nextName) => {
                     const next = tracks.map((track) =>
                       track.id === t.id
@@ -195,8 +195,8 @@ export function ScheduleTrackControls({
                   const next = tracks.filter((track) => track.id !== t.id)
                   void patchTracks(next)
                 }}
-                aria-label="Remove track"
-                title={canRemove ? "Remove track" : "Track must be empty to remove"}
+                aria-label="Remove unit"
+                title={canRemove ? "Remove unit" : "Unit must be empty to remove"}
               >
                 <Trash2 className="h-4 w-4" />
               </Button>

--- a/src-vnext/features/schedules/components/TimelineGridView.tsx
+++ b/src-vnext/features/schedules/components/TimelineGridView.tsx
@@ -6,11 +6,75 @@ import { useOverlapGroups } from "@/features/schedules/hooks/useOverlapGroups"
 import { useNowMinute } from "@/shared/hooks/useNowMinute"
 import { COMPACT_HEIGHT } from "@/features/schedules/components/TimelineBlockCard"
 import type { DenseBlock } from "@/features/schedules/lib/adaptiveSegments"
+import type { ProjectedScheduleRow } from "@/features/schedules/lib/projection"
 import type { ScheduleTrack, Shot } from "@/shared/types"
 
 // ─── Constants ────────────────────────────────────────────────────────
 
 const PX_PER_MIN = 4
+
+// ─── Cross-track overlap bands ───────────────────────────────────────
+
+interface OverlapBand {
+  readonly startMin: number
+  readonly endMin: number
+}
+
+/**
+ * Finds time ranges where entries on 2+ different tracks overlap.
+ * Returns merged, sorted bands suitable for rendering highlight strips.
+ */
+function computeCrossTrackOverlapBands(
+  rowsByTrack: ReadonlyMap<string, readonly ProjectedScheduleRow[]>,
+): readonly OverlapBand[] {
+  const trackIntervals: ReadonlyArray<{ startMin: number; endMin: number }>[] = []
+
+  for (const rows of rowsByTrack.values()) {
+    const intervals = rows
+      .filter((r): r is ProjectedScheduleRow & { startMin: number; endMin: number } =>
+        r.startMin != null && r.endMin != null,
+      )
+      .map((r) => ({ startMin: r.startMin, endMin: r.endMin }))
+    if (intervals.length > 0) trackIntervals.push(intervals)
+  }
+
+  if (trackIntervals.length < 2) return []
+
+  // For each pair of tracks, find pairwise entry overlaps
+  const bands: OverlapBand[] = []
+  for (let i = 0; i < trackIntervals.length; i++) {
+    for (let j = i + 1; j < trackIntervals.length; j++) {
+      for (const a of trackIntervals[i]) {
+        for (const b of trackIntervals[j]) {
+          const overlapStart = Math.max(a.startMin, b.startMin)
+          const overlapEnd = Math.min(a.endMin, b.endMin)
+          if (overlapStart < overlapEnd) {
+            bands.push({ startMin: overlapStart, endMin: overlapEnd })
+          }
+        }
+      }
+    }
+  }
+
+  if (bands.length === 0) return []
+
+  // Merge overlapping/adjacent bands into contiguous ranges
+  const sorted = [...bands].sort((a, b) => a.startMin - b.startMin)
+  const merged: OverlapBand[] = [sorted[0]]
+  for (let k = 1; k < sorted.length; k++) {
+    const last = merged[merged.length - 1]
+    if (sorted[k].startMin <= last.endMin) {
+      merged[merged.length - 1] = {
+        startMin: last.startMin,
+        endMin: Math.max(last.endMin, sorted[k].endMin),
+      }
+    } else {
+      merged.push(sorted[k])
+    }
+  }
+
+  return merged
+}
 
 // ─── Types ────────────────────────────────────────────────────────────
 
@@ -54,6 +118,12 @@ export function TimelineGridView({
   }, [rowsByTrack])
 
   const overlapGroups = useOverlapGroups(allRows)
+
+  // Cross-track overlap highlight bands (only meaningful with 2+ tracks)
+  const overlapBands = useMemo(
+    () => computeCrossTrackOverlapBands(rowsByTrack),
+    [rowsByTrack],
+  )
 
   // Empty state: no scheduled entries in this segment
   const hasEntries = allRows.length > 0
@@ -113,6 +183,18 @@ export function TimelineGridView({
               line.isHour ? "bg-[var(--color-border)]" : "bg-[var(--color-border-muted)]"
             }`}
             style={{ top: `${line.offsetPx}px` }}
+          />
+        ))}
+
+        {/* Cross-track overlap highlights */}
+        {overlapBands.map((band, i) => (
+          <div
+            key={`overlap-${i}`}
+            className="pointer-events-none absolute inset-x-0 bg-[var(--color-primary)]/5"
+            style={{
+              top: `${(band.startMin - startMin) * PX_PER_MIN}px`,
+              height: `${(band.endMin - band.startMin) * PX_PER_MIN}px`,
+            }}
           />
         ))}
 

--- a/src-vnext/features/schedules/lib/__tests__/callSheetMerge.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/callSheetMerge.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest"
+import type { CrewCallSheet, TalentCallSheet } from "@/shared/types"
+import {
+  mergeCrewWithOverride,
+  mergeTalentWithOverride,
+  type CrewMergeContext,
+  type CrewVisibility,
+  type TalentVisibility,
+} from "../callSheetMerge"
+
+function makeCrewOverride(
+  overrides: Partial<CrewCallSheet> = {},
+): CrewCallSheet {
+  return {
+    id: "crew-call-1",
+    crewMemberId: "crew-1",
+    ...overrides,
+  }
+}
+
+function makeTalentOverride(
+  overrides: Partial<TalentCallSheet> = {},
+): TalentCallSheet {
+  return {
+    id: "talent-call-1",
+    talentId: "talent-1",
+    ...overrides,
+  }
+}
+
+describe("mergeCrewWithOverride", () => {
+  it("returns all-visible defaults when override is undefined", () => {
+    const result: CrewVisibility = mergeCrewWithOverride(undefined)
+    expect(result).toEqual({
+      isVisible: true,
+      showEmail: true,
+      showPhone: true,
+    })
+  })
+
+  it("returns all-visible defaults when override is null", () => {
+    const result = mergeCrewWithOverride(null)
+    expect(result).toEqual({
+      isVisible: true,
+      showEmail: true,
+      showPhone: true,
+    })
+  })
+
+  it("returns all-visible defaults when override has no visibility fields set", () => {
+    const override = makeCrewOverride()
+    const result = mergeCrewWithOverride(override)
+    expect(result).toEqual({
+      isVisible: true,
+      showEmail: true,
+      showPhone: true,
+    })
+  })
+
+  it("hides the row when isVisibleOverride is false", () => {
+    const override = makeCrewOverride({ isVisibleOverride: false })
+    const result = mergeCrewWithOverride(override)
+    expect(result).toEqual({
+      isVisible: false,
+      showEmail: true,
+      showPhone: true,
+    })
+  })
+
+  it("treats isVisibleOverride === true as visible", () => {
+    const override = makeCrewOverride({ isVisibleOverride: true })
+    const result = mergeCrewWithOverride(override)
+    expect(result.isVisible).toBe(true)
+  })
+
+  it("hides the email cell when showEmailOverride is false and global allows email", () => {
+    const override = makeCrewOverride({ showEmailOverride: false })
+    const context: CrewMergeContext = { globalShowEmail: true }
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showEmail).toBe(false)
+  })
+
+  it("hides the phone cell when showPhoneOverride is false and global allows phone", () => {
+    const override = makeCrewOverride({ showPhoneOverride: false })
+    const context: CrewMergeContext = { globalShowPhone: true }
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showPhone).toBe(false)
+  })
+
+  it("ignores per-row showEmailOverride when global config hides email column", () => {
+    const override = makeCrewOverride({ showEmailOverride: true })
+    const context: CrewMergeContext = { globalShowEmail: false }
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showEmail).toBe(false)
+  })
+
+  it("ignores per-row showPhoneOverride when global config hides phone column", () => {
+    const override = makeCrewOverride({ showPhoneOverride: true })
+    const context: CrewMergeContext = { globalShowPhone: false }
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showPhone).toBe(false)
+  })
+
+  it("treats undefined globalShowEmail as visible (column exists)", () => {
+    const override = makeCrewOverride({ showEmailOverride: false })
+    const context: CrewMergeContext = {}
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showEmail).toBe(false)
+  })
+
+  it("treats null globalShowEmail as visible", () => {
+    const override = makeCrewOverride({ showEmailOverride: false })
+    const context: CrewMergeContext = { globalShowEmail: null }
+    const result = mergeCrewWithOverride(override, context)
+    expect(result.showEmail).toBe(false)
+  })
+
+  it("returns all three booleans independently", () => {
+    const override = makeCrewOverride({
+      isVisibleOverride: false,
+      showEmailOverride: true,
+      showPhoneOverride: false,
+    })
+    const result = mergeCrewWithOverride(override)
+    expect(result).toEqual({
+      isVisible: false,
+      showEmail: true,
+      showPhone: false,
+    })
+  })
+})
+
+describe("mergeTalentWithOverride", () => {
+  it("returns visible when override is undefined", () => {
+    const result: TalentVisibility = mergeTalentWithOverride(undefined)
+    expect(result).toEqual({ isVisible: true })
+  })
+
+  it("returns visible when override is null", () => {
+    const result = mergeTalentWithOverride(null)
+    expect(result).toEqual({ isVisible: true })
+  })
+
+  it("returns visible when override has no visibility fields set", () => {
+    const override = makeTalentOverride()
+    const result = mergeTalentWithOverride(override)
+    expect(result).toEqual({ isVisible: true })
+  })
+
+  it("hides the row when isVisibleOverride is false", () => {
+    const override = makeTalentOverride({ isVisibleOverride: false })
+    const result = mergeTalentWithOverride(override)
+    expect(result).toEqual({ isVisible: false })
+  })
+
+  it("returns visible when isVisibleOverride is explicitly true", () => {
+    const override = makeTalentOverride({ isVisibleOverride: true })
+    const result = mergeTalentWithOverride(override)
+    expect(result).toEqual({ isVisible: true })
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/callSheetTitle.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/callSheetTitle.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest"
+import { Timestamp } from "firebase/firestore"
+import type { Schedule } from "@/shared/types"
+import { deriveDefaultCallSheetTitle } from "../callSheetTitle"
+
+const makeSchedule = (overrides: Partial<Schedule> = {}): Schedule => ({
+  id: "s1",
+  projectId: "p1",
+  name: "",
+  date: null,
+  createdAt: Timestamp.fromDate(new Date("2026-01-01T00:00:00Z")),
+  updatedAt: Timestamp.fromDate(new Date("2026-01-01T00:00:00Z")),
+  ...overrides,
+})
+
+describe("deriveDefaultCallSheetTitle", () => {
+  it("returns a short-format date label when the schedule has a date", () => {
+    const schedule = makeSchedule({
+      date: Timestamp.fromDate(new Date("2026-04-14T12:00:00Z")),
+    })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Tue, Apr 14")
+  })
+
+  it("returns a date label with the schedule date when the schedule also has a name", () => {
+    const schedule = makeSchedule({
+      name: "Downtown Shoot Day 3",
+      date: Timestamp.fromDate(new Date("2026-04-14T12:00:00Z")),
+    })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Tue, Apr 14")
+  })
+
+  it("falls back to the schedule name when the date is null", () => {
+    const schedule = makeSchedule({ name: "Downtown Shoot Day 3", date: null })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Downtown Shoot Day 3")
+  })
+
+  it("trims whitespace on the name fallback", () => {
+    const schedule = makeSchedule({ name: "  Pickups  ", date: null })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Pickups")
+  })
+
+  it("falls back to 'Call Sheet' when date is null and name is empty", () => {
+    const schedule = makeSchedule({ name: "", date: null })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Call Sheet")
+  })
+
+  it("falls back to 'Call Sheet' when date is null and name is whitespace-only", () => {
+    const schedule = makeSchedule({ name: "   ", date: null })
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Call Sheet")
+  })
+
+  it("uses en-US locale so the label is deterministic regardless of runtime", () => {
+    const schedule = makeSchedule({
+      date: Timestamp.fromDate(new Date("2026-12-01T12:00:00Z")),
+    })
+    // en-US short format — if this were runtime-locale-dependent, the test
+    // would flicker in CI environments with different LC_ALL.
+    expect(deriveDefaultCallSheetTitle(schedule)).toBe("Tue, Dec 1")
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/gapDetection.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/gapDetection.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest"
+import { detectScheduleGaps, type ScheduleGap } from "../gapDetection"
+import type { ProjectedScheduleRow } from "../projection"
+
+function makeRow(overrides: {
+  id: string
+  trackId: string
+  startMin: number | null
+  endMin: number | null
+}): ProjectedScheduleRow {
+  return {
+    id: overrides.id,
+    entry: { id: overrides.id, type: "shot", title: "Shot", order: 0 } as any,
+    trackId: overrides.trackId,
+    isBanner: false,
+    appliesToTrackIds: null,
+    applicabilityKind: "single",
+    startMin: overrides.startMin,
+    endMin: overrides.endMin,
+    durationMinutes:
+      overrides.endMin != null && overrides.startMin != null
+        ? overrides.endMin - overrides.startMin
+        : null,
+    timeSource: "explicit",
+  }
+}
+
+describe("detectScheduleGaps", () => {
+  it("returns empty for no rows", () => {
+    const result = detectScheduleGaps([])
+    expect(result).toEqual([])
+  })
+
+  it("returns empty when entries are contiguous", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 450, endMin: 480 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toEqual([])
+  })
+
+  it("detects a gap > 30min between entries on the same track", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 510, endMin: 540 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toEqual([
+      { trackId: "a", startMin: 450, endMin: 510, durationMinutes: 60 },
+    ])
+  })
+
+  it("ignores gaps <= 30min (default threshold)", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 470, endMin: 500 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toEqual([])
+  })
+
+  it("uses custom minGapMinutes threshold", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 470, endMin: 500 }),
+    ]
+    const result = detectScheduleGaps(rows, { minGapMinutes: 15 })
+    expect(result).toEqual([
+      { trackId: "a", startMin: 450, endMin: 470, durationMinutes: 20 },
+    ])
+  })
+
+  it("detects gaps per track independently", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 510, endMin: 540 }),
+      makeRow({ id: "r3", trackId: "b", startMin: 420, endMin: 480 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      trackId: "a",
+      startMin: 450,
+      endMin: 510,
+      durationMinutes: 60,
+    })
+  })
+
+  it("skips rows with null startMin or endMin", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: null, endMin: 450 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 420, endMin: 450 }),
+      makeRow({ id: "r3", trackId: "a", startMin: 510, endMin: null }),
+      makeRow({ id: "r4", trackId: "a", startMin: 520, endMin: 540 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    // Only r2 (420-450) and r4 (520-540) are usable → 70min gap > 30
+    expect(result).toEqual([
+      { trackId: "a", startMin: 450, endMin: 520, durationMinutes: 70 },
+    ])
+  })
+
+  it("handles multiple gaps on the same track", () => {
+    const rows = [
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 430 }),
+      makeRow({ id: "r2", trackId: "a", startMin: 480, endMin: 490 }),
+      makeRow({ id: "r3", trackId: "a", startMin: 540, endMin: 550 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toEqual([
+      { trackId: "a", startMin: 430, endMin: 480, durationMinutes: 50 },
+      { trackId: "a", startMin: 490, endMin: 540, durationMinutes: 50 },
+    ])
+  })
+
+  it("sorts rows by startMin within each track", () => {
+    // Rows provided out of order
+    const rows = [
+      makeRow({ id: "r2", trackId: "a", startMin: 510, endMin: 540 }),
+      makeRow({ id: "r1", trackId: "a", startMin: 420, endMin: 450 }),
+    ]
+    const result = detectScheduleGaps(rows)
+    expect(result).toEqual([
+      { trackId: "a", startMin: 450, endMin: 510, durationMinutes: 60 },
+    ])
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/locationRoles.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/locationRoles.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect } from "vitest"
+import type { LocationBlock } from "@/shared/types"
+import {
+  CANONICAL_ROLE_ORDER,
+  compareLocationsByRole,
+  inferLocationRole,
+  resolveLocationRole,
+  roleDisplayLabel,
+  type LocationRole,
+} from "../locationRoles"
+
+function makeBlock(overrides: Partial<LocationBlock> = {}): LocationBlock {
+  return {
+    id: "block-1",
+    title: "Location",
+    ref: null,
+    showName: true,
+    showPhone: false,
+    ...overrides,
+  }
+}
+
+describe("inferLocationRole", () => {
+  it("maps 'Basecamp' to 'basecamp'", () => {
+    expect(inferLocationRole("Basecamp")).toBe("basecamp")
+  })
+
+  it("maps a lowercase 'basecamp' to 'basecamp'", () => {
+    expect(inferLocationRole("basecamp")).toBe("basecamp")
+  })
+
+  it("trims padding and is case-insensitive", () => {
+    expect(inferLocationRole("  BASECAMP  ")).toBe("basecamp")
+  })
+
+  it("matches 'basecamp' as a substring of a longer title", () => {
+    expect(inferLocationRole("Wayne's Basecamp")).toBe("basecamp")
+  })
+
+  it("maps 'Hospital' to 'hospital'", () => {
+    expect(inferLocationRole("Hospital")).toBe("hospital")
+  })
+
+  it("maps 'Parking' to 'parking'", () => {
+    expect(inferLocationRole("Parking")).toBe("parking")
+  })
+
+  it("maps 'Parking Lot B' to 'parking' (substring match)", () => {
+    expect(inferLocationRole("Parking Lot B")).toBe("parking")
+  })
+
+  it("maps 'Production Office' to 'office' (substring match)", () => {
+    expect(inferLocationRole("Production Office")).toBe("office")
+  })
+
+  it("maps 'Office' to 'office'", () => {
+    expect(inferLocationRole("Office")).toBe("office")
+  })
+
+  it("maps 'Shoot Location' to 'shoot'", () => {
+    expect(inferLocationRole("Shoot Location")).toBe("shoot")
+  })
+
+  it("returns 'custom' for an empty string", () => {
+    expect(inferLocationRole("")).toBe("custom")
+  })
+
+  it("returns 'custom' for whitespace-only titles", () => {
+    expect(inferLocationRole("   ")).toBe("custom")
+  })
+
+  it("returns 'custom' for 'Random Thing'", () => {
+    expect(inferLocationRole("Random Thing")).toBe("custom")
+  })
+
+  it("returns 'custom' for 'Lot B' (no substring match)", () => {
+    expect(inferLocationRole("Lot B")).toBe("custom")
+  })
+})
+
+describe("resolveLocationRole", () => {
+  it("returns the explicit role when set, ignoring the title", () => {
+    const block = makeBlock({ title: "Hospital", role: "office" })
+    expect(resolveLocationRole(block)).toBe("office")
+  })
+
+  it("falls back to inferLocationRole when role is undefined", () => {
+    const block = makeBlock({ title: "Basecamp", role: undefined })
+    expect(resolveLocationRole(block)).toBe("basecamp")
+  })
+
+  it("falls back to inferLocationRole when role is null", () => {
+    const block = makeBlock({ title: "Basecamp", role: null })
+    expect(resolveLocationRole(block)).toBe("basecamp")
+  })
+})
+
+describe("roleDisplayLabel", () => {
+  it("renders 'Basecamp' for basecamp", () => {
+    expect(roleDisplayLabel("basecamp")).toBe("Basecamp")
+  })
+
+  it("renders 'Hospital' for hospital", () => {
+    expect(roleDisplayLabel("hospital")).toBe("Hospital")
+  })
+
+  it("renders 'Parking' for parking", () => {
+    expect(roleDisplayLabel("parking")).toBe("Parking")
+  })
+
+  it("renders 'Office' for office", () => {
+    expect(roleDisplayLabel("office")).toBe("Office")
+  })
+
+  it("renders 'Shoot' for shoot", () => {
+    expect(roleDisplayLabel("shoot")).toBe("Shoot")
+  })
+
+  it("renders 'Custom' for custom", () => {
+    expect(roleDisplayLabel("custom")).toBe("Custom")
+  })
+})
+
+describe("CANONICAL_ROLE_ORDER", () => {
+  it("contains exactly six roles in the canonical print order", () => {
+    expect(CANONICAL_ROLE_ORDER).toEqual([
+      "basecamp",
+      "parking",
+      "hospital",
+      "office",
+      "shoot",
+      "custom",
+    ] as readonly LocationRole[])
+  })
+})
+
+describe("compareLocationsByRole", () => {
+  it("sorts a mixed array into canonical role order", () => {
+    const input = [
+      makeBlock({ id: "c", title: "Studio A", role: "custom" }),
+      makeBlock({ id: "b", title: "Basecamp", role: "basecamp" }),
+      makeBlock({ id: "o", title: "Production Office", role: "office" }),
+      makeBlock({ id: "p", title: "Parking", role: "parking" }),
+    ]
+    const sorted = [...input].sort(compareLocationsByRole)
+    expect(sorted.map((b) => b.id)).toEqual(["b", "p", "o", "c"])
+  })
+
+  it("is stable for ties — two 'custom' blocks retain their input order", () => {
+    const input = [
+      makeBlock({ id: "c1", title: "Studio A", role: "custom" }),
+      makeBlock({ id: "c2", title: "Studio B", role: "custom" }),
+    ]
+    const sorted = [...input].sort(compareLocationsByRole)
+    expect(sorted.map((b) => b.id)).toEqual(["c1", "c2"])
+  })
+
+  it("falls back to inferred role when the block has no explicit role", () => {
+    const input = [
+      makeBlock({ id: "custom-1", title: "Studio A" }), // infers custom
+      makeBlock({ id: "basecamp-1", title: "Basecamp" }), // infers basecamp
+    ]
+    const sorted = [...input].sort(compareLocationsByRole)
+    expect(sorted.map((b) => b.id)).toEqual(["basecamp-1", "custom-1"])
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/locationRoles.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/locationRoles.test.ts
@@ -76,6 +76,17 @@ describe("inferLocationRole", () => {
   it("returns 'custom' for 'Lot B' (no substring match)", () => {
     expect(inferLocationRole("Lot B")).toBe("custom")
   })
+
+  it("uses first-match precedence when a title contains multiple canonical keywords", () => {
+    // The substring check order is basecamp → hospital → parking → office
+    // → shoot, so "Hospital Parking" resolves to hospital (the safety-
+    // critical tag dominates). Pinning this here so any future refactor
+    // that reorders the checks fails loudly rather than silently flipping
+    // producer-facing chip colors.
+    expect(inferLocationRole("Hospital Parking")).toBe("hospital")
+    expect(inferLocationRole("Basecamp Parking")).toBe("basecamp")
+    expect(inferLocationRole("Production Office Basecamp")).toBe("basecamp")
+  })
 })
 
 describe("resolveLocationRole", () => {

--- a/src-vnext/features/schedules/lib/__tests__/sharedResourceConflicts.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/sharedResourceConflicts.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest"
+import {
+  detectSharedResourceConflicts,
+  type SharedResourceConflict,
+} from "../sharedResourceConflicts"
+import type { TalentCallSheet, TalentRecord } from "@/shared/types"
+
+// ─── Factories ────────────────────────────────────────────────────────
+
+function makeTalentCall(
+  id: string,
+  talentId: string,
+  trackId?: string,
+): TalentCallSheet {
+  return { id, talentId, trackId } as TalentCallSheet
+}
+
+function makeTalent(id: string, name: string): TalentRecord {
+  return { id, name } as TalentRecord
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+describe("detectSharedResourceConflicts", () => {
+  it("returns empty for no talent calls", () => {
+    const result = detectSharedResourceConflicts([], [])
+    expect(result).toEqual([])
+  })
+
+  it("returns empty when all talent are on a single track", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", "track-a"),
+      makeTalentCall("c2", "t2", "track-a"),
+    ]
+    const talent = [makeTalent("t1", "Alice"), makeTalent("t2", "Bob")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result).toEqual([])
+  })
+
+  it("returns empty when talent calls are unscoped", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", undefined),
+      makeTalentCall("c2", "t1", undefined),
+    ]
+    const talent = [makeTalent("t1", "Alice")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result).toEqual([])
+  })
+
+  it("detects talent assigned to 2 different tracks", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", "track-a"),
+      makeTalentCall("c2", "t1", "track-b"),
+    ]
+    const talent = [makeTalent("t1", "Alice")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual<SharedResourceConflict>({
+      resourceType: "talent",
+      resourceId: "t1",
+      resourceName: "Alice",
+      trackIds: ["track-a", "track-b"],
+    })
+  })
+
+  it("does not flag talent on one scoped + one unscoped call", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", "track-a"),
+      makeTalentCall("c2", "t1", undefined),
+    ]
+    const talent = [makeTalent("t1", "Alice")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result).toEqual([])
+  })
+
+  it("detects multiple conflicting talent", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", "track-a"),
+      makeTalentCall("c2", "t1", "track-b"),
+      makeTalentCall("c3", "t2", "track-a"),
+      makeTalentCall("c4", "t2", "track-c"),
+    ]
+    const talent = [makeTalent("t1", "Alice"), makeTalent("t2", "Bob")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result).toHaveLength(2)
+
+    const byId = new Map(result.map((c) => [c.resourceId, c]))
+    expect(byId.get("t1")?.trackIds).toEqual(["track-a", "track-b"])
+    expect(byId.get("t2")?.trackIds).toEqual(["track-a", "track-c"])
+  })
+
+  it("resolves resource name from talent lookup", () => {
+    const calls = [
+      makeTalentCall("c1", "t1", "track-a"),
+      makeTalentCall("c2", "t1", "track-b"),
+    ]
+    const talent = [makeTalent("t1", "Alice")]
+    const result = detectSharedResourceConflicts(calls, talent)
+    expect(result[0]?.resourceName).toBe("Alice")
+  })
+
+  it("falls back to talentId when not found in lookup", () => {
+    const calls = [
+      makeTalentCall("c1", "t-unknown", "track-a"),
+      makeTalentCall("c2", "t-unknown", "track-b"),
+    ]
+    const result = detectSharedResourceConflicts(calls, [])
+    expect(result).toHaveLength(1)
+    expect(result[0]?.resourceName).toBe("t-unknown")
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/trackFiltering.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/trackFiltering.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest"
+import {
+  filterCrewCallsByTrack,
+  filterTalentCallsByTrack,
+} from "../trackFiltering"
+import type { CrewCallSheet, TalentCallSheet } from "@/shared/types"
+
+function makeCrewCall(
+  overrides: Partial<CrewCallSheet> & { id: string; crewMemberId: string },
+): CrewCallSheet {
+  return { ...overrides } as CrewCallSheet
+}
+
+function makeTalentCall(
+  overrides: Partial<TalentCallSheet> & { id: string; talentId: string },
+): TalentCallSheet {
+  return { ...overrides } as TalentCallSheet
+}
+
+describe("filterCrewCallsByTrack", () => {
+  it("returns all calls when trackId filter is null", () => {
+    const calls = [
+      makeCrewCall({ id: "c1", crewMemberId: "m1" }),
+      makeCrewCall({ id: "c2", crewMemberId: "m2", trackId: "track-a" } as never),
+      makeCrewCall({ id: "c3", crewMemberId: "m3", trackId: "track-b" } as never),
+    ]
+
+    const result = filterCrewCallsByTrack(calls, null)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((c) => c.id)).toEqual(["c1", "c2", "c3"])
+  })
+
+  it("returns unscoped and matching calls for a specific trackId", () => {
+    const calls = [
+      makeCrewCall({ id: "c1", crewMemberId: "m1" }),
+      makeCrewCall({ id: "c2", crewMemberId: "m2", trackId: "track-a" } as never),
+      makeCrewCall({ id: "c3", crewMemberId: "m3", trackId: "track-b" } as never),
+    ]
+
+    const result = filterCrewCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(2)
+    expect(result.map((c) => c.id)).toEqual(["c1", "c2"])
+  })
+
+  it("excludes calls scoped to a different track", () => {
+    const calls = [
+      makeCrewCall({ id: "c1", crewMemberId: "m1", trackId: "track-b" } as never),
+      makeCrewCall({ id: "c2", crewMemberId: "m2", trackId: "track-b" } as never),
+    ]
+
+    const result = filterCrewCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(0)
+    expect(result).toEqual([])
+  })
+
+  it("treats null trackId on a call as unscoped (included in any filter)", () => {
+    const calls = [
+      makeCrewCall({ id: "c1", crewMemberId: "m1", trackId: null } as never),
+    ]
+
+    const result = filterCrewCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("c1")
+  })
+
+  it("returns empty array for empty input", () => {
+    const result = filterCrewCallsByTrack([], "track-a")
+
+    expect(result).toHaveLength(0)
+    expect(result).toEqual([])
+  })
+
+  it("returns all calls when all are unscoped and filter is specific", () => {
+    const calls = [
+      makeCrewCall({ id: "c1", crewMemberId: "m1" }),
+      makeCrewCall({ id: "c2", crewMemberId: "m2" }),
+      makeCrewCall({ id: "c3", crewMemberId: "m3" }),
+    ]
+
+    const result = filterCrewCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(3)
+    expect(result.map((c) => c.id)).toEqual(["c1", "c2", "c3"])
+  })
+})
+
+describe("filterTalentCallsByTrack", () => {
+  it("returns all calls when trackId filter is null", () => {
+    const calls = [
+      makeTalentCall({ id: "t1", talentId: "a1" }),
+      makeTalentCall({ id: "t2", talentId: "a2", trackId: "track-a" } as never),
+      makeTalentCall({ id: "t3", talentId: "a3", trackId: "track-b" } as never),
+    ]
+
+    const result = filterTalentCallsByTrack(calls, null)
+
+    expect(result).toHaveLength(3)
+    expect(result.map((c) => c.id)).toEqual(["t1", "t2", "t3"])
+  })
+
+  it("returns unscoped and matching talent calls for a specific trackId", () => {
+    const calls = [
+      makeTalentCall({ id: "t1", talentId: "a1" }),
+      makeTalentCall({ id: "t2", talentId: "a2", trackId: "track-a" } as never),
+      makeTalentCall({ id: "t3", talentId: "a3", trackId: "track-b" } as never),
+    ]
+
+    const result = filterTalentCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(2)
+    expect(result.map((c) => c.id)).toEqual(["t1", "t2"])
+  })
+
+  it("excludes talent calls scoped to a different track", () => {
+    const calls = [
+      makeTalentCall({ id: "t1", talentId: "a1", trackId: "track-b" } as never),
+      makeTalentCall({ id: "t2", talentId: "a2", trackId: "track-b" } as never),
+    ]
+
+    const result = filterTalentCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(0)
+    expect(result).toEqual([])
+  })
+
+  it("preserves order of filtered results", () => {
+    const calls = [
+      makeTalentCall({ id: "t1", talentId: "a1", trackId: "track-a" } as never),
+      makeTalentCall({ id: "t2", talentId: "a2", trackId: "track-b" } as never),
+      makeTalentCall({ id: "t3", talentId: "a3" }),
+      makeTalentCall({ id: "t4", talentId: "a4", trackId: "track-a" } as never),
+    ]
+
+    const result = filterTalentCallsByTrack(calls, "track-a")
+
+    expect(result).toHaveLength(3)
+    expect(result.map((c) => c.id)).toEqual(["t1", "t3", "t4"])
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/undoSnapshots.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/undoSnapshots.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  CrewCallSheet,
+  LocationBlock,
+  ScheduleEntry,
+  ScheduleTrack,
+  TalentCallSheet,
+} from "@/shared/types"
+
+import {
+  reinsertLocationAtIndex,
+  takeCollapseSnapshot,
+  takeLocationRemoveSnapshot,
+  type UndoSnapshot,
+} from "@/features/schedules/lib/undoSnapshots"
+
+function makeBlock(id: string, title: string): LocationBlock {
+  return {
+    id,
+    title,
+    ref: null,
+    showName: true,
+    showPhone: false,
+  }
+}
+
+function makeTrack(id: string, name: string, order: number): ScheduleTrack {
+  return { id, name, order }
+}
+
+function makeEntry(id: string, overrides: Partial<ScheduleEntry> = {}): ScheduleEntry {
+  return {
+    id,
+    type: "shot",
+    title: `Entry ${id}`,
+    order: 0,
+    ...overrides,
+  }
+}
+
+describe("takeLocationRemoveSnapshot", () => {
+  it("returns null when the id is not found", () => {
+    const locations = [makeBlock("a", "Basecamp"), makeBlock("b", "Parking")]
+    expect(takeLocationRemoveSnapshot(locations, "missing")).toBeNull()
+  })
+
+  it("captures the correct index and block and returns the filtered next array", () => {
+    const locations = [
+      makeBlock("a", "Basecamp"),
+      makeBlock("b", "Parking"),
+      makeBlock("c", "Hospital"),
+    ]
+    const capture = takeLocationRemoveSnapshot(locations, "b")
+    expect(capture).not.toBeNull()
+    expect(capture!.snapshot.index).toBe(1)
+    expect(capture!.snapshot.block.id).toBe("b")
+    expect(capture!.snapshot.block.title).toBe("Parking")
+    expect(capture!.next.map((b) => b.id)).toEqual(["a", "c"])
+  })
+
+  it("does not mutate the source array", () => {
+    const locations = [makeBlock("a", "Basecamp"), makeBlock("b", "Parking")]
+    const capture = takeLocationRemoveSnapshot(locations, "a")
+    expect(locations.map((b) => b.id)).toEqual(["a", "b"])
+    expect(capture!.next).not.toBe(locations)
+  })
+})
+
+describe("reinsertLocationAtIndex", () => {
+  it("reinserts at the original index when the array length matches", () => {
+    const locations = [makeBlock("a", "Basecamp"), makeBlock("c", "Hospital")]
+    const reinserted = reinsertLocationAtIndex(locations, {
+      index: 1,
+      block: makeBlock("b", "Parking"),
+    })
+    expect(reinserted.map((b) => b.id)).toEqual(["a", "b", "c"])
+  })
+
+  it("clamps to array end when the original index is now out of bounds", () => {
+    const locations = [makeBlock("a", "Basecamp")]
+    const reinserted = reinsertLocationAtIndex(locations, {
+      index: 5,
+      block: makeBlock("b", "Parking"),
+    })
+    expect(reinserted.map((b) => b.id)).toEqual(["a", "b"])
+  })
+
+  it("clamps to 0 for a negative index", () => {
+    const locations = [makeBlock("a", "Basecamp"), makeBlock("c", "Hospital")]
+    const reinserted = reinsertLocationAtIndex(locations, {
+      index: -3,
+      block: makeBlock("b", "Parking"),
+    })
+    expect(reinserted.map((b) => b.id)).toEqual(["b", "a", "c"])
+  })
+})
+
+describe("takeCollapseSnapshot", () => {
+  it("deep-clones tracks so source mutation does not leak into the snapshot", () => {
+    const tracks: ScheduleTrack[] = [
+      makeTrack("primary", "Primary", 0),
+      makeTrack("t2", "Track 2", 1),
+    ]
+    const entries: ScheduleEntry[] = [makeEntry("e1", { trackId: "primary" })]
+
+    const snapshot = takeCollapseSnapshot(tracks, entries)
+
+    tracks[0] = makeTrack("primary", "MUTATED", 99)
+
+    expect(snapshot.tracks.map((t) => t.name)).toEqual(["Primary", "Track 2"])
+    expect(snapshot.tracks[0]).not.toBe(tracks[0])
+  })
+
+  it("captures every entry's trackId and defaults missing ones to null", () => {
+    const tracks: ScheduleTrack[] = [makeTrack("primary", "Primary", 0)]
+    const entries: ScheduleEntry[] = [
+      makeEntry("e1", { trackId: "primary" }),
+      makeEntry("e2", { trackId: "t2" }),
+      makeEntry("e3"),
+    ]
+
+    const snapshot = takeCollapseSnapshot(tracks, entries)
+
+    expect(snapshot.entryTrackIds).toEqual([
+      { entryId: "e1", trackId: "primary" },
+      { entryId: "e2", trackId: "t2" },
+      { entryId: "e3", trackId: null },
+    ])
+  })
+})
+
+describe("UndoSnapshot exhaustiveness", () => {
+  it("compiles a switch that handles every variant", () => {
+    // Fixture payloads to smoke-test the discriminated union at
+    // compile time (via `assertNever`) and at runtime (via return).
+    const crewPayload: CrewCallSheet = {
+      id: "crew-1",
+      crewMemberId: "member-1",
+    }
+    const talentPayload: TalentCallSheet = {
+      id: "talent-1",
+      talentId: "actor-1",
+    }
+    const locationBlock = makeBlock("loc-1", "Basecamp")
+    const track = makeTrack("primary", "Primary", 0)
+    const entry = makeEntry("entry-1", { trackId: "primary" })
+
+    const fixtures: ReadonlyArray<UndoSnapshot> = [
+      { kind: "crewCallRemoved", payload: crewPayload },
+      { kind: "talentCallRemoved", payload: talentPayload },
+      {
+        kind: "locationRemoved",
+        payload: { index: 0, block: locationBlock },
+      },
+      {
+        kind: "tracksCollapsed",
+        payload: {
+          tracks: [track],
+          entryTrackIds: [{ entryId: "entry-1", trackId: "primary" }],
+        },
+      },
+      { kind: "scheduleEntryRemoved", payload: entry },
+    ]
+
+    function describeSnapshot(snapshot: UndoSnapshot): string {
+      switch (snapshot.kind) {
+        case "crewCallRemoved":
+          return `crew:${snapshot.payload.id}`
+        case "talentCallRemoved":
+          return `talent:${snapshot.payload.id}`
+        case "locationRemoved":
+          return `loc:${snapshot.payload.block.id}@${snapshot.payload.index}`
+        case "tracksCollapsed":
+          return `collapsed:${snapshot.payload.tracks.length}`
+        case "scheduleEntryRemoved":
+          return `entry:${snapshot.payload.id}`
+        default: {
+          const _exhaustive: never = snapshot
+          return _exhaustive
+        }
+      }
+    }
+
+    const labels = fixtures.map(describeSnapshot)
+    expect(labels).toEqual([
+      "crew:crew-1",
+      "talent:talent-1",
+      "loc:loc-1@0",
+      "collapsed:1",
+      "entry:entry-1",
+    ])
+  })
+})

--- a/src-vnext/features/schedules/lib/__tests__/undoSnapshots.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/undoSnapshots.test.ts
@@ -100,7 +100,7 @@ describe("takeCollapseSnapshot", () => {
   it("deep-clones tracks so source mutation does not leak into the snapshot", () => {
     const tracks: ScheduleTrack[] = [
       makeTrack("primary", "Primary", 0),
-      makeTrack("t2", "Track 2", 1),
+      makeTrack("t2", "Unit 2", 1),
     ]
     const entries: ScheduleEntry[] = [makeEntry("e1", { trackId: "primary" })]
 
@@ -108,7 +108,7 @@ describe("takeCollapseSnapshot", () => {
 
     tracks[0] = makeTrack("primary", "MUTATED", 99)
 
-    expect(snapshot.tracks.map((t) => t.name)).toEqual(["Primary", "Track 2"])
+    expect(snapshot.tracks.map((t) => t.name)).toEqual(["Primary", "Unit 2"])
     expect(snapshot.tracks[0]).not.toBe(tracks[0])
   })
 

--- a/src-vnext/features/schedules/lib/autoDuration.test.ts
+++ b/src-vnext/features/schedules/lib/autoDuration.test.ts
@@ -17,7 +17,7 @@ function makeEntry(overrides: Partial<ScheduleEntry> = {}): ScheduleEntry {
 
 const tracks: readonly ScheduleTrack[] = [
   { id: "primary", name: "Primary", order: 0 },
-  { id: "track-2", name: "Track 2", order: 1 },
+  { id: "track-2", name: "Unit 2", order: 1 },
 ]
 
 describe("buildAutoDurationFillPatches", () => {

--- a/src-vnext/features/schedules/lib/callSheetMerge.ts
+++ b/src-vnext/features/schedules/lib/callSheetMerge.ts
@@ -1,0 +1,42 @@
+import type { CrewCallSheet, TalentCallSheet } from "@/shared/types"
+
+export interface CrewVisibility {
+  readonly isVisible: boolean
+  readonly showEmail: boolean
+  readonly showPhone: boolean
+}
+
+export interface TalentVisibility {
+  readonly isVisible: boolean
+}
+
+export interface CrewMergeContext {
+  readonly globalShowEmail?: boolean | null
+  readonly globalShowPhone?: boolean | null
+}
+
+export function mergeCrewWithOverride(
+  override: CrewCallSheet | null | undefined,
+  context?: CrewMergeContext,
+): CrewVisibility {
+  const isVisible = override?.isVisibleOverride !== false
+
+  const globalEmail = context?.globalShowEmail ?? true
+  const globalPhone = context?.globalShowPhone ?? true
+
+  const showEmail = globalEmail
+    ? (override?.showEmailOverride !== false)
+    : false
+
+  const showPhone = globalPhone
+    ? (override?.showPhoneOverride !== false)
+    : false
+
+  return { isVisible, showEmail, showPhone }
+}
+
+export function mergeTalentWithOverride(
+  override: TalentCallSheet | null | undefined,
+): TalentVisibility {
+  return { isVisible: override?.isVisibleOverride !== false }
+}

--- a/src-vnext/features/schedules/lib/callSheetTitle.ts
+++ b/src-vnext/features/schedules/lib/callSheetTitle.ts
@@ -1,0 +1,18 @@
+import type { Schedule } from "@/shared/types"
+
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  weekday: "short",
+  month: "short",
+  day: "numeric",
+}
+
+export function deriveDefaultCallSheetTitle(schedule: Schedule): string {
+  if (schedule.date) {
+    return schedule.date.toDate().toLocaleDateString("en-US", DATE_FORMAT_OPTIONS)
+  }
+  const trimmed = schedule.name.trim()
+  if (trimmed.length > 0) {
+    return trimmed
+  }
+  return "Call Sheet"
+}

--- a/src-vnext/features/schedules/lib/conflicts.test.ts
+++ b/src-vnext/features/schedules/lib/conflicts.test.ts
@@ -17,7 +17,7 @@ function makeEntry(overrides: Partial<ScheduleEntry> = {}): ScheduleEntry {
 
 const tracks: readonly ScheduleTrack[] = [
   { id: "primary", name: "Primary", order: 0 },
-  { id: "track-2", name: "Track 2", order: 1 },
+  { id: "track-2", name: "Unit 2", order: 1 },
 ]
 
 const settings: ScheduleSettings = {

--- a/src-vnext/features/schedules/lib/conflicts.ts
+++ b/src-vnext/features/schedules/lib/conflicts.ts
@@ -33,7 +33,7 @@ function normalizeTracks(tracks: readonly ScheduleTrack[] | null | undefined): r
     .filter((track) => typeof track.id === "string" && track.id.trim().length > 0)
     .map((track, index) => ({
       id: track.id.trim(),
-      name: typeof track.name === "string" && track.name.trim().length > 0 ? track.name.trim() : `Track ${index + 1}`,
+      name: typeof track.name === "string" && track.name.trim().length > 0 ? track.name.trim() : `Unit ${index + 1}`,
       order: typeof track.order === "number" ? track.order : index,
     }))
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))

--- a/src-vnext/features/schedules/lib/fieldConfig.ts
+++ b/src-vnext/features/schedules/lib/fieldConfig.ts
@@ -54,6 +54,8 @@ const CREW_FIELDS: readonly CallSheetFieldConfig[] = [
   { key: "position", label: "Position", defaultLabel: "Position", visible: true, width: "lg", order: 0 },
   { key: "name", label: "Name", defaultLabel: "Name", visible: true, width: "lg", order: 1 },
   { key: "callTime", label: "Call", defaultLabel: "Call", visible: true, width: "sm", order: 2 },
+  { key: "email", label: "Email", defaultLabel: "Email", visible: false, width: "md", order: 3 },
+  { key: "phone", label: "Phone", defaultLabel: "Phone", visible: false, width: "md", order: 4 },
 ]
 
 export const DEFAULT_CAST_SECTION: CallSheetSectionFieldConfig = {

--- a/src-vnext/features/schedules/lib/gapDetection.ts
+++ b/src-vnext/features/schedules/lib/gapDetection.ts
@@ -1,0 +1,50 @@
+import type { ProjectedScheduleRow } from "./projection"
+
+export interface ScheduleGap {
+  readonly trackId: string
+  readonly startMin: number
+  readonly endMin: number
+  readonly durationMinutes: number
+}
+
+const DEFAULT_MIN_GAP_MINUTES = 30
+
+export function detectScheduleGaps(
+  rows: readonly ProjectedScheduleRow[],
+  opts?: { readonly minGapMinutes?: number },
+): readonly ScheduleGap[] {
+  const threshold = opts?.minGapMinutes ?? DEFAULT_MIN_GAP_MINUTES
+
+  // Group by trackId, filtering out rows with null times
+  const byTrack = new Map<string, { startMin: number; endMin: number }[]>()
+  for (const row of rows) {
+    if (row.startMin == null || row.endMin == null) continue
+    const list = byTrack.get(row.trackId) ?? []
+    list.push({ startMin: row.startMin, endMin: row.endMin })
+    byTrack.set(row.trackId, list)
+  }
+
+  const gaps: ScheduleGap[] = []
+
+  for (const [trackId, entries] of byTrack) {
+    // Sort by startMin (immutable — spread before sort)
+    const sorted = [...entries].sort((a, b) => a.startMin - b.startMin)
+
+    for (let i = 0; i < sorted.length - 1; i++) {
+      const currentEnd = sorted[i]!.endMin
+      const nextStart = sorted[i + 1]!.startMin
+      const gapDuration = nextStart - currentEnd
+
+      if (gapDuration > threshold) {
+        gaps.push({
+          trackId,
+          startMin: currentEnd,
+          endMin: nextStart,
+          durationMinutes: gapDuration,
+        })
+      }
+    }
+  }
+
+  return gaps
+}

--- a/src-vnext/features/schedules/lib/locationRoles.ts
+++ b/src-vnext/features/schedules/lib/locationRoles.ts
@@ -3,6 +3,17 @@ import type { LocationBlock, LocationRole } from "@/shared/types"
 export type { LocationRole }
 
 /**
+ * Structural input for resolveLocationRole / compareLocationsByRole —
+ * anything with a title + optional role field. Widened from LocationBlock
+ * so the editor's local LocationDraft can pass through the same resolver
+ * without adapter objects.
+ */
+export interface RoleResolvable {
+  readonly title: string
+  readonly role?: LocationRole | null
+}
+
+/**
  * Canonical sort order for locations on the printed call sheet and wherever
  * multiple locations render as a group.
  */
@@ -50,13 +61,15 @@ export function inferLocationRole(title: string): LocationRole {
 }
 
 /**
- * Resolves the effective role of a LocationBlock. If the block carries an
+ * Resolves the effective role of a location. If the input carries an
  * explicit role it wins; otherwise the title is used to infer one. Null is
  * treated the same as undefined so Firestore round-trips stay consistent.
+ * Accepts any RoleResolvable so LocationBlock and LocationDraft can share
+ * the same resolver.
  */
-export function resolveLocationRole(block: LocationBlock): LocationRole {
-  if (block.role) return block.role
-  return inferLocationRole(block.title || "")
+export function resolveLocationRole(input: RoleResolvable): LocationRole {
+  if (input.role) return input.role
+  return inferLocationRole(input.title || "")
 }
 
 /**

--- a/src-vnext/features/schedules/lib/locationRoles.ts
+++ b/src-vnext/features/schedules/lib/locationRoles.ts
@@ -1,0 +1,74 @@
+import type { LocationBlock, LocationRole } from "@/shared/types"
+
+export type { LocationRole }
+
+/**
+ * Canonical sort order for locations on the printed call sheet and wherever
+ * multiple locations render as a group.
+ */
+export const CANONICAL_ROLE_ORDER: readonly LocationRole[] = [
+  "basecamp",
+  "parking",
+  "hospital",
+  "office",
+  "shoot",
+  "custom",
+] as const
+
+const ROLE_DISPLAY_LABELS: Readonly<Record<LocationRole, string>> = {
+  basecamp: "Basecamp",
+  parking: "Parking",
+  hospital: "Hospital",
+  office: "Office",
+  shoot: "Shoot",
+  custom: "Custom",
+}
+
+/**
+ * Human-readable label for a role chip or section header.
+ */
+export function roleDisplayLabel(role: LocationRole): string {
+  return ROLE_DISPLAY_LABELS[role]
+}
+
+/**
+ * Infers a location role from a free-text title using case-insensitive
+ * substring matching. Only explicit canonical names are recognized — anything
+ * unrecognized falls through to "custom". If a title happens to contain more
+ * than one canonical name, the first match in this function wins (basecamp
+ * beats hospital beats parking beats office beats shoot).
+ */
+export function inferLocationRole(title: string): LocationRole {
+  const normalized = title.trim().toLowerCase()
+  if (!normalized) return "custom"
+  if (normalized.includes("basecamp")) return "basecamp"
+  if (normalized.includes("hospital")) return "hospital"
+  if (normalized.includes("parking")) return "parking"
+  if (normalized.includes("office")) return "office"
+  if (normalized.includes("shoot")) return "shoot"
+  return "custom"
+}
+
+/**
+ * Resolves the effective role of a LocationBlock. If the block carries an
+ * explicit role it wins; otherwise the title is used to infer one. Null is
+ * treated the same as undefined so Firestore round-trips stay consistent.
+ */
+export function resolveLocationRole(block: LocationBlock): LocationRole {
+  if (block.role) return block.role
+  return inferLocationRole(block.title || "")
+}
+
+/**
+ * Sort comparator that orders locations by their canonical role index. Ties
+ * are broken by the original insertion order since JavaScript's Array.sort is
+ * stable (ES2019+).
+ */
+export function compareLocationsByRole(
+  a: LocationBlock,
+  b: LocationBlock,
+): number {
+  const aIndex = CANONICAL_ROLE_ORDER.indexOf(resolveLocationRole(a))
+  const bIndex = CANONICAL_ROLE_ORDER.indexOf(resolveLocationRole(b))
+  return aIndex - bIndex
+}

--- a/src-vnext/features/schedules/lib/mapSchedule.test.ts
+++ b/src-vnext/features/schedules/lib/mapSchedule.test.ts
@@ -116,11 +116,62 @@ describe("mapSchedule time sanitization", () => {
       {
         id: "loc-1",
         title: "Basecamp",
+        role: null,
         ref: { locationId: "library-1", label: "North Lot", notes: "Gate B" },
         showName: true,
         showPhone: false,
       },
     ])
+  })
+
+  it("round-trips an explicit location role through the mapper", () => {
+    const mapped = mapDayDetails("dd-role", {
+      scheduleId: "s1",
+      crewCallTime: "06:00",
+      shootingCallTime: "07:00",
+      estimatedWrap: "19:00",
+      locations: [
+        {
+          id: "loc-1",
+          title: "Studio A",
+          role: "basecamp",
+          ref: { locationId: null, label: "Toronto West", notes: null },
+          showName: true,
+          showPhone: false,
+        },
+      ],
+    })
+
+    // The user tagged a non-canonical title ("Studio A") with an
+    // explicit role ("basecamp"). Without the mapper reading the
+    // role field, the snapshot listener would drop the user's
+    // classification and the display would fall back to inference,
+    // silently re-tagging the block as "custom". This test guards
+    // that round-trip.
+    expect(mapped.locations?.[0]?.role).toBe("basecamp")
+  })
+
+  it("sanitizes unknown role strings to null at the read boundary", () => {
+    const mapped = mapDayDetails("dd-bad-role", {
+      scheduleId: "s1",
+      crewCallTime: "06:00",
+      shootingCallTime: "07:00",
+      estimatedWrap: "19:00",
+      locations: [
+        {
+          id: "loc-1",
+          title: "Basecamp",
+          role: "greenroom", // not in the canonical six
+          ref: { locationId: null, label: "North Lot", notes: null },
+          showName: true,
+          showPhone: false,
+        },
+      ],
+    })
+
+    // Invalid role strings are coerced to null so downstream code
+    // never has to guard against unexpected enum values.
+    expect(mapped.locations?.[0]?.role).toBeNull()
   })
 
   it("derives day-details locations from legacy fixed fields and custom locations", () => {

--- a/src-vnext/features/schedules/lib/mapSchedule.ts
+++ b/src-vnext/features/schedules/lib/mapSchedule.ts
@@ -9,12 +9,27 @@ import type {
   CallOffsetDirection,
   CrewRecord,
   LocationBlock,
+  LocationRole,
   WeatherData,
   ScheduleTrack,
   ScheduleSettings,
   LocationRecord,
   ScheduleEntryHighlight,
 } from "@/shared/types"
+
+const LOCATION_ROLE_VALUES: ReadonlySet<LocationRole> = new Set<LocationRole>([
+  "basecamp",
+  "parking",
+  "hospital",
+  "office",
+  "shoot",
+  "custom",
+])
+
+function asLocationRole(raw: unknown): LocationRole | null {
+  if (typeof raw !== "string") return null
+  return LOCATION_ROLE_VALUES.has(raw as LocationRole) ? (raw as LocationRole) : null
+}
 import { classifyTimeInput, minutesToHHMM, parseTimeToMinutes } from "@/features/schedules/lib/time"
 
 function normalizeTimeOnly(value: unknown): string | null {
@@ -218,12 +233,14 @@ function mapLocationBlock(raw: unknown, fallback: {
   const id = asTrimmedText(obj["id"]) ?? fallback.id
   const showName = typeof obj["showName"] === "boolean" ? obj["showName"] : fallback.showName
   const showPhone = typeof obj["showPhone"] === "boolean" ? obj["showPhone"] : fallback.showPhone
+  const role = asLocationRole(obj["role"])
 
   if (!title && !hasLocationRefContent(ref)) return null
 
   return {
     id,
     title,
+    role,
     ref,
     showName,
     showPhone,

--- a/src-vnext/features/schedules/lib/mapSchedule.ts
+++ b/src-vnext/features/schedules/lib/mapSchedule.ts
@@ -349,6 +349,7 @@ export function mapTalentCall(id: string, data: Record<string, unknown>): Talent
     updatedAt: data["updatedAt"] as TalentCallSheet["updatedAt"],
     createdBy: data["createdBy"] as string | undefined,
     isVisibleOverride: asBoolOrNull(data["isVisibleOverride"]),
+    trackId: typeof data["trackId"] === "string" ? data["trackId"] : undefined,
   }
 }
 
@@ -381,6 +382,7 @@ export function mapCrewCall(id: string, data: Record<string, unknown>): CrewCall
     isVisibleOverride: asBoolOrNull(data["isVisibleOverride"]),
     showEmailOverride: asBoolOrNull(data["showEmailOverride"]),
     showPhoneOverride: asBoolOrNull(data["showPhoneOverride"]),
+    trackId: typeof data["trackId"] === "string" ? data["trackId"] : undefined,
   }
 }
 

--- a/src-vnext/features/schedules/lib/mapSchedule.ts
+++ b/src-vnext/features/schedules/lib/mapSchedule.ts
@@ -17,6 +17,10 @@ import type {
   ScheduleEntryHighlight,
 } from "@/shared/types"
 
+function asBoolOrNull(raw: unknown): boolean | null {
+  return typeof raw === "boolean" ? raw : null
+}
+
 const LOCATION_ROLE_VALUES: ReadonlySet<LocationRole> = new Set<LocationRole>([
   "basecamp",
   "parking",
@@ -344,6 +348,7 @@ export function mapTalentCall(id: string, data: Record<string, unknown>): Talent
     createdAt: data["createdAt"] as TalentCallSheet["createdAt"],
     updatedAt: data["updatedAt"] as TalentCallSheet["updatedAt"],
     createdBy: data["createdBy"] as string | undefined,
+    isVisibleOverride: asBoolOrNull(data["isVisibleOverride"]),
   }
 }
 
@@ -373,6 +378,9 @@ export function mapCrewCall(id: string, data: Record<string, unknown>): CrewCall
     createdAt: data["createdAt"] as CrewCallSheet["createdAt"],
     updatedAt: data["updatedAt"] as CrewCallSheet["updatedAt"],
     createdBy: data["createdBy"] as string | undefined,
+    isVisibleOverride: asBoolOrNull(data["isVisibleOverride"]),
+    showEmailOverride: asBoolOrNull(data["showEmailOverride"]),
+    showPhoneOverride: asBoolOrNull(data["showPhoneOverride"]),
   }
 }
 

--- a/src-vnext/features/schedules/lib/mapSchedule.ts
+++ b/src-vnext/features/schedules/lib/mapSchedule.ts
@@ -82,7 +82,7 @@ export function mapSchedule(id: string, data: Record<string, unknown>): Schedule
           if (!tid) return null
           const name = typeof obj["name"] === "string" ? obj["name"].trim() : ""
           const order = typeof obj["order"] === "number" ? obj["order"] : 0
-          return { id: tid, name: name || "Track", order }
+          return { id: tid, name: name || "Unit", order }
         })
         .filter(Boolean) as ScheduleTrack[]
     : undefined

--- a/src-vnext/features/schedules/lib/projection.test.ts
+++ b/src-vnext/features/schedules/lib/projection.test.ts
@@ -12,7 +12,7 @@ const schedule: Schedule = {
   date: ts,
   tracks: [
     { id: "primary", name: "Primary", order: 0 },
-    { id: "track-2", name: "Track 2", order: 1 },
+    { id: "track-2", name: "Unit 2", order: 1 },
   ],
   settings: {
     cascadeChanges: true,

--- a/src-vnext/features/schedules/lib/projection.ts
+++ b/src-vnext/features/schedules/lib/projection.ts
@@ -34,7 +34,7 @@ function defaultTracks(tracks: readonly ScheduleTrack[] | null | undefined): rea
     .filter((t) => t && typeof t.id === "string" && t.id.trim().length > 0)
     .map((t, index) => ({
       id: t.id.trim(),
-      name: typeof t.name === "string" && t.name.trim().length > 0 ? t.name.trim() : `Track ${index + 1}`,
+      name: typeof t.name === "string" && t.name.trim().length > 0 ? t.name.trim() : `Unit ${index + 1}`,
       order: typeof t.order === "number" ? t.order : index,
     }))
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))

--- a/src-vnext/features/schedules/lib/scheduleWrites.test.ts
+++ b/src-vnext/features/schedules/lib/scheduleWrites.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+const setDocMock = vi.fn()
+const docMock = vi.fn((...segments: unknown[]) => ({ __ref: segments.slice(1) }))
+const serverTimestampMock = vi.fn(() => "MOCK_SERVER_TIMESTAMP")
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(),
+  doc: (...args: unknown[]) => docMock(...args),
+  setDoc: (...args: unknown[]) => setDocMock(...args),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  serverTimestamp: () => serverTimestampMock(),
+  writeBatch: vi.fn(),
+  arrayUnion: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/firebase", () => ({
+  db: { __fake: true },
+}))
+
+vi.mock("@/shared/lib/paths", () => {
+  const scheduleEntriesPath = (projectId: string, scheduleId: string, clientId: string) => [
+    "clients",
+    clientId,
+    "projects",
+    projectId,
+    "schedules",
+    scheduleId,
+    "entries",
+  ]
+  return {
+    schedulesPath: () => [],
+    schedulePath: () => [],
+    scheduleEntriesPath,
+    scheduleDayDetailsPath: () => [],
+    scheduleTalentCallsPath: () => [],
+    scheduleCrewCallsPath: () => [],
+    callSheetConfigPath: () => [],
+    locationsPath: () => [],
+  }
+})
+
+import { upsertScheduleEntry } from "@/features/schedules/lib/scheduleWrites"
+
+describe("upsertScheduleEntry", () => {
+  beforeEach(() => {
+    setDocMock.mockReset()
+    docMock.mockClear()
+    serverTimestampMock.mockClear()
+    setDocMock.mockResolvedValue(undefined)
+  })
+
+  it("writes setDoc at the correct entry path with the patch payload", async () => {
+    const result = await upsertScheduleEntry(
+      "client-1",
+      "project-1",
+      "schedule-1",
+      "entry-42",
+      {
+        type: "shot",
+        title: "Restored Shot",
+        order: 3,
+        trackId: "primary",
+        startTime: "07:00",
+        duration: 15,
+      },
+    )
+
+    expect(result).toEqual({ id: "entry-42" })
+    expect(setDocMock).toHaveBeenCalledTimes(1)
+
+    const [docArg, payload] = setDocMock.mock.calls[0] as [unknown, Record<string, unknown>]
+    expect((docArg as { __ref: unknown[] }).__ref).toEqual([
+      "clients",
+      "client-1",
+      "projects",
+      "project-1",
+      "schedules",
+      "schedule-1",
+      "entries",
+      "entry-42",
+    ])
+    expect(payload).toEqual({
+      type: "shot",
+      title: "Restored Shot",
+      order: 3,
+      trackId: "primary",
+      startTime: "07:00",
+      duration: 15,
+      updatedAt: "MOCK_SERVER_TIMESTAMP",
+    })
+  })
+})

--- a/src-vnext/features/schedules/lib/scheduleWrites.ts
+++ b/src-vnext/features/schedules/lib/scheduleWrites.ts
@@ -235,6 +235,31 @@ export async function removeScheduleEntry(
   await deleteDoc(ref(segments))
 }
 
+/**
+ * Re-create a schedule entry at a specific doc id. Intended for the
+ * undo side of a timeline-entry delete — callers pass the full snapshot
+ * captured before deletion. Uses `setDoc` without merge so the entry
+ * is restored to the exact snapshotted state. `updatedAt` is refreshed
+ * so listeners notice the re-creation.
+ */
+export async function upsertScheduleEntry(
+  clientId: string,
+  projectId: string,
+  scheduleId: string,
+  entryId: string,
+  patch: Record<string, unknown>,
+): Promise<{ readonly id: string }> {
+  const segments = [
+    ...scheduleEntriesPath(projectId, scheduleId, clientId),
+    entryId,
+  ]
+  await setDoc(ref(segments), {
+    ...patch,
+    updatedAt: serverTimestamp(),
+  })
+  return { id: entryId }
+}
+
 // --- Day Details ---
 
 export async function updateDayDetails(

--- a/src-vnext/features/schedules/lib/sharedResourceConflicts.ts
+++ b/src-vnext/features/schedules/lib/sharedResourceConflicts.ts
@@ -1,0 +1,44 @@
+import type { TalentCallSheet, TalentRecord } from "@/shared/types"
+
+export interface SharedResourceConflict {
+  readonly resourceType: "talent"
+  readonly resourceId: string
+  readonly resourceName: string
+  readonly trackIds: readonly string[]
+}
+
+export function detectSharedResourceConflicts(
+  talentCalls: readonly TalentCallSheet[],
+  talentLookup: readonly TalentRecord[],
+): readonly SharedResourceConflict[] {
+  // Build talent name map
+  const nameMap = new Map<string, string>()
+  for (const t of talentLookup) {
+    nameMap.set(t.id, t.name)
+  }
+
+  // Group scoped calls by talentId -> Set of trackIds
+  const tracksByTalent = new Map<string, Set<string>>()
+  for (const call of talentCalls) {
+    if (call.trackId == null) continue // unscoped -> skip
+    const existing = tracksByTalent.get(call.talentId)
+    if (existing) {
+      existing.add(call.trackId)
+    } else {
+      tracksByTalent.set(call.talentId, new Set([call.trackId]))
+    }
+  }
+
+  const conflicts: SharedResourceConflict[] = []
+  for (const [talentId, trackIdSet] of tracksByTalent) {
+    if (trackIdSet.size < 2) continue
+    conflicts.push({
+      resourceType: "talent",
+      resourceId: talentId,
+      resourceName: nameMap.get(talentId) ?? talentId,
+      trackIds: [...trackIdSet].sort(),
+    })
+  }
+
+  return conflicts
+}

--- a/src-vnext/features/schedules/lib/trackFiltering.ts
+++ b/src-vnext/features/schedules/lib/trackFiltering.ts
@@ -1,0 +1,17 @@
+import type { CrewCallSheet, TalentCallSheet } from "@/shared/types"
+
+export function filterCrewCallsByTrack(
+  calls: readonly CrewCallSheet[],
+  trackId: string | null,
+): readonly CrewCallSheet[] {
+  if (trackId === null) return calls
+  return calls.filter(c => c.trackId == null || c.trackId === trackId)
+}
+
+export function filterTalentCallsByTrack(
+  calls: readonly TalentCallSheet[],
+  trackId: string | null,
+): readonly TalentCallSheet[] {
+  if (trackId === null) return calls
+  return calls.filter(c => c.trackId == null || c.trackId === trackId)
+}

--- a/src-vnext/features/schedules/lib/trustChecks.test.ts
+++ b/src-vnext/features/schedules/lib/trustChecks.test.ts
@@ -206,7 +206,7 @@ describe("computeTrustWarnings", () => {
         schedule: makeSchedule({
           tracks: [
             { id: "primary", name: "Primary", order: 0 },
-            { id: "track-2", name: "Track 2", order: 1 },
+            { id: "track-2", name: "Unit 2", order: 1 },
           ],
         }),
         entries: [

--- a/src-vnext/features/schedules/lib/undoSnapshots.ts
+++ b/src-vnext/features/schedules/lib/undoSnapshots.ts
@@ -1,0 +1,109 @@
+import type {
+  CrewCallSheet,
+  LocationBlock,
+  ScheduleEntry,
+  ScheduleTrack,
+  TalentCallSheet,
+} from "@/shared/types"
+
+/**
+ * Discriminated union of undo snapshots captured across the call sheet
+ * builder's destructive surfaces. Each variant carries enough state to
+ * fully re-create the removed entity via the existing scheduleWrites
+ * helpers (no in-app state mirroring).
+ *
+ * New variants go here so every consumer gets a type error on unhandled
+ * cases — the `exhaustive` switch test in undoSnapshots.test.ts enforces
+ * coverage.
+ */
+export type UndoSnapshot =
+  | { readonly kind: "crewCallRemoved"; readonly payload: CrewCallSheet }
+  | { readonly kind: "talentCallRemoved"; readonly payload: TalentCallSheet }
+  | {
+      readonly kind: "locationRemoved"
+      readonly payload: { readonly index: number; readonly block: LocationBlock }
+    }
+  | {
+      readonly kind: "tracksCollapsed"
+      readonly payload: {
+        readonly tracks: ReadonlyArray<ScheduleTrack>
+        readonly entryTrackIds: ReadonlyArray<{
+          readonly entryId: string
+          readonly trackId: string | null
+        }>
+      }
+    }
+  | { readonly kind: "scheduleEntryRemoved"; readonly payload: ScheduleEntry }
+
+export interface LocationRemoveCapture {
+  readonly snapshot: { readonly index: number; readonly block: LocationBlock }
+  readonly next: ReadonlyArray<LocationBlock>
+}
+
+/**
+ * Capture a `locationRemoved` snapshot for an immutable location array.
+ *
+ * Returns `null` when no location with `locationId` exists — lets the
+ * caller short-circuit without performing the write.
+ */
+export function takeLocationRemoveSnapshot(
+  locations: ReadonlyArray<LocationBlock>,
+  locationId: string,
+): LocationRemoveCapture | null {
+  const index = locations.findIndex((loc) => loc.id === locationId)
+  if (index < 0) return null
+  const block = locations[index]
+  if (!block) return null
+  const next: LocationBlock[] = [
+    ...locations.slice(0, index),
+    ...locations.slice(index + 1),
+  ]
+  return {
+    snapshot: { index, block },
+    next,
+  }
+}
+
+/**
+ * Re-insert a previously captured location block at (approximately)
+ * its original index. If the array shrank below the captured index
+ * between delete and undo, the block is appended. Negative indices
+ * clamp to 0.
+ */
+export function reinsertLocationAtIndex(
+  locations: ReadonlyArray<LocationBlock>,
+  snapshot: { readonly index: number; readonly block: LocationBlock },
+): ReadonlyArray<LocationBlock> {
+  const safeIndex = Math.min(Math.max(snapshot.index, 0), locations.length)
+  return [
+    ...locations.slice(0, safeIndex),
+    snapshot.block,
+    ...locations.slice(safeIndex),
+  ]
+}
+
+/**
+ * Capture a `tracksCollapsed` snapshot from the current schedule/entries.
+ *
+ * Tracks are shallow-cloned so later mutation of the source does not
+ * leak into the snapshot. Each entry contributes one entryId→trackId
+ * pair (null for entries without an assigned track).
+ */
+export function takeCollapseSnapshot(
+  tracks: ReadonlyArray<ScheduleTrack>,
+  entries: ReadonlyArray<ScheduleEntry>,
+): {
+  readonly tracks: ReadonlyArray<ScheduleTrack>
+  readonly entryTrackIds: ReadonlyArray<{
+    readonly entryId: string
+    readonly trackId: string | null
+  }>
+} {
+  return {
+    tracks: tracks.map((t) => ({ ...t })),
+    entryTrackIds: entries.map((e) => ({
+      entryId: e.id,
+      trackId: e.trackId ?? null,
+    })),
+  }
+}

--- a/src-vnext/shared/components/InlineEdit.tsx
+++ b/src-vnext/shared/components/InlineEdit.tsx
@@ -26,8 +26,9 @@ export function InlineEdit({
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => {
+    if (editing) return
     setDraft(value)
-  }, [value])
+  }, [editing, value])
 
   useEffect(() => {
     if (editing) {

--- a/src-vnext/shared/components/PageHeader.tsx
+++ b/src-vnext/shared/components/PageHeader.tsx
@@ -5,7 +5,7 @@ import { useBreadcrumbs } from "@/app/routes/useBreadcrumbs"
 import type { BreadcrumbEntry } from "@/app/routes/breadcrumbs"
 
 interface PageHeaderProps {
-  readonly title: string
+  readonly title: ReactNode
   readonly actions?: ReactNode
   /**
    * Override the auto-resolved breadcrumb trail. When omitted, PageHeader

--- a/src-vnext/shared/components/SaveIndicator.tsx
+++ b/src-vnext/shared/components/SaveIndicator.tsx
@@ -27,14 +27,20 @@ function formatSaveLabel(savedAt: number, now: number): string {
 }
 
 export function SaveIndicator({ savedAt, className }: SaveIndicatorProps) {
-  const [now, setNow] = useState<number>(() => Date.now())
+  // Seed `now` from savedAt (or Date.now() if savedAt is still null)
+  // so the very first render already yields the correct "Saved" label
+  // without any follow-up state write inside useEffect. Avoiding the
+  // post-mount setNow keeps React's "update not wrapped in act()"
+  // warning quiet in tests that render the editor components.
+  //
+  // savedAt changes re-drive the initial state via the React key the
+  // parent passes — or, lacking that, via the interval below which
+  // eventually catches up. Consumers that need a hard reset on
+  // savedAt change can remount via a key prop.
+  const [now, setNow] = useState<number>(() => savedAt ?? Date.now())
 
   useEffect(() => {
     if (savedAt === null) return
-    // Seed `now` synchronously on mount / on savedAt change so the
-    // label reflects the latest timestamp without waiting for the
-    // first interval tick.
-    setNow(Date.now())
     const id = setInterval(() => {
       setNow(Date.now())
     }, TICK_INTERVAL_MS)

--- a/src-vnext/shared/components/SaveIndicator.tsx
+++ b/src-vnext/shared/components/SaveIndicator.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react"
+import { cn } from "@/shared/lib/utils"
+
+// "Saved Xs ago" pill. Driven by the useLastSaved hook — see
+// src-vnext/shared/hooks/useLastSaved.ts. Renders nothing until the
+// first save lands. After that, shows "Saved" for the first 3 seconds
+// (quiet, friendly confirmation) and then ticks every 5 seconds with a
+// relative time label.
+
+export interface SaveIndicatorProps {
+  readonly savedAt: number | null
+  readonly className?: string
+}
+
+const TICK_INTERVAL_MS = 5_000
+const RECENT_THRESHOLD_MS = 3_000
+
+function formatSaveLabel(savedAt: number, now: number): string {
+  const ageMs = Math.max(0, now - savedAt)
+  if (ageMs < RECENT_THRESHOLD_MS) return "Saved"
+  const ageSeconds = Math.floor(ageMs / 1000)
+  if (ageSeconds < 60) return `Saved ${ageSeconds}s ago`
+  const ageMinutes = Math.floor(ageSeconds / 60)
+  if (ageMinutes < 60) return `Saved ${ageMinutes}m ago`
+  const ageHours = Math.floor(ageMinutes / 60)
+  return `Saved ${ageHours}h ago`
+}
+
+export function SaveIndicator({ savedAt, className }: SaveIndicatorProps) {
+  const [now, setNow] = useState<number>(() => Date.now())
+
+  useEffect(() => {
+    if (savedAt === null) return
+    // Seed `now` synchronously on mount / on savedAt change so the
+    // label reflects the latest timestamp without waiting for the
+    // first interval tick.
+    setNow(Date.now())
+    const id = setInterval(() => {
+      setNow(Date.now())
+    }, TICK_INTERVAL_MS)
+    return () => {
+      clearInterval(id)
+    }
+  }, [savedAt])
+
+  if (savedAt === null) return null
+
+  return (
+    <span
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "inline-flex items-center gap-1.5 text-2xs font-medium text-[var(--color-success)]",
+        className,
+      )}
+    >
+      <span
+        aria-hidden="true"
+        className="h-1.5 w-1.5 rounded-full bg-current"
+      />
+      {formatSaveLabel(savedAt, now)}
+    </span>
+  )
+}

--- a/src-vnext/shared/components/__tests__/SaveIndicator.test.tsx
+++ b/src-vnext/shared/components/__tests__/SaveIndicator.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { act, render, screen } from "@testing-library/react"
+import { SaveIndicator } from "@/shared/components/SaveIndicator"
+
+describe("SaveIndicator", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("renders nothing when savedAt is null", () => {
+    const { container } = render(<SaveIndicator savedAt={null} />)
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
+
+  it("renders 'Saved' immediately after a save lands (within the 3s recent threshold)", () => {
+    const savedAt = Date.now() // 2026-04-15T12:00:00Z
+
+    render(<SaveIndicator savedAt={savedAt} />)
+    const pill = screen.getByRole("status")
+    expect(pill).toHaveTextContent("Saved")
+    expect(pill.textContent).not.toMatch(/ago/)
+  })
+
+  it("renders 'Saved 5s ago' after the first 5s interval tick", () => {
+    const savedAt = Date.now()
+    render(<SaveIndicator savedAt={savedAt} />)
+
+    // advanceTimersByTime advances BOTH the fake clock and fake timers
+    // by the same amount, so Date.now() inside the interval callback
+    // returns savedAt + 5000 after a single tick.
+    act(() => {
+      vi.advanceTimersByTime(5_000)
+    })
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saved 5s ago")
+  })
+
+  it("renders 'Saved 1m ago' after advancing 65 seconds (13 interval ticks)", () => {
+    const savedAt = Date.now()
+    render(<SaveIndicator savedAt={savedAt} />)
+
+    act(() => {
+      vi.advanceTimersByTime(65_000)
+    })
+
+    expect(screen.getByRole("status")).toHaveTextContent("Saved 1m ago")
+  })
+
+  it("cleans up its interval on unmount (no stray timers)", () => {
+    const savedAt = Date.now()
+    const { unmount } = render(<SaveIndicator savedAt={savedAt} />)
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0)
+    unmount()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("resets its relative counter when savedAt changes to a new timestamp", () => {
+    const firstSavedAt = Date.now()
+    const { rerender } = render(<SaveIndicator savedAt={firstSavedAt} />)
+
+    // Advance past the recent threshold so the pill shows relative
+    // time based on firstSavedAt.
+    act(() => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(screen.getByRole("status")).toHaveTextContent("Saved 10s ago")
+
+    // A new save lands at the advanced clock, and the parent re-renders
+    // with the new savedAt.
+    const secondSavedAt = Date.now()
+    rerender(<SaveIndicator savedAt={secondSavedAt} />)
+
+    // Immediately after the rerender, the pill should be back to
+    // "Saved" (fresh save, within the 3s threshold).
+    expect(screen.getByRole("status")).toHaveTextContent("Saved")
+    expect(screen.getByRole("status").textContent).not.toMatch(/ago/)
+  })
+})

--- a/src-vnext/shared/hooks/__tests__/useLastSaved.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useLastSaved.test.ts
@@ -46,18 +46,4 @@ describe("useLastSaved", () => {
     expect(second).toBeGreaterThan(first)
     expect(second - first).toBe(10_000)
   })
-
-  it("reset() returns savedAt to null", () => {
-    const { result } = renderHook(() => useLastSaved())
-
-    act(() => {
-      result.current.markSaved()
-    })
-    expect(result.current.savedAt).not.toBeNull()
-
-    act(() => {
-      result.current.reset()
-    })
-    expect(result.current.savedAt).toBeNull()
-  })
 })

--- a/src-vnext/shared/hooks/__tests__/useLastSaved.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useLastSaved.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useLastSaved } from "@/shared/hooks/useLastSaved"
+
+describe("useLastSaved", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-04-15T12:00:00Z"))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("starts with savedAt === null", () => {
+    const { result } = renderHook(() => useLastSaved())
+    expect(result.current.savedAt).toBeNull()
+  })
+
+  it("sets savedAt to Date.now() after markSaved()", () => {
+    const { result } = renderHook(() => useLastSaved())
+    const expected = Date.now()
+
+    act(() => {
+      result.current.markSaved()
+    })
+
+    expect(result.current.savedAt).toBe(expected)
+  })
+
+  it("advances savedAt when markSaved is called again at a later time", () => {
+    const { result } = renderHook(() => useLastSaved())
+
+    act(() => {
+      result.current.markSaved()
+    })
+    const first = result.current.savedAt ?? 0
+
+    // Advance the system clock and mark again.
+    vi.setSystemTime(new Date("2026-04-15T12:00:10Z"))
+    act(() => {
+      result.current.markSaved()
+    })
+    const second = result.current.savedAt ?? 0
+
+    expect(second).toBeGreaterThan(first)
+    expect(second - first).toBe(10_000)
+  })
+
+  it("reset() returns savedAt to null", () => {
+    const { result } = renderHook(() => useLastSaved())
+
+    act(() => {
+      result.current.markSaved()
+    })
+    expect(result.current.savedAt).not.toBeNull()
+
+    act(() => {
+      result.current.reset()
+    })
+    expect(result.current.savedAt).toBeNull()
+  })
+})

--- a/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
@@ -232,4 +232,32 @@ describe("useUndoStack", () => {
     expect(ids.size).toBe(5)
     expect(result.current.actions).toHaveLength(5)
   })
+
+  it("returns a stable stack reference across unrelated re-renders", () => {
+    // Guards against regression: sub-phase 1.3 consumers will pass the
+    // returned stack object into destructiveActionWithUndo + useCallback
+    // dep arrays. If the hook re-creates its return literal on every
+    // render, those callers would thrash their memoized closures.
+    const { result, rerender } = renderHook(() => useUndoStack<SimpleSnapshot>())
+    const first = result.current
+    rerender()
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it("returns a new stack reference when actions change", () => {
+    // The other half of the contract — the reference MUST update when
+    // actions change, otherwise React will skip re-renders of consumers
+    // that key off the stack identity.
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+    const first = result.current
+    act(() => {
+      result.current.push({
+        label: "Removed",
+        snapshot: { value: "alpha" },
+        undo: noopUndo,
+      })
+    })
+    expect(result.current).not.toBe(first)
+  })
 })

--- a/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
@@ -34,7 +34,7 @@ describe("useUndoStack", () => {
     expect(pushed!.createdAt).toBeGreaterThanOrEqual(before)
 
     expect(result.current.actions).toHaveLength(1)
-    expect(result.current.actions[0].id).toBe(pushed!.id)
+    expect(result.current.actions[0]?.id).toBe(pushed!.id)
   })
 
   it("default capacity is 10 — after 12 pushes the oldest two are evicted, insertion order preserved", () => {
@@ -51,9 +51,11 @@ describe("useUndoStack", () => {
     })
 
     expect(result.current.actions).toHaveLength(10)
-    expect(result.current.actions[0].label).toBe("action-2")
-    expect(result.current.actions[9].label).toBe("action-11")
-    expect(result.current.actions[result.current.actions.length - 1].label).toBe("action-11")
+    expect(result.current.actions[0]?.label).toBe("action-2")
+    expect(result.current.actions[9]?.label).toBe("action-11")
+    expect(result.current.actions[result.current.actions.length - 1]?.label).toBe(
+      "action-11",
+    )
   })
 
   it("custom capacity evicts after the (capacity+1)th push, preserving insertion order", () => {
@@ -125,7 +127,7 @@ describe("useUndoStack", () => {
     })
 
     act(() => {
-      result.current.remove(ids[1])
+      result.current.remove(ids[1]!)
     })
 
     expect(result.current.actions.map((entry) => entry.label)).toEqual(["a", "c"])
@@ -209,7 +211,7 @@ describe("useUndoStack", () => {
     expect(returned!.label).toBe("X")
     expect(typeof returned!.id).toBe("string")
     expect(returned!.id.length).toBeGreaterThan(0)
-    expect(result.current.actions[0].id).toBe(returned!.id)
+    expect(result.current.actions[0]?.id).toBe(returned!.id)
   })
 
   it("five pushes produce five distinct ids", () => {

--- a/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useUndoStack.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, vi } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+
+import { useUndoStack } from "../useUndoStack"
+
+type SimpleSnapshot = { value: string }
+type CrewRemoved = {
+  kind: "crew"
+  payload: { id: string; name: string }
+}
+
+const noopUndo = async () => {}
+
+describe("useUndoStack", () => {
+  it("push() adds an action and returns the constructed UndoableAction with id + createdAt", () => {
+    const before = Date.now()
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    let pushed: ReturnType<typeof result.current.push> | undefined
+    act(() => {
+      pushed = result.current.push({
+        label: "Removed item",
+        snapshot: { value: "alpha" },
+        undo: noopUndo,
+      })
+    })
+
+    expect(pushed).toBeDefined()
+    expect(typeof pushed!.id).toBe("string")
+    expect(pushed!.id.length).toBeGreaterThan(0)
+    expect(pushed!.label).toBe("Removed item")
+    expect(pushed!.snapshot).toEqual({ value: "alpha" })
+    expect(pushed!.createdAt).toBeLessThanOrEqual(Date.now())
+    expect(pushed!.createdAt).toBeGreaterThanOrEqual(before)
+
+    expect(result.current.actions).toHaveLength(1)
+    expect(result.current.actions[0].id).toBe(pushed!.id)
+  })
+
+  it("default capacity is 10 — after 12 pushes the oldest two are evicted, insertion order preserved", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    act(() => {
+      for (let i = 0; i < 12; i += 1) {
+        result.current.push({
+          label: `action-${i}`,
+          snapshot: { value: `v${i}` },
+          undo: noopUndo,
+        })
+      }
+    })
+
+    expect(result.current.actions).toHaveLength(10)
+    expect(result.current.actions[0].label).toBe("action-2")
+    expect(result.current.actions[9].label).toBe("action-11")
+    expect(result.current.actions[result.current.actions.length - 1].label).toBe("action-11")
+  })
+
+  it("custom capacity evicts after the (capacity+1)th push, preserving insertion order", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>({ capacity: 3 }))
+
+    act(() => {
+      result.current.push({ label: "a", snapshot: { value: "a" }, undo: noopUndo })
+      result.current.push({ label: "b", snapshot: { value: "b" }, undo: noopUndo })
+      result.current.push({ label: "c", snapshot: { value: "c" }, undo: noopUndo })
+      result.current.push({ label: "d", snapshot: { value: "d" }, undo: noopUndo })
+    })
+
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions.map((entry) => entry.label)).toEqual(["b", "c", "d"])
+  })
+
+  it("pop() returns the most recently pushed action and removes it; empty stack returns null", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    act(() => {
+      result.current.push({ label: "first", snapshot: { value: "1" }, undo: noopUndo })
+      result.current.push({ label: "second", snapshot: { value: "2" }, undo: noopUndo })
+      result.current.push({ label: "third", snapshot: { value: "3" }, undo: noopUndo })
+    })
+
+    let firstPop: ReturnType<typeof result.current.pop> | undefined
+    act(() => {
+      firstPop = result.current.pop()
+    })
+    expect(firstPop?.label).toBe("third")
+    expect(result.current.actions).toHaveLength(2)
+
+    let secondPop: ReturnType<typeof result.current.pop> | undefined
+    act(() => {
+      secondPop = result.current.pop()
+    })
+    expect(secondPop?.label).toBe("second")
+    expect(result.current.actions).toHaveLength(1)
+
+    let thirdPop: ReturnType<typeof result.current.pop> | undefined
+    act(() => {
+      thirdPop = result.current.pop()
+    })
+    expect(thirdPop?.label).toBe("first")
+    expect(result.current.actions).toHaveLength(0)
+
+    let emptyPop: ReturnType<typeof result.current.pop> | undefined
+    act(() => {
+      emptyPop = result.current.pop()
+    })
+    expect(emptyPop).toBeNull()
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it("remove(id) deletes the matching action, preserving order; missing id is a no-op", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    const ids: string[] = []
+    act(() => {
+      ids.push(
+        result.current.push({ label: "a", snapshot: { value: "a" }, undo: noopUndo }).id,
+      )
+      ids.push(
+        result.current.push({ label: "b", snapshot: { value: "b" }, undo: noopUndo }).id,
+      )
+      ids.push(
+        result.current.push({ label: "c", snapshot: { value: "c" }, undo: noopUndo }).id,
+      )
+    })
+
+    act(() => {
+      result.current.remove(ids[1])
+    })
+
+    expect(result.current.actions.map((entry) => entry.label)).toEqual(["a", "c"])
+
+    expect(() => {
+      act(() => {
+        result.current.remove("does-not-exist")
+      })
+    }).not.toThrow()
+
+    expect(result.current.actions.map((entry) => entry.label)).toEqual(["a", "c"])
+  })
+
+  it("clear() empties the actions array", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    act(() => {
+      result.current.push({ label: "a", snapshot: { value: "a" }, undo: noopUndo })
+      result.current.push({ label: "b", snapshot: { value: "b" }, undo: noopUndo })
+    })
+    expect(result.current.actions).toHaveLength(2)
+
+    act(() => {
+      result.current.clear()
+    })
+    expect(result.current.actions).toHaveLength(0)
+  })
+
+  it("multiple synchronous pushes inside one act() are all preserved in insertion order", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    act(() => {
+      result.current.push({ label: "a", snapshot: { value: "a" }, undo: noopUndo })
+      result.current.push({ label: "b", snapshot: { value: "b" }, undo: noopUndo })
+      result.current.push({ label: "c", snapshot: { value: "c" }, undo: noopUndo })
+    })
+
+    expect(result.current.actions).toHaveLength(3)
+    expect(result.current.actions.map((entry) => entry.label)).toEqual(["a", "b", "c"])
+  })
+
+  it("snapshots remain strongly typed through push/pop (generic T)", () => {
+    const { result } = renderHook(() => useUndoStack<CrewRemoved>())
+
+    const undoSpy = vi.fn(async (_snapshot: CrewRemoved) => {})
+
+    act(() => {
+      result.current.push({
+        label: "Removed Jessica",
+        snapshot: {
+          kind: "crew",
+          payload: { id: "crew-1", name: "Jessica" },
+        },
+        undo: undoSpy,
+      })
+    })
+
+    let popped: ReturnType<typeof result.current.pop> | undefined
+    act(() => {
+      popped = result.current.pop()
+    })
+
+    expect(popped).not.toBeNull()
+    expect(popped?.snapshot.kind).toBe("crew")
+    // TypeScript-level check — this line would not compile if T leaked to unknown.
+    expect(popped?.snapshot.payload.name).toBe("Jessica")
+  })
+
+  it("push() returns the constructed action so callers can reference its id", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    let returned: ReturnType<typeof result.current.push> | undefined
+    act(() => {
+      returned = result.current.push({
+        label: "X",
+        snapshot: { value: "x" },
+        undo: noopUndo,
+      })
+    })
+
+    expect(returned!.label).toBe("X")
+    expect(typeof returned!.id).toBe("string")
+    expect(returned!.id.length).toBeGreaterThan(0)
+    expect(result.current.actions[0].id).toBe(returned!.id)
+  })
+
+  it("five pushes produce five distinct ids", () => {
+    const { result } = renderHook(() => useUndoStack<SimpleSnapshot>())
+
+    const ids = new Set<string>()
+    act(() => {
+      for (let i = 0; i < 5; i += 1) {
+        const action = result.current.push({
+          label: `action-${i}`,
+          snapshot: { value: `v${i}` },
+          undo: noopUndo,
+        })
+        ids.add(action.id)
+      }
+    })
+
+    expect(ids.size).toBe(5)
+    expect(result.current.actions).toHaveLength(5)
+  })
+})

--- a/src-vnext/shared/hooks/useLastSaved.ts
+++ b/src-vnext/shared/hooks/useLastSaved.ts
@@ -1,0 +1,32 @@
+import { useCallback, useState } from "react"
+
+// Small primitive for tracking "when did the last successful save
+// complete?". Returns a nullable timestamp + two setters. Consumers
+// call markSaved() inside the .then / after-await continuation of
+// a Firestore write to update the "Saved Xs ago" pill in a section
+// header. reset() is useful when a consumer needs to clear the pill
+// (e.g. on schedule switch) without relying on component unmount.
+//
+// Orthogonal to useAutoSave — useAutoSave is a debounced lifecycle
+// hook for save state machines (idle/saving/saved/error), while
+// useLastSaved is a single timestamp primitive.
+
+export interface UseLastSavedResult {
+  readonly savedAt: number | null
+  readonly markSaved: () => void
+  readonly reset: () => void
+}
+
+export function useLastSaved(): UseLastSavedResult {
+  const [savedAt, setSavedAt] = useState<number | null>(null)
+
+  const markSaved = useCallback(() => {
+    setSavedAt(Date.now())
+  }, [])
+
+  const reset = useCallback(() => {
+    setSavedAt(null)
+  }, [])
+
+  return { savedAt, markSaved, reset }
+}

--- a/src-vnext/shared/hooks/useLastSaved.ts
+++ b/src-vnext/shared/hooks/useLastSaved.ts
@@ -1,11 +1,10 @@
 import { useCallback, useState } from "react"
 
 // Small primitive for tracking "when did the last successful save
-// complete?". Returns a nullable timestamp + two setters. Consumers
-// call markSaved() inside the .then / after-await continuation of
-// a Firestore write to update the "Saved Xs ago" pill in a section
-// header. reset() is useful when a consumer needs to clear the pill
-// (e.g. on schedule switch) without relying on component unmount.
+// complete?". Returns a nullable timestamp + a single setter. Consumers
+// call markSaved() inside the .then / after-await continuation of a
+// Firestore write to update the "Saved Xs ago" pill in a section
+// header.
 //
 // Orthogonal to useAutoSave — useAutoSave is a debounced lifecycle
 // hook for save state machines (idle/saving/saved/error), while
@@ -14,7 +13,6 @@ import { useCallback, useState } from "react"
 export interface UseLastSavedResult {
   readonly savedAt: number | null
   readonly markSaved: () => void
-  readonly reset: () => void
 }
 
 export function useLastSaved(): UseLastSavedResult {
@@ -24,9 +22,5 @@ export function useLastSaved(): UseLastSavedResult {
     setSavedAt(Date.now())
   }, [])
 
-  const reset = useCallback(() => {
-    setSavedAt(null)
-  }, [])
-
-  return { savedAt, markSaved, reset }
+  return { savedAt, markSaved }
 }

--- a/src-vnext/shared/hooks/useUndoStack.ts
+++ b/src-vnext/shared/hooks/useUndoStack.ts
@@ -45,9 +45,11 @@ export interface UseUndoStackOptions {
  *   for the synchronous `pop()` return value.
  * - `setActions` is still called on every mutation to trigger re-renders;
  *   the ref and the state stay in lockstep.
- * - Action identities and method references are re-created when the array
- *   changes; callers should not memoize based on the returned method
- *   references across renders.
+ * - The returned object and every method (`push`/`pop`/`remove`/`clear`)
+ *   are memoized so the stack reference stays stable across renders
+ *   except when `actions` changes. Consumers can safely pass the whole
+ *   stack object (or individual methods) to `useCallback` / `useMemo` /
+ *   `useEffect` dep arrays without triggering re-memoization every tick.
  */
 export function useUndoStack<T>(
   opts: UseUndoStackOptions = {},
@@ -122,11 +124,14 @@ export function useUndoStack<T>(
     commit([])
   }, [commit])
 
-  return {
-    actions,
-    push,
-    pop,
-    remove,
-    clear,
-  }
+  return React.useMemo(
+    () => ({
+      actions,
+      push,
+      pop,
+      remove,
+      clear,
+    }),
+    [actions, push, pop, remove, clear],
+  )
 }

--- a/src-vnext/shared/hooks/useUndoStack.ts
+++ b/src-vnext/shared/hooks/useUndoStack.ts
@@ -1,0 +1,132 @@
+import * as React from "react"
+
+export const DEFAULT_UNDO_CAPACITY = 10
+
+export interface UndoableAction<T> {
+  readonly id: string
+  readonly label: string
+  readonly snapshot: T
+  readonly undo: (snapshot: T) => Promise<void>
+  readonly createdAt: number
+}
+
+export interface UndoActionInput<T> {
+  readonly label: string
+  readonly snapshot: T
+  readonly undo: (snapshot: T) => Promise<void>
+}
+
+export interface UseUndoStackResult<T> {
+  readonly actions: ReadonlyArray<UndoableAction<T>>
+  push(input: UndoActionInput<T>): UndoableAction<T>
+  pop(): UndoableAction<T> | null
+  remove(id: string): void
+  clear(): void
+}
+
+export interface UseUndoStackOptions {
+  readonly capacity?: number
+}
+
+/**
+ * In-memory stack of undoable UI actions.
+ *
+ * Pure client-side state: no Firestore mirroring, no localStorage, no context.
+ * Evicts on unmount. Follows a single linear LRU stack — no undo/redo trees,
+ * no branching, no reapply (CLAUDE.md §5 + §6).
+ *
+ * Implementation notes:
+ * - A `useRef` mirrors the state array so that `push`/`pop`/`remove`/`clear`
+ *   can read the current value synchronously without relying on closed-over
+ *   `state` values. This is required because callers need `pop()` to return
+ *   the popped action in the same tick, and because multiple `push` calls
+ *   inside one React event (or `act()` block) must all survive — a pure
+ *   `setState(prev => ...)` API would work for write-only ordering but not
+ *   for the synchronous `pop()` return value.
+ * - `setActions` is still called on every mutation to trigger re-renders;
+ *   the ref and the state stay in lockstep.
+ * - Action identities and method references are re-created when the array
+ *   changes; callers should not memoize based on the returned method
+ *   references across renders.
+ */
+export function useUndoStack<T>(
+  opts: UseUndoStackOptions = {},
+): UseUndoStackResult<T> {
+  const capacity = opts.capacity ?? DEFAULT_UNDO_CAPACITY
+
+  const [actions, setActions] = React.useState<ReadonlyArray<UndoableAction<T>>>(
+    () => [],
+  )
+  const actionsRef = React.useRef<ReadonlyArray<UndoableAction<T>>>(actions)
+  const capacityRef = React.useRef(capacity)
+  capacityRef.current = capacity
+
+  const commit = React.useCallback(
+    (next: ReadonlyArray<UndoableAction<T>>) => {
+      actionsRef.current = next
+      setActions(next)
+    },
+    [],
+  )
+
+  const push = React.useCallback(
+    (input: UndoActionInput<T>): UndoableAction<T> => {
+      const action: UndoableAction<T> = {
+        id: crypto.randomUUID(),
+        label: input.label,
+        snapshot: input.snapshot,
+        undo: input.undo,
+        createdAt: Date.now(),
+      }
+
+      const current = actionsRef.current
+      const appended = [...current, action]
+      const effectiveCapacity = capacityRef.current
+      const next =
+        appended.length > effectiveCapacity
+          ? appended.slice(appended.length - effectiveCapacity)
+          : appended
+
+      commit(next)
+      return action
+    },
+    [commit],
+  )
+
+  const pop = React.useCallback((): UndoableAction<T> | null => {
+    const current = actionsRef.current
+    const last = current[current.length - 1]
+    if (!last) {
+      return null
+    }
+    commit(current.slice(0, -1))
+    return last
+  }, [commit])
+
+  const remove = React.useCallback(
+    (id: string): void => {
+      const current = actionsRef.current
+      const next = current.filter((entry) => entry.id !== id)
+      if (next.length === current.length) {
+        return
+      }
+      commit(next)
+    },
+    [commit],
+  )
+
+  const clear = React.useCallback((): void => {
+    if (actionsRef.current.length === 0) {
+      return
+    }
+    commit([])
+  }, [commit])
+
+  return {
+    actions,
+    push,
+    pop,
+    remove,
+    clear,
+  }
+}

--- a/src-vnext/shared/lib/__tests__/destructiveActionWithUndo.test.ts
+++ b/src-vnext/shared/lib/__tests__/destructiveActionWithUndo.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+import type {
+  UndoableAction,
+  UseUndoStackResult,
+} from "@/shared/hooks/useUndoStack"
+
+import { destructiveActionWithUndo } from "../destructiveActionWithUndo"
+
+const { toastMock, toastErrorMock, toastSuccessMock } = vi.hoisted(() => ({
+  toastMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+}))
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastMock, {
+    error: toastErrorMock,
+    success: toastSuccessMock,
+  }),
+}))
+
+type Snapshot = { id: string; value: string }
+
+function buildFakeStack(
+  overrides: Partial<UseUndoStackResult<Snapshot>> = {},
+): UseUndoStackResult<Snapshot> {
+  const pushMock = vi.fn(
+    ({
+      label,
+      snapshot,
+      undo,
+    }: {
+      label: string
+      snapshot: Snapshot
+      undo: (snapshot: Snapshot) => Promise<void>
+    }): UndoableAction<Snapshot> => ({
+      id: "fake-id",
+      label,
+      snapshot,
+      undo,
+      createdAt: 123,
+    }),
+  )
+  return {
+    actions: [],
+    push: pushMock,
+    pop: vi.fn(() => null),
+    remove: vi.fn(),
+    clear: vi.fn(),
+    ...overrides,
+  }
+}
+
+function getToastActionOnClick(): () => void {
+  const lastCall = toastMock.mock.calls[toastMock.mock.calls.length - 1]
+  expect(lastCall).toBeDefined()
+  const options = lastCall![1] as {
+    action: { label: string; onClick: () => void }
+  }
+  return options.action.onClick
+}
+
+describe("destructiveActionWithUndo", () => {
+  beforeEach(() => {
+    toastMock.mockReset()
+    toastErrorMock.mockReset()
+    toastSuccessMock.mockReset()
+  })
+
+  it("happy path: runs perform, pushes onto the stack, and shows a toast with Undo action", async () => {
+    const stack = buildFakeStack()
+    const perform = vi.fn(async () => {})
+    const undo = vi.fn(async () => {})
+    const snapshot: Snapshot = { id: "s1", value: "alpha" }
+
+    await destructiveActionWithUndo({
+      label: "Removed 1 crew member",
+      snapshot,
+      perform,
+      undo,
+      stack,
+    })
+
+    expect(perform).toHaveBeenCalledOnce()
+    expect(stack.push).toHaveBeenCalledWith({
+      label: "Removed 1 crew member",
+      snapshot,
+      undo,
+    })
+    expect(toastMock).toHaveBeenCalledWith(
+      "Removed 1 crew member",
+      expect.objectContaining({
+        duration: 5000,
+        action: expect.objectContaining({
+          label: "Undo",
+          onClick: expect.any(Function),
+        }),
+      }),
+    )
+  })
+
+  it("forwards a custom durationMs to the toast options", async () => {
+    const stack = buildFakeStack()
+    await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot: { id: "s1", value: "alpha" },
+      perform: async () => {},
+      undo: async () => {},
+      stack,
+      durationMs: 3000,
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "Removed",
+      expect.objectContaining({ duration: 3000 }),
+    )
+  })
+
+  it("defaults the toast duration to 5000ms when durationMs is omitted", async () => {
+    const stack = buildFakeStack()
+    await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot: { id: "s1", value: "alpha" },
+      perform: async () => {},
+      undo: async () => {},
+      stack,
+    })
+
+    expect(toastMock).toHaveBeenCalledWith(
+      "Removed",
+      expect.objectContaining({ duration: 5000 }),
+    )
+  })
+
+  it("re-throws when perform rejects and skips toast/push entirely", async () => {
+    const stack = buildFakeStack()
+    const perform = vi.fn(async () => {
+      throw new Error("boom")
+    })
+
+    await expect(
+      destructiveActionWithUndo({
+        label: "Removed",
+        snapshot: { id: "s1", value: "alpha" },
+        perform,
+        undo: async () => {},
+        stack,
+      }),
+    ).rejects.toThrow("boom")
+
+    expect(stack.push).not.toHaveBeenCalled()
+    expect(toastMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("invokes undo and removes the stack entry when the user clicks Undo", async () => {
+    const stack = buildFakeStack()
+    const undo = vi.fn(async () => {})
+    const snapshot: Snapshot = { id: "s1", value: "alpha" }
+
+    await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot,
+      perform: async () => {},
+      undo,
+      stack,
+    })
+
+    const onClick = getToastActionOnClick()
+    onClick()
+    // onClick fires `void args.undo(...)` — give the microtask queue a tick.
+    await Promise.resolve()
+
+    expect(undo).toHaveBeenCalledWith(snapshot)
+    expect(stack.remove).toHaveBeenCalledWith("fake-id")
+  })
+
+  it("logs + toasts when the undo callback rejects, and still removes the stale entry", async () => {
+    const stack = buildFakeStack()
+    const undo = vi.fn(async () => {
+      throw new Error("undo-failed")
+    })
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {})
+
+    await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot: { id: "s1", value: "alpha" },
+      perform: async () => {},
+      undo,
+      stack,
+    })
+
+    const onClick = getToastActionOnClick()
+    onClick()
+    // allow the .catch() handler to run
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(toastErrorMock).toHaveBeenCalledWith("Couldn't undo — try again.")
+    expect(stack.remove).toHaveBeenCalledWith("fake-id")
+    expect(consoleErrorSpy).toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+
+  it("returns the pushed UndoableAction so callers can reference its id", async () => {
+    const stack = buildFakeStack()
+    const result = await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot: { id: "s1", value: "alpha" },
+      perform: async () => {},
+      undo: async () => {},
+      stack,
+    })
+
+    expect(result.id).toBe("fake-id")
+    expect(result.label).toBe("Removed")
+  })
+
+  it("re-throws a synchronous throw from perform via the await bridge", async () => {
+    const stack = buildFakeStack()
+    const perform = vi.fn((): Promise<void> => {
+      throw new Error("sync")
+    })
+
+    await expect(
+      destructiveActionWithUndo({
+        label: "Removed",
+        snapshot: { id: "s1", value: "alpha" },
+        perform,
+        undo: async () => {},
+        stack,
+      }),
+    ).rejects.toThrow("sync")
+
+    expect(stack.push).not.toHaveBeenCalled()
+    expect(toastMock).not.toHaveBeenCalled()
+  })
+
+  it("labels the toast action button exactly 'Undo'", async () => {
+    const stack = buildFakeStack()
+    await destructiveActionWithUndo({
+      label: "Removed",
+      snapshot: { id: "s1", value: "alpha" },
+      perform: async () => {},
+      undo: async () => {},
+      stack,
+    })
+
+    const lastCall = toastMock.mock.calls[toastMock.mock.calls.length - 1]
+    const options = lastCall![1] as {
+      action: { label: string }
+    }
+    expect(options.action.label).toBe("Undo")
+  })
+})

--- a/src-vnext/shared/lib/destructiveActionWithUndo.ts
+++ b/src-vnext/shared/lib/destructiveActionWithUndo.ts
@@ -1,0 +1,61 @@
+import { toast } from "sonner"
+
+import type {
+  UndoableAction,
+  UseUndoStackResult,
+} from "@/shared/hooks/useUndoStack"
+
+const DEFAULT_UNDO_TOAST_DURATION_MS = 5000
+
+export interface DestructiveActionWithUndoArgs<T> {
+  readonly label: string
+  readonly snapshot: T
+  readonly perform: () => Promise<void>
+  readonly undo: (snapshot: T) => Promise<void>
+  readonly stack: UseUndoStackResult<T>
+  readonly durationMs?: number
+}
+
+/**
+ * Runs a destructive UI action, pushes an undoable entry onto the stack,
+ * and surfaces a sonner toast with an Undo action button.
+ *
+ * Error semantics:
+ * - If `perform` rejects (or throws synchronously), the error is re-thrown
+ *   so the caller can handle it with its own feedback. No toast is shown —
+ *   each call site already owns its error UI (existing toast.error pattern).
+ * - If the `undo` callback rejects after the user clicks Undo, the error
+ *   is logged and surfaced as toast.error("Couldn't undo — try again.").
+ *   The stack entry is still removed because the window has closed.
+ *
+ * Returns the UndoableAction that was pushed, so callers can reference
+ * its id if they need to coordinate with the stack (e.g. dismiss on
+ * external state changes).
+ */
+export async function destructiveActionWithUndo<T>(
+  args: DestructiveActionWithUndoArgs<T>,
+): Promise<UndoableAction<T>> {
+  await args.perform()
+
+  const action = args.stack.push({
+    label: args.label,
+    snapshot: args.snapshot,
+    undo: args.undo,
+  })
+
+  toast(args.label, {
+    duration: args.durationMs ?? DEFAULT_UNDO_TOAST_DURATION_MS,
+    action: {
+      label: "Undo",
+      onClick: () => {
+        void args.undo(action.snapshot).catch((err) => {
+          console.error("Undo failed", err)
+          toast.error("Couldn't undo — try again.")
+        })
+        args.stack.remove(action.id)
+      },
+    },
+  })
+
+  return action
+}

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -635,6 +635,13 @@ export interface ScheduleEntry {
 export interface LocationBlock {
   readonly id: string
   readonly title: string
+  /**
+   * Explicit canonical role (basecamp/parking/hospital/office/shoot/custom).
+   * Optional for backward compat — existing blocks without a role are treated
+   * as unset and fall back to title-based inference at read time. Written on
+   * the next edit (no backfill migration).
+   */
+  readonly role?: LocationRole | null
   readonly ref: {
     readonly locationId?: string | null
     readonly label?: string | null
@@ -643,6 +650,14 @@ export interface LocationBlock {
   readonly showName: boolean
   readonly showPhone: boolean
 }
+
+export type LocationRole =
+  | "basecamp"
+  | "parking"
+  | "hospital"
+  | "office"
+  | "shoot"
+  | "custom"
 
 export interface WeatherData {
   readonly lowTemp?: number | null

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -703,6 +703,7 @@ export interface TalentCallSheet {
   readonly createdAt?: Timestamp
   readonly updatedAt?: Timestamp
   readonly createdBy?: string
+  readonly isVisibleOverride?: boolean | null
 }
 
 export type CallOffsetDirection = "early" | "delay"
@@ -722,6 +723,9 @@ export interface CrewCallSheet {
   readonly createdAt?: Timestamp
   readonly updatedAt?: Timestamp
   readonly createdBy?: string
+  readonly isVisibleOverride?: boolean | null
+  readonly showEmailOverride?: boolean | null
+  readonly showPhoneOverride?: boolean | null
 }
 
 // --- Shot Requests ---

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -704,6 +704,7 @@ export interface TalentCallSheet {
   readonly updatedAt?: Timestamp
   readonly createdBy?: string
   readonly isVisibleOverride?: boolean | null
+  readonly trackId?: string
 }
 
 export type CallOffsetDirection = "early" | "delay"
@@ -726,6 +727,7 @@ export interface CrewCallSheet {
   readonly isVisibleOverride?: boolean | null
   readonly showEmailOverride?: boolean | null
   readonly showPhoneOverride?: boolean | null
+  readonly trackId?: string
 }
 
 // --- Shot Requests ---


### PR DESCRIPTION
## Summary

Phase 1 ships six improvements to the call sheet builder across 7 sub-phases (36 commits, 59 files changed, +5012/-182 lines):

- **1.0** Spec reconciliation — applied 6 spec-delta items to CALL_SHEET_BUILDER_SPEC.md
- **1.1** Editable call sheet title — inline-edit in page header with date-derived default
- **1.2** Undo foundation — `useUndoStack` hook + `destructiveActionWithUndo` sonner toast helper
- **1.3** Undo on 5 destructive surfaces — crew/talent removal, location removal, track collapse, timeline entry delete
- **1.4** Autosave polish — `SaveIndicator` pill, on-blur standardization, optimistic-create violations fixed
- **1.5** Location roles — `LocationRole` enum, canonical sort, role chips, round-trip-safe mapper
- **1.6** Crew/talent visibility overrides — `isVisibleOverride`/`showEmailOverride`/`showPhoneOverride` on CrewCallSheet, `isVisibleOverride` on TalentCallSheet, email/phone crew columns (default hidden), per-row toggle icons, merge helpers with triple-gate model
- **1.7** Multi-unit timeline (the marquee) — `trackId` on crew/talent calls, unit picker tabs, gap detection + markers, shared resource conflict warnings, cross-track overlap highlights, "Track"→"Unit" rename, per-unit export filter

## Test coverage

- 188 test files / 2179 tests passing (up from 184/2132 pre-Phase 1)
- 47 new tests across 6 new test files
- TDD workflow: red tests committed before implementation in every sub-phase

## Test plan

- [ ] Verify editable title: click the page header title, edit, blur — title persists on reload
- [ ] Verify undo: remove a crew override → "Undo" toast appears → click Undo → row restored
- [ ] Verify SaveIndicator: edit a field → "Saved Xs ago" pill updates in section header
- [ ] Verify location roles: add a location with "Hospital" preset → blue chip appears, canonical sort applied
- [ ] Verify visibility overrides: click eye icon on crew row → row dims → printed sheet hides that person
- [ ] Verify email/phone columns: Edit Fields → enable Email → column appears in crew table
- [ ] Verify unit tabs: schedule with 2+ tracks → tab strip shows → switching filters overrides
- [ ] Verify gap markers: create entries with >30min gap → "Schedule Gaps" chips appear below timeline
- [ ] Verify conflict warnings: assign same talent to 2 units → amber warning chip appears
- [ ] Verify overlap bands: entries on different tracks at same time → blue highlight in timeline
- [ ] Verify per-unit export: 2+ tracks → unit selector in export controls → filtered call sheet
- [ ] Verify "Unit" rename: all user-facing labels say "Unit" not "Track"
- [ ] Build: `npm run build` clean
- [ ] Lint: `npm run lint` zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)