### PR TITLE
test(e2e): un-quarantine auth.spec via a robust interactive-login helper

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,8 +16,19 @@ export default defineConfig({
   // regression. DO NOT add specs here without a tracking entry in QUARANTINE.md.
   testIgnore: [
     '**/a11y.spec.ts',            // real WCAG AA contrast violations in the app
-    '**/auth.spec.ts',            // interactive-login helper times out on post-login redirect
-    '**/sidebar-summary.spec.ts', // interactive-login helper (same root cause)
+    // auth.spec.ts un-quarantined 2026-06-06: helpers/auth.ts now waits on authed
+    // SIGNALS (emulator form detaches + we leave /login + nav renders) instead of
+    // the brittle post-login waitForURL race, the goto/reload use 'domcontentloaded'
+    // (emulator sockets never go idle), and signOut() clicks the real
+    // aria-label="Sign out" control. The spec is trimmed to the 5 genuine
+    // login-flow tests (sign-in/out, unauth redirect, session persist, invalid
+    // creds); RBAC/admin coverage stays in smoke + shots-crud. See QUARANTINE.md.
+    '**/sidebar-summary.spec.ts', // FALSE-PREMISE (not the login helper): targets a
+                                  // removed shot edit MODAL (role="dialog") + an
+                                  // aside[data-testid="sidebar-summary"] + Basics/
+                                  // Logistics tabs that no longer exist — editing is
+                                  // on ShotDetailPage now. Needs a ground-up rewrite
+                                  // against the detail page. See QUARANTINE.md.
     // shots-crud.spec.ts un-quarantined 2026-06-05: emulator seed step added
     // (seedShotsCrudScenario) + spec rewritten to the real project-scoped routes
     // and selectors. See tests/QUARANTINE.md.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,13 +16,9 @@ export default defineConfig({
   // regression. DO NOT add specs here without a tracking entry in QUARANTINE.md.
   testIgnore: [
     '**/a11y.spec.ts',            // real WCAG AA contrast violations in the app
-    // auth.spec.ts un-quarantined 2026-06-06: helpers/auth.ts now waits on authed
-    // SIGNALS (emulator form detaches + we leave /login + nav renders) instead of
-    // the brittle post-login waitForURL race, the goto/reload use 'domcontentloaded'
-    // (emulator sockets never go idle), and signOut() clicks the real
-    // aria-label="Sign out" control. The spec is trimmed to the 5 genuine
-    // login-flow tests (sign-in/out, unauth redirect, session persist, invalid
-    // creds); RBAC/admin coverage stays in smoke + shots-crud. See QUARANTINE.md.
+    // auth.spec.ts un-quarantined 2026-06-06: interactive-login helper fixed
+    // (authed-signal wait + domcontentloaded + real sign-out + emulator-only
+    // submit selector). See QUARANTINE.md "Interactive-login helper fix".
     '**/sidebar-summary.spec.ts', // FALSE-PREMISE (not the login helper): targets a
                                   // removed shot edit MODAL (role="dialog") + an
                                   // aside[data-testid="sidebar-summary"] + Basics/

--- a/src-vnext/features/auth/components/LoginPage.tsx
+++ b/src-vnext/features/auth/components/LoginPage.tsx
@@ -253,7 +253,7 @@ export default function LoginPage() {
 
             {/* Error message */}
             {error && (
-              <p className="text-xs text-red-400">{error}</p>
+              <p className="text-xs text-red-400" data-testid="login-error">{error}</p>
             )}
           </div>
         </div>

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -1,6 +1,6 @@
 # E2E (`ui-checks`) Quarantine & Backlog
 
-_Last updated: 2026-06-05_
+_Last updated: 2026-06-06_
 
 ## Why this file exists
 
@@ -55,8 +55,47 @@ the "merge past red" norm without silently dropping coverage.
   Requires the Storage emulator (see below) and a desktop viewport (`canEdit`
   needs `!isMobile`). Runs serial — it mutates the shared seeded shot.
 
+- **`tests/auth.spec.ts`** (interactive login, NO storageState) — chromium only.
+  Un-quarantined 2026-06-06. The ONLY suite that drives the real login form, so
+  it covers what storageState fixtures cannot: sign-in, sign-out, redirect when
+  unauthenticated, session persistence across reload, and the invalid-credential
+  error path (5 tests). See "Interactive-login helper fix" below.
+
 This set exercises authenticated page loads + CRUD and so directly guards against
 the white-screen regression and the shot + pull data paths.
+
+## Interactive-login helper fix (added 2026-06-06)
+
+`tests/helpers/auth.ts` (`authenticateTestUser`) timed out on its post-login
+`waitForURL` — NOT because of selectors or the URL regex (both matched the real
+`/projects` landing), but because:
+
+1. **`waitUntil: 'networkidle'`** on its `goto`/`reload` fought the Firebase
+   emulator's long-lived streaming connections (Firestore listeners,
+   Installations), which never go idle — the page could submit in an unsettled
+   state and the wait could hang until timeout. Changed to `'domcontentloaded'`.
+2. **It raced a single client-side redirect** (`waitForURL`). The redirect is
+   driven in-app (`onIdTokenChanged → claims → navigate('/projects')`) and can
+   lag. Replaced with a wait on concrete authed SIGNALS — the emulator login
+   form **detaches**, `location.pathname` leaves `/login`, and the app nav
+   renders. This mirrors the proven-stable shape `global.setup.ts` relies on.
+
+The `signOut` helper was also broken: it looked for `button[aria-label*="user"]`
+/ `button:has-text("Sign out")`, but the real control is an **icon-only** button
+in `SidebarUserSection` with `aria-label="Sign out"` (no visible text, no
+separate user-menu trigger). It now clicks `button[aria-label="Sign out"]`
+directly and waits for the genuine redirect to `/login`.
+
+The only app-source change is a behavior-free `data-testid="login-error"` on
+`LoginPage.tsx`'s error `<p>`, so the invalid-credential test can scope to the
+real error element instead of a page-wide text regex.
+
+`auth.spec.ts` was trimmed to the 5 genuine login-flow tests. The 3 prior
+role-access tests (non-admin/viewer/producer on `/products`) were dropped — two
+had vacuous `if (count > 0)` guards that silently passed (≈no coverage), and
+real RBAC coverage already lives in smoke + shots-crud via storageState. The
+`admin role can access admin page` test was dropped as a duplicate of
+smoke.spec.ts's `test.fixme` (same unresolved admin-heading gap, below).
 
 ## Emulator seed (added 2026-06-05)
 
@@ -122,11 +161,10 @@ image contentType <10MB — no project-membership doc required (unlike pulls).
 | Spec | Category | Failure | Fix needed |
 |---|---|---|---|
 | `a11y.spec.ts` | App a11y | 93+ genuine WCAG AA contrast violations (e.g. muted `#71717a` on `#f4f4f5` = 4.39 vs 4.5) | Fix app contrast tokens (touches brand palette — product/design decision) or adjust the assertion threshold |
-| `auth.spec.ts` | Test infra | `helpers/auth.ts` interactive login times out on the post-login `waitForURL` redirect | Make the helper rehydrate via the app's real modular-SDK persistence (or switch these specs to storageState fixtures) |
-| `sidebar-summary.spec.ts` | Test infra | Same interactive-login helper root cause | As above |
+| `sidebar-summary.spec.ts` | False premise / stale UI | Targets a shot **edit modal** (`role="dialog"`) with an `aside[data-testid="sidebar-summary"]` + Basics/Logistics tabs + "No date scheduled"/"No location" strings — **none of which exist** in current source. Editing now happens on the detail **page** (`ShotDetailPage.tsx`). Essentially every selector is stale. (NOT the interactive-login helper — that's fixed.) | Ground-up rewrite against `ShotDetailPage` (producerPage fixture + `SEED_SHOT_AURORA`/`SEED_SHOT_EDITABLE`): status select + autosave Saving/Saved, Date/Location "Not set" empty states, Tags. The seed currently lacks date/location/tags data, so assert empty states or extend the seed. |
 | `visual.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines on the CI runner image |
 | `e2e/richtext-bubble.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines |
-| `diagnose-sticky.spec.js` | Scratch | Ad-hoc sticky-toolbar diagnostic that drives the broken interactive-login helper (1-min timeout) | Delete it, or convert to a real assertion once the login helper is fixed |
+| `diagnose-sticky.spec.js` | Scratch | Ad-hoc sticky-toolbar diagnostic (1-min timeout); pre-dates and is unrelated to the now-fixed login helper | Delete it, or convert to a real assertion |
 
 ### Single-test quarantine
 
@@ -174,9 +212,15 @@ fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
    Storage-upload E2E (empty → upload → replace → reset) using the producer
    storageState fixture. The Storage emulator was wired into `ui-checks`
    (`--only ...,storage` + a 9199 readiness wait). Un-quarantined.
-4. **Robust interactive-login helper** — fixes `auth` + `sidebar-summary`.
-5. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
-6. **Visual baselines** — regenerate on the CI runner image; un-quarantines
+4. ~~**Robust interactive-login helper** — fixes `auth` + `sidebar-summary`.~~
+   **Partly done 2026-06-06**: the helper was fixed (authed-signal wait +
+   `domcontentloaded` + real `signOut` control) and `auth.spec.ts` un-quarantined.
+   Scouting revealed `sidebar-summary` was NEVER a login-helper victim — it is a
+   **false-premise spec** (targets a removed shot edit modal); it is now item 5.
+5. **Rewrite `sidebar-summary`** — ground-up against `ShotDetailPage` (it targets
+   a removed edit-modal sidebar; see the quarantine table for the real shape).
+6. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
+7. **Visual baselines** — regenerate on the CI runner image; un-quarantines
    `visual` + `richtext-bubble`.
-7. **Cross-browser job** — re-add firefox/webkit as a separate, non-blocking job
+8. **Cross-browser job** — re-add firefox/webkit as a separate, non-blocking job
    once the above land.

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -79,6 +79,14 @@ the white-screen regression and the shot + pull data paths.
    lag. Replaced with a wait on concrete authed SIGNALS — the emulator login
    form **detaches**, `location.pathname` leaves `/login`, and the app nav
    renders. This mirrors the proven-stable shape `global.setup.ts` relies on.
+3. **Its submit selector clicked the wrong button.** The old selector listed
+   `..., button:has-text("Sign in"), ...` and `.first()` returns the DOM-first
+   match — which is the Google OAuth button ("Sign in **with Google**" contains
+   "Sign in" and renders before the emulator form), opening a popup so the form
+   never submitted. Narrowed to `[data-testid="emulator-login-form"]
+   button[type="submit"], button[type="submit"]` (the Google button is
+   `type="button"`, so it's excluded), matching `global.setup.ts`. This was the
+   first-CI-run failure on the two helper-driven tests.
 
 The `signOut` helper was also broken: it looked for `button[aria-label*="user"]`
 / `button:has-text("Sign out")`, but the real control is an **icon-only** button

--- a/tests/auth.spec.ts
+++ b/tests/auth.spec.ts
@@ -3,243 +3,117 @@ import { TEST_CREDENTIALS } from './fixtures/auth';
 import { authenticateTestUser, signOut } from './helpers/auth';
 
 /**
- * Authentication flow E2E tests.
- * Tests the complete authentication lifecycle without using fixtures.
+ * Authentication-flow E2E tests — the genuine login lifecycle that can ONLY be
+ * exercised by driving the real form: sign-in, sign-out, redirect-when-unauth,
+ * session persistence across reload, and the invalid-credential error path.
+ * These are the tests that depend on the interactive-login helper
+ * (helpers/auth.ts authenticateTestUser / signOut).
+ *
+ * Role-access (RBAC) coverage deliberately lives elsewhere via the storageState
+ * fixtures — smoke.spec.ts (producer/viewer) and shots-crud / pulls-crud
+ * (project-scoped role behavior) — because those need an authed session, not a
+ * live login flow. The admin-page access test stays deferred alongside
+ * smoke.spec.ts's test.fixme: the admin route renders an <h1>Team</h1> with no
+ * stable admin-named heading in the emulator build (see tests/QUARANTINE.md).
+ *
+ * Selectors are scoped to [data-testid="emulator-login-form"] so they never hit
+ * the Google OAuth button — "Sign in with Google" also matches :has-text("Sign in")
+ * and is rendered earlier in the DOM.
  */
+
+const EMU_FORM = '[data-testid="emulator-login-form"]';
 
 test.describe('Authentication Flow', () => {
   test('user can sign in with email and password', async ({ page }) => {
     await page.goto('/');
 
-    // Wait for login form to be visible.
-    // Prefer the emulator-only form (data-testid="emulator-login-form") so we
-    // don't accidentally target the Google OAuth button — "Sign in with Google"
-    // also matches :has-text("Sign in") and is rendered earlier in the DOM.
-    const emailInput = page.locator(
-      '[data-testid="emulator-login-form"] input[type="email"], input[type="email"], input[placeholder*="email" i]'
-    ).first();
+    const emailInput = page.locator(`${EMU_FORM} input[type="email"]`).first();
     await expect(emailInput).toBeVisible({ timeout: 10000 });
-
-    // Fill in credentials
     await emailInput.fill(TEST_CREDENTIALS.producer.email);
 
-    const passwordInput = page.locator(
-      '[data-testid="emulator-login-form"] input[type="password"], input[type="password"], input[placeholder*="password" i]'
-    ).first();
+    const passwordInput = page.locator(`${EMU_FORM} input[type="password"]`).first();
     await passwordInput.fill(TEST_CREDENTIALS.producer.password);
 
-    // Submit — emulator form first, then generic fallbacks.
-    const signInButton = page.locator(
-      '[data-testid="emulator-login-form"] button[type="submit"], button:has-text("Sign in"), button:has-text("Sign In"), button[type="submit"]'
-    ).first();
-    await signInButton.click();
+    await page.locator(`${EMU_FORM} button[type="submit"]`).first().click();
 
-    // Should redirect to authenticated page
-    await page.waitForURL(/\/(shots|dashboard|projects|planner)/, { timeout: 15000 });
-
-    // Should be authenticated
-    const currentUrl = page.url();
-    expect(currentUrl).toMatch(/\/(shots|dashboard|projects)/);
-
-    // Should see navigation
-    const nav = page.locator('nav, [role="navigation"]');
-    await expect(nav).toBeVisible();
+    // Authed signals (not a single redirect race): the emulator form unmounts,
+    // we leave /login, and the app nav renders.
+    await page.locator(EMU_FORM).waitFor({ state: 'detached', timeout: 30000 });
+    await page.waitForFunction(
+      () => !window.location.pathname.startsWith('/login'),
+      undefined,
+      { timeout: 30000 }
+    );
+    await expect(page.locator('nav, [role="navigation"]').first()).toBeVisible();
+    // The only real post-login landing is /projects (routes/index.tsx index →
+    // <Navigate to="/projects">; LoginPage `from` defaults to /projects).
+    expect(page.url()).toMatch(/\/projects/);
   });
 
   test('user can sign out', async ({ page }) => {
-    // First sign in
     await authenticateTestUser(page, {
       email: TEST_CREDENTIALS.producer.email,
       password: TEST_CREDENTIALS.producer.password,
       role: TEST_CREDENTIALS.producer.role,
     });
 
-    // Should be authenticated
-    await page.waitForURL(/\/(shots|dashboard|projects)/, { timeout: 10000 });
-
-    // Sign out
     await signOut(page);
 
-    // Should redirect to login page
-    const currentUrl = page.url();
-    expect(currentUrl).toMatch(/\/(login|signin|auth|$)/);
-
-    // Should see login form
-    const emailInput = page.locator('input[type="email"]').first();
-    await expect(emailInput).toBeVisible({ timeout: 5000 });
+    expect(page.url()).toMatch(/\/login/);
+    await expect(page.locator('input[type="email"]').first()).toBeVisible();
   });
 
   test('unauthenticated user is redirected to login', async ({ page }) => {
-    // Try to access protected page without auth
-    await page.goto('/shots');
+    // Hit a protected route with no session — RequireAuth must bounce to /login.
+    // Use /projects (a real RequireAuth child). NOTE: /shots is NOT a top-level
+    // route — it falls through to the catch-all NotFoundPage, which sits OUTSIDE
+    // RequireAuth and would render a 404 instead of redirecting.
+    await page.goto('/projects');
 
-    // Wait for redirect and login form
-    const emailInput = page.locator('input[type="email"]').first();
-    await expect(emailInput).toBeVisible({ timeout: 10000 });
-
-    // Should redirect to login
-    const currentUrl = page.url();
-    expect(currentUrl).toMatch(/\/(login|signin|auth|$)/);
-
-    // Should see login form (reuse existing locator)
-    await expect(emailInput).toBeVisible();
-  });
-
-  test('admin role can access admin page', async ({ page }) => {
-    // Sign in as admin
-    await authenticateTestUser(page, {
-      email: TEST_CREDENTIALS.admin.email,
-      password: TEST_CREDENTIALS.admin.password,
-      role: TEST_CREDENTIALS.admin.role,
-    });
-
-    // Navigate to admin page
-    await page.goto('/admin');
-    // Wait for admin content to be visible
-    await page.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Should be able to access
-    expect(page.url()).toContain('/admin');
-
-    // Should see admin content
-    const heading = page.getByRole('heading', { name: /admin|user management|settings/i }).first();
-    await expect(heading).toBeVisible();
-  });
-
-  test('non-admin role cannot access admin page', async ({ page }) => {
-    // Sign in as producer (not admin)
-    await authenticateTestUser(page, {
-      email: TEST_CREDENTIALS.producer.email,
-      password: TEST_CREDENTIALS.producer.password,
-      role: TEST_CREDENTIALS.producer.role,
-    });
-
-    // Try to access admin page
-    await page.goto('/admin');
-    // Wait for page to settle
-    await page.waitForTimeout(1000);
-
-    // Should be redirected away or see permission denied
-    const currentUrl = page.url();
-
-    // Either redirected to projects/dashboard, or on admin page but see error/empty state
-    if (currentUrl.includes('/admin')) {
-      // Check for permission denied message
-      const permissionDenied = page.getByText(/permission denied|not authorized|access denied/i);
-      const adminHeading = page.getByRole('heading', { name: /admin|user management/i });
-
-      // Should either see permission denied or not see admin-specific content
-      const hasPermissionMessage = await permissionDenied.count() > 0;
-      const hasAdminHeading = await adminHeading.count() > 0;
-
-      expect(hasPermissionMessage || !hasAdminHeading).toBeTruthy();
-    } else {
-      // Redirected away from admin page
-      expect(currentUrl).toMatch(/\/(shots|dashboard|projects)/);
-    }
-  });
-
-  test('viewer role has read-only permissions', async ({ page }) => {
-    // Sign in as viewer
-    await authenticateTestUser(page, {
-      email: TEST_CREDENTIALS.viewer.email,
-      password: TEST_CREDENTIALS.viewer.password,
-      role: TEST_CREDENTIALS.viewer.role,
-    });
-
-    await page.waitForURL(/\/(shots|dashboard|projects)/, { timeout: 10000 });
-
-    // Navigate to products page
-    await page.goto('/products');
-    // Wait for products page content
-    await page.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Look for create/add buttons - they should be disabled or hidden
-    const createButtons = page.getByRole('button', { name: /create|new|add/i });
-    const count = await createButtons.count();
-
-    if (count > 0) {
-      // If buttons exist, they should be disabled
-      for (let i = 0; i < count; i++) {
-        const button = createButtons.nth(i);
-        if (await button.isVisible()) {
-          await expect(button).toBeDisabled();
-        }
-      }
-    }
-  });
-
-  test('producer role can create and edit content', async ({ page }) => {
-    // Sign in as producer
-    await authenticateTestUser(page, {
-      email: TEST_CREDENTIALS.producer.email,
-      password: TEST_CREDENTIALS.producer.password,
-      role: TEST_CREDENTIALS.producer.role,
-    });
-
-    await page.waitForURL(/\/(shots|dashboard|projects)/, { timeout: 10000 });
-
-    // Navigate to products page
-    await page.goto('/products');
-    // Wait for products page content
-    await page.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Should see create button and it should be enabled
-    const createButton = page.getByRole('button', { name: /create|new|add product/i }).first();
-
-    if (await createButton.count() > 0) {
-      await expect(createButton).toBeEnabled();
-    }
+    await page.waitForFunction(
+      () => window.location.pathname.startsWith('/login'),
+      undefined,
+      { timeout: 10000 }
+    );
+    await expect(page.locator(`${EMU_FORM} input[type="email"]`).first()).toBeVisible();
   });
 
   test('session persists across page reloads', async ({ page }) => {
-    // Sign in
     await authenticateTestUser(page, {
       email: TEST_CREDENTIALS.producer.email,
       password: TEST_CREDENTIALS.producer.password,
       role: TEST_CREDENTIALS.producer.role,
     });
 
-    await page.waitForURL(/\/(shots|dashboard|projects)/, { timeout: 10000 });
+    expect(page.url()).toMatch(/\/projects/);
 
-    const firstUrl = page.url();
+    // A session established through the real login flow must survive a reload
+    // (Firebase rehydrates auth from IndexedDB).
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.locator('nav, [role="navigation"]').first()).toBeVisible({ timeout: 15000 });
 
-    // Reload the page
-    await page.reload();
-    // Wait for navigation elements after reload
-    await page.locator('nav, [role="navigation"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Should still be authenticated (not redirected to login)
     const afterReloadUrl = page.url();
-    expect(afterReloadUrl).not.toMatch(/\/(login|signin|auth)/);
-
-    // Should still be on an authenticated page
-    expect(afterReloadUrl).toMatch(/\/(shots|dashboard|projects)/);
+    expect(afterReloadUrl).not.toMatch(/\/login/);
+    expect(afterReloadUrl).toMatch(/\/projects/);
   });
 
   test('invalid credentials show error message', async ({ page }) => {
     await page.goto('/');
 
-    const emailInput = page.locator('input[type="email"]').first();
+    const emailInput = page.locator(`${EMU_FORM} input[type="email"]`).first();
     await emailInput.waitFor({ state: 'visible', timeout: 10000 });
-
-    // Fill in invalid credentials
     await emailInput.fill('invalid@example.com');
+    await page.locator(`${EMU_FORM} input[type="password"]`).first().fill('wrong-password');
+    await page.locator(`${EMU_FORM} button[type="submit"]`).first().click();
 
-    const passwordInput = page.locator('input[type="password"]').first();
-    await passwordInput.fill('wrong-password');
+    // LoginPage renders the Firebase error in a dedicated element; the emulator
+    // returns "Firebase: Error (auth/invalid-credential)." Scope to the error
+    // element (not a page-wide text regex) so stray future copy can't pass it.
+    await expect(page.locator('[data-testid="login-error"]')).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('[data-testid="login-error"]')).toHaveText(/error|invalid|incorrect|failed/i);
 
-    // Submit
-    const signInButton = page.locator('button:has-text("Sign in"), button:has-text("Sign In"), button[type="submit"]').first();
-    await signInButton.click();
-
-    // Should show error message
-    const errorMessage = page.locator('text=/error|invalid|incorrect|failed/i');
-    await expect(errorMessage.first()).toBeVisible({ timeout: 5000 });
-
-    // Should still be on login page
-    await page.waitForTimeout(1000);
-    const currentUrl = page.url();
-    expect(currentUrl).toMatch(/\/(login|signin|auth|$)/);
+    // Stays on /login — the emulator form is still mounted.
+    await expect(page.locator(EMU_FORM)).toBeVisible();
+    expect(page.url()).toMatch(/\/login/);
   });
 });

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -76,12 +76,15 @@ export async function authenticateTestUser(
       // Small delay to ensure form is ready
       await page.waitForTimeout(500);
 
-      // Click sign in button — emulator form first, then generic fallbacks.
-      // Without the emulator-form-scoped selector, `.first()` would pick the
-      // Google OAuth button because "Sign in with Google" matches :has-text("Sign in")
-      // and it's rendered earlier in the DOM.
+      // Click the emulator form's submit button. Match ONLY type="submit"
+      // buttons — NEVER a :has-text("Sign in") selector: the Google OAuth button
+      // ("Sign in with Google") contains the text "Sign in" AND is rendered
+      // earlier in the DOM, so `.first()` across a :has-text list would click
+      // Google (opening a popup) and the form would never submit. The Google
+      // button is type="button", so a type="submit" filter excludes it. This is
+      // the proven-safe selector global.setup.ts uses.
       const signInButton = page.locator(
-        '[data-testid="emulator-login-form"] button[type="submit"], button:has-text("Sign in"), button:has-text("Sign In"), button[type="submit"]'
+        '[data-testid="emulator-login-form"] button[type="submit"], button[type="submit"]'
       ).first();
       await signInButton.click();
 

--- a/tests/helpers/auth.ts
+++ b/tests/helpers/auth.ts
@@ -37,9 +37,12 @@ export async function authenticateTestUser(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      // Navigate to the app with increased timeout for CI
+      // Navigate to the app with increased timeout for CI.
+      // Use 'domcontentloaded', NOT 'networkidle': against the Firebase emulator
+      // the app opens long-lived streaming connections (Firestore listeners,
+      // Installations) that never go idle, so 'networkidle' can hang until timeout.
       await page.goto(`${baseURL}/`, {
-        waitUntil: 'networkidle',
+        waitUntil: 'domcontentloaded',
         timeout: 30000
       });
 
@@ -82,13 +85,23 @@ export async function authenticateTestUser(
       ).first();
       await signInButton.click();
 
-      // Wait for authentication to complete and redirect with increased timeout
-      await page.waitForURL(/\/(shots|dashboard|projects|planner)/, {
-        timeout: 20000
+      // Wait for authed SIGNALS rather than racing a single client-side redirect.
+      // The post-login redirect is driven in-app (onIdTokenChanged → claims →
+      // navigate('/projects')); waiting on page.waitForURL alone is flaky because
+      // that chain can lag behind the emulator's never-idle connections. Instead
+      // wait for concrete evidence the session took hold: (1) the emulator login
+      // form unmounts, (2) we are no longer on /login, (3) the app nav renders.
+      // This is an authed-signal variant of global.setup.ts's waitForURL + nav
+      // check, hardened against the redirect race rather than relying on the URL.
+      await page.locator('[data-testid="emulator-login-form"]').waitFor({
+        state: 'detached',
+        timeout: 30000
       });
-
-      // Wait for DOM to be ready (don't use networkidle with Firebase real-time listeners)
-      await page.waitForLoadState('domcontentloaded', { timeout: 10000 });
+      await page.waitForFunction(
+        () => !window.location.pathname.startsWith('/login'),
+        undefined,
+        { timeout: 30000 }
+      );
 
       // Wait for authenticated UI to appear (ensures Firebase auth state is loaded)
       await page.locator('nav, header, [role="navigation"]').first().waitFor({
@@ -107,9 +120,10 @@ export async function authenticateTestUser(
         console.log(`Retrying authentication in 2 seconds...`);
         await page.waitForTimeout(2000);
 
-        // Try to reload the page for next attempt
+        // Try to reload the page for next attempt (domcontentloaded, not
+        // networkidle — see the goto note above re: never-idle emulator sockets)
         try {
-          await page.reload({ waitUntil: 'networkidle', timeout: 10000 });
+          await page.reload({ waitUntil: 'domcontentloaded', timeout: 10000 });
         } catch (reloadError) {
           // If reload fails, continue to next attempt anyway
           console.log('Page reload failed, continuing with next attempt');
@@ -136,30 +150,33 @@ export async function setupFirebaseEmulators(page: Page): Promise<void> {
 }
 
 /**
- * Clear authentication state.
+ * Sign the current user out through the real app control and wait until the
+ * session is actually cleared.
+ *
+ * The sign-out control lives in the sidebar user section (SidebarUserSection)
+ * as an icon-only button with aria-label="Sign out" — there is NO separate
+ * user-menu trigger to open first, and it has no visible text (so a
+ * :has-text("Sign out") selector would not match it). It renders on desktop
+ * when the sidebar is expanded, which is the default state.
  *
  * @param page - Playwright page instance
  */
 export async function signOut(page: Page): Promise<void> {
-  // Look for sign out button or user menu
-  const userMenu = page.locator('button[aria-label*="user" i], button:has-text("Sign out")').first();
-  const userMenuExists = await userMenu.count() > 0;
+  const signOutButton = page.locator('button[aria-label="Sign out"]').first();
+  await signOutButton.waitFor({ state: 'visible', timeout: 10000 });
+  await signOutButton.click();
 
-  if (userMenuExists) {
-    await userMenu.click();
-
-    const signOutButton = page.locator('button:has-text("Sign out"), a:has-text("Sign out")').first();
-    const signOutExists = await signOutButton.count() > 0;
-
-    if (signOutExists) {
-      await signOutButton.click();
-      await page.waitForURL(/\/(login|signin|auth)/, { timeout: 5000 });
-    }
-  }
-
-  // Clear all storage
-  await page.evaluate(() => {
-    localStorage.clear();
-    sessionStorage.clear();
+  // App signOut() → auth.signOut() → onIdTokenChanged(null) → RequireAuth
+  // redirects to /login. Wait for that redirect and the login form to reappear,
+  // proving the session is genuinely gone (the modular SDK stores auth in
+  // IndexedDB, so observing the real redirect is the reliable signal).
+  await page.waitForFunction(
+    () => window.location.pathname.startsWith('/login'),
+    undefined,
+    { timeout: 10000 }
+  );
+  await page.locator('input[type="email"]').first().waitFor({
+    state: 'visible',
+    timeout: 10000
   });
 }


### PR DESCRIPTION
## Backlog #4 — robust interactive-login helper

Un-quarantines **`tests/auth.spec.ts`** by fixing the interactive-login helper, via a scout → build → adversarial-verify dynamic workflow (same shape as #424/#425).

### Root cause (not a selector/regex bug)
`helpers/auth.ts` and `global.setup.ts` use equivalent selectors and the same `waitForURL` regex — and `/projects` (the real post-login landing) **does** match it. The helper timed out because:
1. **`waitUntil:'networkidle'`** on its goto/reload never settles against the Firebase emulator's long-lived streaming connections (Firestore listeners, Installations). → `'domcontentloaded'`.
2. It **raced a single client-side redirect** (`waitForURL`). Replaced with a wait on authed **signals**: the emulator login form **detaches**, `location` leaves `/login`, and the app nav renders.

`signOut()` was independently broken — it looked for a non-existent user-menu / text button. The real control is an **icon-only** `button[aria-label="Sign out"]` in `SidebarUserSection` (sidebar expanded by default at desktop). It now clicks that and waits for the genuine `/login` redirect.

### auth.spec.ts → the 5 genuine login-flow tests
sign-in · sign-out · unauth-redirect · session-persist · invalid-creds. All selectors scoped to `[data-testid="emulator-login-form"]` so they never hit the Google OAuth button.

Dropped: the 3 RBAC tests (two had **vacuous `if(count>0)` guards** = no real coverage; RBAC lives in smoke + shots-crud) and the admin test (duplicate of smoke's `test.fixme`).

### Adversarial verify caught a real blocker
The verify pass flagged that the unauth test's original `/shots` target is **not a top-level route** — it 404s on `NotFoundPage` *outside* `RequireAuth`, so it would never redirect to `/login` (the old lenient `$`-regex masked this; it never ran behind the white screen). Fixed to navigate to `/projects` (a real `RequireAuth` child). Also tightened the over-broad landing-URL regexes to `/projects` and scoped the invalid-creds assertion to a new behavior-free `data-testid="login-error"`.

### sidebar-summary — RE-DOCUMENTED, not fixed
Scouting overturned the handoff's assumption: it's a **false-premise spec** targeting a removed shot **edit modal** + `aside[data-testid="sidebar-summary"]` + Basics/Logistics tabs that no longer exist (editing is on `ShotDetailPage` now). Stays quarantined; QUARANTINE.md reclassifies it and adds a ground-up-rewrite backlog item.

### Files (5)
`tests/helpers/auth.ts` · `tests/auth.spec.ts` · `playwright.config.ts` · `tests/QUARANTINE.md` · `src-vnext/features/auth/components/LoginPage.tsx` (behavior-free testid only).

### Verification
- Emulators can't run locally (Java 8 vs Java 11+); **the CI `ui-checks` emulator job is the real gate.**
- The only active consumer of the changed helper is `auth.spec.ts`; `sidebar-summary`/`diagnose-sticky` also import it but stay quarantined.
- `tsc` is not a gate; no unused imports after the trim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)