### PR TITLE
hotfix: Phase 2 polish bundle (ReferenceError + 4 bugs from verification)

### DIFF
--- a/src-vnext/features/export/components/PageSettingsPanel.tsx
+++ b/src-vnext/features/export/components/PageSettingsPanel.tsx
@@ -165,6 +165,7 @@ export function PageSettingsPanel({
                 <SelectItem value="Helvetica">Helvetica</SelectItem>
                 <SelectItem value="Georgia">Georgia</SelectItem>
                 <SelectItem value="Courier New">Courier New</SelectItem>
+                <SelectItem value="Arial">Arial</SelectItem>
               </SelectContent>
             </Select>
           </div>

--- a/src-vnext/features/export/components/TemplateDialog.tsx
+++ b/src-vnext/features/export/components/TemplateDialog.tsx
@@ -76,38 +76,41 @@ function TemplateCard({
   readonly onSelect: () => void
   readonly onDelete?: () => void
 }) {
+  // Card + delete are SIBLING buttons inside a positioning wrapper to avoid
+  // nested <button> elements (invalid HTML — fires validateDOMNesting warning
+  // and breaks keyboard semantics).
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={`group flex items-start gap-2 rounded-md border p-3 text-left transition-colors ${
-        selected
-          ? "border-[var(--color-accent)] bg-[var(--color-accent)]/5"
-          : "border-[var(--color-border)] hover:border-[var(--color-text-muted)]"
-      }`}
-    >
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <span className="text-sm font-medium text-[var(--color-text)]">
-          {template.name}
-        </span>
-        <span className="text-2xs text-[var(--color-text-muted)]">
-          {template.description}
-        </span>
-      </div>
+    <div className="group relative">
+      <button
+        type="button"
+        onClick={onSelect}
+        className={`flex w-full items-start gap-2 rounded-md border p-3 text-left transition-colors ${
+          selected
+            ? "border-[var(--color-accent)] bg-[var(--color-accent)]/5"
+            : "border-[var(--color-border)] hover:border-[var(--color-text-muted)]"
+        }`}
+      >
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <span className="text-sm font-medium text-[var(--color-text)]">
+            {template.name}
+          </span>
+          <span className="text-2xs text-[var(--color-text-muted)]">
+            {template.description}
+          </span>
+        </div>
+        {onDelete && <span aria-hidden="true" className="h-5 w-5 shrink-0" />}
+      </button>
       {onDelete && (
         <button
           type="button"
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-          className="shrink-0 rounded p-1 text-[var(--color-text-muted)] opacity-0 transition-opacity hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-destructive)] group-hover:opacity-100"
+          onClick={onDelete}
+          className="absolute right-2 top-2 rounded p-1 text-[var(--color-text-muted)] opacity-0 transition-opacity hover:bg-[var(--color-surface-hover)] hover:text-[var(--color-destructive)] group-hover:opacity-100 focus-visible:opacity-100"
           aria-label={`Delete ${template.name}`}
         >
           <Trash2 className="h-3.5 w-3.5" />
         </button>
       )}
-    </button>
+    </div>
   )
 }
 

--- a/src-vnext/features/export/hooks/__tests__/useExportTemplates.test.tsx
+++ b/src-vnext/features/export/hooks/__tests__/useExportTemplates.test.tsx
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook, waitFor } from "@testing-library/react"
+
+// ---- Hoisted mocks (Firestore callables + Auth) ----
+
+const firestoreMocks = vi.hoisted(() => {
+  const setDoc = vi.fn(async () => undefined)
+  const updateDoc = vi.fn(async () => undefined)
+  const deleteDoc = vi.fn(async () => undefined)
+  const getDocs = vi.fn(async () => ({ docs: [] as unknown[] }))
+  const onSnapshot = vi.fn(
+    (
+      _q: unknown,
+      onNext: (snap: { docs: unknown[] }) => void,
+      _onErr?: (e: unknown) => void,
+    ) => {
+      // Fire success once with empty docs so setLoading(false) runs, then return
+      // an unsubscribe. The migration effect we're testing does NOT depend on
+      // this firing, but keeping it realistic avoids console noise.
+      try {
+        onNext({ docs: [] })
+      } catch {
+        /* swallow — not under test */
+      }
+      return () => undefined
+    },
+  )
+  // `doc(collRef)` with no id is used by the migration path. We return a
+  // stable-ish ref shape; the hook only uses `.id`.
+  const doc = vi.fn(() => ({ id: "generated-doc-id" }))
+  const collection = vi.fn(() => ({ __type: "collectionRef" }))
+  const query = vi.fn((ref: unknown) => ref)
+  const orderBy = vi.fn((field: string, dir: string) => ({ field, dir }))
+  const serverTimestamp = vi.fn(() => ({ __type: "serverTimestamp" }))
+  return {
+    setDoc,
+    updateDoc,
+    deleteDoc,
+    getDocs,
+    onSnapshot,
+    doc,
+    collection,
+    query,
+    orderBy,
+    serverTimestamp,
+  }
+})
+
+vi.mock("firebase/firestore", () => ({
+  setDoc: firestoreMocks.setDoc,
+  updateDoc: firestoreMocks.updateDoc,
+  deleteDoc: firestoreMocks.deleteDoc,
+  getDocs: firestoreMocks.getDocs,
+  onSnapshot: firestoreMocks.onSnapshot,
+  doc: firestoreMocks.doc,
+  collection: firestoreMocks.collection,
+  query: firestoreMocks.query,
+  orderBy: firestoreMocks.orderBy,
+  serverTimestamp: firestoreMocks.serverTimestamp,
+}))
+
+vi.mock("@/shared/lib/firebase", () => ({
+  db: { __type: "mockDb" },
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/paths", () => ({
+  exportTemplatesPath: (clientId: string) => [
+    "clients",
+    clientId,
+    "exportTemplates",
+  ],
+  exportTemplateDocPath: (clientId: string, templateId: string) => [
+    "clients",
+    clientId,
+    "exportTemplates",
+    templateId,
+  ],
+}))
+
+const loadLocalStorageTemplatesMock = vi.fn<() => unknown[]>(() => [])
+vi.mock("../../lib/documentPersistence", () => ({
+  loadTemplates: (...args: unknown[]) => loadLocalStorageTemplatesMock(...args),
+}))
+
+vi.mock("../../lib/builtInTemplates", () => ({
+  BUILT_IN_TEMPLATES: [],
+}))
+
+// ---- Imports after mocks ----
+
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useExportTemplates } from "../useExportTemplates"
+
+const mockAuth = useAuth as unknown as {
+  mockReturnValue: (v: unknown) => void
+}
+
+// ---- Real Map-backed localStorage stub (mirrors documentPersistence.test.ts) ----
+
+let storage: Map<string, string>
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  storage = new Map()
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => storage.set(key, value),
+    removeItem: (key: string) => storage.delete(key),
+    clear: () => storage.clear(),
+    get length() {
+      return storage.size
+    },
+    key: (index: number) => [...storage.keys()][index] ?? null,
+  })
+
+  mockAuth.mockReturnValue({ user: { uid: "test-uid" } })
+  loadLocalStorageTemplatesMock.mockReturnValue([])
+  firestoreMocks.getDocs.mockResolvedValue({ docs: [] })
+})
+
+describe("useExportTemplates — migration effect", () => {
+  it("sets the migrated flag for an empty localStorage workspace without throwing (regression: LS_MIGRATED_KEY ReferenceError)", async () => {
+    // GIVEN: signed-in user, valid clientId, empty localStorage (no legacy
+    // templates, no prior migration flag). This is the production-default path
+    // that every new workspace hits on first Export Builder mount.
+    loadLocalStorageTemplatesMock.mockReturnValue([])
+
+    // WHEN: the hook mounts.
+    // THEN: it must not throw. Today this throws
+    //   ReferenceError: LS_MIGRATED_KEY is not defined
+    // at useExportTemplates.ts:112, which React surfaces out of the commit
+    // phase and ErrorBoundary catches as "Something went wrong in Export".
+    expect(() => {
+      renderHook(() => useExportTemplates("client-abc"))
+    }).not.toThrow()
+
+    // AND: the migrated marker must be written under the per-client key so the
+    // effect does not re-run on every mount.
+    await waitFor(() => {
+      expect(storage.get("sb:export-templates-migrated:client-abc")).toBe(
+        "true",
+      )
+    })
+
+    // AND: no Firestore writes should happen on the empty branch.
+    expect(firestoreMocks.setDoc).not.toHaveBeenCalled()
+  })
+
+  it("migrates a populated localStorage workspace to Firestore, clears the legacy key, and sets the migrated flag", async () => {
+    // GIVEN: one legacy template in localStorage under the export-templates
+    // key, a signed-in user, and no prior migration flag.
+    const legacyTemplate = {
+      id: "t-legacy-1",
+      name: "Legacy Template",
+      description: "Pre-Firestore template",
+      category: "workspace",
+      pages: [{ id: "p1", items: [] }],
+      settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
+    }
+    loadLocalStorageTemplatesMock.mockReturnValue([legacyTemplate])
+    // Seed the legacy localStorage key so we can assert it's removed post-migration.
+    storage.set("sb:export-templates", JSON.stringify([legacyTemplate]))
+
+    firestoreMocks.getDocs.mockResolvedValueOnce({ docs: [] })
+
+    // WHEN: the hook mounts.
+    renderHook(() => useExportTemplates("client-abc"))
+
+    // THEN: the migration writes the template to Firestore.
+    await waitFor(() => {
+      expect(firestoreMocks.setDoc).toHaveBeenCalledTimes(1)
+    })
+
+    const [, payload] = firestoreMocks.setDoc.mock.calls[0]!
+    expect(payload).toMatchObject({
+      name: "Legacy Template",
+      description: "Pre-Firestore template",
+      createdBy: "test-uid",
+    })
+
+    // AND: the migrated marker is set and the legacy key is removed.
+    await waitFor(() => {
+      expect(storage.get("sb:export-templates-migrated:client-abc")).toBe(
+        "true",
+      )
+    })
+    expect(storage.has("sb:export-templates")).toBe(false)
+  })
+
+  it("no-ops when the migrated flag is already set for this client", async () => {
+    // GIVEN: the migrated flag for this client already exists.
+    storage.set("sb:export-templates-migrated:client-abc", "true")
+    loadLocalStorageTemplatesMock.mockReturnValue([])
+
+    // WHEN: the hook mounts.
+    renderHook(() => useExportTemplates("client-abc"))
+
+    // THEN: no Firestore write, no call into loadLocalStorageTemplates.
+    // (The guard returns before loadTemplates is invoked.)
+    expect(firestoreMocks.setDoc).not.toHaveBeenCalled()
+    expect(loadLocalStorageTemplatesMock).not.toHaveBeenCalled()
+  })
+
+  it("does nothing when clientId is null", () => {
+    mockAuth.mockReturnValue({ user: { uid: "test-uid" } })
+
+    const { result } = renderHook(() => useExportTemplates(null))
+
+    expect(result.current.loading).toBe(false)
+    expect(result.current.workspaceTemplates).toEqual([])
+    expect(firestoreMocks.setDoc).not.toHaveBeenCalled()
+    expect(loadLocalStorageTemplatesMock).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/export/hooks/useExportTemplates.ts
+++ b/src-vnext/features/export/hooks/useExportTemplates.ts
@@ -109,7 +109,7 @@ export function useExportTemplates(
 
     const localTemplates = loadLocalStorageTemplates()
     if (localTemplates.length === 0) {
-      localStorage.setItem(LS_MIGRATED_KEY, "true")
+      localStorage.setItem(migratedKey, "true")
       return
     }
 

--- a/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/TextBlockPdf.tsx
@@ -186,7 +186,12 @@ export function TextBlockPdf({ block, variables }: TextBlockPdfProps) {
             if (containsHtml(seg.value)) {
               return renderHtmlContent(seg.value, {}, textStyle, fontSize, fontFamily, i)
             }
-            return <Text key={i} style={textStyle}>{seg.value}</Text>
+            // Plain text segment — wrap unresolved tokens with warning highlights
+            return (
+              <Text key={i} style={textStyle}>
+                {renderWithWarningHighlights(seg.value)}
+              </Text>
+            )
           })}
         </View>
       )
@@ -217,7 +222,10 @@ export function TextBlockPdf({ block, variables }: TextBlockPdfProps) {
             if (containsHtml(seg.value)) {
               return renderHtmlSegment(seg.value, fontSize, fontFamily, i)
             }
-            return <Text key={i}>{seg.value}</Text>
+            // Plain inline text segment — wrap unresolved tokens with warning highlights
+            return (
+              <Text key={i}>{renderWithWarningHighlights(seg.value)}</Text>
+            )
           })}
         </Text>
       </View>

