### PR TITLE
Phase 2: Export Builder polish

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -503,6 +503,19 @@ service cloud.firestore {
       allow delete: if clientMatches(clientId) && isAdmin();
     }
 
+    // Export templates - workspace-level shared PDF builder templates
+    match /clients/{clientId}/exportTemplates/{templateId} {
+      allow read: if clientMatches(clientId) && (isAdmin() || isProducer());
+      allow create: if clientMatches(clientId) &&
+        (isAdmin() || isProducer()) &&
+        request.resource.data.createdBy == request.auth.uid;
+      allow update: if clientMatches(clientId) &&
+        (isAdmin() || isProducer()) &&
+        request.resource.data.createdBy == resource.data.createdBy;
+      allow delete: if clientMatches(clientId) &&
+        (isAdmin() || isProducer());
+    }
+
 	    match /clients/{clientId}/projects/{projectId} {
         // --- Project Visibility Model ---
         // Projects have an optional 'visibility' field: 'team' (default), 'private', or 'restricted'.

--- a/src-vnext/features/export/components/DocumentPreview.tsx
+++ b/src-vnext/features/export/components/DocumentPreview.tsx
@@ -36,6 +36,7 @@ interface DocumentPreviewProps {
   readonly onDeletePage?: (pageId: string) => void
   readonly isPaletteDrag?: boolean
   readonly onPageClick?: (pageId: string) => void
+  readonly onOpenBlockPicker?: (pageId: string, insertIndex: number) => void
 }
 
 /** Flatten page items into ExportBlocks (expanding HStack columns) */
@@ -70,36 +71,57 @@ function splitItemsByPageBreaks(
   return pages
 }
 
-/** Drop zone indicator between blocks for palette drag */
+/** Drop zone indicator between blocks for palette drag, plus inline add button */
 function DropGap({
   id,
   isPaletteDrag,
+  onClickAdd,
 }: {
   readonly id: string
   readonly isPaletteDrag: boolean
+  readonly onClickAdd?: () => void
 }) {
   const { isOver, setNodeRef } = useDroppable({ id })
 
-  if (!isPaletteDrag) return null
+  if (isPaletteDrag) {
+    return (
+      <div
+        ref={setNodeRef}
+        className="relative flex items-center justify-center"
+        style={{ height: isOver ? 40 : 12 }}
+      >
+        <div
+          className={`absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 transition-all ${
+            isOver
+              ? "bg-[var(--color-accent)] opacity-100"
+              : "bg-transparent opacity-0"
+          }`}
+        />
+        {isOver && (
+          <div className="relative z-10 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--color-accent)] text-white">
+            <Plus className="h-3 w-3" />
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  if (!onClickAdd) return null
 
   return (
-    <div
-      ref={setNodeRef}
-      className="relative flex items-center justify-center"
-      style={{ height: isOver ? 40 : 12 }}
-    >
-      <div
-        className={`absolute inset-x-0 top-1/2 h-0.5 -translate-y-1/2 transition-all ${
-          isOver
-            ? "bg-[var(--color-accent)] opacity-100"
-            : "bg-transparent opacity-0"
-        }`}
-      />
-      {isOver && (
-        <div className="relative z-10 flex h-5 w-5 items-center justify-center rounded-full bg-[var(--color-accent)] text-white">
-          <Plus className="h-3 w-3" />
-        </div>
-      )}
+    <div className="group/gap relative flex h-4 items-center justify-center">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation()
+          onClickAdd()
+        }}
+        className="absolute z-10 flex h-5 w-5 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] text-[var(--color-text-subtle)] opacity-0 shadow-sm transition-opacity hover:border-[var(--color-accent)] hover:text-[var(--color-accent)] group-hover/gap:opacity-100"
+        aria-label="Insert block"
+      >
+        <Plus className="h-3 w-3" />
+      </button>
+      <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-transparent transition-colors group-hover/gap:bg-[var(--color-border)]" />
     </div>
   )
 }
@@ -182,6 +204,7 @@ export function DocumentPreview({
   onDeletePage,
   isPaletteDrag = false,
   onPageClick,
+  onOpenBlockPicker,
 }: DocumentPreviewProps) {
   // Each ExportPage is a distinct visual page; within each, page-break blocks
   // create additional visual pages. Result: a flat list of visual pages.
@@ -294,6 +317,7 @@ export function DocumentPreview({
                         <DropGap
                           id={`drop-gap-${currentPageId}-0`}
                           isPaletteDrag={isPaletteDrag}
+                          onClickAdd={onOpenBlockPicker ? () => onOpenBlockPicker(currentPageId, 0) : undefined}
                         />
                         <div className="flex flex-col items-center justify-center py-24 text-center">
                           <p className="text-sm text-[var(--color-text-subtle)]">
@@ -309,6 +333,7 @@ export function DocumentPreview({
                             <DropGap
                               id={`drop-gap-${currentPageId}-${String(localIndex)}`}
                               isPaletteDrag={isPaletteDrag}
+                              onClickAdd={onOpenBlockPicker ? () => onOpenBlockPicker(currentPageId, localIndex) : undefined}
                             />
                             {isHStackRow(item) ? (
                               <HStackRowView
@@ -352,6 +377,7 @@ export function DocumentPreview({
                       <DropGap
                         id={`drop-gap-${currentPageId}-${String(localIndexOffset + pageItems.length)}`}
                         isPaletteDrag={isPaletteDrag}
+                        onClickAdd={onOpenBlockPicker ? () => onOpenBlockPicker(currentPageId, localIndexOffset + pageItems.length) : undefined}
                       />
                     )}
 

--- a/src-vnext/features/export/components/ExportBuilderPage.tsx
+++ b/src-vnext/features/export/components/ExportBuilderPage.tsx
@@ -39,10 +39,8 @@ import {
 import {
   saveDocument,
   loadDocument,
-  saveTemplate as persistTemplate,
 } from "../lib/documentPersistence"
 import { BLOCK_REGISTRY } from "../lib/blockRegistry"
-import { BUILT_IN_TEMPLATES } from "../lib/builtInTemplates"
 import { BlockPalette } from "./BlockPalette"
 import { BlockSettingsPanel } from "./BlockSettingsPanel"
 import { DocumentPreview } from "./DocumentPreview"
@@ -55,6 +53,7 @@ import { PaletteDragOverlay } from "./PaletteDragOverlay"
 import { generateExportPdf } from "../lib/pdf/generateExportPdf"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useExportReports } from "../hooks/useExportReports"
+import { useExportTemplates } from "../hooks/useExportTemplates"
 import { useExportBlockOps } from "../hooks/useExportBlockOps"
 import { useExportPageOps } from "../hooks/useExportPageOps"
 
@@ -120,6 +119,14 @@ function ExportBuilderPageInner() {
     loadReport,
     importReport,
   } = useExportReports(clientId, projectId)
+
+  // --- Firestore workspace templates ---
+  const {
+    workspaceTemplates,
+    loading: templatesLoading,
+    saveTemplate: saveWorkspaceTemplate,
+    deleteTemplate: deleteWorkspaceTemplate,
+  } = useExportTemplates(clientId)
 
   const [activeReportId, setActiveReportId] = useState<string | null>(null)
   const [hasInitialized, setHasInitialized] = useState(false)
@@ -620,16 +627,13 @@ function ExportBuilderPageInner() {
   }, [])
 
   const handleSaveCurrentAsTemplate = useCallback(() => {
-    const template: ExportTemplate = {
-      id: crypto.randomUUID(),
-      name: document.name,
-      description: `Saved from "${document.name}"`,
-      category: "saved",
-      pages: document.pages,
-      settings: document.settings,
-    }
-    persistTemplate(template)
-    toast.success("Template saved")
+    void saveWorkspaceTemplate(
+      document.name,
+      `Saved from "${document.name}"`,
+      document.pages,
+      document.settings,
+    ).then(() => toast.success("Template saved to workspace"))
+      .catch(() => toast.error("Failed to save template"))
   }, [document])
 
   const handleUpdateSettings = useCallback((settings: PageSettings) => {
@@ -777,6 +781,9 @@ function ExportBuilderPageInner() {
         onOpenChange={setShowTemplates}
         onSelectTemplate={handleSelectTemplate}
         onSaveCurrent={handleSaveCurrentAsTemplate}
+        workspaceTemplates={workspaceTemplates}
+        onDeleteTemplate={deleteWorkspaceTemplate}
+        workspaceLoading={templatesLoading}
       />
 
       <VariablesPanel

--- a/src-vnext/features/export/components/ExportBuilderPage.tsx
+++ b/src-vnext/features/export/components/ExportBuilderPage.tsx
@@ -45,6 +45,7 @@ import { BlockPalette } from "./BlockPalette"
 import { BlockSettingsPanel } from "./BlockSettingsPanel"
 import { DocumentPreview } from "./DocumentPreview"
 import { ExportTopBar } from "./ExportTopBar"
+import { InlineBlockPicker } from "./InlineBlockPicker"
 import { TemplateDialog } from "./TemplateDialog"
 import { VariablesPanel } from "./VariablesPanel"
 import { PageSettingsPanel } from "./PageSettingsPanel"
@@ -55,6 +56,7 @@ import { useAuth } from "@/app/providers/AuthProvider"
 import { useExportReports } from "../hooks/useExportReports"
 import { useExportTemplates } from "../hooks/useExportTemplates"
 import { useExportBlockOps } from "../hooks/useExportBlockOps"
+import { useInlineBlockPicker } from "../hooks/useInlineBlockPicker"
 import { useExportPageOps } from "../hooks/useExportPageOps"
 
 function createDefaultDocument(): ExportDocument {
@@ -166,6 +168,13 @@ function ExportBuilderPageInner() {
     handleAddColumn,
     handleRemoveColumn,
   } = useExportPageOps(document, setDocument, activePageId, setActivePageId)
+
+  const {
+    blockPickerOpen,
+    setBlockPickerOpen,
+    handleBlockPickerSelect,
+    handleOpenBlockPicker,
+  } = useInlineBlockPicker(document, setDocument, setSelectedBlockId, handleAddBlock, activePageIdRef)
 
   // --- Initialization: select first report or detect legacy localStorage ---
   useEffect(() => {
@@ -755,6 +764,7 @@ function ExportBuilderPageInner() {
             onDeletePage={handleDeletePage}
             isPaletteDrag={activeDragType !== null}
             onPageClick={setActivePageId}
+            onOpenBlockPicker={handleOpenBlockPicker}
           />
 
           {/* Right -- Block Settings */}
@@ -776,6 +786,12 @@ function ExportBuilderPageInner() {
       </DndContext>
 
       {/* Panels / Dialogs */}
+      <InlineBlockPicker
+        open={blockPickerOpen}
+        onOpenChange={setBlockPickerOpen}
+        onSelectBlock={handleBlockPickerSelect}
+      />
+
       <TemplateDialog
         open={showTemplates}
         onOpenChange={setShowTemplates}

--- a/src-vnext/features/export/components/ExportBuilderPage.tsx
+++ b/src-vnext/features/export/components/ExportBuilderPage.tsx
@@ -45,6 +45,7 @@ import { BlockPalette } from "./BlockPalette"
 import { BlockSettingsPanel } from "./BlockSettingsPanel"
 import { DocumentPreview } from "./DocumentPreview"
 import { ExportTopBar } from "./ExportTopBar"
+import { ExportKeyboardHelp } from "./ExportKeyboardHelp"
 import { InlineBlockPicker } from "./InlineBlockPicker"
 import { TemplateDialog } from "./TemplateDialog"
 import { VariablesPanel } from "./VariablesPanel"
@@ -139,6 +140,7 @@ function ExportBuilderPageInner() {
   const [showTemplates, setShowTemplates] = useState(false)
   const [showVariables, setShowVariables] = useState(false)
   const [showPageSettings, setShowPageSettings] = useState(false)
+  const [showKeyboardHelp, setShowKeyboardHelp] = useState(false)
   const [zoom, setZoom] = useState(100)
   const [activeDragType, setActiveDragType] = useState<string | null>(null)
 
@@ -655,20 +657,33 @@ function ExportBuilderPageInner() {
     void generateExportPdf(document, exportData, variables, user?.displayName ?? undefined)
   }, [document, exportData, variables, user?.displayName])
 
-  // --- Keyboard shortcut: Delete/Backspace removes selected block ---
+  // --- Keyboard shortcuts: Delete/Backspace + Esc + ? ---
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement
+      const inInput = target.isContentEditable || target.tagName === "INPUT" || target.tagName === "TEXTAREA"
+      if (inInput) return
+
+      if (e.key === "Escape" && selectedBlockId) {
+        setSelectedBlockId(null)
+        return
+      }
+
+      if (e.key === "?" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault()
+        setShowKeyboardHelp(true)
+        return
+      }
+
       if (!selectedBlockId) return
       if (e.key === "Delete" || e.key === "Backspace") {
-        const target = e.target as HTMLElement
-        if (target.isContentEditable || target.tagName === "INPUT" || target.tagName === "TEXTAREA") return
         e.preventDefault()
         handleDeleteBlock(selectedBlockId)
       }
     }
     window.document.addEventListener("keydown", handleKeyDown)
     return () => window.document.removeEventListener("keydown", handleKeyDown)
-  }, [selectedBlockId, handleDeleteBlock])
+  }, [selectedBlockId, handleDeleteBlock, setSelectedBlockId])
 
   // --- Derived ---
 
@@ -786,6 +801,11 @@ function ExportBuilderPageInner() {
       </DndContext>
 
       {/* Panels / Dialogs */}
+      <ExportKeyboardHelp
+        open={showKeyboardHelp}
+        onOpenChange={setShowKeyboardHelp}
+      />
+
       <InlineBlockPicker
         open={blockPickerOpen}
         onOpenChange={setBlockPickerOpen}

--- a/src-vnext/features/export/components/ExportBuilderPage.tsx
+++ b/src-vnext/features/export/components/ExportBuilderPage.tsx
@@ -107,7 +107,7 @@ export default function ExportBuilderPage() {
 function ExportBuilderPageInner() {
   const { id: projectId } = useParams<{ id: string }>()
   const [searchParams, setSearchParams] = useSearchParams()
-  const { clientId } = useAuth()
+  const { clientId, user } = useAuth()
   const { project, shots, productFamilies } = useExportDataContext()
 
   // --- Firestore multi-report ---
@@ -639,8 +639,8 @@ function ExportBuilderPageInner() {
   const exportData = useExportDataContext()
 
   const handleExport = useCallback(() => {
-    void generateExportPdf(document, exportData, variables)
-  }, [document, exportData, variables])
+    void generateExportPdf(document, exportData, variables, user?.displayName ?? undefined)
+  }, [document, exportData, variables, user?.displayName])
 
   // --- Keyboard shortcut: Delete/Backspace removes selected block ---
   useEffect(() => {

--- a/src-vnext/features/export/components/ExportKeyboardHelp.tsx
+++ b/src-vnext/features/export/components/ExportKeyboardHelp.tsx
@@ -1,0 +1,55 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/ui/dialog"
+
+interface ExportKeyboardHelpProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}
+
+interface ShortcutEntry {
+  readonly keys: string
+  readonly description: string
+}
+
+const SHORTCUTS: readonly ShortcutEntry[] = [
+  { keys: "⌘ /", description: "Insert block at cursor" },
+  { keys: "Delete", description: "Remove selected block" },
+  { keys: "Esc", description: "Deselect block" },
+  { keys: "?", description: "Show this help" },
+]
+
+function ShortcutRow({ entry }: { readonly entry: ShortcutEntry }) {
+  return (
+    <div className="flex items-center justify-between py-1.5">
+      <span className="text-sm text-[var(--color-text)]">{entry.description}</span>
+      <kbd className="rounded border border-[var(--color-border)] bg-[var(--color-surface-muted)] px-2 py-0.5 font-mono text-xs text-[var(--color-text-muted)]">
+        {entry.keys}
+      </kbd>
+    </div>
+  )
+}
+
+export function ExportKeyboardHelp({ open, onOpenChange }: ExportKeyboardHelpProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-xs">
+        <DialogHeader>
+          <DialogTitle>Keyboard Shortcuts</DialogTitle>
+          <DialogDescription>
+            Shortcuts available in the export builder.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="divide-y divide-[var(--color-border)]">
+          {SHORTCUTS.map((entry) => (
+            <ShortcutRow key={entry.keys} entry={entry} />
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src-vnext/features/export/components/InlineBlockPicker.tsx
+++ b/src-vnext/features/export/components/InlineBlockPicker.tsx
@@ -1,0 +1,101 @@
+import {
+  ClipboardList,
+  Columns,
+  FileDown,
+  Grid3x3,
+  Image,
+  Minus,
+  Square,
+  Table,
+  Type,
+  Users,
+  type LucideIcon,
+} from "lucide-react"
+import {
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from "@/ui/command"
+import { BLOCK_REGISTRY, type BlockRegistryEntry } from "../lib/blockRegistry"
+import type { BlockType } from "../types/exportBuilder"
+
+interface InlineBlockPickerProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly onSelectBlock: (type: BlockType | "hstack") => void
+}
+
+const ICON_MAP: Record<string, LucideIcon> = {
+  Type,
+  Image,
+  Grid3X3: Grid3x3,
+  Square,
+  Table,
+  ClipboardList,
+  Users,
+  Minus,
+  FileDown,
+  Columns,
+}
+
+const CATEGORY_LABELS: Record<BlockRegistryEntry["category"], string> = {
+  content: "Content",
+  data: "Data",
+  layout: "Layout",
+}
+
+function groupByCategory(
+  entries: readonly BlockRegistryEntry[],
+): ReadonlyMap<BlockRegistryEntry["category"], readonly BlockRegistryEntry[]> {
+  const groups = new Map<BlockRegistryEntry["category"], BlockRegistryEntry[]>()
+  for (const entry of entries) {
+    const existing = groups.get(entry.category) ?? []
+    groups.set(entry.category, [...existing, entry])
+  }
+  return groups
+}
+
+const GROUPED_BLOCKS = groupByCategory(BLOCK_REGISTRY)
+
+export function InlineBlockPicker({
+  open,
+  onOpenChange,
+  onSelectBlock,
+}: InlineBlockPickerProps) {
+  return (
+    <CommandDialog open={open} onOpenChange={onOpenChange}>
+      <CommandInput placeholder="Search blocks..." />
+      <CommandList>
+        <CommandEmpty>No matching blocks.</CommandEmpty>
+        {Array.from(GROUPED_BLOCKS.entries()).map(([category, entries]) => (
+          <CommandGroup key={category} heading={CATEGORY_LABELS[category]}>
+            {entries.map((entry) => {
+              const Icon = ICON_MAP[entry.icon]
+              return (
+                <CommandItem
+                  key={entry.type}
+                  value={`${entry.label} ${entry.description}`}
+                  onSelect={() => {
+                    onSelectBlock(entry.type)
+                    onOpenChange(false)
+                  }}
+                >
+                  {Icon && <Icon className="h-4 w-4 text-[var(--color-text-muted)]" />}
+                  <div className="flex flex-col">
+                    <span>{entry.label}</span>
+                    <span className="text-2xs text-[var(--color-text-muted)]">
+                      {entry.description}
+                    </span>
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </CommandGroup>
+        ))}
+      </CommandList>
+    </CommandDialog>
+  )
+}

--- a/src-vnext/features/export/components/TemplateDialog.tsx
+++ b/src-vnext/features/export/components/TemplateDialog.tsx
@@ -1,7 +1,6 @@
 import { useState, useCallback } from "react"
 import type { ExportBlock, ExportTemplate } from "../types/exportBuilder"
 import { BUILT_IN_TEMPLATES } from "../lib/builtInTemplates"
-import { loadTemplates } from "../lib/documentPersistence"
 import {
   Dialog,
   DialogContent,
@@ -12,12 +11,16 @@ import {
 } from "@/ui/dialog"
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/ui/tabs"
 import { Button } from "@/ui/button"
+import { Trash2 } from "lucide-react"
 
 interface TemplateDialogProps {
   readonly open: boolean
   readonly onOpenChange: (open: boolean) => void
   readonly onSelectTemplate: (template: ExportTemplate) => void
   readonly onSaveCurrent?: () => void
+  readonly workspaceTemplates?: readonly ExportTemplate[]
+  readonly onDeleteTemplate?: (templateId: string) => void
+  readonly workspaceLoading?: boolean
 }
 
 function TemplatePreview({
@@ -66,27 +69,44 @@ function TemplateCard({
   template,
   selected,
   onSelect,
+  onDelete,
 }: {
   readonly template: ExportTemplate
   readonly selected: boolean
   readonly onSelect: () => void
+  readonly onDelete?: () => void
 }) {
   return (
     <button
       type="button"
       onClick={onSelect}
-      className={`flex flex-col gap-1 rounded-md border p-3 text-left transition-colors ${
+      className={`group flex items-start gap-2 rounded-md border p-3 text-left transition-colors ${
         selected
           ? "border-[var(--color-accent)] bg-[var(--color-accent)]/5"
           : "border-[var(--color-border)] hover:border-[var(--color-text-muted)]"
       }`}
     >
-      <span className="text-sm font-medium text-[var(--color-text)]">
-        {template.name}
-      </span>
-      <span className="text-2xs text-[var(--color-text-muted)]">
-        {template.description}
-      </span>
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-sm font-medium text-[var(--color-text)]">
+          {template.name}
+        </span>
+        <span className="text-2xs text-[var(--color-text-muted)]">
+          {template.description}
+        </span>
+      </div>
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete()
+          }}
+          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] opacity-0 transition-opacity hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-destructive)] group-hover:opacity-100"
+          aria-label={`Delete ${template.name}`}
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      )}
     </button>
   )
 }
@@ -96,9 +116,11 @@ export function TemplateDialog({
   onOpenChange,
   onSelectTemplate,
   onSaveCurrent,
+  workspaceTemplates = [],
+  onDeleteTemplate,
+  workspaceLoading = false,
 }: TemplateDialogProps) {
   const [selected, setSelected] = useState<ExportTemplate | null>(null)
-  const savedTemplates = open ? loadTemplates() : []
 
   const handleConfirm = useCallback(() => {
     if (!selected) return
@@ -118,7 +140,7 @@ export function TemplateDialog({
         <DialogHeader>
           <DialogTitle>Choose a Template</DialogTitle>
           <DialogDescription>
-            Start with a pre-built layout or one of your saved templates.
+            Start with a pre-built layout or one of your workspace templates.
           </DialogDescription>
         </DialogHeader>
 
@@ -127,7 +149,7 @@ export function TemplateDialog({
             <Tabs defaultValue="built-in">
               <TabsList>
                 <TabsTrigger value="built-in">Built-in</TabsTrigger>
-                <TabsTrigger value="saved">Saved</TabsTrigger>
+                <TabsTrigger value="workspace">Workspace</TabsTrigger>
               </TabsList>
 
               <TabsContent value="built-in">
@@ -143,7 +165,7 @@ export function TemplateDialog({
                 </div>
               </TabsContent>
 
-              <TabsContent value="saved">
+              <TabsContent value="workspace">
                 <div className="flex flex-col gap-2 pt-2">
                   {onSaveCurrent && (
                     <Button
@@ -155,17 +177,26 @@ export function TemplateDialog({
                       Save current as template
                     </Button>
                   )}
-                  {savedTemplates.length === 0 ? (
+                  {workspaceLoading ? (
                     <p className="py-6 text-center text-2xs text-[var(--color-text-muted)]">
-                      No saved templates yet.
+                      Loading templates...
+                    </p>
+                  ) : workspaceTemplates.length === 0 ? (
+                    <p className="py-6 text-center text-2xs text-[var(--color-text-muted)]">
+                      No workspace templates yet. Save your current document as a template to get started.
                     </p>
                   ) : (
-                    savedTemplates.map((template) => (
+                    workspaceTemplates.map((template) => (
                       <TemplateCard
                         key={template.id}
                         template={template}
                         selected={selected?.id === template.id}
                         onSelect={() => setSelected(template)}
+                        onDelete={
+                          onDeleteTemplate
+                            ? () => onDeleteTemplate(template.id)
+                            : undefined
+                        }
                       />
                     ))
                   )}

--- a/src-vnext/features/export/components/__tests__/ExportKeyboardHelp.test.tsx
+++ b/src-vnext/features/export/components/__tests__/ExportKeyboardHelp.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ExportKeyboardHelp } from "../ExportKeyboardHelp"
+
+describe("ExportKeyboardHelp", () => {
+  it("renders all shortcut descriptions when open", () => {
+    render(
+      <ExportKeyboardHelp open={true} onOpenChange={vi.fn()} />,
+    )
+
+    expect(screen.getByText("Insert block at cursor")).toBeInTheDocument()
+    expect(screen.getByText("Remove selected block")).toBeInTheDocument()
+    expect(screen.getByText("Deselect block")).toBeInTheDocument()
+    expect(screen.getByText("Show this help")).toBeInTheDocument()
+  })
+
+  it("renders keyboard shortcut keys", () => {
+    render(
+      <ExportKeyboardHelp open={true} onOpenChange={vi.fn()} />,
+    )
+
+    expect(screen.getByText("⌘ /")).toBeInTheDocument()
+    expect(screen.getByText("Delete")).toBeInTheDocument()
+    expect(screen.getByText("Esc")).toBeInTheDocument()
+    expect(screen.getByText("?")).toBeInTheDocument()
+  })
+
+  it("has a title", () => {
+    render(
+      <ExportKeyboardHelp open={true} onOpenChange={vi.fn()} />,
+    )
+
+    expect(screen.getByText("Keyboard Shortcuts")).toBeInTheDocument()
+  })
+
+  it("does not render when open is false", () => {
+    const { container } = render(
+      <ExportKeyboardHelp open={false} onOpenChange={vi.fn()} />,
+    )
+
+    expect(container.querySelector("[role='dialog']")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/export/components/__tests__/InlineBlockPicker.test.tsx
+++ b/src-vnext/features/export/components/__tests__/InlineBlockPicker.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { InlineBlockPicker } from "../InlineBlockPicker"
+import { BLOCK_REGISTRY } from "../../lib/blockRegistry"
+
+describe("InlineBlockPicker", () => {
+  it("renders all block types when open", () => {
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    for (const entry of BLOCK_REGISTRY) {
+      expect(screen.getByText(entry.label)).toBeInTheDocument()
+    }
+  })
+
+  it("renders category group headings", () => {
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Content")).toBeInTheDocument()
+    expect(screen.getByText("Data")).toBeInTheDocument()
+    expect(screen.getByText("Layout")).toBeInTheDocument()
+  })
+
+  it("renders the search input", () => {
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText("Search blocks...")).toBeInTheDocument()
+  })
+
+  it("calls onSelectBlock when a block type is selected", async () => {
+    const user = userEvent.setup()
+    const onSelect = vi.fn()
+
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectBlock={onSelect}
+      />,
+    )
+
+    await user.click(screen.getByText("Text"))
+    expect(onSelect).toHaveBeenCalledWith("text")
+  })
+
+  it("calls onOpenChange(false) when a block is selected", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={onOpenChange}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByText("Shot Grid"))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("does not render when open is false", () => {
+    const { container } = render(
+      <InlineBlockPicker
+        open={false}
+        onOpenChange={vi.fn()}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector("[role='dialog']")).not.toBeInTheDocument()
+  })
+
+  it("filters blocks by search query", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <InlineBlockPicker
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectBlock={vi.fn()}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText("Search blocks...")
+    await user.type(input, "shot")
+
+    expect(screen.getByText("Shot Grid")).toBeInTheDocument()
+    expect(screen.getByText("Shot Detail")).toBeInTheDocument()
+    expect(screen.queryByText("Divider")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/export/components/__tests__/TemplateDialog.test.tsx
+++ b/src-vnext/features/export/components/__tests__/TemplateDialog.test.tsx
@@ -1,24 +1,9 @@
-import { describe, expect, it, vi, beforeEach } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { TemplateDialog } from "../TemplateDialog"
 import { BUILT_IN_TEMPLATES } from "../../lib/builtInTemplates"
 import type { ExportTemplate } from "../../types/exportBuilder"
-
-// Mock localStorage for saved templates
-let storage: Map<string, string>
-
-beforeEach(() => {
-  storage = new Map()
-  vi.stubGlobal("localStorage", {
-    getItem: (key: string) => storage.get(key) ?? null,
-    setItem: (key: string, value: string) => storage.set(key, value),
-    removeItem: (key: string) => storage.delete(key),
-    clear: () => storage.clear(),
-    get length() { return storage.size },
-    key: (index: number) => [...storage.keys()][index] ?? null,
-  })
-})
 
 describe("TemplateDialog", () => {
   it("renders all built-in template names", () => {
@@ -84,9 +69,7 @@ describe("TemplateDialog", () => {
       />,
     )
 
-    // Click the first built-in template
     fireEvent.click(screen.getByText(BUILT_IN_TEMPLATES[0]!.name))
-    // Click Use Template
     fireEvent.click(screen.getByRole("button", { name: /use template/i }))
 
     expect(onSelect).toHaveBeenCalledTimes(1)
@@ -109,44 +92,45 @@ describe("TemplateDialog", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false)
   })
 
-  it("shows saved tab with empty message when no saved templates exist", async () => {
+  it("shows workspace tab with empty message when no workspace templates", async () => {
     const user = userEvent.setup()
     render(
       <TemplateDialog
         open={true}
         onOpenChange={vi.fn()}
         onSelectTemplate={vi.fn()}
+        workspaceTemplates={[]}
       />,
     )
 
-    // Use userEvent to click the Saved tab (Radix uses pointer events)
-    await user.click(screen.getByRole("tab", { name: /saved/i }))
-    expect(screen.getByText(/no saved templates/i)).toBeInTheDocument()
+    await user.click(screen.getByRole("tab", { name: /workspace/i }))
+    expect(screen.getByText(/no workspace templates/i)).toBeInTheDocument()
   })
 
-  it("shows saved templates from localStorage", async () => {
+  it("shows workspace templates when provided", async () => {
     const user = userEvent.setup()
-    const saved: ExportTemplate[] = [
+    const templates: ExportTemplate[] = [
       {
-        id: "saved-1",
+        id: "ws-1",
         name: "My Custom Template",
         description: "Custom layout",
-        category: "saved",
+        category: "workspace",
         settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
         pages: [{ id: "p1", items: [] }],
+        createdBy: "user-1",
       },
     ]
-    storage.set("sb:export-templates", JSON.stringify(saved))
 
     render(
       <TemplateDialog
         open={true}
         onOpenChange={vi.fn()}
         onSelectTemplate={vi.fn()}
+        workspaceTemplates={templates}
       />,
     )
 
-    await user.click(screen.getByRole("tab", { name: /saved/i }))
+    await user.click(screen.getByRole("tab", { name: /workspace/i }))
     expect(screen.getByText("My Custom Template")).toBeInTheDocument()
   })
 
@@ -174,11 +158,56 @@ describe("TemplateDialog", () => {
       />,
     )
 
-    await user.click(screen.getByRole("tab", { name: /saved/i }))
+    await user.click(screen.getByRole("tab", { name: /workspace/i }))
     const saveBtn = screen.getByRole("button", { name: /save current/i })
     expect(saveBtn).toBeInTheDocument()
 
     await user.click(saveBtn)
     expect(onSaveCurrent).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows delete button on workspace templates when onDeleteTemplate provided", async () => {
+    const user = userEvent.setup()
+    const onDelete = vi.fn()
+    const templates: ExportTemplate[] = [
+      {
+        id: "ws-1",
+        name: "Deletable Template",
+        description: "Can be deleted",
+        category: "workspace",
+        settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
+        pages: [{ id: "p1", items: [] }],
+      },
+    ]
+
+    render(
+      <TemplateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectTemplate={vi.fn()}
+        workspaceTemplates={templates}
+        onDeleteTemplate={onDelete}
+      />,
+    )
+
+    await user.click(screen.getByRole("tab", { name: /workspace/i }))
+    const deleteBtn = screen.getByRole("button", { name: /delete deletable template/i })
+    await user.click(deleteBtn)
+    expect(onDelete).toHaveBeenCalledWith("ws-1")
+  })
+
+  it("shows loading state when workspaceLoading is true", async () => {
+    const user = userEvent.setup()
+    render(
+      <TemplateDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onSelectTemplate={vi.fn()}
+        workspaceLoading={true}
+      />,
+    )
+
+    await user.click(screen.getByRole("tab", { name: /workspace/i }))
+    expect(screen.getByText(/loading templates/i)).toBeInTheDocument()
   })
 })

--- a/src-vnext/features/export/components/blocks/TextBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/TextBlockView.tsx
@@ -18,6 +18,8 @@ function escapeHtml(str: string): string {
   )
 }
 
+const PDF_RENDER_TIME_TOKENS = new Set(["pageNumber", "pageCount"])
+
 /** Replace {{variableKey}} tokens with styled chip spans for display */
 function renderContentWithChips(
   content: string,
@@ -28,7 +30,11 @@ function renderContentWithChips(
     const variable = variableMap.get(key)
     const safeKey = escapeHtml(key)
     const safeLabel = escapeHtml(variable?.label ?? key)
-    return `<span class="inline-flex items-center rounded bg-[var(--color-accent-subtle)] px-1.5 text-xs text-[var(--color-accent)]" data-token="${safeKey}" contenteditable="false">${safeLabel}</span>`
+    const isResolved = variable !== undefined || PDF_RENDER_TIME_TOKENS.has(key)
+    const chipClass = isResolved
+      ? "inline-flex items-center rounded bg-[var(--color-accent-subtle)] px-1.5 text-xs text-[var(--color-accent)]"
+      : "inline-flex items-center rounded bg-amber-100 dark:bg-amber-900/30 px-1.5 text-xs text-amber-700 dark:text-amber-400 ring-1 ring-amber-300 dark:ring-amber-700"
+    return `<span class="${chipClass}" data-token="${safeKey}" contenteditable="false" ${!isResolved ? 'title="Undefined variable"' : ""}>${safeLabel}</span>`
   })
 }
 

--- a/src-vnext/features/export/hooks/useExportTemplates.ts
+++ b/src-vnext/features/export/hooks/useExportTemplates.ts
@@ -20,7 +20,7 @@ import type { ExportTemplate, ExportPage, PageSettings } from "../types/exportBu
 import { loadTemplates as loadLocalStorageTemplates } from "../lib/documentPersistence"
 
 const LS_TEMPLATES_KEY = "sb:export-templates"
-const LS_MIGRATED_KEY = "sb:export-templates-migrated"
+const LS_MIGRATED_PREFIX = "sb:export-templates-migrated:"
 
 export interface UseExportTemplatesReturn {
   readonly templates: readonly ExportTemplate[]
@@ -103,7 +103,8 @@ export function useExportTemplates(
     if (!clientId || !user?.uid || migrationAttempted.current) return
     migrationAttempted.current = true
 
-    const alreadyMigrated = localStorage.getItem(LS_MIGRATED_KEY)
+    const migratedKey = `${LS_MIGRATED_PREFIX}${clientId}`
+    const alreadyMigrated = localStorage.getItem(migratedKey)
     if (alreadyMigrated) return
 
     const localTemplates = loadLocalStorageTemplates()
@@ -112,7 +113,7 @@ export function useExportTemplates(
       return
     }
 
-    void migrateLocalTemplates(clientId, user.uid, localTemplates)
+    void migrateLocalTemplates(clientId, user.uid, localTemplates, migratedKey)
   }, [clientId, user?.uid])
 
   const saveTemplate = useCallback(
@@ -162,6 +163,7 @@ async function migrateLocalTemplates(
   clientId: string,
   uid: string,
   localTemplates: readonly ExportTemplate[],
+  migratedKey: string,
 ): Promise<void> {
   try {
     const pathSegments = exportTemplatesPath(clientId)
@@ -185,7 +187,7 @@ async function migrateLocalTemplates(
       })
     }
 
-    localStorage.setItem(LS_MIGRATED_KEY, "true")
+    localStorage.setItem(migratedKey, "true")
     localStorage.removeItem(LS_TEMPLATES_KEY)
   } catch (err) {
     console.error("[useExportTemplates] migration failed:", err)

--- a/src-vnext/features/export/hooks/useExportTemplates.ts
+++ b/src-vnext/features/export/hooks/useExportTemplates.ts
@@ -1,0 +1,193 @@
+import { useEffect, useState, useCallback, useRef } from "react"
+import {
+  collection,
+  query,
+  orderBy,
+  onSnapshot,
+  doc,
+  setDoc,
+  updateDoc,
+  deleteDoc,
+  getDocs,
+  serverTimestamp,
+  type Timestamp,
+} from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { exportTemplatesPath, exportTemplateDocPath } from "@/shared/lib/paths"
+import { BUILT_IN_TEMPLATES } from "../lib/builtInTemplates"
+import type { ExportTemplate, ExportPage, PageSettings } from "../types/exportBuilder"
+import { loadTemplates as loadLocalStorageTemplates } from "../lib/documentPersistence"
+
+const LS_TEMPLATES_KEY = "sb:export-templates"
+const LS_MIGRATED_KEY = "sb:export-templates-migrated"
+
+export interface UseExportTemplatesReturn {
+  readonly templates: readonly ExportTemplate[]
+  readonly workspaceTemplates: readonly ExportTemplate[]
+  readonly loading: boolean
+  readonly saveTemplate: (
+    name: string,
+    description: string,
+    pages: readonly ExportPage[],
+    settings: PageSettings,
+  ) => Promise<string>
+  readonly deleteTemplate: (templateId: string) => Promise<void>
+}
+
+function mapTemplate(
+  id: string,
+  data: Record<string, unknown>,
+): ExportTemplate {
+  const createdAt = data.createdAt as Timestamp | null | undefined
+  const updatedAt = data.updatedAt as Timestamp | null | undefined
+  return {
+    id,
+    name: (data.name as string) ?? "Untitled",
+    description: (data.description as string) ?? "",
+    category: "workspace",
+    pages: (data.pages as ExportPage[]) ?? [],
+    settings: (data.settings as PageSettings) ?? {
+      layout: "portrait",
+      size: "letter",
+      fontFamily: "Inter",
+    },
+    createdBy: (data.createdBy as string) ?? "",
+    createdAt: createdAt?.toDate?.().toISOString() ?? undefined,
+    updatedAt: updatedAt?.toDate?.().toISOString() ?? undefined,
+  }
+}
+
+export function useExportTemplates(
+  clientId: string | null,
+): UseExportTemplatesReturn {
+  const { user } = useAuth()
+  const [workspaceTemplates, setWorkspaceTemplates] = useState<
+    readonly ExportTemplate[]
+  >([])
+  const [loading, setLoading] = useState(true)
+  const migrationAttempted = useRef(false)
+
+  useEffect(() => {
+    if (!clientId) {
+      setWorkspaceTemplates([])
+      setLoading(false)
+      return
+    }
+
+    const pathSegments = exportTemplatesPath(clientId)
+    const collRef = collection(db, pathSegments[0]!, ...pathSegments.slice(1))
+    const q = query(collRef, orderBy("updatedAt", "desc"))
+
+    const unsubscribe = onSnapshot(
+      q,
+      (snapshot) => {
+        const docs = snapshot.docs.map((d) =>
+          mapTemplate(d.id, d.data() as Record<string, unknown>),
+        )
+        setWorkspaceTemplates(docs)
+        setLoading(false)
+      },
+      (err) => {
+        const fireErr = err as { message?: string }
+        console.error("[useExportTemplates]", fireErr.message ?? err)
+        setLoading(false)
+      },
+    )
+
+    return unsubscribe
+  }, [clientId])
+
+  // One-time localStorage → Firestore migration
+  useEffect(() => {
+    if (!clientId || !user?.uid || migrationAttempted.current) return
+    migrationAttempted.current = true
+
+    const alreadyMigrated = localStorage.getItem(LS_MIGRATED_KEY)
+    if (alreadyMigrated) return
+
+    const localTemplates = loadLocalStorageTemplates()
+    if (localTemplates.length === 0) {
+      localStorage.setItem(LS_MIGRATED_KEY, "true")
+      return
+    }
+
+    void migrateLocalTemplates(clientId, user.uid, localTemplates)
+  }, [clientId, user?.uid])
+
+  const saveTemplate = useCallback(
+    async (
+      name: string,
+      description: string,
+      pages: readonly ExportPage[],
+      settings: PageSettings,
+    ): Promise<string> => {
+      if (!clientId) throw new Error("Missing clientId")
+      const pathSegments = exportTemplatesPath(clientId)
+      const collRef = collection(db, pathSegments[0]!, ...pathSegments.slice(1))
+      const newDocRef = doc(collRef)
+      await setDoc(newDocRef, {
+        name,
+        description,
+        pages,
+        settings,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        createdBy: user?.uid ?? "",
+      })
+      return newDocRef.id
+    },
+    [clientId, user?.uid],
+  )
+
+  const deleteTemplate = useCallback(
+    async (templateId: string) => {
+      if (!clientId) return
+      const pathSegments = exportTemplateDocPath(clientId, templateId)
+      const docRef = doc(db, pathSegments[0]!, ...pathSegments.slice(1))
+      await deleteDoc(docRef)
+    },
+    [clientId],
+  )
+
+  const templates: readonly ExportTemplate[] = [
+    ...BUILT_IN_TEMPLATES,
+    ...workspaceTemplates,
+  ]
+
+  return { templates, workspaceTemplates, loading, saveTemplate, deleteTemplate }
+}
+
+async function migrateLocalTemplates(
+  clientId: string,
+  uid: string,
+  localTemplates: readonly ExportTemplate[],
+): Promise<void> {
+  try {
+    const pathSegments = exportTemplatesPath(clientId)
+    const collRef = collection(db, pathSegments[0]!, ...pathSegments.slice(1))
+    const existing = await getDocs(collRef)
+    const existingNames = new Set(
+      existing.docs.map((d) => (d.data() as Record<string, unknown>).name),
+    )
+
+    for (const template of localTemplates) {
+      if (existingNames.has(template.name)) continue
+      const newDocRef = doc(collRef)
+      await setDoc(newDocRef, {
+        name: template.name,
+        description: template.description,
+        pages: template.pages,
+        settings: template.settings,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+        createdBy: uid,
+      })
+    }
+
+    localStorage.setItem(LS_MIGRATED_KEY, "true")
+    localStorage.removeItem(LS_TEMPLATES_KEY)
+  } catch (err) {
+    console.error("[useExportTemplates] migration failed:", err)
+  }
+}

--- a/src-vnext/features/export/hooks/useInlineBlockPicker.ts
+++ b/src-vnext/features/export/hooks/useInlineBlockPicker.ts
@@ -1,0 +1,84 @@
+import { useState, useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from "react"
+import type { BlockType, ExportBlock, ExportDocument, ExportPage } from "../types/exportBuilder"
+import { createBlock } from "../lib/blockDefaults"
+import { insertBlockAtIndex } from "../lib/documentOperations"
+
+export interface UseInlineBlockPickerReturn {
+  readonly blockPickerOpen: boolean
+  readonly setBlockPickerOpen: Dispatch<SetStateAction<boolean>>
+  readonly handleBlockPickerSelect: (type: BlockType | "hstack") => void
+  readonly handleOpenBlockPicker: (pageId: string, insertIndex: number) => void
+}
+
+export function useInlineBlockPicker(
+  document: ExportDocument,
+  setDocument: Dispatch<SetStateAction<ExportDocument>>,
+  setSelectedBlockId: Dispatch<SetStateAction<string | null>>,
+  handleAddBlock: (type: BlockType | "hstack") => void,
+  activePageIdRef: React.RefObject<string | null>,
+): UseInlineBlockPickerReturn {
+  const [blockPickerOpen, setBlockPickerOpen] = useState(false)
+  const insertRef = useRef<{ pageId: string; index: number } | null>(null)
+
+  useEffect(() => {
+    const handleCmdSlash = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.key !== "/") return
+      const target = e.target as HTMLElement
+      if (target.isContentEditable || target.tagName === "INPUT" || target.tagName === "TEXTAREA") return
+      e.preventDefault()
+      const pageId = activePageIdRef.current ?? document.pages[0]?.id
+      if (!pageId) return
+      const page = document.pages.find((p) => p.id === pageId)
+      insertRef.current = { pageId, index: page?.items.length ?? 0 }
+      setBlockPickerOpen(true)
+    }
+    window.document.addEventListener("keydown", handleCmdSlash)
+    return () => window.document.removeEventListener("keydown", handleCmdSlash)
+  }, [document.pages, activePageIdRef])
+
+  const handleBlockPickerSelect = useCallback(
+    (type: BlockType | "hstack") => {
+      const insert = insertRef.current
+      if (!insert) {
+        handleAddBlock(type)
+        return
+      }
+      if (type === "hstack") {
+        setDocument((prev) => {
+          const row = {
+            id: crypto.randomUUID(),
+            type: "hstack" as const,
+            columns: [
+              { id: crypto.randomUUID(), widthPercent: 50, blocks: [] as readonly ExportBlock[] },
+              { id: crypto.randomUUID(), widthPercent: 50, blocks: [] as readonly ExportBlock[] },
+            ],
+          }
+          return insertBlockAtIndex(prev, insert.pageId, row, insert.index)
+        })
+      } else {
+        const newBlock = createBlock(type)
+        setDocument((prev) =>
+          insertBlockAtIndex(prev, insert.pageId, newBlock, insert.index),
+        )
+        setSelectedBlockId(newBlock.id)
+      }
+      insertRef.current = null
+    },
+    [handleAddBlock, setDocument, setSelectedBlockId],
+  )
+
+  const handleOpenBlockPicker = useCallback(
+    (pageId: string, insertIndex: number) => {
+      insertRef.current = { pageId, index: insertIndex }
+      setBlockPickerOpen(true)
+    },
+    [],
+  )
+
+  return {
+    blockPickerOpen,
+    setBlockPickerOpen,
+    handleBlockPickerSelect,
+    handleOpenBlockPicker,
+  }
+}

--- a/src-vnext/features/export/lib/__tests__/documentPersistence.test.ts
+++ b/src-vnext/features/export/lib/__tests__/documentPersistence.test.ts
@@ -24,7 +24,7 @@ function makeTemplate(id: string, name: string): ExportTemplate {
     id,
     name,
     description: "Test template",
-    category: "saved",
+    category: "workspace",
     settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
     pages: [{ id: "page-1", items: [] }],
   }

--- a/src-vnext/features/export/lib/__tests__/exportVariables.test.ts
+++ b/src-vnext/features/export/lib/__tests__/exportVariables.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getDynamicVariables, resolveVariables } from "../exportVariables"
+import { getDynamicVariables, resolveVariables, findUnresolvedTokens } from "../exportVariables"
 import type { ExportVariable } from "../../types/exportBuilder"
 
 describe("getDynamicVariables", () => {
@@ -112,5 +112,67 @@ describe("resolveVariables", () => {
   it("handles empty variables array", () => {
     const result = resolveVariables("{{projectName}} stays", [])
     expect(result).toBe("{{projectName}} stays")
+  })
+})
+
+describe("findUnresolvedTokens", () => {
+  const variables: ExportVariable[] = [
+    { key: "projectName", label: "Project Name", value: "FW26 Campaign", source: "dynamic" },
+    { key: "clientName", label: "Client", value: "Acme Corp", source: "dynamic" },
+  ]
+
+  it("returns empty array when all tokens are resolved", () => {
+    const result = findUnresolvedTokens(
+      "{{projectName}} by {{clientName}}",
+      variables,
+    )
+    expect(result).toEqual([])
+  })
+
+  it("returns unresolved token keys", () => {
+    const result = findUnresolvedTokens(
+      "Hello {{unknown}} and {{projectName}}",
+      variables,
+    )
+    expect(result).toEqual(["unknown"])
+  })
+
+  it("returns multiple unresolved tokens", () => {
+    const result = findUnresolvedTokens(
+      "{{foo}} {{bar}} {{projectName}}",
+      variables,
+    )
+    expect(result).toEqual(["foo", "bar"])
+  })
+
+  it("deduplicates repeated unresolved tokens", () => {
+    const result = findUnresolvedTokens(
+      "{{unknown}} and {{unknown}} again",
+      variables,
+    )
+    expect(result).toEqual(["unknown"])
+  })
+
+  it("returns empty array when text has no tokens", () => {
+    const result = findUnresolvedTokens("No tokens here", variables)
+    expect(result).toEqual([])
+  })
+
+  it("returns empty array for empty text", () => {
+    const result = findUnresolvedTokens("", variables)
+    expect(result).toEqual([])
+  })
+
+  it("treats pageNumber and pageCount as resolved (PDF render-time tokens)", () => {
+    const result = findUnresolvedTokens(
+      "Page {{pageNumber}} of {{pageCount}} — {{unknown}}",
+      variables,
+    )
+    expect(result).toEqual(["unknown"])
+  })
+
+  it("works with empty variables array — all tokens are unresolved", () => {
+    const result = findUnresolvedTokens("{{projectName}} {{clientName}}", [])
+    expect(result).toEqual(["projectName", "clientName"])
   })
 })

--- a/src-vnext/features/export/lib/exportVariables.ts
+++ b/src-vnext/features/export/lib/exportVariables.ts
@@ -79,12 +79,36 @@ export function resolveVariables(
   let resolved = text
   for (const variable of variables) {
     const token = `{{${variable.key}}}`
-    // Only replace if the token exists to avoid unnecessary string allocations
     if (resolved.includes(token)) {
       resolved = resolved.split(token).join(variable.value)
     }
   }
   return resolved
+}
+
+const PDF_RENDER_TIME_TOKENS = new Set(["pageNumber", "pageCount"])
+
+/** Find all {{token}} keys in text that don't match any known variable */
+export function findUnresolvedTokens(
+  text: string,
+  variables: readonly ExportVariable[],
+): readonly string[] {
+  const knownKeys = new Set(variables.map((v) => v.key))
+  const tokenPattern = /\{\{(\w+)\}\}/g
+  const unresolved: string[] = []
+  const seen = new Set<string>()
+
+  let match: RegExpExecArray | null
+  while ((match = tokenPattern.exec(text)) !== null) {
+    const key = match[1]
+    if (!key) continue
+    if (!knownKeys.has(key) && !PDF_RENDER_TIME_TOKENS.has(key) && !seen.has(key)) {
+      seen.add(key)
+      unresolved.push(key)
+    }
+  }
+
+  return unresolved
 }
 
 function formatShootDates(dates?: readonly string[]): string {

--- a/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
+++ b/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
@@ -7,6 +7,7 @@ import type {
 import { isHStackRow } from "../../types/exportBuilder"
 import type { ExportData } from "../../hooks/useExportData"
 import { styles, PAGE_SIZES } from "./pdfStyles"
+import { mapFontFamilyBase } from "./fontMapping"
 import { WatermarkOverlay } from "./WatermarkOverlay"
 import { ExportPdfBlockMapper } from "./ExportPdfBlockMapper"
 import { HStackRowPdf } from "./blocks/HStackRowPdf"
@@ -74,7 +75,7 @@ export function ExportPdfDocument({
       producer="Production Hub"
     >
       {pages.map((pageItems, pageIndex) => (
-        <Page key={pageIndex} size={pageSize} style={styles.page} wrap>
+        <Page key={pageIndex} size={pageSize} style={{ ...styles.page, fontFamily: mapFontFamilyBase(settings.fontFamily) }} wrap>
           {settings.watermark?.text && (
             <WatermarkOverlay watermark={settings.watermark} />
           )}

--- a/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
+++ b/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
@@ -17,6 +17,8 @@ interface ExportPdfDocumentProps {
   readonly variables: readonly ExportVariable[]
   readonly data: ExportData
   readonly imageMap: ReadonlyMap<string, string>
+  readonly documentName?: string
+  readonly authorName?: string
 }
 
 /** Render a single page item (block or HStack row) as a PDF element */
@@ -54,6 +56,8 @@ export function ExportPdfDocument({
   variables,
   data,
   imageMap,
+  documentName,
+  authorName,
 }: ExportPdfDocumentProps) {
   const sizeKey = settings.size ?? "letter"
   const dims = PAGE_SIZES[sizeKey] ?? PAGE_SIZES.letter
@@ -64,7 +68,11 @@ export function ExportPdfDocument({
       : { width: dims.width, height: dims.height }
 
   return (
-    <Document>
+    <Document
+      title={documentName ?? "Export"}
+      author={authorName ?? ""}
+      producer="Production Hub"
+    >
       {pages.map((pageItems, pageIndex) => (
         <Page key={pageIndex} size={pageSize} style={styles.page} wrap>
           {settings.watermark?.text && (

--- a/src-vnext/features/export/lib/pdf/__tests__/ExportPdfDocument.test.tsx
+++ b/src-vnext/features/export/lib/pdf/__tests__/ExportPdfDocument.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  return {
+    Document: (props: Record<string, unknown>) =>
+      React.createElement("pdf-document", props, props.children),
+    Page: (props: Record<string, unknown>) =>
+      React.createElement("pdf-page", props, props.children),
+    Text: (props: Record<string, unknown>) =>
+      React.createElement("pdf-text", props),
+    View: (props: Record<string, unknown>) =>
+      React.createElement("pdf-view", props, props.children),
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import React from "react"
+import { render } from "@testing-library/react"
+import { ExportPdfDocument } from "../ExportPdfDocument"
+import type { PageSettings, ExportVariable, PageItem } from "../../../types/exportBuilder"
+import type { ExportData } from "../../../hooks/useExportData"
+
+function makeProps(overrides?: {
+  documentName?: string
+  authorName?: string
+}) {
+  const settings: PageSettings = {
+    layout: "portrait",
+    size: "letter",
+    fontFamily: "Inter",
+  }
+  const variables: ExportVariable[] = []
+  const data: ExportData = {
+    project: null,
+    shots: [],
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+  }
+  const pages: readonly (readonly PageItem[])[] = [[]]
+  const imageMap = new Map<string, string>()
+
+  return {
+    pages,
+    settings,
+    variables,
+    data,
+    imageMap,
+    documentName: overrides?.documentName,
+    authorName: overrides?.authorName,
+  }
+}
+
+describe("ExportPdfDocument metadata", () => {
+  it("passes title prop to Document derived from documentName", () => {
+    const props = makeProps({ documentName: "FW26 Campaign - Shot List" })
+    const { container } = render(<ExportPdfDocument {...props} />)
+    const doc = container.querySelector("pdf-document")
+    expect(doc).toBeTruthy()
+    expect(doc?.getAttribute("title")).toBe("FW26 Campaign - Shot List")
+  })
+
+  it("passes author prop to Document from authorName", () => {
+    const props = makeProps({ authorName: "Ted Ghanime" })
+    const { container } = render(<ExportPdfDocument {...props} />)
+    const doc = container.querySelector("pdf-document")
+    expect(doc?.getAttribute("author")).toBe("Ted Ghanime")
+  })
+
+  it("passes producer prop as Production Hub", () => {
+    const props = makeProps()
+    const { container } = render(<ExportPdfDocument {...props} />)
+    const doc = container.querySelector("pdf-document")
+    expect(doc?.getAttribute("producer")).toBe("Production Hub")
+  })
+
+  it("defaults title to Export when documentName is undefined", () => {
+    const props = makeProps()
+    const { container } = render(<ExportPdfDocument {...props} />)
+    const doc = container.querySelector("pdf-document")
+    expect(doc?.getAttribute("title")).toBe("Export")
+  })
+
+  it("defaults author to empty string when authorName is undefined", () => {
+    const props = makeProps()
+    const { container } = render(<ExportPdfDocument {...props} />)
+    const doc = container.querySelector("pdf-document")
+    expect(doc?.getAttribute("author")).toBe("")
+  })
+})

--- a/src-vnext/features/export/lib/pdf/__tests__/fontMapping.test.ts
+++ b/src-vnext/features/export/lib/pdf/__tests__/fontMapping.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { mapFontFamilyToPdf, mapFontFamilyBase } from "../fontMapping"
+
+describe("mapFontFamilyToPdf", () => {
+  it("maps Inter to Helvetica", () => {
+    expect(mapFontFamilyToPdf("Inter")).toBe("Helvetica")
+  })
+
+  it("maps undefined to Helvetica", () => {
+    expect(mapFontFamilyToPdf(undefined)).toBe("Helvetica")
+  })
+
+  it("maps Georgia to Times-Roman", () => {
+    expect(mapFontFamilyToPdf("Georgia")).toBe("Times-Roman")
+  })
+
+  it("maps Georgia bold to Times-Bold", () => {
+    expect(mapFontFamilyToPdf("Georgia", true)).toBe("Times-Bold")
+  })
+
+  it("maps Georgia italic to Times-Italic", () => {
+    expect(mapFontFamilyToPdf("Georgia", false, true)).toBe("Times-Italic")
+  })
+
+  it("maps Georgia bold+italic to Times-BoldItalic", () => {
+    expect(mapFontFamilyToPdf("Georgia", true, true)).toBe("Times-BoldItalic")
+  })
+
+  it("maps Courier New to Courier", () => {
+    expect(mapFontFamilyToPdf("Courier New")).toBe("Courier")
+  })
+
+  it("maps Courier New bold to Courier-Bold", () => {
+    expect(mapFontFamilyToPdf("Courier New", true)).toBe("Courier-Bold")
+  })
+
+  it("maps Helvetica bold to Helvetica-Bold", () => {
+    expect(mapFontFamilyToPdf("Helvetica", true)).toBe("Helvetica-Bold")
+  })
+
+  it("maps unknown fonts to Helvetica family", () => {
+    expect(mapFontFamilyToPdf("Arial")).toBe("Helvetica")
+    expect(mapFontFamilyToPdf("Arial", true)).toBe("Helvetica-Bold")
+  })
+})
+
+describe("mapFontFamilyBase", () => {
+  it("returns base family without bold/italic", () => {
+    expect(mapFontFamilyBase("Georgia")).toBe("Times-Roman")
+    expect(mapFontFamilyBase("Courier New")).toBe("Courier")
+    expect(mapFontFamilyBase("Inter")).toBe("Helvetica")
+    expect(mapFontFamilyBase(undefined)).toBe("Helvetica")
+  })
+})

--- a/src-vnext/features/export/lib/pdf/__tests__/widowOrphan.test.ts
+++ b/src-vnext/features/export/lib/pdf/__tests__/widowOrphan.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+import { computeOrphanGroupIndex } from "../widowOrphan"
+
+describe("computeOrphanGroupIndex", () => {
+  it("returns -1 for empty arrays (no grouping needed)", () => {
+    expect(computeOrphanGroupIndex(0)).toBe(-1)
+  })
+
+  it("returns -1 for 1 row (no orphan possible)", () => {
+    expect(computeOrphanGroupIndex(1)).toBe(-1)
+  })
+
+  it("returns -1 for rows <= MIN_ROWS threshold (all fit together)", () => {
+    expect(computeOrphanGroupIndex(3)).toBe(-1)
+    expect(computeOrphanGroupIndex(4)).toBe(-1)
+  })
+
+  it("returns the start index of the last group for larger row counts", () => {
+    // With MIN_ROWS_KEEP_TOGETHER = 4, for 10 rows the last group
+    // should start at index 6 (rows 6,7,8,9 stay together)
+    expect(computeOrphanGroupIndex(10)).toBe(6)
+  })
+
+  it("returns the start index for exactly MIN_ROWS + 1", () => {
+    // 5 rows: last 4 should stay together, group starts at index 1
+    expect(computeOrphanGroupIndex(5)).toBe(1)
+  })
+
+  it("returns the start index for large row counts", () => {
+    // 50 rows: last 4 stay together, group starts at index 46
+    expect(computeOrphanGroupIndex(50)).toBe(46)
+  })
+
+  it("returns the start index for exactly MIN_ROWS + 2", () => {
+    // 6 rows: last 4 together, group at index 2
+    expect(computeOrphanGroupIndex(6)).toBe(2)
+  })
+})

--- a/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
@@ -14,6 +14,7 @@ import {
   resolveProductNamesString,
   resolveTalentNames,
 } from "../../blockDataResolvers"
+import { computeOrphanGroupIndex } from "../widowOrphan"
 
 interface ShotGridBlockPdfProps {
   readonly block: ShotGridBlock
@@ -54,6 +55,22 @@ export function ShotGridBlockPdf({ block, data }: ShotGridBlockPdfProps) {
   const showHeaderBg = ts?.showHeaderBg !== false
   const stripe = ts?.stripeRows !== false
 
+  const orphanGroupStart = computeOrphanGroupIndex(sorted.length)
+  const headRows = orphanGroupStart > 0 ? sorted.slice(0, orphanGroupStart) : sorted
+  const tailRows = orphanGroupStart > 0 ? sorted.slice(orphanGroupStart) : []
+
+  function renderRow(shot: Shot, i: number) {
+    return (
+      <View
+        key={shot.id}
+        wrap={false}
+        style={stripe && i % 2 === 1 ? styles.tableRowStriped : styles.tableRow}
+      >
+        {cols.map((col) => renderCell(col, shot, data))}
+      </View>
+    )
+  }
+
   return (
     <View style={showBorders ? styles.tableContainer : undefined}>
       <View style={showHeaderBg ? styles.tableHeader : { flexDirection: "row" as const }}>
@@ -63,70 +80,73 @@ export function ShotGridBlockPdf({ block, data }: ShotGridBlockPdfProps) {
           </Text>
         ))}
       </View>
-      {sorted.map((shot, i) => (
-        <View
-          key={shot.id}
-          wrap={false}
-          style={stripe && i % 2 === 1 ? styles.tableRowStriped : styles.tableRow}
-        >
-          {cols.map((col) => {
-            if (col.key === "status") {
-              const color = getShotStatusColor(shot.status as ShotFirestoreStatus)
-              const sc = PDF_STATUS_COLORS[color] ?? { bg: "#F3F4F6", text: "#374151" }
-              return (
-                <View key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
-                  <Text style={{ ...styles.badge, backgroundColor: sc.bg, color: sc.text }}>
-                    {getShotStatusLabel(shot.status as ShotFirestoreStatus)}
-                  </Text>
-                </View>
-              )
-            }
-            if (col.key === "tags") {
-              const tags: readonly ShotTag[] = shot.tags ?? []
-              if (tags.length === 0) {
-                return (
-                  <Text key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
-                    {"\u2014"}
-                  </Text>
-                )
-              }
-              return (
-                <View key={col.key} style={{ ...styles.tableCell, flex: colFlex(col), flexDirection: "row", flexWrap: "wrap", gap: 2 }}>
-                  {tags.map((t) => {
-                    const cat = resolveShotTagCategory(t)
-                    const catColors = PDF_TAG_CATEGORY_COLORS[cat] ?? PDF_TAG_CATEGORY_COLORS.other!
-                    const borderColor = (typeof t.color === "string" && isTagColorKey(t.color))
-                      ? (PDF_TAG_COLOR_MAP[t.color] ?? catColors.border)
-                      : catColors.border
-                    return (
-                      <Text
-                        key={t.id}
-                        style={{
-                          ...styles.badge,
-                          backgroundColor: catColors.bg,
-                          color: catColors.text,
-                          borderLeftWidth: 2,
-                          borderLeftColor: borderColor,
-                          borderRadius: 3,
-                          marginRight: 2,
-                          marginBottom: 1,
-                        }}
-                      >
-                        {t.label.length > 24 ? `${t.label.slice(0, 22)}\u2026` : t.label}
-                      </Text>
-                    )
-                  })}
-                </View>
-              )
-            }
-            return (
-              <Text key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
-                {cellText(shot, col.key, data)}
-              </Text>
-            )
-          })}
+      {headRows.map((shot, i) => renderRow(shot, i))}
+      {tailRows.length > 0 && (
+        <View wrap={false}>
+          {tailRows.map((shot, i) => renderRow(shot, orphanGroupStart + i))}
         </View>
-      ))}
+      )}
     </View>
+  )
+}
+
+function renderCell(
+  col: ShotGridColumn,
+  shot: Shot,
+  data: ExportData,
+): React.ReactNode {
+  if (col.key === "status") {
+    const color = getShotStatusColor(shot.status as ShotFirestoreStatus)
+    const sc = PDF_STATUS_COLORS[color] ?? { bg: "#F3F4F6", text: "#374151" }
+    return (
+      <View key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
+        <Text style={{ ...styles.badge, backgroundColor: sc.bg, color: sc.text }}>
+          {getShotStatusLabel(shot.status as ShotFirestoreStatus)}
+        </Text>
+      </View>
+    )
+  }
+  if (col.key === "tags") {
+    const tags: readonly ShotTag[] = shot.tags ?? []
+    if (tags.length === 0) {
+      return (
+        <Text key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
+          {"\u2014"}
+        </Text>
+      )
+    }
+    return (
+      <View key={col.key} style={{ ...styles.tableCell, flex: colFlex(col), flexDirection: "row", flexWrap: "wrap", gap: 2 }}>
+        {tags.map((t) => {
+          const cat = resolveShotTagCategory(t)
+          const catColors = PDF_TAG_CATEGORY_COLORS[cat] ?? PDF_TAG_CATEGORY_COLORS.other!
+          const borderColor = (typeof t.color === "string" && isTagColorKey(t.color))
+            ? (PDF_TAG_COLOR_MAP[t.color] ?? catColors.border)
+            : catColors.border
+          return (
+            <Text
+              key={t.id}
+              style={{
+                ...styles.badge,
+                backgroundColor: catColors.bg,
+                color: catColors.text,
+                borderLeftWidth: 2,
+                borderLeftColor: borderColor,
+                borderRadius: 3,
+                marginRight: 2,
+                marginBottom: 1,
+              }}
+            >
+              {t.label.length > 24 ? `${t.label.slice(0, 22)}\u2026` : t.label}
+            </Text>
+          )
+        })}
+      </View>
+    )
+  }
+  return (
+    <Text key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
+      {cellText(shot, col.key, data)}
+    </Text>
   )
 }

--- a/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
@@ -1,7 +1,7 @@
 import { Text, View } from "@react-pdf/renderer"
 import type { Style } from "@react-pdf/types"
 import type { TextBlock, ExportVariable } from "../../../types/exportBuilder"
-import { resolveVariables } from "../../exportVariables"
+import { resolveVariables, findUnresolvedTokens } from "../../exportVariables"
 import { styles } from "../pdfStyles"
 import {
   parseHtmlToNodes,
@@ -253,6 +253,17 @@ export function TextBlockPdf({ block, variables }: TextBlockPdfProps) {
   }
 
   // Plain text fallback
+  const unresolvedKeys = findUnresolvedTokens(resolved, variables)
+  if (unresolvedKeys.length > 0) {
+    return (
+      <View style={containerStyle}>
+        <Text style={textStyle}>
+          {renderWithWarningHighlights(resolved)}
+        </Text>
+      </View>
+    )
+  }
+
   return (
     <View style={containerStyle}>
       <Text style={textStyle}>{resolved}</Text>
@@ -308,6 +319,23 @@ function renderHtmlContent(
       })}
     </View>
   )
+}
+
+/** Split text on unresolved {{token}} patterns and wrap them in yellow highlight */
+function renderWithWarningHighlights(text: string): React.ReactNode {
+  const parts = text.split(/(\{\{\w+\}\})/g)
+  if (parts.length === 1) return text
+
+  return parts.map((part, i) => {
+    if (/^\{\{\w+\}\}$/.test(part)) {
+      return (
+        <Text key={i} style={{ backgroundColor: "#FEF3C7", color: "#92400E" }}>
+          {part}
+        </Text>
+      )
+    }
+    return part.length > 0 ? <Text key={i}>{part}</Text> : null
+  })
 }
 
 /** Group consecutive text nodes together, keeping list nodes separate */

--- a/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
@@ -44,32 +44,9 @@ function splitRenderTokens(
     })
 }
 
-/** Map fontFamily name to the Helvetica-based PDF font */
-function resolvePdfFontFamily(
-  fontFamily: string | undefined,
-  bold?: boolean,
-  italic?: boolean,
-): string {
-  const base = fontFamily ?? "Helvetica"
+import { mapFontFamilyToPdf } from "../fontMapping"
 
-  if (base === "Courier New" || base === "Courier") {
-    if (bold && italic) return "Courier-BoldOblique"
-    if (bold) return "Courier-Bold"
-    if (italic) return "Courier-Oblique"
-    return "Courier"
-  }
-  if (base === "Georgia" || base === "Times New Roman") {
-    if (bold && italic) return "Times-BoldItalic"
-    if (bold) return "Times-Bold"
-    if (italic) return "Times-Italic"
-    return "Times-Roman"
-  }
-
-  if (bold && italic) return "Helvetica-BoldOblique"
-  if (bold) return "Helvetica-Bold"
-  if (italic) return "Helvetica-Oblique"
-  return "Helvetica"
-}
+const resolvePdfFontFamily = mapFontFamilyToPdf
 
 /** Build style object for a PdfTextNode */
 function buildTextNodeStyle(

--- a/src-vnext/features/export/lib/pdf/fontMapping.ts
+++ b/src-vnext/features/export/lib/pdf/fontMapping.ts
@@ -1,0 +1,34 @@
+/**
+ * Map UI font family names to @react-pdf/renderer built-in font families.
+ * Built-in fonts: Helvetica, Courier, Times-Roman (+ Bold/Italic variants).
+ */
+export function mapFontFamilyToPdf(
+  fontFamily: string | undefined,
+  bold?: boolean,
+  italic?: boolean,
+): string {
+  const base = fontFamily ?? "Helvetica"
+
+  if (base === "Courier New" || base === "Courier") {
+    if (bold && italic) return "Courier-BoldOblique"
+    if (bold) return "Courier-Bold"
+    if (italic) return "Courier-Oblique"
+    return "Courier"
+  }
+  if (base === "Georgia" || base === "Times New Roman") {
+    if (bold && italic) return "Times-BoldItalic"
+    if (bold) return "Times-Bold"
+    if (italic) return "Times-Italic"
+    return "Times-Roman"
+  }
+
+  if (bold && italic) return "Helvetica-BoldOblique"
+  if (bold) return "Helvetica-Bold"
+  if (italic) return "Helvetica-Oblique"
+  return "Helvetica"
+}
+
+/** Map UI font to its PDF base family (no bold/italic variant) */
+export function mapFontFamilyBase(fontFamily: string | undefined): string {
+  return mapFontFamilyToPdf(fontFamily)
+}

--- a/src-vnext/features/export/lib/pdf/generateExportPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/generateExportPdf.tsx
@@ -52,6 +52,7 @@ export async function generateExportPdf(
   doc: ExportDocument,
   data: ExportData,
   variables: readonly ExportVariable[],
+  authorName?: string,
 ): Promise<void> {
   const toastId = toast.loading("Generating PDF...")
 
@@ -87,6 +88,8 @@ export async function generateExportPdf(
         variables={variables}
         data={data}
         imageMap={imageMap}
+        documentName={doc.name || undefined}
+        authorName={authorName}
       />
     )
 

--- a/src-vnext/features/export/lib/pdf/widowOrphan.ts
+++ b/src-vnext/features/export/lib/pdf/widowOrphan.ts
@@ -1,0 +1,16 @@
+const MIN_ROWS_KEEP_TOGETHER = 4
+
+/**
+ * Compute the index at which the "keep-together" group starts.
+ * Returns -1 if no grouping is needed (too few rows).
+ *
+ * When a table has more than MIN_ROWS_KEEP_TOGETHER rows, the last
+ * MIN_ROWS_KEEP_TOGETHER rows should be wrapped in a single
+ * non-breaking View so they always land on the same page. This
+ * prevents the Saturation-style orphan problem where a total row
+ * ends up alone on the last page.
+ */
+export function computeOrphanGroupIndex(totalRows: number): number {
+  if (totalRows <= MIN_ROWS_KEEP_TOGETHER) return -1
+  return totalRows - MIN_ROWS_KEEP_TOGETHER
+}

--- a/src-vnext/features/export/types/exportBuilder.ts
+++ b/src-vnext/features/export/types/exportBuilder.ts
@@ -247,7 +247,10 @@ export interface ExportTemplate {
   readonly id: string
   readonly name: string
   readonly description: string
-  readonly category: "built-in" | "saved"
+  readonly category: "built-in" | "workspace"
   readonly pages: readonly ExportPage[]
   readonly settings: PageSettings
+  readonly createdBy?: string
+  readonly createdAt?: string
+  readonly updatedAt?: string
 }

--- a/src-vnext/features/schedules/components/CallSheetRenderer.tsx
+++ b/src-vnext/features/schedules/components/CallSheetRenderer.tsx
@@ -50,18 +50,24 @@ export interface ScheduleBlockFields {
   readonly showNotes?: boolean
 }
 
+export type SectionKey = keyof Required<CallSheetSectionVisibility>
+
+export const DEFAULT_SECTION_ORDER: readonly SectionKey[] = [
+  "header",
+  "dayDetails",
+  "schedule",
+  "talent",
+  "crew",
+  "notes",
+]
+
 export interface CallSheetConfig {
   readonly sections?: CallSheetSectionVisibility
   readonly colors?: CallSheetColors
   readonly scheduleBlockFields?: ScheduleBlockFields
-  /**
-   * Header layout variant.
-   * 'legacy' = current header (default, never breaks existing call sheets).
-   * 'grid' = new 3-zone modular grid header (S7-7).
-   */
   readonly headerLayout?: CallSheetHeaderLayout
-  /** Per-section field configs (cast/crew column customization). */
   readonly fieldConfigs?: Readonly<Record<string, CallSheetSectionFieldConfig>>
+  readonly sectionOrder?: readonly SectionKey[]
 }
 
 // --- Data props ---
@@ -379,31 +385,21 @@ export function CallSheetRenderer({
   const headerSubtitle = projectName?.trim() ? schedule.name : ""
   const resolvedProjectName = projectName?.trim() || schedule.name
 
-  return (
-    <div
-      className="flex flex-col gap-4"
-      style={{
-        color: "var(--color-doc-ink)",
-        ...(primary
-          ? ({ ["--doc-section-band-bg" as string]: primary } as CSSProperties)
-          : {}),
-        ...(accent
-          ? ({ ["--doc-accent" as string]: accent } as CSSProperties)
-          : {}),
-        ...(text ? ({ ["--color-doc-ink" as string]: text } as CSSProperties) : {}),
-      }}
-    >
-      {/* Header section */}
-      {sections.header && (
+  const sectionOrder = config?.sectionOrder ?? DEFAULT_SECTION_ORDER
+
+  const sectionRenderers: Record<SectionKey, () => React.ReactNode> = {
+    header: () =>
+      sections.header ? (
         headerLayout === "grid" ? (
           <CallSheetPageHeader
+            key="header"
             projectName={resolvedProjectName}
             scheduleName={schedule.name}
             schedule={schedule}
             dayDetails={dayDetails}
           />
         ) : (
-          <div className="border-b-2 border-[var(--color-doc-ink)] pb-3">
+          <div key="header" className="border-b-2 border-[var(--color-doc-ink)] pb-3">
             <h2 className="text-lg font-bold" style={{ color: "var(--color-doc-ink)" }}>
               {headerTitle}
             </h2>
@@ -419,11 +415,11 @@ export function CallSheetRenderer({
             )}
           </div>
         )
-      )}
+      ) : null,
 
-      {/* Day details section — only shown in legacy header mode */}
-      {sections.dayDetails && dayDetails && headerLayout === "legacy" && (
-        <div className="flex flex-col gap-3">
+    dayDetails: () =>
+      sections.dayDetails && dayDetails && headerLayout === "legacy" ? (
+        <div key="dayDetails" className="flex flex-col gap-3">
           <div className="callsheet-section-label">Day Details</div>
           <div className="grid grid-cols-2 gap-x-6 gap-y-2">
             <TimeField label="Crew Call" value={dayDetails.crewCallTime} />
@@ -435,138 +431,92 @@ export function CallSheetRenderer({
           </div>
           {dayDetails.weather?.summary && (
             <p className="text-xs text-[var(--color-text-muted)]">
-              <span
-                className="font-semibold uppercase tracking-wide"
-                style={{ color: "var(--doc-accent,#2563eb)" }}
-              >
-                Weather
-              </span>{" "}
+              <span className="font-semibold uppercase tracking-wide" style={{ color: "var(--doc-accent,#2563eb)" }}>Weather</span>{" "}
               {dayDetails.weather.summary}
             </p>
           )}
           {dayDetails.locations && dayDetails.locations.length > 0 && (
             <div className="flex flex-col gap-1 text-xs text-[var(--color-text-muted)]">
-              {dayDetails.locations
-                .slice()
-                .sort(compareLocationsByRole)
-                .map((loc) => (
-                  <p key={loc.id}>
-                    <span
-                      className="font-semibold uppercase tracking-wide"
-                      style={{ color: "var(--doc-accent,#2563eb)" }}
-                    >
-                      {loc.title}
-                    </span>{" "}
-                    {loc.ref?.label ?? loc.ref?.locationId ?? ""}
-                  </p>
-                ))}
+              {dayDetails.locations.slice().sort(compareLocationsByRole).map((loc) => (
+                <p key={loc.id}>
+                  <span className="font-semibold uppercase tracking-wide" style={{ color: "var(--doc-accent,#2563eb)" }}>{loc.title}</span>{" "}
+                  {loc.ref?.label ?? loc.ref?.locationId ?? ""}
+                </p>
+              ))}
             </div>
           )}
         </div>
-      )}
+      ) : null,
 
-      {/* Schedule entries */}
-      {sections.schedule && (
-        <div className="flex flex-col gap-1">
+    schedule: () =>
+      sections.schedule ? (
+        <div key="schedule" className="flex flex-col gap-1">
           <div className="callsheet-section-label">Schedule</div>
           {(!entries || entries.length === 0) ? (
-            <p className="py-2 text-xs text-[var(--color-text-subtle)]">
-              No entries scheduled.
-            </p>
+            <p className="py-2 text-xs text-[var(--color-text-subtle)]">No entries scheduled.</p>
+          ) : hasMultiStream ? (
+            <AdvancedScheduleBlockSection schedule={schedule} entries={entries} shots={shots ?? []} talentLookup={talentLookup ?? []} fields={scheduleFields} />
           ) : (
-            hasMultiStream ? (
-              <AdvancedScheduleBlockSection
-                schedule={schedule}
-                entries={entries}
-                shots={shots ?? []}
-                talentLookup={talentLookup ?? []}
-                fields={scheduleFields}
-              />
-            ) : (
-              <div className="flex flex-col">
-                {entries.map((entry) => {
-                  const shot = entry.shotId ? (shotMap.get(entry.shotId) ?? null) : null
-                  const talentIds =
-                    shot?.talentIds && shot.talentIds.length > 0
-                      ? shot.talentIds
-                      : (shot?.talent ?? [])
-                  const talentNames = entry.type === "shot" && shot
-                    ? talentIds
-                        .map((id) => talentMap.get(id)?.name ?? id)
-                        .filter(Boolean)
-                    : []
-                  return (
-                    <RendererEntryRow
-                      key={entry.id}
-                      entry={entry}
-                      shot={shot}
-                      fields={scheduleFields}
-                      talentNames={talentNames}
-                    />
-                  )
-                })}
-              </div>
-            )
+            <div className="flex flex-col">
+              {entries.map((entry) => {
+                const shot = entry.shotId ? (shotMap.get(entry.shotId) ?? null) : null
+                const talentIds = shot?.talentIds && shot.talentIds.length > 0 ? shot.talentIds : (shot?.talent ?? [])
+                const talentNames = entry.type === "shot" && shot ? talentIds.map((id) => talentMap.get(id)?.name ?? id).filter(Boolean) : []
+                return <RendererEntryRow key={entry.id} entry={entry} shot={shot} fields={scheduleFields} talentNames={talentNames} />
+              })}
+            </div>
           )}
-          {/* Key times strip after schedule entries */}
-          {dayDetails && (
-            <CallSheetKeyTimesStrip dayDetails={dayDetails} />
-          )}
+          {dayDetails && <CallSheetKeyTimesStrip dayDetails={dayDetails} />}
         </div>
-      )}
+      ) : null,
 
-      {/* Talent / Cast calls */}
-      {sections.talent && (
-        <div className="flex flex-col gap-1">
+    talent: () =>
+      sections.talent ? (
+        <div key="talent" className="flex flex-col gap-1">
           <div className="callsheet-section-label">
             {fieldConfigs?.cast?.title ?? "Cast"}
-            {talentCalls && talentCalls.length > 0 && (
-              <span className="callsheet-section-label-meta">{talentCalls.length} Talent</span>
-            )}
+            {talentCalls && talentCalls.length > 0 && <span className="callsheet-section-label-meta">{talentCalls.length} Talent</span>}
           </div>
-          <CallSheetCastTable
-            talentCalls={talentCalls ?? []}
-            talentLookup={talentLookup ?? []}
-            dayDetails={dayDetails}
-            fieldConfig={fieldConfigs?.cast}
-          />
+          <CallSheetCastTable talentCalls={talentCalls ?? []} talentLookup={talentLookup ?? []} dayDetails={dayDetails} fieldConfig={fieldConfigs?.cast} />
         </div>
-      )}
+      ) : null,
 
-      {/* Crew calls — grouped by department */}
-      {sections.crew && (
-        <div className="flex flex-col gap-1">
-          {/* Running header for print page 2+ */}
+    crew: () =>
+      sections.crew ? (
+        <div key="crew" className="flex flex-col gap-1">
           <div className="callsheet-running-header" aria-hidden="true">
             <span>{resolvedProjectName}</span>
             <span>Crew Call Sheet</span>
           </div>
           <div className="callsheet-section-label">
             {fieldConfigs?.crew?.title ?? "Crew"}
-            {crewCalls && crewCalls.length > 0 && (
-              <span className="callsheet-section-label-meta">{crewCalls.length} Members</span>
-            )}
+            {crewCalls && crewCalls.length > 0 && <span className="callsheet-section-label-meta">{crewCalls.length} Members</span>}
           </div>
-          <CallSheetDeptGrid
-            crewCalls={crewCalls ?? []}
-            crewLookup={crewLookup ?? []}
-            dayDetails={dayDetails}
-            fieldConfig={fieldConfigs?.crew}
-          />
+          <CallSheetDeptGrid crewCalls={crewCalls ?? []} crewLookup={crewLookup ?? []} dayDetails={dayDetails} fieldConfig={fieldConfigs?.crew} />
         </div>
-      )}
+      ) : null,
 
-      {/* Notes */}
-      {sections.notes && dayDetails?.notes && dayDetails.notes.trim().length > 0 && (
-        <div className="flex flex-col gap-1">
+    notes: () =>
+      sections.notes && dayDetails?.notes && dayDetails.notes.trim().length > 0 ? (
+        <div key="notes" className="flex flex-col gap-1">
           <div className="callsheet-section-label">Production Notes</div>
-          <div className="whitespace-pre-wrap text-xs text-[var(--color-text)]">
-            {dayDetails.notes}
-          </div>
+          <div className="whitespace-pre-wrap text-xs text-[var(--color-text)]">{dayDetails.notes}</div>
         </div>
-      )}
+      ) : null,
+  }
 
-      {/* Page footer (confidential + print only) */}
+  return (
+    <div
+      className="flex flex-col gap-4"
+      style={{
+        color: "var(--color-doc-ink)",
+        ...(primary ? ({ ["--doc-section-band-bg" as string]: primary } as CSSProperties) : {}),
+        ...(accent ? ({ ["--doc-accent" as string]: accent } as CSSProperties) : {}),
+        ...(text ? ({ ["--color-doc-ink" as string]: text } as CSSProperties) : {}),
+      }}
+    >
+      {sectionOrder.map((key) => sectionRenderers[key]())}
+
       <div className="callsheet-page-footer-left" aria-hidden="true">
         {resolvedProjectName} &mdash; Call Sheet &mdash; Confidential
       </div>

--- a/src-vnext/features/schedules/components/SectionOrderDialog.tsx
+++ b/src-vnext/features/schedules/components/SectionOrderDialog.tsx
@@ -1,0 +1,168 @@
+import { useState, useCallback } from "react"
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { GripVertical, RotateCcw } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/ui/dialog"
+import { Button } from "@/ui/button"
+import { DEFAULT_SECTION_ORDER, type SectionKey } from "./CallSheetRenderer"
+
+interface SectionOrderDialogProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly sectionOrder: readonly SectionKey[]
+  readonly onSave: (order: readonly SectionKey[]) => void
+}
+
+const SECTION_LABELS: Record<SectionKey, string> = {
+  header: "Header",
+  dayDetails: "Day Details",
+  schedule: "Schedule",
+  talent: "Cast / Talent",
+  crew: "Crew",
+  notes: "Production Notes",
+}
+
+function SortableSectionItem({ sectionKey }: { readonly sectionKey: SectionKey }) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: sectionKey })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="flex items-center gap-3 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2"
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        className="inline-flex h-5 w-5 shrink-0 cursor-grab items-center justify-center text-[var(--color-text-subtle)] hover:text-[var(--color-text)] active:cursor-grabbing"
+        aria-label={`Reorder ${SECTION_LABELS[sectionKey]}`}
+      >
+        <GripVertical className="h-3.5 w-3.5" />
+      </button>
+      <span className="text-sm text-[var(--color-text)]">
+        {SECTION_LABELS[sectionKey]}
+      </span>
+    </div>
+  )
+}
+
+export function SectionOrderDialog({
+  open,
+  onOpenChange,
+  sectionOrder,
+  onSave,
+}: SectionOrderDialogProps) {
+  const [order, setOrder] = useState<readonly SectionKey[]>(sectionOrder)
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  )
+
+  const handleDragEnd = useCallback((event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    setOrder((prev) => {
+      const oldIndex = prev.indexOf(active.id as SectionKey)
+      const newIndex = prev.indexOf(over.id as SectionKey)
+      if (oldIndex === -1 || newIndex === -1) return prev
+      return arrayMove([...prev], oldIndex, newIndex)
+    })
+  }, [])
+
+  const handleReset = useCallback(() => {
+    setOrder(DEFAULT_SECTION_ORDER)
+  }, [])
+
+  const handleSave = useCallback(() => {
+    onSave(order)
+    onOpenChange(false)
+  }, [order, onSave, onOpenChange])
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Section Order</DialogTitle>
+          <DialogDescription>
+            Drag sections to reorder how they appear on the call sheet.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext
+            items={order as SectionKey[]}
+            strategy={verticalListSortingStrategy}
+          >
+            <div className="flex flex-col gap-1.5">
+              {order.map((key) => (
+                <SortableSectionItem key={key} sectionKey={key} />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+
+        <DialogFooter className="flex items-center justify-between">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={handleReset}
+            className="gap-1.5"
+          >
+            <RotateCcw className="h-3.5 w-3.5" />
+            Reset to Default
+          </Button>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave}>
+              Save Order
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src-vnext/features/schedules/components/SectionOrderDialog.tsx
+++ b/src-vnext/features/schedules/components/SectionOrderDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, useEffect } from "react"
 import {
   DndContext,
   closestCenter,
@@ -89,6 +89,10 @@ export function SectionOrderDialog({
   onSave,
 }: SectionOrderDialogProps) {
   const [order, setOrder] = useState<readonly SectionKey[]>(sectionOrder)
+
+  useEffect(() => {
+    if (open) setOrder(sectionOrder)
+  }, [open, sectionOrder])
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),

--- a/src-vnext/features/schedules/components/__tests__/SectionOrderDialog.test.tsx
+++ b/src-vnext/features/schedules/components/__tests__/SectionOrderDialog.test.tsx
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { SectionOrderDialog } from "../SectionOrderDialog"
+import { DEFAULT_SECTION_ORDER } from "../CallSheetRenderer"
+
+describe("SectionOrderDialog", () => {
+  it("renders all section labels when open", () => {
+    render(
+      <SectionOrderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sectionOrder={DEFAULT_SECTION_ORDER}
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText("Header")).toBeInTheDocument()
+    expect(screen.getByText("Day Details")).toBeInTheDocument()
+    expect(screen.getByText("Schedule")).toBeInTheDocument()
+    expect(screen.getByText("Cast / Talent")).toBeInTheDocument()
+    expect(screen.getByText("Crew")).toBeInTheDocument()
+    expect(screen.getByText("Production Notes")).toBeInTheDocument()
+  })
+
+  it("renders drag handles for each section", () => {
+    render(
+      <SectionOrderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sectionOrder={DEFAULT_SECTION_ORDER}
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /reorder header/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /reorder crew/i })).toBeInTheDocument()
+  })
+
+  it("calls onSave with current order when Save is clicked", async () => {
+    const user = userEvent.setup()
+    const onSave = vi.fn()
+
+    render(
+      <SectionOrderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sectionOrder={DEFAULT_SECTION_ORDER}
+        onSave={onSave}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: /save order/i }))
+    expect(onSave).toHaveBeenCalledWith(DEFAULT_SECTION_ORDER)
+  })
+
+  it("calls onOpenChange(false) when Cancel is clicked", async () => {
+    const user = userEvent.setup()
+    const onOpenChange = vi.fn()
+
+    render(
+      <SectionOrderDialog
+        open={true}
+        onOpenChange={onOpenChange}
+        sectionOrder={DEFAULT_SECTION_ORDER}
+        onSave={vi.fn()}
+      />,
+    )
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }))
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("has a Reset to Default button", () => {
+    render(
+      <SectionOrderDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sectionOrder={["notes", "crew", "talent", "schedule", "dayDetails", "header"]}
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: /reset to default/i })).toBeInTheDocument()
+  })
+
+  it("does not render when open is false", () => {
+    const { container } = render(
+      <SectionOrderDialog
+        open={false}
+        onOpenChange={vi.fn()}
+        sectionOrder={DEFAULT_SECTION_ORDER}
+        onSave={vi.fn()}
+      />,
+    )
+
+    expect(container.querySelector("[role='dialog']")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/schedules/hooks/useCallSheetConfig.ts
+++ b/src-vnext/features/schedules/hooks/useCallSheetConfig.ts
@@ -16,6 +16,7 @@ import type {
   CallSheetConfig,
   CallSheetHeaderLayout,
   CallSheetSectionVisibility,
+  SectionKey,
   ScheduleBlockFields,
 } from "@/features/schedules/components/CallSheetRenderer"
 
@@ -120,6 +121,21 @@ export function useCallSheetConfig(
     [clientId, projectId, scheduleId, raw],
   )
 
+  const setSectionOrder = useCallback(
+    async (order: readonly SectionKey[]) => {
+      if (!clientId || !scheduleId) return
+      try {
+        await upsertCallSheetConfig(clientId, projectId, scheduleId, {
+          sectionOrder: order,
+        })
+      } catch (err) {
+        toast.error("Failed to save section order.")
+        throw err
+      }
+    },
+    [clientId, projectId, scheduleId],
+  )
+
   return {
     raw,
     config,
@@ -130,6 +146,7 @@ export function useCallSheetConfig(
     setColors,
     setHeaderLayout,
     setSectionFieldConfig,
+    setSectionOrder,
   }
 }
 

--- a/src-vnext/features/schedules/lib/__tests__/callSheetSectionOrder.test.ts
+++ b/src-vnext/features/schedules/lib/__tests__/callSheetSectionOrder.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { normalizeCallSheetConfig } from "../callSheetConfig"
+
+describe("callSheetConfig sectionOrder", () => {
+  it("defaults to standard order when sectionOrder is absent", () => {
+    const config = normalizeCallSheetConfig(null)
+    expect(config.sectionOrder).toEqual([
+      "header",
+      "dayDetails",
+      "schedule",
+      "talent",
+      "crew",
+      "notes",
+    ])
+  })
+
+  it("preserves a valid custom sectionOrder", () => {
+    const config = normalizeCallSheetConfig({
+      sectionOrder: ["notes", "crew", "talent", "schedule", "dayDetails", "header"],
+    })
+    expect(config.sectionOrder).toEqual([
+      "notes",
+      "crew",
+      "talent",
+      "schedule",
+      "dayDetails",
+      "header",
+    ])
+  })
+
+  it("appends missing sections to the end of a partial sectionOrder", () => {
+    const config = normalizeCallSheetConfig({
+      sectionOrder: ["header", "schedule"],
+    })
+    expect(config.sectionOrder).toEqual([
+      "header",
+      "schedule",
+      "dayDetails",
+      "talent",
+      "crew",
+      "notes",
+    ])
+  })
+
+  it("strips unknown keys from sectionOrder", () => {
+    const config = normalizeCallSheetConfig({
+      sectionOrder: ["header", "unknown", "schedule", "bogus"],
+    })
+    expect(config.sectionOrder).toEqual([
+      "header",
+      "schedule",
+      "dayDetails",
+      "talent",
+      "crew",
+      "notes",
+    ])
+  })
+
+  it("falls back to default when sectionOrder is not an array", () => {
+    const config = normalizeCallSheetConfig({
+      sectionOrder: "invalid",
+    })
+    expect(config.sectionOrder).toEqual([
+      "header",
+      "dayDetails",
+      "schedule",
+      "talent",
+      "crew",
+      "notes",
+    ])
+  })
+})

--- a/src-vnext/features/schedules/lib/callSheetConfig.ts
+++ b/src-vnext/features/schedules/lib/callSheetConfig.ts
@@ -5,7 +5,8 @@ import {
   serializeSectionFieldConfig,
   type CallSheetSectionFieldConfig,
 } from "@/features/schedules/lib/fieldConfig"
-import type { CallSheetConfig, CallSheetSectionVisibility, ScheduleBlockFields, CallSheetColors, CallSheetHeaderLayout } from "@/features/schedules/components/CallSheetRenderer"
+import type { CallSheetConfig, CallSheetSectionVisibility, ScheduleBlockFields, CallSheetColors, CallSheetHeaderLayout, SectionKey } from "@/features/schedules/components/CallSheetRenderer"
+import { DEFAULT_SECTION_ORDER } from "@/features/schedules/components/CallSheetRenderer"
 
 type LegacySectionType =
   | "header"
@@ -56,6 +57,7 @@ export const DEFAULT_CALLSHEET_COLORS: Required<CallSheetColors> = {
 interface LegacyConfigExtended extends LegacyConfig {
   readonly headerLayout?: string
   readonly fieldConfigs?: Record<string, unknown>
+  readonly sectionOrder?: unknown
 }
 
 export function normalizeCallSheetConfig(raw: Record<string, unknown> | null): CallSheetConfig {
@@ -117,13 +119,40 @@ export function normalizeCallSheetConfig(raw: Record<string, unknown> | null): C
     ),
   }
 
+  const sectionOrder = normalizeSectionOrder(legacy.sectionOrder)
+
   return {
     sections,
     scheduleBlockFields,
     colors,
     headerLayout,
     fieldConfigs,
+    sectionOrder,
   }
+}
+
+function normalizeSectionOrder(raw: unknown): readonly SectionKey[] {
+  const validKeys = new Set<string>(DEFAULT_SECTION_ORDER)
+
+  if (!Array.isArray(raw)) return DEFAULT_SECTION_ORDER
+
+  const seen = new Set<string>()
+  const ordered: SectionKey[] = []
+
+  for (const item of raw) {
+    if (typeof item === "string" && validKeys.has(item) && !seen.has(item)) {
+      seen.add(item)
+      ordered.push(item as SectionKey)
+    }
+  }
+
+  for (const key of DEFAULT_SECTION_ORDER) {
+    if (!seen.has(key)) {
+      ordered.push(key)
+    }
+  }
+
+  return ordered
 }
 
 export function upsertLegacySectionVisibility(

--- a/src-vnext/shared/lib/paths.ts
+++ b/src-vnext/shared/lib/paths.ts
@@ -285,6 +285,17 @@ export const exportReportDocPath = (
   reportId: string,
 ): string[] => [...exportReportsPath(clientId, projectId), reportId]
 
+// --- Export Templates (workspace-scoped) ---
+
+export const exportTemplatesPath = (
+  clientId: string,
+): string[] => ["clients", clientId, "exportTemplates"]
+
+export const exportTemplateDocPath = (
+  clientId: string,
+  templateId: string,
+): string[] => [...exportTemplatesPath(clientId), templateId]
+
 // --- Casting Board (project-scoped) ---
 
 export const castingBoardPath = (


### PR DESCRIPTION
## Summary

Phase 2 of the swift-dreaming-wren initiative. 9 commits closing the Saturation.io export builder gaps identified in the April 2026 research capture.

- **PDF metadata** — title (from document name), author (from Firebase Auth), producer ("Production Hub"). Saturation ships "New Document" / empty.
- **Undefined variable warnings** — unresolved `{{token}}` patterns render with yellow/amber warning chips in preview and yellow highlight in PDF. Saturation renders empty strings silently.
- **Firestore export templates** — workspace-level `clients/{clientId}/exportTemplates` collection replaces localStorage. TemplateDialog gets "Workspace" tab with save/delete, one-time localStorage migration.
- **Inline block picker** — `Cmd+/` command palette + hover-reveal `+` button between blocks. Saturation has no inline picker (drag-only from rail).
- **Widow/orphan control** — last 4 rows of shot grid tables kept together via `<View wrap={false}>`. Saturation has 11% orphan page waste.
- **Section drag-to-reorder** — `SectionOrderDialog` with `@dnd-kit` sortable list for call sheet sections. Per Q4 locked decision (one DnD infra build).
- **Esc deselect + ? help overlay** — global keyboard shortcuts for export builder. Neither Saturation nor SetHero has a discoverable shortcut overlay.
- **Font picker fix** — document-level font setting now threads into PDF output via shared `fontMapping.ts`.

**Stats:** 32 files changed, +1747 / -306 lines, 40 new tests (195 files / 2234 tests total), lint clean.

## Test plan

- [ ] Verify PDF metadata: export a PDF, open in Preview.app → Get Info → confirm Title, Author, Producer fields
- [ ] Verify undefined variable warning: add `{{bogus}}` to a text block → confirm yellow chip in preview, yellow highlight in PDF
- [ ] Verify Firestore templates: save current as template → refresh page → open template dialog → Workspace tab shows saved template
- [ ] Verify localStorage migration: if `sb:export-templates` exists in localStorage, templates appear in Workspace tab after first load
- [ ] Verify Cmd+/ block picker: press Cmd+/ on the export canvas → palette appears → type "shot" → Shot Grid and Shot Detail shown → select inserts block
- [ ] Verify + button: hover between two blocks → circular + appears → click → picker opens → insert at that position
- [ ] Verify widow/orphan: export a shot grid with 18+ shots → confirm no 1-2 row orphan pages
- [ ] Verify section reorder: open Section Order dialog → drag Crew above Talent → save → confirm call sheet renders in new order
- [ ] Verify Esc: select a block → press Esc → block deselected
- [ ] Verify ? help: press ? key → keyboard shortcuts dialog appears
- [ ] Verify font picker: change font to Georgia → export PDF → confirm Times-Roman renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)