### PR TITLE
feat(projects): make the project-home next-action choosable for empty projects

### DIFF
--- a/src-vnext/features/projects/components/ProjectHomePage.tsx
+++ b/src-vnext/features/projects/components/ProjectHomePage.tsx
@@ -222,6 +222,10 @@ export default function ProjectHomePage() {
       shotCounts: insights.statusCounts,
       casting: { unbooked: countUnbooked(castingEntries) },
       samples: { missing: samplesMissing },
+      // TODO: `sent` is a stub — the schedule model has no "sent" field yet, so
+      // we hardcode false. Wire to real data when call-sheet send state exists;
+      // until then computeNextAction's build-shot-list branch only fires via the
+      // empty-project path.
       schedule: { hasCallSheet: schedules.length > 0, sent: false },
       shootDate: project ? earliestUpcomingShoot(project.shootDates, new Date()) : null,
     })

--- a/src-vnext/features/projects/components/ProjectHomePage.tsx
+++ b/src-vnext/features/projects/components/ProjectHomePage.tsx
@@ -222,10 +222,6 @@ export default function ProjectHomePage() {
       shotCounts: insights.statusCounts,
       casting: { unbooked: countUnbooked(castingEntries) },
       samples: { missing: samplesMissing },
-      // TODO: `sent` is a stub — the schedule model has no "sent" field yet, so
-      // we hardcode false. Wire to real data when call-sheet send state exists;
-      // until then computeNextAction's build-shot-list branch only fires via the
-      // empty-project path.
       schedule: { hasCallSheet: schedules.length > 0, sent: false },
       shootDate: project ? earliestUpcomingShoot(project.shootDates, new Date()) : null,
     })

--- a/src-vnext/features/projects/components/__tests__/ProjectHomePage.test.tsx
+++ b/src-vnext/features/projects/components/__tests__/ProjectHomePage.test.tsx
@@ -115,13 +115,14 @@ describe("ProjectHomePage", () => {
     expect(screen.getByTestId("status-ledger")).toHaveAttribute("data-rows", "5")
   })
 