--- a/src-vnext/features/export/lib/pdf/blocks/__tests__/TextBlockPdf.test.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/__tests__/TextBlockPdf.test.tsx
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest"
+
+// Mock @react-pdf/renderer so we can render the component tree into
+// queryable DOM elements. We serialize the `style` prop into a JSON
+// data-attribute so tests can assert on it, and convert the `render`
+// callback into a marker attribute so tests can confirm the render-token
+// branch is still wiring up page-number callbacks.
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  const serializeStyle = (style: unknown) => {
+    if (style === undefined || style === null) return undefined
+    try {
+      return JSON.stringify(style)
+    } catch {
+      return undefined
+    }
+  }
+  return {
+    Document: (props: Record<string, unknown>) =>
+      React.createElement("pdf-document", props, props.children),
+    Page: (props: Record<string, unknown>) =>
+      React.createElement("pdf-page", props, props.children),
+    Text: (props: Record<string, unknown>) => {
+      const { style, render, children, ...rest } = props as {
+        style?: unknown
+        render?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      const domProps: Record<string, unknown> = {
+        ...rest,
+        "data-style": serializeStyle(style),
+      }
+      if (typeof render === "function") {
+        domProps["data-has-render"] = "true"
+      }
+      return React.createElement("pdf-text", domProps, children as React.ReactNode)
+    },
+    View: (props: Record<string, unknown>) => {
+      const { style, children, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      return React.createElement(
+        "pdf-view",
+        { ...rest, "data-style": serializeStyle(style) },
+        children as React.ReactNode,
+      )
+    },
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import React from "react"
+import { render } from "@testing-library/react"
+import { TextBlockPdf } from "../TextBlockPdf"
+import type { TextBlock, ExportVariable } from "../../../../types/exportBuilder"
+
+const WARNING_BG = "#FEF3C7"
+const WARNING_FG = "#92400E"
+
+function makeBlock(content: string): TextBlock {
+  return {
+    id: "block-1",
+    type: "text",
+    content,
+  }
+}
+
+/** Built-in variables that the export builder always provides. */
+function builtInVariables(): readonly ExportVariable[] {
+  return [
+    { key: "projectName", label: "Project Name", value: "Test Project", source: "dynamic" },
+    { key: "clientName", label: "Client", value: "Test Client", source: "dynamic" },
+    { key: "shootDates", label: "Shoot Dates", value: "", source: "dynamic" },
+    { key: "currentDate", label: "Current Date", value: "2026-04-16", source: "dynamic" },
+    // Render-time tokens — values intentionally keep the {{token}} form
+    { key: "pageNumber", label: "Page Number", value: "{{pageNumber}}", source: "dynamic" },
+    { key: "pageCount", label: "Page Count", value: "{{pageCount}}", source: "dynamic" },
+    { key: "shotCount", label: "Shot Count", value: "0", source: "dynamic" },
+    { key: "productCount", label: "Product Count", value: "0", source: "dynamic" },
+  ]
+}
+
+/** Find a pdf-text element whose text content equals the given literal. */
+function findTextByContent(container: HTMLElement, literal: string): HTMLElement | null {
+  const candidates = Array.from(container.querySelectorAll("pdf-text"))
+  for (const el of candidates) {
+    if (el.textContent === literal) return el as HTMLElement
+  }
+  return null
+}
+
+/** Parse the serialized style JSON from a rendered element. */
+function parseStyle(el: Element | null): Record<string, unknown> | null {
+  if (!el) return null
+  const raw = el.getAttribute("data-style")
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as Record<string, unknown>
+  } catch {
+    return null
+  }
+}
+
+describe("TextBlockPdf — unresolved-token highlighting", () => {
+  it("highlights {{bogus}} when block ALSO contains render tokens (regression)", () => {
+    // RED test: before the fix, the render-token branch skips
+    // findUnresolvedTokens / renderWithWarningHighlights, so {{bogus}}
+    // renders as plain text without the yellow highlight.
+    const block = makeBlock("Page {{pageNumber}} of {{pageCount}} — {{bogus}}")
+    const { container } = render(
+      <TextBlockPdf block={block} variables={builtInVariables()} />,
+    )
+
+    const bogusEl = findTextByContent(container, "{{bogus}}")
+    expect(bogusEl).not.toBeNull()
+
+    const style = parseStyle(bogusEl)
+    expect(style).not.toBeNull()
+    expect(style?.backgroundColor).toBe(WARNING_BG)
+    expect(style?.color).toBe(WARNING_FG)
+  })
+
+  it("highlights {{bogus}} when block has NO render tokens (happy path)", () => {
+    // Should pass both before and after the fix — this is the existing
+    // plain-text fallback path. Pins it so refactoring doesn't regress.
+    const block = makeBlock("Just {{bogus}}")
+    const { container } = render(
+      <TextBlockPdf block={block} variables={builtInVariables()} />,
+    )
+
+    const bogusEl = findTextByContent(container, "{{bogus}}")
+    expect(bogusEl).not.toBeNull()
+
+    const style = parseStyle(bogusEl)
+    expect(style?.backgroundColor).toBe(WARNING_BG)
+    expect(style?.color).toBe(WARNING_FG)
+  })
+
+  it("preserves the render-token callback for {{pageNumber}}", () => {
+    // Passes before and after the fix — confirms the render prop still
+    // wires up to @react-pdf/renderer. Pins the fix so it doesn't break
+    // page-number rendering.
+    const block = makeBlock("Page {{pageNumber}}")
+    const { container } = render(
+      <TextBlockPdf block={block} variables={builtInVariables()} />,
+    )
+
+    const renderEls = container.querySelectorAll('pdf-text[data-has-render="true"]')
+    expect(renderEls.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it("preserves the render-token callback for {{pageCount}}", () => {
+    const block = makeBlock("Page {{pageNumber}} of {{pageCount}}")
+    const { container } = render(
+      <TextBlockPdf block={block} variables={builtInVariables()} />,
+    )
+
+    const renderEls = container.querySelectorAll('pdf-text[data-has-render="true"]')
+    // One for pageNumber, one for pageCount
+    expect(renderEls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("does NOT highlight recognized non-render tokens ({{projectName}})", () => {
+    // Regression guard: {{projectName}} should be resolved to 'Test Project'
+    // (via resolveVariables) — the literal {{projectName}} must not leak
+    // into the rendered tree as a highlighted token.
+    const block = makeBlock("Project {{projectName}} — page {{pageNumber}}")
+    const { container } = render(
+      <TextBlockPdf block={block} variables={builtInVariables()} />,
+    )
+
+    const leaked = findTextByContent(container, "{{projectName}}")
+    expect(leaked).toBeNull()
+  })
+})

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
-import { CalendarDays, ZoomIn, ZoomOut } from "lucide-react"
+import { CalendarDays, ListOrdered, ZoomIn, ZoomOut } from "lucide-react"
 import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
 import { LoadingState } from "@/shared/components/LoadingState"
 import { DetailPageSkeleton } from "@/shared/components/Skeleton"
@@ -15,6 +15,7 @@ import { useTalent } from "@/features/shots/hooks/usePickerData"
 import { useShots } from "@/features/shots/hooks/useShots"
 import { useCrew } from "@/features/schedules/hooks/useCrew"
 import { CallSheetRenderer } from "@/features/schedules/components/CallSheetRenderer"
+import { SectionOrderDialog } from "@/features/schedules/components/SectionOrderDialog"
 import { DayDetailsEditor } from "@/features/schedules/components/DayDetailsEditor"
 import { AdaptiveTimelineView } from "@/features/schedules/components/AdaptiveTimelineView"
 import { ScheduleTrackControls } from "@/features/schedules/components/ScheduleTrackControls"
@@ -103,6 +104,7 @@ export default function CallSheetBuilderPage() {
   const [previewScale, setPreviewScale] = useState(100)
   const [previewOpen, setPreviewOpen] = useState(false)
   const [printOpen, setPrintOpen] = useState(false)
+  const [sectionOrderOpen, setSectionOrderOpen] = useState(false)
   const undoStack = useUndoStack<UndoSnapshot>()
   // Drives the "Saved Xs ago" pill on the Output controls header. The
   // output writes are all routed through callSheetConfig setters from
@@ -341,6 +343,15 @@ export default function CallSheetBuilderPage() {
               <Button
                 variant="outline"
                 size="sm"
+                aria-label="Section order"
+                onClick={() => setSectionOrderOpen(true)}
+              >
+                <ListOrdered className="mr-1 h-3.5 w-3.5" />
+                Section Order
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
                 onClick={() => setPreviewOpen(true)}
               >
                 Preview
@@ -350,6 +361,20 @@ export default function CallSheetBuilderPage() {
               </Button>
             </div>
           </div>
+
+          <SectionOrderDialog
+            open={sectionOrderOpen}
+            onOpenChange={setSectionOrderOpen}
+            sectionOrder={rendererConfig.sectionOrder ?? []}
+            onSave={(order) => {
+              void callSheetConfig
+                .setSectionOrder(order)
+                .then(() => outputLastSaved.markSaved())
+                .catch(() => {
+                  // setSectionOrder surfaces its own toast on failure
+                })
+            }}
+          />
 
           <Sheet open={previewOpen} onOpenChange={setPreviewOpen}>
             <SheetContent

--- a/src-vnext/features/schedules/components/__tests__/CallSheetBuilderPage.test.tsx
+++ b/src-vnext/features/schedules/components/__tests__/CallSheetBuilderPage.test.tsx
@@ -1,0 +1,296 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Route, Routes } from "react-router-dom"
+import type React from "react"
+import CallSheetBuilderPage from "@/features/schedules/components/CallSheetBuilderPage"
+import { DEFAULT_SECTION_ORDER, type SectionKey } from "@/features/schedules/components/CallSheetRenderer"
+import type { Schedule, DayDetails } from "@/shared/types"
+
+// --- Mock data ---
+
+const mockSchedule: Schedule = {
+  id: "sched-1",
+  name: "Day 1",
+  date: { toDate: () => new Date("2026-04-01") } as never,
+  projectId: "proj-1",
+  clientId: "client-1",
+  status: "draft",
+  generalCall: "07:00",
+  wrapTime: null,
+  notes: null,
+  tracks: [],
+}
+
+const mockDayDetails: DayDetails = {
+  id: "dd-1",
+  location: null,
+  parkingNotes: null,
+  nearestHospital: null,
+  covidProtocol: null,
+  notes: null,
+}
+
+// --- Provider mocks ---
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "client-1", role: "producer" }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "proj-1", projectName: "Test Project" }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock("@/shared/lib/rbac", () => ({
+  canManageSchedules: () => true,
+}))
+
+// --- Data hook mocks ---
+
+const setSectionOrderMock = vi.fn().mockResolvedValue(undefined)
+
+vi.mock("@/features/schedules/hooks/useCallSheetBundle", () => ({
+  useCallSheetBundle: () => ({
+    schedule: mockSchedule,
+    dayDetails: mockDayDetails,
+    entries: [],
+    talentCalls: [],
+    crewCalls: [],
+    callSheet: {
+      raw: null,
+      config: {
+        sections: {
+          header: true,
+          dayDetails: true,
+          schedule: true,
+          talent: true,
+          crew: true,
+          notes: true,
+        },
+        scheduleBlockFields: {},
+        colors: {},
+        headerLayout: "legacy",
+        fieldConfigs: {},
+        sectionOrder: DEFAULT_SECTION_ORDER,
+      },
+      loading: false,
+      error: null,
+      setSectionVisibility: vi.fn().mockResolvedValue(undefined),
+      setScheduleBlockFields: vi.fn().mockResolvedValue(undefined),
+      setColors: vi.fn().mockResolvedValue(undefined),
+      setHeaderLayout: vi.fn().mockResolvedValue(undefined),
+      setSectionFieldConfig: vi.fn().mockResolvedValue(undefined),
+      setSectionOrder: setSectionOrderMock,
+    },
+    error: null,
+    loading: false,
+    loadingFlags: {
+      schedule: false,
+      dayDetails: false,
+      entries: false,
+      talentCalls: false,
+      crewCalls: false,
+      config: false,
+    },
+  }),
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useTalent: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/shots/hooks/useShots", () => ({
+  useShots: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/schedules/hooks/useCrew", () => ({
+  useCrew: () => ({ data: [], loading: false, error: null }),
+}))
+
+// --- Heavyweight child mocks (stub to simple markers) ---
+
+vi.mock("@/features/schedules/components/CallSheetRenderer", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/schedules/components/CallSheetRenderer")
+  >("@/features/schedules/components/CallSheetRenderer")
+  return {
+    ...actual,
+    CallSheetRenderer: () => <div data-testid="call-sheet-renderer" />,
+  }
+})
+
+vi.mock("@/features/schedules/components/DayDetailsEditor", () => ({
+  DayDetailsEditor: () => <div data-testid="day-details-editor" />,
+}))
+
+vi.mock("@/features/schedules/components/AdaptiveTimelineView", () => ({
+  AdaptiveTimelineView: () => <div data-testid="adaptive-timeline" />,
+}))
+
+vi.mock("@/features/schedules/components/ScheduleTrackControls", () => ({
+  ScheduleTrackControls: () => <div data-testid="schedule-track-controls" />,
+}))
+
+vi.mock("@/features/schedules/components/CallOverridesEditor", () => ({
+  CallOverridesEditor: () => <div data-testid="call-overrides-editor" />,
+}))
+
+vi.mock("@/features/schedules/components/CallSheetOutputControls", () => ({
+  CallSheetOutputControls: () => <div data-testid="call-sheet-output-controls" />,
+}))
+
+vi.mock("@/features/schedules/components/CallSheetPrintPortal", () => ({
+  CallSheetPrintPortal: () => <div data-testid="call-sheet-print-portal" />,
+}))
+
+vi.mock("@/features/schedules/components/TrustChecks", () => ({
+  TrustChecks: () => <div data-testid="trust-checks" />,
+}))
+
+vi.mock("@/features/schedules/components/OnSetViewer", () => ({
+  OnSetViewer: () => <div data-testid="onset-viewer" />,
+}))
+
+vi.mock("@/features/schedules/components/ScheduleListPage", () => ({
+  default: () => <div data-testid="schedule-list-page" />,
+}))
+
+vi.mock("@/features/schedules/components/SectionOrderDialog", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/features/schedules/components/SectionOrderDialog")
+  >("@/features/schedules/components/SectionOrderDialog")
+  return {
+    ...actual,
+    // Replace with a lightweight controllable stub so we don't need to
+    // exercise the dnd-kit internals inside this page-level test.
+    SectionOrderDialog: ({
+      open,
+      onOpenChange,
+      onSave,
+    }: {
+      readonly open: boolean
+      readonly onOpenChange: (open: boolean) => void
+      readonly sectionOrder: readonly SectionKey[]
+      readonly onSave: (order: readonly SectionKey[]) => void
+    }) =>
+      open ? (
+        <div role="dialog" aria-label="Section Order">
+          <button
+            type="button"
+            onClick={() => {
+              onSave(["notes", "crew", "talent", "schedule", "dayDetails", "header"])
+              onOpenChange(false)
+            }}
+          >
+            Save Order
+          </button>
+          <button type="button" onClick={() => onOpenChange(false)}>
+            Cancel
+          </button>
+        </div>
+      ) : null,
+  }
+})
+
+vi.mock("@/shared/components/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { readonly children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/shared/components/LoadingState", () => ({
+  LoadingState: ({ loading }: { readonly loading: boolean }) =>
+    loading ? <div data-testid="loading-state" /> : null,
+}))
+
+vi.mock("@/shared/components/Skeleton", () => ({
+  DetailPageSkeleton: () => <div data-testid="detail-skeleton" />,
+}))
+
+vi.mock("@/shared/components/EmptyState", () => ({
+  EmptyState: ({ title }: { readonly title: string }) => (
+    <div data-testid="empty-state">{title}</div>
+  ),
+}))
+
+vi.mock("@/shared/components/InlineEdit", () => ({
+  InlineEdit: ({ value }: { readonly value: string }) => <span>{value}</span>,
+}))
+
+vi.mock("@/shared/components/PageHeader", () => ({
+  PageHeader: ({ title }: { readonly title: React.ReactNode }) => <h1>{title}</h1>,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+// --- Helpers ---
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/proj-1/callsheet?scheduleId=sched-1"]}>
+      <Routes>
+        <Route
+          path="/projects/:id/callsheet"
+          element={<CallSheetBuilderPage />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+// --- Tests ---
+
+describe("CallSheetBuilderPage — Section Order wiring", () => {
+  beforeEach(() => {
+    setSectionOrderMock.mockClear()
+  })
+
+  it("renders a Section Order trigger button in the builder header", () => {
+    renderPage()
+
+    expect(
+      screen.getByRole("button", { name: /section order/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("opens the SectionOrderDialog when the trigger is clicked", async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    expect(
+      screen.queryByRole("dialog", { name: /section order/i }),
+    ).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /section order/i }))
+
+    expect(
+      screen.getByRole("dialog", { name: /section order/i }),
+    ).toBeInTheDocument()
+  })
+
+  it("persists a new order through setSectionOrder when the dialog saves", async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    await user.click(screen.getByRole("button", { name: /section order/i }))
+    await user.click(screen.getByRole("button", { name: /save order/i }))
+
+    expect(setSectionOrderMock).toHaveBeenCalledTimes(1)
+    expect(setSectionOrderMock).toHaveBeenCalledWith([
+      "notes",
+      "crew",
+      "talent",
+      "schedule",
+      "dayDetails",
+      "header",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Hotfix bundle landed after hands-on verification of the PR #413 Phase 2 test plan. One production-blocker + four shipped bugs closed, ordered roughly by severity.

5 commits, all independently revertable. 198 files / 2246 tests passing (+3 files / +12 tests over the pre-hotfix baseline). No TSC pre-existing errors touched (TSC is not a CI gate in this repo, per the durable rule).

## Commits

| SHA | Scope | What |
|---|---|---|
| `60906a2d` | export | **P0 crash fix.** `ReferenceError: LS_MIGRATED_KEY is not defined` at `useExportTemplates.ts:112`. Session 7 Codex-review fix renamed the constant to a client-scoped `${LS_MIGRATED_PREFIX}${clientId}` pattern, but missed one call-site in the empty-localStorage short-circuit. Whole Export Builder crashed on mount for every workspace without legacy templates. TSC would have caught it but isn't gated here. |
| `bd0f0a81` | export | **Warning highlight in render-token branch.** `TextBlockPdf.tsx:158` render-token path (for `{{pageNumber}}` / `{{pageCount}}`) never called `findUnresolvedTokens` / `renderWithWarningHighlights`, so undefined tokens rendered without the yellow `#FEF3C7` in PDF when combined with render tokens. Plain-text fallback path worked fine. |
| `47d60a9e` | schedules | **Wire SectionOrderDialog.** Session 7 sub-phase 2.4 built the dialog + `sectionRenderers` map + `setSectionOrder` hook method, but never imported the dialog into `CallSheetBuilderPage`. Shipped dead. Added trigger button in builder header between Change Schedule and Preview. |
| `82250590` | export (a11y) | **Kill button-in-button nesting.** `TemplateCard` had `<button>` (delete) inside `<button>` (card) — invalid HTML, `validateDOMNesting` warning on every Templates dialog open. Restructured to sibling buttons inside `<div className="group relative">`. Existing a11y test passes unchanged. Keyboard-focus reveal added. |
| `5ec44085` | export | **Arial option in Default Font picker.** Block-level font picker had Arial; document-level was missing it. Trivial consistency fix. |

## How it was verified

Every fix has:
- A unit test pinning the behavior (RED before → GREEN after, except Bonus-1/2 which are trivial presentational fixes)
- End-to-end browser verification against the real dev server at `http://localhost:5174/` on the Q2-2026 No. 2 project
- Fix A: PDF content stream decompressed (FlateDecode) and inspected for the yellow RGB triple `0.9961 0.9529 0.7804 scn` before `{{bogus}}` glyphs
- Fix D: button found by accessible name, click opens the dialog
- Bonus-1: zero `validateDOMNesting` warnings in the console with the dialog open; new `.group.relative` sibling structure confirmed in the DOM
- Bonus-2: Default Font dropdown shows all 5 expected options

Code-reviewer agent (staff-level pass) reviewed the batch. It **caught a misdiagnosed "Fix C"** (I originally thought the hook wrote nested arrays to Firestore — it didn't; the real bug was just rules-not-deployed, see below). That Fix C was cleanly reverted before shipping. Net: nothing speculative went in.

## Test plan

- [x] Full suite: `CI=1 npm test -- --run` — 198 files / 2246 tests passing
- [x] Fix A browser-verified on a text block with mixed render-token + undefined-token content
- [x] Fix D browser-verified on the Q2-2026 No. 2 call sheet
- [x] Bonus-1 browser-verified — no nesting warning in console
- [x] Bonus-2 browser-verified — Arial appears in the dropdown
- [x] No Ted WIP files (`AI_RULES.md`, `Architecture.md`, `CLAUDE.md`, `Plan.md`, `docs/DESIGN_SYSTEM.md`, `docs/_runtime/*`) in any commit — verified via `git show --stat`

## Outstanding — action required outside this PR

**`firebase deploy --only firestore:rules`** — the `clients/{clientId}/exportTemplates/{templateId}` rule block has been in `firestore.rules:507-517` since Session 7 but was never deployed. Until it is, template saves + the legacy localStorage→Firestore migration will fail with `permission-denied` for every user regardless of role.

Hit via browser probe: writing a minimal valid doc (even with correct admin role + matching clientId) returns `Missing or insufficient permissions`. This is operational, not code.

## Not in this PR (flagged for follow-up)

- `TextBlockPdf.tsx` HTML-parsed text segments (`renderHtmlSegment` / `renderHtmlContent`) still bypass warning highlights. Larger surface area — needs a separate pass through `parseHtmlToNodes`.
- `lsKeys.ts` extraction to dedupe `TEMPLATES_KEY` / `LS_TEMPLATES_KEY` literal duplication (code-reviewer recommendation).
- `tsc --noEmit` scoped to changed files in CI, to close the gap that let the P0 ReferenceError ship.
- Migration-failure-path test (`getDocs` rejects → flag not set, legacy key not removed).

## Durable context preserved

- Never piped vitest through tail
- Sonner (not react-hot-toast)
- Ted's WIP MDs + untracked mockups preserved on the working tree, never staged
- No unrelated files touched