### PR TITLE
test(e2e): seed Firestore fixtures + un-quarantine shots-crud

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,9 +18,11 @@ export default defineConfig({
     '**/a11y.spec.ts',            // real WCAG AA contrast violations in the app
     '**/auth.spec.ts',            // interactive-login helper times out on post-login redirect
     '**/sidebar-summary.spec.ts', // interactive-login helper (same root cause)
-    '**/shots-crud.spec.ts',      // needs seeded Firestore data + stable selectors
-    '**/pulls-crud.spec.ts',      // needs seeded Firestore data + stable selectors
-    '**/image-crop-editor.spec.js', // needs a seeded shot with an existing image
+    // shots-crud.spec.ts un-quarantined 2026-06-05: emulator seed step added
+    // (seedShotsCrudScenario) + spec rewritten to the real project-scoped routes
+    // and selectors. See tests/QUARANTINE.md.
+    '**/pulls-crud.spec.ts',      // targets nonexistent /pulls route + UI that doesn't exist (deferred — see QUARANTINE.md)
+    '**/image-crop-editor.spec.js', // targets removed legacy react-easy-crop UI (deferred — see QUARANTINE.md)
     '**/visual.spec.ts',          // snapshot baselines missing/mismatched
     '**/e2e/richtext-bubble.spec.ts', // snapshot/visual baselines
     '**/diagnose-sticky.spec.js', // ad-hoc diagnostic scratch test; interactive-login helper

--- a/src-vnext/features/shots/components/ShotCard.tsx
+++ b/src-vnext/features/shots/components/ShotCard.tsx
@@ -157,6 +157,8 @@ export function ShotCard({
 
   return (
     <Card
+      data-testid="shot-card"
+      data-shot-id={shot.id}
       className="cursor-pointer hover-lift"
       onClick={() => onOpenShot ? onOpenShot(shot.id) : navigate(`/projects/${projectId}/shots/${shot.id}`)}
     >

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -222,6 +222,7 @@ export default function ShotDetailPage() {
                 value={shot.title}
                 onSave={(title) => save({ title })}
                 className="heading-page"
+                testId="shot-title-edit"
               />
             ) : (
               <h1 className="heading-page">

--- a/src-vnext/shared/components/InlineEdit.tsx
+++ b/src-vnext/shared/components/InlineEdit.tsx
@@ -11,6 +11,8 @@ interface InlineEditProps {
   readonly disabled?: boolean
   /** When true, shows a pencil icon on hover to indicate the field is editable */
   readonly showEditIcon?: boolean
+  /** Optional stable hook for tests — applied to both the display and edit element. */
+  readonly testId?: string
 }
 
 export function InlineEdit({
@@ -20,6 +22,7 @@ export function InlineEdit({
   className,
   disabled = false,
   showEditIcon = false,
+  testId,
 }: InlineEditProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(value)
@@ -49,6 +52,7 @@ export function InlineEdit({
     return (
       <Input
         ref={inputRef}
+        data-testid={testId}
         value={draft}
         onChange={(e) => setDraft(e.target.value)}
         onBlur={handleSave}
@@ -68,6 +72,7 @@ export function InlineEdit({
 
   return (
     <span
+      data-testid={testId}
       className={cn(
         "group/edit inline-flex items-center gap-1 cursor-pointer rounded px-1 py-0.5 transition-colors hover:bg-[var(--color-surface-subtle)]",
         disabled && "cursor-default hover:bg-transparent",

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -1,6 +1,6 @@
 # E2E (`ui-checks`) Quarantine & Backlog
 
-_Last updated: 2026-06-04_
+_Last updated: 2026-06-05_
 
 ## Why this file exists
 
@@ -31,9 +31,29 @@ the "merge past red" norm without silently dropping coverage.
   - ✅ `producer can navigate between pages`
   - ✅ `viewer has read-only access`
   - ⏸️ `admin can access admin page` — `test.fixme` (see below)
+- **`tests/shots-crud.spec.ts`** (storageState auth) — chromium only. Un-quarantined
+  2026-06-05. Hard-asserts the real, project-scoped shot lifecycle against a
+  seeded fixture: list (read), create, detail deep-link (read), search filter,
+  inline rename (update), and create-then-delete (delete).
 
-This smoke set exercises authenticated page loads and so directly guards against
-the white-screen regression.
+This set exercises authenticated page loads + CRUD and so directly guards against
+the white-screen regression and the shot data path.
+
+## Emulator seed (added 2026-06-05)
+
+`tests/global.setup.ts` now seeds a deterministic Firestore fixture after the
+role users are created and before any spec runs (`seedShotsCrudScenario` in
+`tests/helpers/seed.ts`; IDs/titles in `tests/helpers/seedConstants.ts`): one
+team-visible project (`e2e-seed-project`) plus three app-shaped shots. Two prior
+bugs were fixed so the seed is actually visible to the app:
+
+1. **Partition** — `seed.ts` initialized firebase-admin with `demo-test-project`;
+   the app/emulator/`global.setup.ts` use `demo-test`. Fixed to `demo-test`, and
+   the helper now reuses the already-initialized admin app (a second
+   `initializeApp` throws "default app already exists").
+2. **Shot shape** — seeded shots omitted `deleted` and `date`; the shot-list
+   query filters `where('deleted','==',false)` and orders by `date`, so docs
+   missing either field are excluded. Seed now mirrors `CreateShotDialog`'s write.
 
 ## Quarantined specs (excluded via `testIgnore` in `playwright.config.ts`)
 
@@ -42,9 +62,8 @@ the white-screen regression.
 | `a11y.spec.ts` | App a11y | 93+ genuine WCAG AA contrast violations (e.g. muted `#71717a` on `#f4f4f5` = 4.39 vs 4.5) | Fix app contrast tokens (touches brand palette — product/design decision) or adjust the assertion threshold |
 | `auth.spec.ts` | Test infra | `helpers/auth.ts` interactive login times out on the post-login `waitForURL` redirect | Make the helper rehydrate via the app's real modular-SDK persistence (or switch these specs to storageState fixtures) |
 | `sidebar-summary.spec.ts` | Test infra | Same interactive-login helper root cause | As above |
-| `shots-crud.spec.ts` | Fixtures | storageState auth works, but CRUD flows need seeded Firestore data + stable selectors | Add an emulator seed step (products/shots) and stabilize selectors |
-| `pulls-crud.spec.ts` | Fixtures | Same — needs seeded data | As above |
-| `image-crop-editor.spec.js` | Fixtures | Needs a seeded shot with an existing image | Seed a shot+image in the emulator |
+| `pulls-crud.spec.ts` | Obsolete + fixtures | Navigates to a nonexistent top-level `/pulls` route (real route is `/projects/:id/pulls` → it lands on NotFoundPage); 7 of 9 tests wrap assertions in `if (await x.isVisible())` so they pass vacuously; several target UI that does not exist (Add-item dialog, PDF export, quantity editor, per-card delete — pull items are derived from shots, not hand-added); the fulfill test uses `producer` but only admin/warehouse can fulfill | **Deferred** (Ted, 2026-06-05): rewrite to project-scoped routes + real selectors and trim to flows that exist (create / view / status / share); revisit when pull-item editing UI exists. Do **not** un-quarantine as-is (the vacuous guards would give a false green). Seed already covers a project; extend with an app-shaped pull when rewriting |
+| `image-crop-editor.spec.js` | Obsolete | Targets a **removed legacy** UI: the `react-easy-crop` "Crop & Adjust Image" editor, an "Attachments" tab, an "Edit crop" button and `[data-testid=attachment-thumbnail]` live only in `archive/legacy-src-2026-04/`; `react-easy-crop` is not installed; the current app stores a single `heroImage` per shot (`HeroImageSection`). The spec also imports bare `@playwright/test` (no storageState → unauthenticated) | **Deferred** (Ted, 2026-06-05): seeding alone can never make it green. Rewrite against `HeroImageSection` on the shot detail page (use the producer storageState fixture) or delete the spec. Not just a seed task |
 | `visual.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines on the CI runner image |
 | `e2e/richtext-bubble.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines |
 | `diagnose-sticky.spec.js` | Scratch | Ad-hoc sticky-toolbar diagnostic that drives the broken interactive-login helper (1-min timeout) | Delete it, or convert to a real assertion once the login helper is fixed |
@@ -79,11 +98,16 @@ fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
 
 ## Follow-up backlog (separate work)
 
-1. **Seed fixtures** — an emulator seed step so CRUD/image specs have data. Highest
-   leverage: un-quarantines `shots-crud`, `pulls-crud`, `image-crop-editor`.
-2. **Robust interactive-login helper** — fixes `auth` + `sidebar-summary`.
-3. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
-4. **Visual baselines** — regenerate on the CI runner image; un-quarantines
+1. ~~**Seed fixtures** — an emulator seed step so CRUD/image specs have data.~~
+   **Done 2026-06-05** for shots (`seedShotsCrudScenario`), which un-quarantined
+   `shots-crud`. The seed is reusable for the rewrites below.
+2. **Rewrite `pulls-crud`** — to project-scoped routes + real selectors, trimmed
+   to flows that exist; extend the seed with an app-shaped pull. (Deferred per Ted.)
+3. **Rewrite or delete `image-crop-editor`** — against `HeroImageSection`, not the
+   removed legacy crop editor. (Deferred per Ted.)
+4. **Robust interactive-login helper** — fixes `auth` + `sidebar-summary`.
+5. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
+6. **Visual baselines** — regenerate on the CI runner image; un-quarantines
    `visual` + `richtext-bubble`.
-5. **Cross-browser job** — re-add firefox/webkit as a separate, non-blocking job
+7. **Cross-browser job** — re-add firefox/webkit as a separate, non-blocking job
    once the above land.

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -4,6 +4,7 @@ import { getAuth } from 'firebase-admin/auth';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
+import { seedShotsCrudScenario } from './helpers/seed';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -279,6 +280,20 @@ async function globalSetup(config: FullConfig) {
       console.error(`❌ Failed to set up ${roleName} user:`, error);
       throw error;
     }
+  }
+
+  // Seed the deterministic Firestore fixture the CRUD specs read (one
+  // team-visible project + app-shaped shots). Runs after users are created and
+  // before any spec, so all specs share one seeded dataset. Reuses the same
+  // firebase-admin app (projectId 'demo-test') initialized above — the seed
+  // helper guards against a double initializeApp.
+  console.log('Seeding Firestore fixtures (shots-crud)...');
+  try {
+    await seedShotsCrudScenario();
+    console.log('✅ Firestore fixtures seeded\n');
+  } catch (error) {
+    console.error('❌ Failed to seed Firestore fixtures:', error);
+    throw error;
   }
 
   console.log('========================================');

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -1,6 +1,12 @@
-import { initializeApp, type App } from 'firebase-admin/app';
+import { initializeApp, getApps, getApp, type App } from 'firebase-admin/app';
 import { getFirestore, type Firestore } from 'firebase-admin/firestore';
 import { getAuth } from 'firebase-admin/auth';
+import {
+  SEED_CLIENT_ID,
+  SEED_PROJECT_ID,
+  SEED_PROJECT_NAME,
+  SEED_SHOTS,
+} from './seedConstants';
 
 /**
  * Test data seeding utilities for Firebase emulator.
@@ -9,7 +15,7 @@ import { getAuth } from 'firebase-admin/auth';
  * All data is scoped to the 'test-client' clientId.
  */
 
-const CLIENT_ID = 'test-client';
+const CLIENT_ID = SEED_CLIENT_ID;
 
 let adminApp: App | null = null;
 let firestoreDb: Firestore | null = null;
@@ -20,13 +26,18 @@ let firestoreDb: Firestore | null = null;
 function getAdminApp(): App {
   if (adminApp) return adminApp;
 
-  // Set emulator environment variables
-  process.env.FIRESTORE_EMULATOR_HOST = 'localhost:8080';
-  process.env.FIREBASE_AUTH_EMULATOR_HOST = 'localhost:9099';
+  // Set emulator environment variables (only if not already set by the caller,
+  // e.g. global.setup.ts, which initializes the same admin app first).
+  process.env.FIRESTORE_EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST || 'localhost:8080';
+  process.env.FIREBASE_AUTH_EMULATOR_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST || 'localhost:9099';
 
-  adminApp = initializeApp({
-    projectId: 'demo-test-project',
-  });
+  // Reuse the already-initialized default app when present (global.setup.ts
+  // initializes firebase-admin first). Initializing a second default app throws
+  // "default app already exists". The projectId MUST be 'demo-test' — the same
+  // emulator partition the app reads (VITE_FIREBASE_PROJECT_ID=demo-test) and
+  // that global.setup.ts uses. A mismatched projectId (the previous
+  // 'demo-test-project') writes to an isolated partition the app never reads.
+  adminApp = getApps().length ? getApp() : initializeApp({ projectId: 'demo-test' });
 
   return adminApp;
 }
@@ -48,16 +59,29 @@ function getDb(): Firestore {
  */
 export async function createTestProject(data: {
   name: string;
-  shootDate?: Date;
-  members?: Record<string, string>; // uid -> role
+  /** Optional deterministic doc id so specs can deep-link to it. */
+  id?: string;
+  shootDates?: Date[];
+  /**
+   * Firestore rules let a producer read a project only when visibility is
+   * 'team' (or absent). Default to 'team' so the producer fixture can see it.
+   */
+  visibility?: 'team' | 'private';
 }): Promise<string> {
   const db = getDb();
-  const projectRef = db.collection(`clients/${CLIENT_ID}/projects`).doc();
+  const col = db.collection(`clients/${CLIENT_ID}/projects`);
+  const projectRef = data.id ? col.doc(data.id) : col.doc();
 
   await projectRef.set({
     name: data.name,
-    shootDate: data.shootDate || new Date(),
-    members: data.members || {},
+    clientId: CLIENT_ID,
+    status: 'active',
+    visibility: data.visibility || 'team',
+    // App reads `shootDates` (plural, normalized) — the old singular `shootDate`
+    // was silently ignored by mapProject.
+    shootDates: data.shootDates ?? [],
+    notes: null,
+    createdBy: null,
     createdAt: new Date(),
     updatedAt: new Date(),
   });
@@ -69,28 +93,48 @@ export async function createTestProject(data: {
  * Create a test shot
  */
 export async function createTestShot(projectId: string, data: {
-  title: string;
+  title?: string;
+  name?: string;
+  /** Optional deterministic doc id so specs can deep-link to it. */
+  id?: string;
   type?: string;
   status?: string;
-  description?: string;
+  description?: string | null;
   products?: string[];
   talent?: string[];
-  location?: string;
+  location?: string | null;
+  date?: Date | null;
+  sortOrder?: number;
+  shotNumber?: string | null;
 }): Promise<string> {
   const db = getDb();
-  const shotRef = db.collection(`clients/${CLIENT_ID}/shots`).doc();
+  const col = db.collection(`clients/${CLIENT_ID}/shots`);
+  const shotRef = data.id ? col.doc(data.id) : col.doc();
 
+  // Mirror CreateShotDialog's write contract. The shot-list query filters
+  // `where('deleted','==',false)` and orders by `date` — a doc MISSING either
+  // field is excluded from the list, so both are always set here.
   await shotRef.set({
+    title: data.title ?? data.name ?? 'Untitled Shot',
+    description: data.description ?? null,
     projectId,
-    title: data.title,
+    clientId: CLIENT_ID,
+    status: data.status || 'todo',
     type: data.type || 'On-Figure',
-    status: data.status || 'planned',
-    description: data.description || '',
+    deleted: false,
+    date: data.date ?? null,
+    sortOrder: data.sortOrder ?? Date.now(),
+    shotNumber: data.shotNumber ?? null,
+    products: data.products || [],
     productIds: data.products || [],
+    talent: data.talent || [],
     talentIds: data.talent || [],
-    locationId: data.location || null,
+    locationId: data.location ?? null,
+    notes: null,
+    referenceLinks: [],
     createdAt: new Date(),
     updatedAt: new Date(),
+    createdBy: '',
   });
 
   return shotRef.id;
@@ -264,7 +308,7 @@ export async function seedCompleteScenario(): Promise<{
   // Create project
   const projectId = await createTestProject({
     name: 'Fall 2024 Campaign',
-    shootDate: new Date('2024-11-15'),
+    shootDates: [new Date('2024-11-15')],
   });
 
   // Create locations
@@ -347,4 +391,51 @@ export async function seedCompleteScenario(): Promise<{
     talentIds: [model1Id, model2Id],
     locationIds: [studioId, outdoorId],
   };
+}
+
+/**
+ * Clear the shots-crud E2E fixture: every shot under the seed project (including
+ * ones created by the specs themselves) plus the project doc. Safe to call
+ * repeatedly; run before re-seeding so a persisted emulator does not accumulate
+ * duplicate shots across runs.
+ */
+export async function clearShotsCrudData(): Promise<void> {
+  const db = getDb();
+
+  const shotsSnap = await db
+    .collection(`clients/${CLIENT_ID}/shots`)
+    .where('projectId', '==', SEED_PROJECT_ID)
+    .get();
+
+  const batch = db.batch();
+  for (const doc of shotsSnap.docs) batch.delete(doc.ref);
+  batch.delete(db.collection(`clients/${CLIENT_ID}/projects`).doc(SEED_PROJECT_ID));
+  await batch.commit();
+}
+
+/**
+ * Seed the deterministic fixture the shots-crud spec reads: one team-visible
+ * project + the app-shaped shots declared in seedConstants.ts. Cleared first so
+ * the dataset is identical on every run (the emulator persists across a run).
+ */
+export async function seedShotsCrudScenario(): Promise<void> {
+  await clearShotsCrudData();
+
+  await createTestProject({
+    id: SEED_PROJECT_ID,
+    name: SEED_PROJECT_NAME,
+    visibility: 'team',
+  });
+
+  let order = 1;
+  for (const shot of SEED_SHOTS) {
+    await createTestShot(SEED_PROJECT_ID, {
+      id: shot.id,
+      title: shot.title,
+      status: 'todo',
+      sortOrder: order,
+      shotNumber: String(order),
+    });
+    order += 1;
+  }
 }

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -94,7 +94,6 @@ export async function createTestProject(data: {
  */
 export async function createTestShot(projectId: string, data: {
   title?: string;
-  name?: string;
   /** Optional deterministic doc id so specs can deep-link to it. */
   id?: string;
   type?: string;
@@ -115,7 +114,7 @@ export async function createTestShot(projectId: string, data: {
   // `where('deleted','==',false)` and orders by `date` — a doc MISSING either
   // field is excluded from the list, so both are always set here.
   await shotRef.set({
-    title: data.title ?? data.name ?? 'Untitled Shot',
+    title: data.title ?? 'Untitled Shot',
     description: data.description ?? null,
     projectId,
     clientId: CLIENT_ID,
@@ -407,10 +406,17 @@ export async function clearShotsCrudData(): Promise<void> {
     .where('projectId', '==', SEED_PROJECT_ID)
     .get();
 
-  const batch = db.batch();
-  for (const doc of shotsSnap.docs) batch.delete(doc.ref);
-  batch.delete(db.collection(`clients/${CLIENT_ID}/projects`).doc(SEED_PROJECT_ID));
-  await batch.commit();
+  const refs = shotsSnap.docs.map((doc) => doc.ref);
+  refs.push(db.collection(`clients/${CLIENT_ID}/projects`).doc(SEED_PROJECT_ID));
+
+  // Delete in chunks — a Firestore batch is capped at 500 ops. A persisted local
+  // emulator can accumulate test-created shots across runs (CI is fresh each time).
+  const CHUNK = 250;
+  for (let i = 0; i < refs.length; i += CHUNK) {
+    const batch = db.batch();
+    for (const ref of refs.slice(i, i + CHUNK)) batch.delete(ref);
+    await batch.commit();
+  }
 }
 
 /**

--- a/tests/helpers/seedConstants.ts
+++ b/tests/helpers/seedConstants.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic IDs + titles for the E2E emulator seed.
+ *
+ * Shared by `tests/helpers/seed.ts` (writes the docs) and the specs that read
+ * them (e.g. `tests/shots-crud.spec.ts`). Kept free of any `firebase-admin`
+ * import so specs can import it without pulling the admin SDK into the test.
+ *
+ * The IDs are fixed strings (not auto-generated) so a spec can deep-link to
+ * `/projects/<id>/shots` and `/projects/<id>/shots/<sid>` without scraping the
+ * list first. The seed is cleared + rewritten on every global setup, so these
+ * IDs are stable across runs.
+ */
+
+/** clientId every test user carries as a custom claim (see global.setup.ts). */
+export const SEED_CLIENT_ID = 'test-client';
+
+/** The project all seeded shots live under. Team-visible so a producer can read it. */
+export const SEED_PROJECT_ID = 'e2e-seed-project';
+export const SEED_PROJECT_NAME = 'E2E Seed Project';
+
+/**
+ * Seeded shots. Titles use distinct, unique tokens ("Aurora" / "Borealis") so a
+ * search-filter test can assert one stays and the other disappears.
+ *
+ * - AURORA   — read-asserted in the list + opened via deep-link (never mutated).
+ * - BOREALIS — read-asserted in the list + the negative case for the filter test.
+ * - EDITABLE — the dedicated target for the inline-edit (update) test. Not
+ *              read-asserted elsewhere, so renaming it can't break other tests.
+ */
+export const SEED_SHOT_AURORA = { id: 'e2e-shot-aurora', title: 'Aurora Hero Shot' } as const;
+export const SEED_SHOT_BOREALIS = { id: 'e2e-shot-borealis', title: 'Borealis Detail Shot' } as const;
+export const SEED_SHOT_EDITABLE = { id: 'e2e-shot-editable', title: 'Editable Seed Shot' } as const;
+
+/** All seeded shots, in seed order. */
+export const SEED_SHOTS = [SEED_SHOT_AURORA, SEED_SHOT_BOREALIS, SEED_SHOT_EDITABLE] as const;

--- a/tests/shots-crud.spec.ts
+++ b/tests/shots-crud.spec.ts
@@ -99,7 +99,10 @@ test.describe('Shot CRUD Operations', () => {
     await titleEdit.click();
 
     const newTitle = `Edited Seed Shot ${Date.now()}`;
+    // After the click, InlineEdit swaps the display span for a focused input
+    // (same testId). Wait for focus so the fill targets the edit field, not the span.
     const input = producerPage.getByTestId('shot-title-edit');
+    await expect(input).toBeFocused();
     await input.fill(newTitle);
     await input.press('Enter');
 

--- a/tests/shots-crud.spec.ts
+++ b/tests/shots-crud.spec.ts
@@ -1,299 +1,147 @@
 import { test, expect } from './fixtures/auth';
+import {
+  SEED_PROJECT_ID,
+  SEED_SHOT_AURORA,
+  SEED_SHOT_BOREALIS,
+  SEED_SHOT_EDITABLE,
+} from './helpers/seedConstants';
 
 /**
- * Shot CRUD E2E Tests
- * Tests the complete lifecycle of shots: Create, Read, Update, Delete
+ * Shot CRUD E2E tests — exercises the real, project-scoped shot lifecycle
+ * against the Firestore emulator seed (see tests/helpers/seed.ts +
+ * tests/global.setup.ts → seedShotsCrudScenario).
+ *
+ * Every test hard-asserts against the actual app UI. There are intentionally no
+ * `if (await x.isVisible())` guards: a guarded assertion on a route/selector that
+ * no longer exists "passes" by doing nothing (a false green). If the seed or a
+ * selector regresses, these tests must fail loudly.
+ *
+ * Notes on the real app (verified against src-vnext):
+ * - Shots live at `/projects/:id/shots` (there is NO top-level `/shots` route).
+ * - Editing/deleting happen on the detail page (`/projects/:id/shots/:sid`) and
+ *   via the per-shot "Shot actions" menu — there is no "Edit shot" dialog.
+ * - The producer fixture runs at a 1280×720 (desktop) viewport.
  */
 
+const SHOTS_URL = `/projects/${SEED_PROJECT_ID}/shots`;
+
 test.describe('Shot CRUD Operations', () => {
-  // Use producer role for these tests (has permissions to create/edit/delete)
+  // ── READ (list) ──────────────────────────────────────────────────────────
+  // Keystone: proves the seed landed in the partition the app reads, the route
+  // resolves, the producer storageState is authenticated, and the shot-list
+  // query shape (deleted:false + date) surfaces the seeded shots.
+  test('producer sees seeded shots in the project shot list', async ({ producerPage }) => {
+    await producerPage.goto(SHOTS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    await expect(producerPage.getByText(SEED_SHOT_AURORA.title).first()).toBeVisible();
+    await expect(producerPage.getByText(SEED_SHOT_BOREALIS.title).first()).toBeVisible();
+  });
+
+  // ── CREATE ───────────────────────────────────────────────────────────────
   test('producer can create a new shot', async ({ producerPage }) => {
-    // Navigate to shots page
-    await producerPage.goto('/shots');
-    // Wait for shots page content
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+    await producerPage.goto(SHOTS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
 
-    // Find and click create shot button
-    const createButton = producerPage.getByRole('button', { name: /create shot|new shot|new/i }).first();
-    await expect(createButton).toBeVisible({ timeout: 10000 });
-    await createButton.click();
+    // Card view so we can assert on the shot card (not the success toast, which
+    // also renders the title — asserting the card proves list membership).
+    await producerPage.getByRole('button', { name: 'Card view' }).click();
 
-    // Wait for modal/dialog to appear
+    const newShotButton = producerPage.getByRole('button', { name: 'New Shot' });
+    await expect(newShotButton).toBeVisible();
+    await newShotButton.click();
+
     const dialog = producerPage.getByRole('dialog');
-    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await expect(dialog).toBeVisible();
 
-    // Fill in shot name
-    const nameInput = dialog.getByRole('textbox').first();
-    const shotName = `E2E Test Shot ${Date.now()}`;
-    await nameInput.fill(shotName);
+    const title = `E2E Create Shot ${Date.now()}`;
+    await dialog.getByTestId('shot-title-input').fill(title);
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click();
 
-    // Submit the form
-    const submitButton = dialog.getByRole('button', { name: /create shot|create|save/i });
-    await submitButton.click();
-
-    // Wait for modal to close and success message
-    await expect(dialog).not.toBeVisible({ timeout: 5000 });
-
-    // Verify shot appears in the list or we're redirected to shot view
-    await producerPage.waitForTimeout(1000); // Give time for toast/navigation
-
-    // The shot should now be visible somewhere on the page
-    const shotElement = producerPage.getByText(shotName).first();
-    await expect(shotElement).toBeVisible({ timeout: 5000 });
+    await expect(dialog).not.toBeVisible();
+    await expect(
+      producerPage.locator('[data-testid="shot-card"]', { hasText: title }),
+    ).toBeVisible();
   });
 
-  test('producer can view shot details', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── READ (detail, deep-link) ──────────────────────────────────────────────
+  test('producer can open a shot detail page', async ({ producerPage }) => {
+    await producerPage.goto(`${SHOTS_URL}/${SEED_SHOT_AURORA.id}`);
 
-    // Wait for shots to load
-    await producerPage.waitForTimeout(2000);
-
-    // Click on first shot card/row
-    const shotCards = producerPage.locator('[data-shot-card], [data-shot-id], .shot-card, [role="article"]');
-    const count = await shotCards.count();
-
-    if (count > 0) {
-      const firstShot = shotCards.first();
-      await firstShot.click();
-
-      // Should open edit modal or navigate to detail page
-      const dialog = producerPage.getByRole('dialog');
-
-      if (await dialog.isVisible()) {
-        // Modal opened - verify we can see shot details
-        await expect(dialog).toBeVisible();
-
-        // Should have input fields or shot information
-        const textboxes = dialog.getByRole('textbox');
-        expect(await textboxes.count()).toBeGreaterThan(0);
-      } else {
-        // Navigated to detail page - verify URL changed
-        const url = producerPage.url();
-        expect(url).toContain('/shot');
-      }
-    }
+    // "Back to Shots" only renders on the detail page — confirms we did not
+    // land on NotFoundPage.
+    await expect(producerPage.getByRole('button', { name: /back to shots/i })).toBeVisible();
+    await expect(producerPage.getByText(SEED_SHOT_AURORA.title).first()).toBeVisible();
   });
 
-  test('producer can update shot details', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── FILTER ────────────────────────────────────────────────────────────────
+  test('producer can filter shots by search', async ({ producerPage }) => {
+    await producerPage.goto(SHOTS_URL);
+    await producerPage.getByText(SEED_SHOT_BOREALIS.title).first().waitFor({ state: 'visible' });
 
-    // Create a new shot first
-    const createButton = producerPage.getByRole('button', { name: /create shot|new shot|new/i }).first();
+    await producerPage.getByPlaceholder(/search shots/i).fill('Aurora');
 
-    if (await createButton.isVisible()) {
-      await createButton.click();
-
-      const dialog = producerPage.getByRole('dialog');
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      const originalName = `Update Test ${Date.now()}`;
-      const nameInput = dialog.getByRole('textbox').first();
-      await nameInput.fill(originalName);
-
-      const submitButton = dialog.getByRole('button', { name: /create shot|create|save/i });
-      await submitButton.click();
-
-      await expect(dialog).not.toBeVisible({ timeout: 5000 });
-      await producerPage.waitForTimeout(1000);
-
-      // Now find and edit the shot we just created
-      const shotElement = producerPage.getByText(originalName).first();
-      await expect(shotElement).toBeVisible({ timeout: 5000 });
-      await shotElement.click();
-
-      // Edit modal should open
-      const editDialog = producerPage.getByRole('dialog');
-      await expect(editDialog).toBeVisible({ timeout: 5000 });
-
-      // Update the name
-      const updatedName = `${originalName} - Updated`;
-      const editNameInput = editDialog.getByRole('textbox').first();
-      await editNameInput.clear();
-      await editNameInput.fill(updatedName);
-
-      // Save changes
-      const saveButton = editDialog.getByRole('button', { name: /save|update/i });
-      await saveButton.click();
-
-      await expect(editDialog).not.toBeVisible({ timeout: 5000 });
-
-      // Verify updated name appears
-      await producerPage.waitForTimeout(1000);
-      const updatedElement = producerPage.getByText(updatedName).first();
-      await expect(updatedElement).toBeVisible({ timeout: 5000 });
-    }
+    // The matching shot stays; the non-matching one is removed from the list.
+    await expect(producerPage.getByText(SEED_SHOT_AURORA.title).first()).toBeVisible();
+    await expect(producerPage.getByText(SEED_SHOT_BOREALIS.title)).toHaveCount(0);
   });
 
-  test('producer can add products to a shot', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── UPDATE (inline edit on the detail page) ───────────────────────────────
+  // Targets the dedicated editable seed shot (never read-asserted elsewhere) and
+  // renames it to a fresh unique value, so the test is safe under parallel runs
+  // and retries.
+  test('producer can rename a shot inline', async ({ producerPage }) => {
+    await producerPage.goto(`${SHOTS_URL}/${SEED_SHOT_EDITABLE.id}`);
+    await expect(producerPage.getByRole('button', { name: /back to shots/i })).toBeVisible();
 
-    // Click on first shot
-    await producerPage.waitForTimeout(2000);
-    const shotCards = producerPage.locator('[data-shot-card], [data-shot-id]');
-    const count = await shotCards.count();
+    const titleEdit = producerPage.getByTestId('shot-title-edit');
+    await expect(titleEdit).toBeVisible();
+    await titleEdit.click();
 
-    if (count > 0) {
-      await shotCards.first().click();
+    const newTitle = `Edited Seed Shot ${Date.now()}`;
+    const input = producerPage.getByTestId('shot-title-edit');
+    await input.fill(newTitle);
+    await input.press('Enter');
 
-      const dialog = producerPage.getByRole('dialog');
-      await expect(dialog).toBeVisible({ timeout: 5000 });
-
-      // Look for "Add product" or "Products" section
-      const addProductButton = dialog.getByRole('button', { name: /add product/i });
-
-      if (await addProductButton.isVisible()) {
-        await addProductButton.click();
-
-        // Product selection modal should appear
-        await producerPage.waitForTimeout(1000);
-
-        // Look for product list or family selector
-        const productSelectors = dialog.locator('select, [role="combobox"], [role="listbox"]');
-
-        if (await productSelectors.count() > 0) {
-          // Found product selector - this confirms the add product flow works
-          const firstSelector = productSelectors.first();
-          await expect(firstSelector).toBeVisible();
-        }
-      }
-    }
+    await expect(producerPage.getByText(newTitle).first()).toBeVisible();
   });
 
+  // ── DELETE (create-then-delete via the per-shot actions menu) ──────────────
+  // Self-contained: creates its own uniquely-titled shot so it never removes a
+  // seeded shot other tests rely on. Forces card view so the per-card "Shot
+  // actions" kebab is present.
   test('producer can delete a shot', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+    await producerPage.goto(SHOTS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
 
-    // Create a shot to delete
-    const createButton = producerPage.getByRole('button', { name: /create shot|new shot|new/i }).first();
+    // Ensure card view (the per-card actions menu lives on the ShotCard).
+    await producerPage.getByRole('button', { name: 'Card view' }).click();
 
-    if (await createButton.isVisible()) {
-      await createButton.click();
+    // Create the shot to delete.
+    await producerPage.getByRole('button', { name: 'New Shot' }).click();
+    const dialog = producerPage.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+    const title = `E2E Delete Shot ${Date.now()}`;
+    await dialog.getByTestId('shot-title-input').fill(title);
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click();
+    await expect(dialog).not.toBeVisible();
 
-      const dialog = producerPage.getByRole('dialog');
-      await expect(dialog).toBeVisible({ timeout: 5000 });
+    const card = producerPage.locator('[data-testid="shot-card"]', { hasText: title });
+    await expect(card).toBeVisible();
 
-      const shotName = `Delete Test ${Date.now()}`;
-      const nameInput = dialog.getByRole('textbox').first();
-      await nameInput.fill(shotName);
+    // Open the per-shot actions menu and choose delete.
+    await card.getByRole('button', { name: /shot actions/i }).click();
+    await producerPage.getByRole('menuitem', { name: /delete shot/i }).click();
 
-      const submitButton = dialog.getByRole('button', { name: /create shot|create|save/i });
-      await submitButton.click();
+    // Confirm the destructive dialog (requires typing DELETE).
+    const confirm = producerPage.getByRole('dialog');
+    await expect(confirm).toBeVisible();
+    await confirm.getByPlaceholder(/type delete/i).fill('DELETE');
+    await confirm.getByRole('button', { name: 'Delete shot', exact: true }).click();
 
-      await expect(dialog).not.toBeVisible({ timeout: 5000 });
-      await producerPage.waitForTimeout(1000);
-
-      // Find and click on the shot
-      const shotElement = producerPage.getByText(shotName).first();
-      await expect(shotElement).toBeVisible({ timeout: 5000 });
-      await shotElement.click();
-
-      // Edit dialog should open
-      const editDialog = producerPage.getByRole('dialog');
-      await expect(editDialog).toBeVisible({ timeout: 5000 });
-
-      // Look for delete button
-      const deleteButton = editDialog.getByRole('button', { name: /delete/i });
-
-      if (await deleteButton.isVisible()) {
-        await deleteButton.click();
-
-        // May need to confirm deletion
-        await producerPage.waitForTimeout(500);
-
-        // Look for confirmation dialog or confirm button
-        const confirmButton = producerPage.getByRole('button', { name: /delete|confirm/i }).last();
-
-        if (await confirmButton.isVisible()) {
-          await confirmButton.click();
-        }
-
-        // Wait for dialog to close
-        await producerPage.waitForTimeout(2000);
-
-        // Verify shot is gone from the list
-        const deletedElement = producerPage.getByText(shotName);
-        await expect(deletedElement).not.toBeVisible();
-      }
-    }
-  });
-
-  test('producer can filter shots', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Look for filter controls
-    await producerPage.waitForTimeout(2000);
-
-    const filterControls = producerPage.locator('input[placeholder*="search" i], input[placeholder*="filter" i], [role="searchbox"]');
-
-    if (await filterControls.count() > 0) {
-      const searchInput = filterControls.first();
-      await searchInput.fill('test');
-
-      // Wait for filtering to occur
-      await producerPage.waitForTimeout(1000);
-
-      // Verify filtering works (results should change)
-      const visibleShots = producerPage.locator('[data-shot-card], [data-shot-id]');
-      expect(await visibleShots.count()).toBeGreaterThanOrEqual(0);
-    }
-  });
-
-  test('producer can navigate between shot views', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Look for view toggle buttons (grid/table/list)
-    await producerPage.waitForTimeout(2000);
-
-    const viewToggles = producerPage.getByRole('button', { name: /grid|table|list|view/i });
-    const toggleCount = await viewToggles.count();
-
-    if (toggleCount > 1) {
-      // Click between different views
-      const firstToggle = viewToggles.first();
-      await firstToggle.click();
-      await producerPage.waitForTimeout(500);
-
-      const secondToggle = viewToggles.nth(1);
-      await secondToggle.click();
-      await producerPage.waitForTimeout(500);
-
-      // Verify layout changed (hard to test visually, but verify no errors)
-      const currentUrl = producerPage.url();
-      expect(currentUrl).toContain('/shots');
-    }
-  });
-
-  test('producer can export shots', async ({ producerPage }) => {
-    await producerPage.goto('/shots');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Look for export button
-    await producerPage.waitForTimeout(2000);
-
-    const exportButton = producerPage.getByRole('button', { name: /export|download|pdf/i });
-
-    if (await exportButton.count() > 0) {
-      const firstExportButton = exportButton.first();
-
-      if (await firstExportButton.isVisible() && await firstExportButton.isEnabled()) {
-        await firstExportButton.click();
-
-        // Export modal or download should trigger
-        await producerPage.waitForTimeout(1000);
-
-        // Look for export options dialog
-        const exportDialog = producerPage.getByRole('dialog');
-
-        if (await exportDialog.isVisible()) {
-          // Export modal opened - verify it has export options
-          await expect(exportDialog).toBeVisible();
-        }
-      }
-    }
+    // Soft-deleted shots drop out of the active list.
+    await expect(
+      producerPage.locator('[data-testid="shot-card"]', { hasText: title }),
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What

Adds a deterministic Firestore **emulator seed** and rewrites `tests/shots-crud.spec.ts` to the real, project-scoped UI so it leaves the `ui-checks` quarantine. First chip at the E2E quarantine backlog in `tests/QUARANTINE.md`.

## Why the old spec couldn't just be un-quarantined

Scouting showed the diagnosis in QUARANTINE.md ("needs seeded data") was incomplete:
- The seed helper (`tests/helpers/seed.ts`) was **dead code** *and* wrote to the wrong emulator partition (`demo-test-project` vs the app's `demo-test`).
- Seeded shots omitted `deleted`/`date`, which the shot-list query filters/orders on — so they'd be **invisible** even if the partition were right.
- The spec navigated to a **nonexistent `/shots` route** (real route is `/projects/:id/shots`) and most tests passed **vacuously** behind `if (await x.isVisible())` guards (false greens).

## Changes

**Seed infra**
- `seed.ts`: partition fix → `demo-test`; reuse the existing admin app via `getApps()` (avoids "default app already exists"); app-shape project/shot writes (mirror `CreateShotDialog`: `deleted:false`, `date:null`, `clientId`, team-visible projects); add `seedShotsCrudScenario` (clear-then-seed, idempotent) + deterministic IDs in new `seedConstants.ts`.
- `global.setup.ts`: run the seed after role users are created.

**Spec rewrite** — 6 hard-asserting tests (no vacuous guards): list-read · create · detail deep-link · search-filter · inline rename · create-then-delete.

**Testability hooks** (no behavior change when unused): `data-testid="shot-card"` on `ShotCard`; optional `testId` on `InlineEdit`, passed to the detail-page title.

**Un-quarantine + docs**: drop shots-crud from `testIgnore`; `QUARANTINE.md` documents the seed and the **corrected real reasons** `pulls-crud` and `image-crop-editor` stay quarantined (both target removed/nonexistent UI — deferred this round, not merely missing seed data).

## Scope decisions (confirmed with Ted)
- **pulls-crud → deferred**: 7/9 tests vacuous; targets pull UI that doesn't exist (add-item dialog, PDF export, qty editor, per-card delete); needs a rewrite.
- **image-crop-editor → left quarantined**: targets a removed legacy `react-easy-crop` editor (dep not installed); needs a rewrite vs `HeroImageSection` or deletion.

## Verification
- ✅ `vite build`, ✅ Playwright discovers all 6 tests, ✅ unit tests for edited components, ✅ `eslint --max-warnings=0` + `tsc --noEmit` clean on changed files.
- Adversarial 3-reviewer pass (false-green skeptic + seed-wiring + code review): **all pass, zero blockers**.
- ⚠️ The Firestore emulator can't run locally (Java 8) — **the first real green is the CI `ui-checks` job**. Please don't merge until it's green (and per standing rule, awaiting Ted's go-ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)