-  it("surfaces a next action for an empty project (no call sheet yet)", () => {
+  it("surfaces the choosable empty-project next action (both build steps apply)", () => {
     mockUseProject.mockReturnValue({ data: makeProject(), loading: false })
 
     render(<ProjectHomePage />)
 
-    // Priority order lands on the call-sheet gap before the shot-list gap.
-    expect(screen.getByTestId("next-action")).toHaveTextContent("unsent-callsheet")
+    // An empty project (no call sheet, no shots) offers BOTH the shot list and
+    // the call sheet so the user can choose, rather than forcing the call sheet.
+    expect(screen.getByTestId("next-action")).toHaveTextContent("empty-project")
   })
 
   it("shows the loading skeleton before the project loads", () => {

--- a/src-vnext/features/projects/components/home/NextActionBar.tsx
+++ b/src-vnext/features/projects/components/home/NextActionBar.tsx
@@ -66,7 +66,7 @@ export function NextActionBar({ action }: NextActionBarProps) {
         </Link>
 
         {action.alternate && (
-          <p
+          <span
             className="text-sm whitespace-nowrap"
             style={{ color: "var(--color-text-subtle)" }}
           >
@@ -79,7 +79,7 @@ export function NextActionBar({ action }: NextActionBarProps) {
             >
               {action.alternate.ctaText}
             </Link>
-          </p>
+          </span>
         )}
       </div>
     </div>

--- a/src-vnext/features/projects/components/home/NextActionBar.tsx
+++ b/src-vnext/features/projects/components/home/NextActionBar.tsx
@@ -8,7 +8,9 @@ import type { NextAction } from "@/features/projects/components/home/lib/compute
  *
  * Renders nothing when `action` is null (nothing actionable). The CTA is a
  * react-router `Link` to an absolute `/projects/:id/...` route owned by the
- * `NextAction` result.
+ * `NextAction` result. When the action carries an `alternate` (two next steps
+ * apply at once — e.g. an empty project), an equal-weight "or {alternate}" link
+ * is rendered beside the primary so the user picks rather than being forced.
  *
  * Tokens only — the bar uses the near-black ink token (`--color-text`) as its
  * fill to mirror the mockup's `--ink` band, with light text on top and the
@@ -43,7 +45,7 @@ export function NextActionBar({ action }: NextActionBarProps) {
         </p>
       </div>
 
-      <div className="sm:ml-auto sm:shrink-0">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-2 sm:ml-auto sm:shrink-0">
         <Link
           to={action.ctaTo}
           data-testid="next-action-cta"
@@ -62,6 +64,23 @@ export function NextActionBar({ action }: NextActionBarProps) {
             <path d="M5 12h14M12 5l7 7-7 7" />
           </svg>
         </Link>
+
+        {action.alternate && (
+          <p
+            className="text-sm whitespace-nowrap"
+            style={{ color: "var(--color-text-subtle)" }}
+          >
+            or{" "}
+            <Link
+              to={action.alternate.ctaTo}
+              data-testid="next-action-alt"
+              className="font-semibold underline-offset-4 transition-colors hover:underline"
+              style={{ color: "var(--color-bg)" }}
+            >
+              {action.alternate.ctaText}
+            </Link>
+          </p>
+        )}
       </div>
     </div>
   )

--- a/src-vnext/features/projects/components/home/__tests__/NextActionBar.test.tsx
+++ b/src-vnext/features/projects/components/home/__tests__/NextActionBar.test.tsx
@@ -53,4 +53,28 @@ describe("NextActionBar", () => {
     expect(cta).toHaveTextContent("Build Shot List")
     expect(cta).toHaveAttribute("href", "/projects/abc/shots")
   })
+
+  it("does NOT render an alternate link when the action has none", () => {
+    renderBar(sampleAction)
+    expect(screen.queryByTestId("next-action-alt")).not.toBeInTheDocument()
+  })
+
+  it("renders an equal-weight 'or {alternate}' link when the action has an alternate", () => {
+    renderBar({
+      label: "empty-project",
+      message:
+        "This project is empty. Build the shot list to plan the shoot, or start the call sheet for the day — whichever you want to tackle first.",
+      ctaText: "Build Shot List",
+      ctaTo: "/projects/abc/shots",
+      alternate: { ctaText: "Build Call Sheet", ctaTo: "/projects/abc/callsheet" },
+    })
+    // primary stays the shot list
+    const cta = screen.getByTestId("next-action-cta")
+    expect(cta).toHaveTextContent("Build Shot List")
+    expect(cta).toHaveAttribute("href", "/projects/abc/shots")
+    // alternate is a second router link to the call sheet
+    const alt = screen.getByTestId("next-action-alt")
+    expect(alt).toHaveTextContent("Build Call Sheet")
+    expect(alt).toHaveAttribute("href", "/projects/abc/callsheet")
+  })
 })

--- a/src-vnext/features/projects/components/home/lib/__tests__/computeNextAction.test.ts
+++ b/src-vnext/features/projects/components/home/lib/__tests__/computeNextAction.test.ts
@@ -166,6 +166,74 @@ describe("computeNextAction", () => {
     })
   })
 
+  describe("branch 3: empty-project (both build steps apply — choosable)", () => {
+    /** A brand-new project: no call sheet, no shots, nothing else pending. */
+    function emptyProject(): Partial<NextActionInput> {
+      return {
+        casting: { unbooked: 0 },
+        samples: { missing: 0 },
+        schedule: { hasCallSheet: false, sent: false },
+        shotCounts: shotCounts(),
+        shootDate: null,
+      }
+    }
+
+    it("offers BOTH shot list and call sheet when the project is empty", () => {
+      const result = computeNextAction(makeInput(emptyProject()), NOW)
+      expect(result?.label).toBe("empty-project")
+      // primary: build the shot list
+      expect(result?.ctaText).toBe("Build Shot List")
+      expect(result?.ctaTo).toBe(`/projects/${PROJECT_ID}/shots`)
+      // alternate: build the call sheet — equal-weight, user's choice
+      expect(result?.alternate).toEqual({
+        ctaText: "Build Call Sheet",
+        ctaTo: `/projects/${PROJECT_ID}/callsheet`,
+      })
+      expect(result?.message).toContain("whichever you want to tackle first")
+    })
+
+    it("takes precedence over the plain unsent/no-call-sheet branch", () => {
+      // Regression: before this feature, the unsent-callsheet branch (which
+      // always fires because `sent` is a hardcoded stub) made build-shot-list
+      // unreachable, so an empty project only ever showed "Build Call Sheet".
+      const result = computeNextAction(makeInput(emptyProject()), NOW)
+      expect(result?.label).not.toBe("unsent-callsheet")
+      expect(result?.label).toBe("empty-project")
+    })
+
+    it("yields to missing samples (higher priority) even when empty", () => {
+      const result = computeNextAction(
+        makeInput({ ...emptyProject(), samples: { missing: 3 } }),
+        NOW,
+      )
+      expect(result?.label).toBe("missing-samples")
+    })
+
+    it("does NOT fire once any shot exists — falls through to the call sheet", () => {
+      const result = computeNextAction(
+        makeInput({ ...emptyProject(), shotCounts: shotCounts({ todo: 1 }) }),
+        NOW,
+      )
+      expect(result?.label).toBe("unsent-callsheet")
+      expect(result?.ctaText).toBe("Build Call Sheet")
+      expect(result?.alternate).toBeUndefined()
+    })
+
+    it("does NOT fire once a call sheet exists — single build-shot-list action, no alternate", () => {
+      const result = computeNextAction(
+        makeInput({
+          casting: { unbooked: 0 },
+          samples: { missing: 0 },
+          schedule: { hasCallSheet: true, sent: true },
+          shotCounts: shotCounts(),
+        }),
+        NOW,
+      )
+      expect(result?.label).toBe("build-shot-list")
+      expect(result?.alternate).toBeUndefined()
+    })
+  })
+
   describe("null case", () => {
     it("returns null when nothing is actionable", () => {
       expect(computeNextAction(makeInput(), NOW)).toBeNull()

--- a/src-vnext/features/projects/components/home/lib/computeNextAction.ts
+++ b/src-vnext/features/projects/components/home/lib/computeNextAction.ts
@@ -64,13 +64,7 @@ export interface NextActionInput {
   readonly shootDate: Date | null
 }
 
-/**
- * A single navigable choice: button copy + the absolute route it links to.
- *
- * NOTE: unlike `NextAction`, this has no machine-readable `label`. The bar is
- * navigation-only today, so none is needed. If click-tracking is ever wired up,
- * add a `label` here so an alternate-CTA click can emit a stable analytics key.
- */
+/** A single navigable choice: button copy + the absolute route it links to. */
 export interface NextActionLink {
   /** Button / link copy. */
   readonly ctaText: string
@@ -153,6 +147,8 @@ export function computeNextAction(
   //    both and let the user choose (primary CTA + equal-weight alternate)
   //    rather than forcing one. Shot list leads because it's the natural first
   //    creative step, but the call sheet is one click away as the alternate.
+  //    Intentionally ignores `sent` here: a call sheet can't be sent before it
+  //    exists, so `!hasCallSheet` already implies `!sent`.
   if (!schedule.hasCallSheet && totalShots === 0) {
     return {
       label: "empty-project",

--- a/src-vnext/features/projects/components/home/lib/computeNextAction.ts
+++ b/src-vnext/features/projects/components/home/lib/computeNextAction.ts
@@ -12,9 +12,13 @@ import type { ShotFirestoreStatus } from "@/shared/types"
  *      is the most time-critical gap as the shoot approaches.
  *   2. missing samples — product samples not yet arrived; nothing can be shot
  *      without them.
- *   3. unsent / no call sheet — the schedule is not ready to distribute.
- *   4. build shot list — the project has no shots yet, so the very first move is
- *      to draft the list.
+ *   3. empty project — no call sheet AND no shots, so BOTH first build steps
+ *      legitimately apply. There is no one right order ("it's different each
+ *      time"), so we don't force one: the action carries a primary CTA plus an
+ *      equal-weight `alternate`, and the bar lets the user choose.
+ *   4. unsent / no call sheet — the schedule is not ready to distribute.
+ *   5. build shot list — a call sheet exists but the project still has no shots,
+ *      so the next move is to draft the list.
  *
  * Returns null when nothing is actionable (everything below threshold).
  */
@@ -60,11 +64,20 @@ export interface NextActionInput {
   readonly shootDate: Date | null
 }
 
+/** A single navigable choice: button copy + the absolute route it links to. */
+export interface NextActionLink {
+  /** Button / link copy. */
+  readonly ctaText: string
+  /** Absolute route to navigate to. */
+  readonly ctaTo: string
+}
+
 export interface NextAction {
   /** Machine-readable branch key (stable for tests / analytics). */
   readonly label:
     | "unbooked-casting-near-shoot"
     | "missing-samples"
+    | "empty-project"
     | "unsent-callsheet"
     | "build-shot-list"
   /** Human-readable sentence describing the gap and why it matters. */
@@ -73,6 +86,12 @@ export interface NextAction {
   readonly ctaText: string
   /** Absolute route the primary button navigates to. */
   readonly ctaTo: string
+  /**
+   * Optional equal-weight second choice, rendered as "or {ctaText}" beside the
+   * primary CTA. Present only when two next steps apply at once and we want the
+   * user to pick rather than forcing one (today: the empty-project case).
+   */
+  readonly alternate?: NextActionLink
 }
 
 const MS_PER_DAY = 1000 * 60 * 60 * 24
@@ -117,7 +136,32 @@ export function computeNextAction(
     }
   }
 
-  // 3. Call sheet missing or not yet sent.
+  const totalShots =
+    shotCounts.todo +
+    shotCounts.in_progress +
+    shotCounts.on_hold +
+    shotCounts.complete
+
+  // 3. Empty project: no call sheet AND no shots, so the shot list and the call
+  //    sheet are both valid first moves. There's no fixed right order, so offer
+  //    both and let the user choose (primary CTA + equal-weight alternate)
+  //    rather than forcing one. Shot list leads because it's the natural first
+  //    creative step, but the call sheet is one click away as the alternate.
+  if (!schedule.hasCallSheet && totalShots === 0) {
+    return {
+      label: "empty-project",
+      message:
+        "This project is empty. Build the shot list to plan the shoot, or start the call sheet for the day — whichever you want to tackle first.",
+      ctaText: "Build Shot List",
+      ctaTo: `/projects/${projectId}/shots`,
+      alternate: {
+        ctaText: "Build Call Sheet",
+        ctaTo: `/projects/${projectId}/callsheet`,
+      },
+    }
+  }
+
+  // 4. Call sheet missing or not yet sent.
   if (!schedule.hasCallSheet || !schedule.sent) {
     const message = schedule.hasCallSheet
       ? "The call sheet is still a draft. Review and send it so crew and talent get their details."
@@ -130,12 +174,7 @@ export function computeNextAction(
     }
   }
 
-  // 4. No shots drafted yet.
-  const totalShots =
-    shotCounts.todo +
-    shotCounts.in_progress +
-    shotCounts.on_hold +
-    shotCounts.complete
+  // 5. Call sheet exists but no shots drafted yet.
   if (totalShots === 0) {
     return {
       label: "build-shot-list",

--- a/src-vnext/features/projects/components/home/lib/computeNextAction.ts
+++ b/src-vnext/features/projects/components/home/lib/computeNextAction.ts
@@ -64,7 +64,13 @@ export interface NextActionInput {
   readonly shootDate: Date | null
 }
 
-/** A single navigable choice: button copy + the absolute route it links to. */
+/**
+ * A single navigable choice: button copy + the absolute route it links to.
+ *
+ * NOTE: unlike `NextAction`, this has no machine-readable `label`. The bar is
+ * navigation-only today, so none is needed. If click-tracking is ever wired up,
+ * add a `label` here so an alternate-CTA click can emit a stable analytics key.
+ */
 export interface NextActionLink {
   /** Button / link copy. */
   readonly ctaText: string


### PR DESCRIPTION
## What & why

The project-home **"Do this next"** bar had a real bug: for an **empty project** it always showed **Build Call Sheet** and *never* **Build Shot List**.

Root cause: `computeNextAction`'s call-sheet branch fires on `!schedule.hasCallSheet || !schedule.sent`, and `sent` is a hardcoded forward-compat stub (always `false`). So that branch always won and the `build-shot-list` branch below it was unreachable.

Per Ted's call, the fix is **not** a fixed reorder ("it's different each time") — instead, when **both** first build steps legitimately apply (an empty project: no call sheet **and** no shots), surface **both** and let the user choose.

## Changes

- **`computeNextAction.ts`** — new `empty-project` branch (ahead of the call-sheet branch) that returns a primary CTA **plus an equal-weight `alternate`**. Primary = **Build Shot List** (the natural first creative step, and it directly fixes "never shows Build Shot List"); alternate = **Build Call Sheet**. Added a `NextActionLink` type + optional `alternate` field on `NextAction`. `build-shot-list` stays as a forward-compat branch for when a call sheet exists but shots don't.
- **`NextActionBar.tsx`** — renders the alternate as an `or {action}` link beside the primary (light text, no red fill — clear hierarchy, readable on the dark bar). Backward-compatible: no `alternate` ⇒ unchanged single-CTA bar.
- Read-only throughout — navigation only, no mutation.

## Tests

- `computeNextAction.test.ts` — **+5** (both-apply case, precedence over the call-sheet branch, yields to higher-priority samples, doesn't fire once a shot/call-sheet exists). 21 pass.
- `NextActionBar.test.tsx` — **+2** (renders alternate when present, absent otherwise). 6 pass.
- `ProjectHomePage.test.tsx` — updated the empty-project assertion that encoded the old forced-call-sheet behavior. 4 pass.

## Verification

- Targeted vitest files green; production `vite build` clean.
- **Live end-to-end**: seeded a throwaway empty project on the dev server — the bar renders "This project is empty… whichever you want to tackle first" with primary **Build Shot List → `/shots`** and alternate **or Build Call Sheet → `/callsheet`** (link targets confirmed). Demo project deleted after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)