### PR TITLE
test(e2e): rewrite + un-quarantine pulls-crud against project-scoped routes

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,7 +21,11 @@ export default defineConfig({
     // shots-crud.spec.ts un-quarantined 2026-06-05: emulator seed step added
     // (seedShotsCrudScenario) + spec rewritten to the real project-scoped routes
     // and selectors. See tests/QUARANTINE.md.
-    '**/pulls-crud.spec.ts',      // targets nonexistent /pulls route + UI that doesn't exist (deferred — see QUARANTINE.md)
+    // pulls-crud.spec.ts un-quarantined 2026-06-05: emulator seed step added
+    // (seedPullsCrudScenario) + warehouse fixture + spec rewritten to the real
+    // project-scoped routes (/projects/:id/pulls(/:pid)) and real selectors,
+    // trimmed to flows that exist (list/create/detail/status/share/fulfillment).
+    // See tests/QUARANTINE.md.
     '**/image-crop-editor.spec.js', // targets removed legacy react-easy-crop UI (deferred — see QUARANTINE.md)
     '**/visual.spec.ts',          // snapshot baselines missing/mismatched
     '**/e2e/richtext-bubble.spec.ts', // snapshot/visual baselines

--- a/src-vnext/features/pulls/components/PullCard.tsx
+++ b/src-vnext/features/pulls/components/PullCard.tsx
@@ -19,6 +19,7 @@ export function PullCard({ pull }: PullCardProps) {
 
   return (
     <Card
+      data-testid={`pull-card-${pull.id}`}
       className="cursor-pointer transition-shadow hover:shadow-md"
       onClick={() => navigate(`/projects/${projectId}/pulls/${pull.id}`)}
     >

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -35,9 +35,18 @@ the "merge past red" norm without silently dropping coverage.
   2026-06-05. Hard-asserts the real, project-scoped shot lifecycle against a
   seeded fixture: list (read), create, detail deep-link (read), search filter,
   inline rename (update), and create-then-delete (delete).
+- **`tests/pulls-crud.spec.ts`** (storageState auth) — chromium only. Un-quarantined
+  2026-06-05. Hard-asserts the real, project-scoped pull lifecycle against a
+  seeded fixture (`seedPullsCrudScenario`: one app-shaped pull + one item under
+  `e2e-seed-project`): list read (seeded pull card), create (new pull sheet),
+  detail deep-link (name + item family + "Items (1)"), status change (→
+  Published), share/unshare, and fulfillment from **both** RBAC sides — producer
+  toggle **disabled** (`canFulfillPulls` excludes producer) and warehouse live
+  Pending→Fulfilled (via the new `warehousePage` fixture). Sets an explicit
+  desktop viewport because `canEdit = canManagePulls && !isMobile`.
 
 This set exercises authenticated page loads + CRUD and so directly guards against
-the white-screen regression and the shot data path.
+the white-screen regression and the shot + pull data paths.
 
 ## Emulator seed (added 2026-06-05)
 
@@ -55,6 +64,34 @@ bugs were fixed so the seed is actually visible to the app:
    query filters `where('deleted','==',false)` and orders by `date`, so docs
    missing either field are excluded. Seed now mirrors `CreateShotDialog`'s write.
 
+## Pulls seed + warehouse fixture (added 2026-06-05)
+
+`tests/global.setup.ts` now also seeds a deterministic pull fixture
+(`seedPullsCrudScenario` in `tests/helpers/seed.ts`; constants `SEED_PULL` /
+`SEED_PULL_ITEM` in `tests/helpers/seedConstants.ts`) **after**
+`seedShotsCrudScenario` (which creates the `e2e-seed-project` doc the pull lives
+under). It writes ONE app-shaped pull at
+`clients/test-client/projects/e2e-seed-project/pulls/e2e-seed-pull` with one item
+(family `Helios Jacket`, size `M`), mirroring `createPullFromShots.ts` (the
+canonical app writer): Date values coerce to Firestore Timestamps; `familyId` +
+`size` are non-empty (mapItem/mapSize drop items/sizes missing them);
+`colourName` uses British spelling. The pulls subcollection is cleared first
+(`clearPullsCrudData`, CHUNK=250) so the dataset is identical each run and any
+pull the create-test makes is wiped on the next setup.
+
+A new **`warehouse`** role user was added to `TEST_USERS` (and `TEST_CREDENTIALS`)
+with the `warehousePage` fixture in `tests/fixtures/auth.ts` — warehouse is a
+distinct RBAC role from wardrobe (`canFulfillPulls` = admin|warehouse only), so
+the pulls spec can cover fulfillment from both the producer-disabled and the
+warehouse-live side. Because `firestore.rules` gates pull read/write on
+`hasProjectRole(...,'warehouse')` (the warehouse user's *global* role satisfies
+neither `isAdmin` nor `producerCanAccessProject`), `seedPullsCrudScenario` also
+writes a project **members** doc (`.../projects/e2e-seed-project/members/<warehouse-uid>`,
+role `warehouse`) using the uid captured from `createOrUpdateTestUser` in
+`global.setup.ts`. Without it the warehouse user cannot even read the seeded pull.
+Producer needs no member doc — its global role satisfies `producerCanAccessProject`
+on a team-visible project.
+
 ## Quarantined specs (excluded via `testIgnore` in `playwright.config.ts`)
 
 | Spec | Category | Failure | Fix needed |
@@ -62,7 +99,6 @@ bugs were fixed so the seed is actually visible to the app:
 | `a11y.spec.ts` | App a11y | 93+ genuine WCAG AA contrast violations (e.g. muted `#71717a` on `#f4f4f5` = 4.39 vs 4.5) | Fix app contrast tokens (touches brand palette — product/design decision) or adjust the assertion threshold |
 | `auth.spec.ts` | Test infra | `helpers/auth.ts` interactive login times out on the post-login `waitForURL` redirect | Make the helper rehydrate via the app's real modular-SDK persistence (or switch these specs to storageState fixtures) |
 | `sidebar-summary.spec.ts` | Test infra | Same interactive-login helper root cause | As above |
-| `pulls-crud.spec.ts` | Obsolete + fixtures | Navigates to a nonexistent top-level `/pulls` route (real route is `/projects/:id/pulls` → it lands on NotFoundPage); 7 of 9 tests wrap assertions in `if (await x.isVisible())` so they pass vacuously; several target UI that does not exist (Add-item dialog, PDF export, quantity editor, per-card delete — pull items are derived from shots, not hand-added); the fulfill test uses `producer` but only admin/warehouse can fulfill | **Deferred** (Ted, 2026-06-05): rewrite to project-scoped routes + real selectors and trim to flows that exist (create / view / status / share); revisit when pull-item editing UI exists. Do **not** un-quarantine as-is (the vacuous guards would give a false green). Seed already covers a project; extend with an app-shaped pull when rewriting |
 | `image-crop-editor.spec.js` | Obsolete | Targets a **removed legacy** UI: the `react-easy-crop` "Crop & Adjust Image" editor, an "Attachments" tab, an "Edit crop" button and `[data-testid=attachment-thumbnail]` live only in `archive/legacy-src-2026-04/`; `react-easy-crop` is not installed; the current app stores a single `heroImage` per shot (`HeroImageSection`). The spec also imports bare `@playwright/test` (no storageState → unauthenticated) | **Deferred** (Ted, 2026-06-05): seeding alone can never make it green. Rewrite against `HeroImageSection` on the shot detail page (use the producer storageState fixture) or delete the spec. Not just a seed task |
 | `visual.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines on the CI runner image |
 | `e2e/richtext-bubble.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines |
@@ -101,8 +137,13 @@ fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
 1. ~~**Seed fixtures** — an emulator seed step so CRUD/image specs have data.~~
    **Done 2026-06-05** for shots (`seedShotsCrudScenario`), which un-quarantined
    `shots-crud`. The seed is reusable for the rewrites below.
-2. **Rewrite `pulls-crud`** — to project-scoped routes + real selectors, trimmed
-   to flows that exist; extend the seed with an app-shaped pull. (Deferred per Ted.)
+2. ~~**Rewrite `pulls-crud`** — to project-scoped routes + real selectors, trimmed
+   to flows that exist; extend the seed with an app-shaped pull.~~ **Done
+   2026-06-05**: rewritten to `/projects/:id/pulls(/:pid)` + real selectors
+   (list/create/detail/status/share/fulfillment), seed extended with an
+   app-shaped pull (`seedPullsCrudScenario`), and a `warehouse` user +
+   `warehousePage` fixture added so fulfillment is covered producer-disabled +
+   warehouse-live. Un-quarantined.
 3. **Rewrite or delete `image-crop-editor`** — against `HeroImageSection`, not the
    removed legacy crop editor. (Deferred per Ted.)
 4. **Robust interactive-login helper** — fixes `auth` + `sidebar-summary`.

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -41,6 +41,7 @@ type AuthFixtures = {
   adminPage: Page;
   producerPage: Page;
   wardrobePage: Page;
+  warehousePage: Page;
   crewPage: Page;
   viewerPage: Page;
 };
@@ -67,7 +68,7 @@ function installFirebaseErrorFilter(page: Page): void {
 
 async function buildRoleFixture(
   browser: import('@playwright/test').Browser,
-  role: 'admin' | 'producer' | 'wardrobe' | 'crew' | 'viewer',
+  role: 'admin' | 'producer' | 'wardrobe' | 'warehouse' | 'crew' | 'viewer',
   use: (page: Page) => Promise<void>,
 ): Promise<void> {
   const context = await browser.newContext({ storageState: storageStatePath(role) });
@@ -97,6 +98,11 @@ export const test = base.extend<AuthFixtures>({
   /** Wardrobe — can manage products and view/edit shots. */
   wardrobePage: async ({ browser }, use) => {
     await buildRoleFixture(browser, 'wardrobe', use);
+  },
+
+  /** Warehouse — can manage + fulfill pulls (distinct RBAC role from wardrobe). */
+  warehousePage: async ({ browser }, use) => {
+    await buildRoleFixture(browser, 'warehouse', use);
   },
 
   /** Crew — view shots, limited edit. */
@@ -130,6 +136,11 @@ export const TEST_CREDENTIALS = {
     email: 'wardrobe@test.shotbuilder.app',
     password: 'test-password-wardrobe-123',
     role: 'wardrobe',
+  },
+  warehouse: {
+    email: 'warehouse@test.shotbuilder.app',
+    password: 'test-password-warehouse-123',
+    role: 'warehouse',
   },
   crew: {
     email: 'crew@test.shotbuilder.app',

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -4,7 +4,7 @@ import { getAuth } from 'firebase-admin/auth';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
-import { seedShotsCrudScenario } from './helpers/seed';
+import { seedShotsCrudScenario, seedPullsCrudScenario } from './helpers/seed';
 
 // ES module equivalent of __dirname
 const __filename = fileURLToPath(import.meta.url);
@@ -42,6 +42,12 @@ export const TEST_USERS = {
     email: 'wardrobe@test.shotbuilder.app',
     password: 'test-password-wardrobe-123',
     role: 'wardrobe',
+    clientId: 'test-client',
+  },
+  warehouse: {
+    email: 'warehouse@test.shotbuilder.app',
+    password: 'test-password-warehouse-123',
+    role: 'warehouse',
     clientId: 'test-client',
   },
   crew: {
@@ -261,10 +267,16 @@ async function globalSetup(config: FullConfig) {
   // Create test users and authenticate each one
   console.log('Creating test users and authenticating...\n');
 
+  // Capture each role's uid — the pulls-crud fixture needs the warehouse uid to
+  // grant it project membership (see below); without a members doc the warehouse
+  // user satisfies neither producerCanAccessProject (global producer only) nor
+  // hasProjectRole, so firestore.rules would deny it read/write on the pull.
+  const roleUids: Record<string, string> = {};
+
   for (const [roleName, userData] of Object.entries(TEST_USERS)) {
     try {
       // Create/update user with custom claims
-      await createOrUpdateTestUser(
+      roleUids[roleName] = await createOrUpdateTestUser(
         userData.email,
         userData.password,
         userData.role,
@@ -290,6 +302,12 @@ async function globalSetup(config: FullConfig) {
   console.log('Seeding Firestore fixtures (shots-crud)...');
   try {
     await seedShotsCrudScenario();
+    // Seed the pulls-crud fixture AFTER shots-crud — seedPullsCrudScenario
+    // assumes the seed project (created by seedShotsCrudScenario) already exists.
+    // Pass the warehouse uid so the seed can grant it project membership: pull
+    // read/write under firestore.rules requires hasProjectRole(...,'warehouse')
+    // (warehouse's global role satisfies neither isAdmin nor producerCanAccessProject).
+    await seedPullsCrudScenario({ warehouseUid: roleUids.warehouse });
     console.log('✅ Firestore fixtures seeded\n');
   } catch (error) {
     console.error('❌ Failed to seed Firestore fixtures:', error);

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -6,6 +6,8 @@ import {
   SEED_PROJECT_ID,
   SEED_PROJECT_NAME,
   SEED_SHOTS,
+  SEED_PULL,
+  SEED_PULL_ITEM,
 } from './seedConstants';
 
 /**
@@ -443,5 +445,113 @@ export async function seedShotsCrudScenario(): Promise<void> {
       shotNumber: String(order),
     });
     order += 1;
+  }
+}
+
+/**
+ * Clear every pull under the seed project (including ones the pulls-crud spec
+ * creates itself) at `clients/test-client/projects/e2e-seed-project/pulls`.
+ * Mirrors clearShotsCrudData's chunked delete. Does NOT touch the project doc
+ * or its shots — only the pulls subcollection.
+ */
+export async function clearPullsCrudData(): Promise<void> {
+  const db = getDb();
+
+  const pullsSnap = await db
+    .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/pulls`)
+    .get();
+
+  const refs = pullsSnap.docs.map((doc) => doc.ref);
+
+  // Delete in chunks — a Firestore batch is capped at 500 ops. A persisted local
+  // emulator can accumulate test-created pulls across runs (CI is fresh each time).
+  const CHUNK = 250;
+  for (let i = 0; i < refs.length; i += CHUNK) {
+    const batch = db.batch();
+    for (const ref of refs.slice(i, i + CHUNK)) batch.delete(ref);
+    await batch.commit();
+  }
+}
+
+/**
+ * Seed the deterministic fixture the pulls-crud spec reads: ONE app-shaped pull
+ * with ONE item, at `clients/test-client/projects/e2e-seed-project/pulls/<id>`.
+ * Cleared first so the dataset is identical on every run.
+ *
+ * ORDERING DEPENDENCY: assumes the seed PROJECT (e2e-seed-project) already
+ * exists — it is created by seedShotsCrudScenario(). global.setup.ts MUST call
+ * seedShotsCrudScenario() BEFORE seedPullsCrudScenario(). The pull doc shape
+ * mirrors createPullFromShots.ts (the canonical app writer) so usePulls/mapPull
+ * render it: Date values coerce to Firestore Timestamps; familyId + size are
+ * non-empty (mapItem/mapSize drop items/sizes missing them); 'colourName' uses
+ * British spelling.
+ *
+ * WAREHOUSE ACCESS: pass `warehouseUid` to grant the warehouse test user project
+ * membership (a doc at `.../projects/<id>/members/<uid>` with role 'warehouse').
+ * firestore.rules gates pull read on hasProjectRole(...,['producer','crew',
+ * 'warehouse','viewer']) and pull write on hasProjectRole(...,['producer',
+ * 'warehouse']); the warehouse user's GLOBAL role satisfies neither isAdmin nor
+ * producerCanAccessProject (producer-global only), so without this member doc the
+ * warehouse fulfillment test cannot even read the seeded pull. Producer needs no
+ * member doc — its global role satisfies producerCanAccessProject on a team project.
+ */
+export async function seedPullsCrudScenario(
+  opts: { warehouseUid?: string } = {},
+): Promise<void> {
+  await clearPullsCrudData();
+
+  const db = getDb();
+  const pullRef = db
+    .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/pulls`)
+    .doc(SEED_PULL.id);
+
+  const now = new Date();
+
+  await pullRef.set({
+    name: SEED_PULL.name,
+    title: null,
+    projectId: SEED_PROJECT_ID,
+    clientId: CLIENT_ID,
+    shotIds: [],
+    items: [
+      {
+        id: 'e2e-seed-pull-item',
+        familyId: SEED_PULL_ITEM.familyId,
+        familyName: SEED_PULL_ITEM.familyName,
+        colourId: null,
+        colourName: SEED_PULL_ITEM.colourName,
+        sizes: [
+          {
+            size: SEED_PULL_ITEM.size,
+            quantity: SEED_PULL_ITEM.quantity,
+            fulfilled: 0,
+            status: 'pending',
+          },
+        ],
+        fulfillmentStatus: 'pending',
+        notes: null,
+      },
+    ],
+    status: 'draft',
+    shareEnabled: false,
+    shareAllowResponses: false,
+    shareToken: null,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  // Grant the warehouse user project membership so firestore.rules permits it to
+  // read + fulfill the pull (see the WAREHOUSE ACCESS note above). Keyed by uid
+  // because hasProjectRole resolves the member doc at members/<request.auth.uid>.
+  if (opts.warehouseUid) {
+    await db
+      .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/members`)
+      .doc(opts.warehouseUid)
+      .set({
+        role: 'warehouse',
+        clientId: CLIENT_ID,
+        projectId: SEED_PROJECT_ID,
+        addedAt: now,
+      });
   }
 }

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -498,9 +498,23 @@ export async function clearPullsCrudData(): Promise<void> {
 export async function seedPullsCrudScenario(
   opts: { warehouseUid?: string } = {},
 ): Promise<void> {
+  const db = getDb();
+
+  // Fail loud, not silent: the ordering dependency above is only a comment. If
+  // global.setup ever reorders or skips seedShotsCrudScenario, the pull would be
+  // written into a nonexistent project (the admin SDK doesn't enforce parent
+  // existence) and the list test would see zero cards with no clue why.
+  const projectSnap = await db
+    .doc(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}`)
+    .get();
+  if (!projectSnap.exists) {
+    throw new Error(
+      `seedPullsCrudScenario: seed project ${SEED_PROJECT_ID} not found — run seedShotsCrudScenario() first`,
+    );
+  }
+
   await clearPullsCrudData();
 
-  const db = getDb();
   const pullRef = db
     .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/pulls`)
     .doc(SEED_PULL.id);

--- a/tests/helpers/seedConstants.ts
+++ b/tests/helpers/seedConstants.ts
@@ -33,3 +33,27 @@ export const SEED_SHOT_EDITABLE = { id: 'e2e-shot-editable', title: 'Editable Se
 
 /** All seeded shots, in seed order. */
 export const SEED_SHOTS = [SEED_SHOT_AURORA, SEED_SHOT_BOREALIS, SEED_SHOT_EDITABLE] as const;
+
+/**
+ * Seeded pull sheet for the pulls-crud spec. Lives under the seed project at
+ * `clients/test-client/projects/e2e-seed-project/pulls/<SEED_PULL.id>`.
+ *
+ * The name uses a unique token ("Helios") so the create-pull test's freshly
+ * created sheet never collides with this seeded one in a list assertion. The
+ * fixed id lets a spec deep-link to `/projects/<project>/pulls/<SEED_PULL.id>`.
+ */
+export const SEED_PULL = { id: 'e2e-seed-pull', name: 'Helios Day 1 Pull' } as const;
+
+/**
+ * The single item the seeded pull carries. Distinct tokens ("Helios Jacket",
+ * size 'M') so the spec can assert the family name + size render on the detail
+ * page. Mirrors the app PullItem shape mapItem/mapSize read (familyId + size
+ * REQUIRED non-empty; British 'colourName').
+ */
+export const SEED_PULL_ITEM = {
+  familyId: 'e2e-pull-family',
+  familyName: 'Helios Jacket',
+  colourName: 'Black',
+  size: 'M',
+  quantity: 2,
+} as const;

--- a/tests/pulls-crud.spec.ts
+++ b/tests/pulls-crud.spec.ts
@@ -1,379 +1,197 @@
 import { test, expect } from './fixtures/auth';
+import {
+  SEED_PROJECT_ID,
+  SEED_PULL,
+  SEED_PULL_ITEM,
+} from './helpers/seedConstants';
 
 /**
- * Pull Sheet CRUD E2E Tests
- * Tests the complete pull sheet lifecycle: Create, Add Items, Fulfill, Export
+ * Pull Sheet CRUD E2E tests — exercises the real, project-scoped pull lifecycle
+ * against the Firestore emulator seed (see tests/helpers/seed.ts +
+ * tests/global.setup.ts → seedPullsCrudScenario).
+ *
+ * Every test hard-asserts against the actual app UI. There are intentionally no
+ * `if (await x.isVisible())` / `if (count > 0)` guards: a guarded assertion on a
+ * route/selector that no longer exists "passes" by doing nothing (a false green).
+ * If the seed, a route, or a selector regresses, these tests MUST fail loudly.
+ *
+ * Notes on the real app (verified against src-vnext):
+ * - Pulls live at `/projects/:id/pulls` (list) and `/projects/:id/pulls/:pid`
+ *   (detail; the detail route param is `pid`). There is NO top-level `/pulls`.
+ * - The seeded pull (`SEED_PULL`) carries ONE item (`SEED_PULL_ITEM`) with one
+ *   size 'M'. usePulls applies no where()/orderBy filters, so the doc is visible.
+ * - Status + per-item fulfillment are Radix <Select>s (role="combobox"): open the
+ *   trigger, then click the option by role/name. The header status combobox and
+ *   the item FulfillmentToggle combobox are disambiguated by scoping (the item
+ *   one lives inside the item Card, next to the family name).
+ * - RBAC: canManagePulls = admin|producer|warehouse (status/share/create);
+ *   canFulfillPulls = admin|warehouse ONLY (producer CANNOT fulfill). The detail
+ *   page also gates edit on `!isMobile` (canEdit), so a DESKTOP viewport is
+ *   required — set explicitly below in addition to the fixture's 1280×720.
  */
 
-test.describe('Pull Sheet Operations', () => {
-  test('producer can create a new pull', async ({ producerPage }) => {
-    // Navigate to pulls page
-    await producerPage.goto('/pulls');
-    // Wait for pulls page content
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+// Force a desktop viewport: PullDetailPage's canEdit = canManagePulls && !isMobile,
+// so status-edit + Share only render above the mobile breakpoint.
+test.use({ viewport: { width: 1280, height: 800 } });
 
-    // Find and click create pull button
-    const createButton = producerPage.getByRole('button', { name: /create pull|new pull|new/i }).first();
-    await expect(createButton).toBeVisible({ timeout: 10000 });
-    await createButton.click();
+const PULLS_URL = `/projects/${SEED_PROJECT_ID}/pulls`;
+const PULL_DETAIL_URL = `${PULLS_URL}/${SEED_PULL.id}`;
+const SEEDED_CARD = `[data-testid="pull-card-${SEED_PULL.id}"]`;
 
-    // Wait for input field or modal
-    await producerPage.waitForTimeout(500);
+test.describe('Pull Sheet CRUD Operations', () => {
+  // Tests 4 (status), 5 (share), and 7 (fulfillment) all MUTATE the single shared
+  // seeded pull doc. playwright.config has fullyParallel:true, which would otherwise
+  // distribute tests in this file across workers and let those writes race on the
+  // same doc (stale onSnapshot / optimistic churn). Serial mode pins the file to one
+  // worker in declared order; the two spec FILES still parallelize across workers.
+  test.describe.configure({ mode: 'serial' });
 
-    // Fill in pull name
-    const pullName = `E2E Test Pull ${Date.now()}`;
-    const nameInput = producerPage.locator('input[placeholder*="pull" i], input[type="text"]').first();
+  // ── READ (list) ──────────────────────────────────────────────────────────
+  // Keystone: proves the seed landed in the partition the app reads, the route
+  // resolves, the producer storageState is authenticated, and usePulls surfaces
+  // the seeded pull. Fails if the seed or route regresses.
+  test('producer sees the seeded pull in the project pull list', async ({ producerPage }) => {
+    await producerPage.goto(PULLS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
 
-    if (await nameInput.isVisible()) {
-      await nameInput.fill(pullName);
+    await expect(producerPage.getByRole('heading', { name: 'Pull Sheets' })).toBeVisible();
 
-      // Submit (might be same button or a separate create button)
-      const submitButton = producerPage.getByRole('button', { name: /create|add|save/i }).first();
-
-      if (await submitButton.isVisible() && await submitButton.isEnabled()) {
-        await submitButton.click();
-      } else {
-        // Might submit on Enter
-        await nameInput.press('Enter');
-      }
-
-      // Wait for pull to be created
-      await producerPage.waitForTimeout(2000);
-
-      // Verify pull appears in the list
-      const pullElement = producerPage.getByText(pullName);
-      await expect(pullElement.first()).toBeVisible({ timeout: 5000 });
-    }
+    const card = producerPage.locator(SEEDED_CARD);
+    await expect(card).toBeVisible();
+    await expect(card).toContainText(SEED_PULL.name);
   });
 
-  test('producer can view pull details', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── CREATE ───────────────────────────────────────────────────────────────
+  // Uses a fixed unique token (not a timestamp) so the assertion is deterministic
+  // and the created pull never collides with the seeded "Helios Day 1 Pull".
+  // The seed clears the pulls subcollection on every global setup, so this
+  // created pull is wiped before the next run.
+  test('producer can create a new pull sheet', async ({ producerPage }) => {
+    await producerPage.goto(PULLS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
 
-    // Wait for pulls to load
-    await producerPage.waitForTimeout(2000);
+    await producerPage.getByRole('button', { name: 'New Pull Sheet' }).click();
 
-    // Click on first pull card/row
-    const pullCards = producerPage.locator('[data-pull-card], [data-pull-id], .pull-card');
-    const count = await pullCards.count();
+    const dialog = producerPage.getByRole('dialog');
+    await expect(dialog).toBeVisible();
 
-    if (count > 0) {
-      const firstPull = pullCards.first();
-      await firstPull.click();
+    const newName = 'E2E Created Pull Vega';
+    const nameInput = dialog.locator('#pull-name');
+    await nameInput.fill(newName);
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click();
 
-      // Wait for navigation or modal
-      await producerPage.waitForTimeout(1000);
+    await expect(dialog).not.toBeVisible();
 
-      // Should navigate to pull detail page
-      const url = producerPage.url();
-      expect(url).toMatch(/\/pull/);
-
-      // Should see pull items or empty state
-      const heading = producerPage.getByRole('heading').first();
-      await expect(heading).toBeVisible();
-    }
+    // Assert the created pull's card appears in the list (not a toast).
+    await expect(
+      producerPage.locator('[data-testid^="pull-card-"]', { hasText: newName }),
+    ).toBeVisible();
   });
 
-  test('producer can add items to a pull', async ({ producerPage }) => {
-    // First create a pull
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── READ (detail, deep-link) ──────────────────────────────────────────────
+  // Deep-links straight to the seeded pull. Asserts the name heading, the seeded
+  // item's family name (item survived mapItem — familyId non-empty), and the
+  // "Items (1)" label. Fails if the route param/seed/mapItem path regresses.
+  test('producer can open the seeded pull detail page', async ({ producerPage }) => {
+    await producerPage.goto(PULL_DETAIL_URL);
 
-    const createButton = producerPage.getByRole('button', { name: /create pull|new pull|new/i }).first();
-
-    if (await createButton.isVisible()) {
-      await createButton.click();
-      await producerPage.waitForTimeout(500);
-
-      const pullName = `Item Test Pull ${Date.now()}`;
-      const nameInput = producerPage.locator('input[placeholder*="pull" i], input[type="text"]').first();
-
-      if (await nameInput.isVisible()) {
-        await nameInput.fill(pullName);
-        await nameInput.press('Enter');
-
-        await producerPage.waitForTimeout(2000);
-
-        // Click on the pull we just created
-        const pullElement = producerPage.getByText(pullName).first();
-
-        if (await pullElement.isVisible()) {
-          await pullElement.click();
-
-          // Should navigate to pull detail page
-          await producerPage.waitForTimeout(1000);
-
-          // Look for "Add item" or "Add product" button
-          const addItemButton = producerPage.getByRole('button', { name: /add item|add product|new item/i }).first();
-
-          if (await addItemButton.isVisible()) {
-            await addItemButton.click();
-
-            // Item editor modal should appear
-            await producerPage.waitForTimeout(1000);
-
-            const dialog = producerPage.getByRole('dialog');
-
-            if (await dialog.isVisible()) {
-              // Verify modal opened with item form
-              await expect(dialog).toBeVisible();
-
-              // Should have product/family selectors
-              const selectors = dialog.locator('select, [role="combobox"]');
-              expect(await selectors.count()).toBeGreaterThan(0);
-            }
-          }
-        }
-      }
-    }
+    // The pull name renders as the page heading on the detail page.
+    await expect(producerPage.getByText(SEED_PULL.name).first()).toBeVisible();
+    // The seeded item's family name + its single size render (item not dropped).
+    await expect(producerPage.getByText(SEED_PULL_ITEM.familyName).first()).toBeVisible();
+    await expect(producerPage.getByText(SEED_PULL_ITEM.size, { exact: true }).first()).toBeVisible();
+    // Items label reflects the one seeded item.
+    await expect(producerPage.getByText('Items (1)')).toBeVisible();
   });
 
-  test('producer can update pull item quantities', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── UPDATE (status) ───────────────────────────────────────────────────────
+  // Opens the header status combobox (the FIRST combobox on the detail page —
+  // the item FulfillmentToggle is the second) and picks "Published". Asserts the
+  // trigger reflects the new status. Mutates the shared seed, but asserts only
+  // the post-condition it sets, so it is order-independent.
+  test('producer can change the pull status to Published', async ({ producerPage }) => {
+    await producerPage.goto(PULL_DETAIL_URL);
+    await expect(producerPage.getByText(SEED_PULL.name).first()).toBeVisible();
 
-    // Click on first pull
-    await producerPage.waitForTimeout(2000);
-    const pullCards = producerPage.locator('[data-pull-card], [data-pull-id]');
-    const count = await pullCards.count();
+    // Exactly two comboboxes exist with one seeded item: [0]=header status Select,
+    // [1]=item FulfillmentToggle. Assert the count so .first()/.last() can't silently
+    // drift if the page ever grows another combobox.
+    await expect(producerPage.getByRole('combobox')).toHaveCount(2);
 
-    if (count > 0) {
-      await pullCards.first().click();
+    // Header status Select is the first combobox; item fulfillment Select is second.
+    const statusTrigger = producerPage.getByRole('combobox').first();
+    await expect(statusTrigger).toBeEnabled();
+    await statusTrigger.click();
 
-      await producerPage.waitForTimeout(1000);
+    await producerPage.getByRole('option', { name: 'Published' }).click();
 
-      // Look for items in the pull
-      const itemRows = producerPage.locator('[data-pull-item], tr[data-item-id], .pull-item');
-      const itemCount = await itemRows.count();
-
-      if (itemCount > 0) {
-        // Click on first item to edit
-        const firstItem = itemRows.first();
-        await firstItem.click();
-
-        // Edit modal should open
-        await producerPage.waitForTimeout(1000);
-
-        const dialog = producerPage.getByRole('dialog');
-
-        if (await dialog.isVisible()) {
-          // Look for quantity inputs
-          const quantityInputs = dialog.locator('input[type="number"]');
-
-          if (await quantityInputs.count() > 0) {
-            const firstQuantityInput = quantityInputs.first();
-            await firstQuantityInput.clear();
-            await firstQuantityInput.fill('5');
-
-            // Save changes
-            const saveButton = dialog.getByRole('button', { name: /save|update/i });
-            await saveButton.click();
-
-            await producerPage.waitForTimeout(1000);
-
-            // Dialog should close
-            await expect(dialog).not.toBeVisible();
-          }
-        }
-      }
-    }
+    // The trigger now shows the Published badge.
+    await expect(statusTrigger).toContainText('Published');
   });
 
-  test('producer can mark items as fulfilled', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── SHARE / UNSHARE ───────────────────────────────────────────────────────
+  // Toggles share on (button "Share" → "Shared", share link appears), then off
+  // (→ "Share"). Self-contained: it leaves sharing disabled at the end.
+  test('producer can share and unshare the pull', async ({ producerPage }) => {
+    await producerPage.goto(PULL_DETAIL_URL);
+    await expect(producerPage.getByText(SEED_PULL.name).first()).toBeVisible();
 
-    // Click on first pull
-    await producerPage.waitForTimeout(2000);
-    const pullCards = producerPage.locator('[data-pull-card], [data-pull-id]');
-    const count = await pullCards.count();
-
-    if (count > 0) {
-      await pullCards.first().click();
-
-      await producerPage.waitForTimeout(1000);
-
-      // Look for fulfillment controls (checkboxes, inputs, or buttons)
-      const fulfillmentControls = producerPage.locator(
-        'input[type="checkbox"][aria-label*="fulfill" i], button:has-text("Fulfill"), input[placeholder*="fulfilled" i]'
-      );
-
-      if (await fulfillmentControls.count() > 0) {
-        const firstControl = fulfillmentControls.first();
-
-        if (await firstControl.isVisible() && await firstControl.isEnabled()) {
-          await firstControl.click();
-
-          // Wait for update
-          await producerPage.waitForTimeout(1000);
-
-          // Verify some visual feedback (status change, toast, etc.)
-          const currentUrl = producerPage.url();
-          expect(currentUrl).toMatch(/\/pull/);
-        }
-      }
+    // Self-heal: a prior failed attempt (or retry) may have left sharing ON. The
+    // seed only resets in global setup, not between tests, so normalize to OFF
+    // before asserting the on→off transition, otherwise the retry sees 'Shared'
+    // and the exact 'Share' lookup never resolves.
+    const alreadyShared = producerPage.getByRole('button', { name: 'Shared', exact: true });
+    if (await alreadyShared.isVisible().catch(() => false)) {
+      await alreadyShared.click();
     }
+
+    const shareButton = producerPage.getByRole('button', { name: 'Share', exact: true });
+    await expect(shareButton).toBeVisible();
+    await shareButton.click();
+
+    // Becomes "Shared" and the share link block appears.
+    const sharedButton = producerPage.getByRole('button', { name: 'Shared', exact: true });
+    await expect(sharedButton).toBeVisible();
+    await expect(producerPage.getByText(/Share link:/i)).toBeVisible();
+
+    // Toggle back off.
+    await sharedButton.click();
+    await expect(producerPage.getByRole('button', { name: 'Share', exact: true })).toBeVisible();
   });
 
-  test('producer can export a pull sheet to PDF', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── RBAC: producer CANNOT fulfill ─────────────────────────────────────────
+  // The per-item FulfillmentToggle is disabled for producer (canFulfillPulls =
+  // admin|warehouse only). Scope to the item card so we target the fulfillment
+  // combobox, not the header status one.
+  test('producer cannot fulfill items (toggle disabled)', async ({ producerPage }) => {
+    await producerPage.goto(PULL_DETAIL_URL);
+    await expect(producerPage.getByText(SEED_PULL_ITEM.familyName).first()).toBeVisible();
 
-    // Click on first pull
-    await producerPage.waitForTimeout(2000);
-    const pullCards = producerPage.locator('[data-pull-card], [data-pull-id]');
-    const count = await pullCards.count();
-
-    if (count > 0) {
-      await pullCards.first().click();
-
-      await producerPage.waitForTimeout(1000);
-
-      // Look for export/PDF button
-      const exportButton = producerPage.getByRole('button', { name: /export|pdf|download/i });
-
-      if (await exportButton.count() > 0) {
-        const firstExportButton = exportButton.first();
-
-        if (await firstExportButton.isVisible() && await firstExportButton.isEnabled()) {
-          await firstExportButton.click();
-
-          // Export modal should appear
-          await producerPage.waitForTimeout(1000);
-
-          const exportDialog = producerPage.getByRole('dialog');
-
-          if (await exportDialog.isVisible()) {
-            // Verify export options are available
-            await expect(exportDialog).toBeVisible();
-
-            // Look for generate/download button
-            const generateButton = exportDialog.getByRole('button', { name: /generate|download|export/i });
-
-            if (await generateButton.count() > 0) {
-              await expect(generateButton.first()).toBeVisible();
-            }
-          }
-        }
-      }
-    }
+    // The item card containing the seeded family name; its combobox is the
+    // FulfillmentToggle (the second of exactly two). Producer lacks
+    // canFulfillPulls → disabled.
+    await expect(producerPage.getByRole('combobox')).toHaveCount(2);
+    const fulfillmentTrigger = producerPage.getByRole('combobox').last();
+    await expect(fulfillmentTrigger).toBeDisabled();
   });
 
-  test('producer can delete a pull', async ({ producerPage }) => {
-    // Create a pull to delete
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
+  // ── RBAC: warehouse CAN fulfill ───────────────────────────────────────────
+  // As warehouse, open the item FulfillmentToggle and set Pending → Fulfilled,
+  // then assert the trigger reflects Fulfilled. Uses warehousePage (the new
+  // fixture) — warehouse has canFulfillPulls.
+  test('warehouse can fulfill an item (Pending → Fulfilled)', async ({ warehousePage }) => {
+    await warehousePage.goto(PULL_DETAIL_URL);
+    await expect(warehousePage.getByText(SEED_PULL_ITEM.familyName).first()).toBeVisible();
 
-    const createButton = producerPage.getByRole('button', { name: /create pull|new pull|new/i }).first();
+    // The FulfillmentToggle is the item-scoped combobox (the second of exactly two;
+    // the first is the header status Select). Enabled for warehouse.
+    await expect(warehousePage.getByRole('combobox')).toHaveCount(2);
+    const fulfillmentTrigger = warehousePage.getByRole('combobox').last();
+    await expect(fulfillmentTrigger).toBeEnabled();
+    await fulfillmentTrigger.click();
 
-    if (await createButton.isVisible()) {
-      await createButton.click();
-      await producerPage.waitForTimeout(500);
+    await warehousePage.getByRole('option', { name: 'Fulfilled' }).click();
 
-      const pullName = `Delete Test Pull ${Date.now()}`;
-      const nameInput = producerPage.locator('input[placeholder*="pull" i], input[type="text"]').first();
-
-      if (await nameInput.isVisible()) {
-        await nameInput.fill(pullName);
-        await nameInput.press('Enter');
-
-        await producerPage.waitForTimeout(2000);
-
-        // Find the pull we just created
-        const pullElement = producerPage.getByText(pullName).first();
-
-        if (await pullElement.isVisible()) {
-          // Look for delete button (might be on pull card or need to open pull first)
-          const deleteButton = producerPage.getByRole('button', { name: /delete/i });
-
-          if (await deleteButton.count() > 0) {
-            const visibleDeleteButton = deleteButton.first();
-
-            if (await visibleDeleteButton.isVisible()) {
-              await visibleDeleteButton.click();
-
-              // Confirmation dialog may appear
-              await producerPage.waitForTimeout(500);
-
-              const confirmButton = producerPage.getByRole('button', { name: /delete|confirm/i }).last();
-
-              if (await confirmButton.isVisible()) {
-                await confirmButton.click();
-              }
-
-              // Wait for deletion
-              await producerPage.waitForTimeout(2000);
-
-              // Verify pull is gone
-              const deletedElement = producerPage.getByText(pullName);
-              await expect(deletedElement).not.toBeVisible();
-            }
-          }
-        }
-      }
-    }
-  });
-
-  test('producer can filter pulls by status', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Look for status filter controls
-    await producerPage.waitForTimeout(2000);
-
-    const statusFilters = producerPage.locator('select, [role="combobox"], button[aria-haspopup="listbox"]');
-
-    if (await statusFilters.count() > 0) {
-      // Try to interact with filter
-      const firstFilter = statusFilters.first();
-
-      if (await firstFilter.isVisible()) {
-        await firstFilter.click();
-
-        // Wait for dropdown/options
-        await producerPage.waitForTimeout(500);
-
-        // Verify options are available
-        const options = producerPage.locator('[role="option"], option');
-        expect(await options.count()).toBeGreaterThan(0);
-      }
-    }
-  });
-
-  test('producer can share a pull with warehouse', async ({ producerPage }) => {
-    await producerPage.goto('/pulls');
-    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Click on first pull
-    await producerPage.waitForTimeout(2000);
-    const pullCards = producerPage.locator('[data-pull-card], [data-pull-id]');
-    const count = await pullCards.count();
-
-    if (count > 0) {
-      await pullCards.first().click();
-
-      await producerPage.waitForTimeout(1000);
-
-      // Look for share button
-      const shareButton = producerPage.getByRole('button', { name: /share|send|email/i });
-
-      if (await shareButton.count() > 0) {
-        const firstShareButton = shareButton.first();
-
-        if (await firstShareButton.isVisible() && await firstShareButton.isEnabled()) {
-          await firstShareButton.click();
-
-          // Share modal should appear
-          await producerPage.waitForTimeout(1000);
-
-          const shareDialog = producerPage.getByRole('dialog');
-
-          if (await shareDialog.isVisible()) {
-            // Verify share options are available
-            await expect(shareDialog).toBeVisible();
-          }
-        }
-      }
-    }
+    await expect(fulfillmentTrigger).toContainText('Fulfilled');
   });
 });


### PR DESCRIPTION
## What

Rewrites the obsolete `pulls-crud.spec.ts` and un-quarantines it — the next-highest-leverage item on the E2E backlog after Session 6 un-quarantined `shots-crud` (#423).

The old spec was a **false green**: it navigated a nonexistent top-level `/pulls` route (real route is `/projects/:id/pulls`) with most assertions wrapped in vacuous `if (await x.isVisible())` guards, and targeted UI that doesn't exist (add-item dialog, PDF export, quantity editor, per-card delete — pull items are derived from shots). See `tests/QUARANTINE.md`.

## Approach (scout → build → adversarial verify)

Built via a dynamic multi-agent workflow: a parallel scout verified the current pulls UI/data/RBAC/rules against source (correcting three stale handoff facts), a build phase extended the seed, and a 3-lens adversarial verifier (false-green / selectors / infra+rules) stress-tested it before commit. The verifier caught a **blocker** — fixed below.

## Changes

**Seed + infra**
- `seedConstants.ts` — `SEED_PULL` + `SEED_PULL_ITEM` (one app-shaped pull, one item).
- `seed.ts` — `clearPullsCrudData` + `seedPullsCrudScenario` writing the canonical app pull shape (mirrors `createPullFromShots`); `familyId`/`size` non-empty so `mapItem`/`mapSize` don't drop them.
- `global.setup.ts` — new `warehouse` test user; `seedPullsCrudScenario` wired in after `seedShotsCrudScenario`; captures the warehouse uid and writes a project **members** doc so `firestore.rules` permits warehouse to read/fulfill the pull (its global role alone is denied — `hasProjectRole('warehouse')` is required).
- `fixtures/auth.ts` — `warehousePage` fixture.
- `PullCard.tsx` — stable `data-testid={`pull-card-${pull.id}`}` (behavior-free).

**Spec** — 7 hard-asserting tests (serial mode, since they mutate one shared seeded doc under `fullyParallel`), desktop viewport for the `canEdit = canManagePulls && !isMobile` gate:
1. list read · 2. create (New Pull Sheet → dialog) · 3. detail deep-link · 4. status → Published · 5. share/unshare · 6. RBAC: producer fulfillment toggle **disabled** · 7. warehouse live fulfillment Pending → Fulfilled.

Dropped tests for nonexistent UI; no vacuous guards — each test is shaped to **fail without the seed/route/selector**.

## Verification

- `tsc --noEmit` clean on all touched files (the ~150 pre-existing errors elsewhere are unaffected; tsc is not a CI gate).
- The Firestore emulator can't run locally (Java 8) — the `ui-checks` CI job is the real gate. Adversarially verified each test would fail without the seed (anti-false-green), and the warehouse read/write path against `firestore.rules`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)