### PR TITLE
test(e2e): rewrite + un-quarantine sidebar-summary against ShotDetailPage

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,12 +19,12 @@ export default defineConfig({
     // auth.spec.ts un-quarantined 2026-06-06: interactive-login helper fixed
     // (authed-signal wait + domcontentloaded + real sign-out + emulator-only
     // submit selector). See QUARANTINE.md "Interactive-login helper fix".
-    '**/sidebar-summary.spec.ts', // FALSE-PREMISE (not the login helper): targets a
-                                  // removed shot edit MODAL (role="dialog") + an
-                                  // aside[data-testid="sidebar-summary"] + Basics/
-                                  // Logistics tabs that no longer exist — editing is
-                                  // on ShotDetailPage now. Needs a ground-up rewrite
-                                  // against the detail page. See QUARANTINE.md.
+    // sidebar-summary.spec.ts un-quarantined 2026-06-06: it was a FALSE-PREMISE
+    // spec (removed shot edit MODAL + aside[data-testid="sidebar-summary"] +
+    // Basics/Logistics tabs). Rewritten ground-up against ShotDetailPage
+    // (/projects/:id/shots/:sid) using the storageState viewer/producer fixtures
+    // + emulator seed (read-only summary on SEED_SHOT_AURORA, status mutation +
+    // autosave on SEED_SHOT_EDITABLE). See tests/QUARANTINE.md.
     // shots-crud.spec.ts un-quarantined 2026-06-05: emulator seed step added
     // (seedShotsCrudScenario) + spec rewritten to the real project-scoped routes
     // and selectors. See tests/QUARANTINE.md.

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -307,7 +307,7 @@ export default function ShotDetailPage() {
                 <ActiveLookCoverReferencesPanel shot={shot} canEdit={canEdit} />
               </div>
               <div className="mt-2 grid grid-cols-1 gap-1.5 md:grid-cols-3">
-                <MetaEditorCard label="Date">
+                <MetaEditorCard label="Date" testId="meta-date">
                   {canEdit ? (
                     <DateEditor
                       value={formatDateOnly(shot.date)}
@@ -329,7 +329,7 @@ export default function ShotDetailPage() {
                   )}
                 </MetaEditorCard>
 
-                <MetaEditorCard label="Location">
+                <MetaEditorCard label="Location" testId="meta-location">
                   {canEdit ? (
                     <LocationPicker
                       selectedId={shot.locationId}
@@ -346,7 +346,7 @@ export default function ShotDetailPage() {
                   )}
                 </MetaEditorCard>
 
-                <MetaEditorCard label="Talent">
+                <MetaEditorCard label="Talent" testId="meta-talent">
                   {canEdit ? (
                     <TalentPicker
                       selectedIds={shot.talentIds ?? shot.talent}
@@ -387,7 +387,7 @@ export default function ShotDetailPage() {
                 }}
               />
 
-              <div>
+              <div data-testid="tags-section">
                 <SectionLabel>Tags</SectionLabel>
                 <TagEditor
                   tags={shot.tags ?? []}

--- a/src-vnext/features/shots/components/ShotDetailShared.tsx
+++ b/src-vnext/features/shots/components/ShotDetailShared.tsx
@@ -22,12 +22,17 @@ export function SectionLabel({ children }: { readonly children: React.ReactNode 
 export function MetaEditorCard({
   label,
   children,
+  testId,
 }: {
   readonly label: string
   readonly children: React.ReactNode
+  readonly testId?: string
 }) {
   return (
-    <div className="rounded-md border border-[var(--color-border)] px-2 py-1.5">
+    <div
+      className="rounded-md border border-[var(--color-border)] px-2 py-1.5"
+      data-testid={testId}
+    >
       <p className="text-3xs font-semibold uppercase tracking-wide text-[var(--color-text-subtle)]">
         {label}
       </p>

--- a/src-vnext/features/shots/components/ShotStatusSelect.tsx
+++ b/src-vnext/features/shots/components/ShotStatusSelect.tsx
@@ -68,7 +68,10 @@ export function ShotStatusSelect({
       onValueChange={handleChange}
       disabled={disabled}
     >
-      <SelectTrigger className={compact ? "h-7 w-[108px] px-2 text-xs" : "h-8 w-[128px]"}>
+      <SelectTrigger
+        data-testid="shot-status-select-trigger"
+        className={compact ? "h-7 w-[108px] px-2 text-xs" : "h-8 w-[128px]"}
+      >
         <SelectValue>
           <StatusBadge
             label={getShotStatusLabel(displayStatus)}

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -61,6 +61,18 @@ the "merge past red" norm without silently dropping coverage.
   unauthenticated, session persistence across reload, and the invalid-credential
   error path (5 tests). See "Interactive-login helper fix" below.
 
+- **`tests/sidebar-summary.spec.ts`** (storageState auth) — chromium only.
+  Un-quarantined 2026-06-06. Was a false-premise spec (a removed shot edit
+  modal); rewritten ground-up against the shot DETAIL PAGE (`ShotDetailPage` at
+  `/projects/:id/shots/:sid`). Hard-asserts the real summary surfaces against the
+  seed: a **read-only** group (`viewerPage` + `SEED_SHOT_AURORA`, `canEdit=false`)
+  asserting the status badge ("Draft"), empty meta cells (`meta-date`/
+  `meta-location` "Not set", `meta-talent` "0 assigned"), and the empty Tags
+  editor ("Add tags…"); and an **editing** group (serial, `producerPage` +
+  `SEED_SHOT_EDITABLE`) that changes status via the Radix Select and proves
+  persistence across reload (then resets to `todo`), plus the Notes autosave
+  indicator reaching "Saved". See "Sidebar-summary rewrite" below.
+
 This set exercises authenticated page loads + CRUD and so directly guards against
 the white-screen regression and the shot + pull data paths.
 
@@ -104,6 +116,64 @@ had vacuous `if (count > 0)` guards that silently passed (≈no coverage), and
 real RBAC coverage already lives in smoke + shots-crud via storageState. The
 `admin role can access admin page` test was dropped as a duplicate of
 smoke.spec.ts's `test.fixme` (same unresolved admin-heading gap, below).
+
+## Sidebar-summary rewrite (added 2026-06-06)
+
+`tests/sidebar-summary.spec.ts` was a **false-premise** spec, not a login-helper
+victim: it drove a shot **edit modal** (`role="dialog"`) with an
+`aside[data-testid="sidebar-summary"]`, a native `<select>` status control,
+Status/Schedule/Tags sections, and Basics/Logistics `role="tab"` tabs — none of
+which exist. The shot summary/edit experience is the detail **page**
+(`ShotDetailPage`, `/projects/:id/shots/:sid`). It was rewritten ground-up
+against the real page and the existing emulator seed, following the
+`shots-crud.spec.ts` storageState pattern.
+
+Selectors verified against `src-vnext` (the rewrite corrects three stale
+assumptions in the original handoff):
+
+1. **Status is a Radix Select, not a native `<select>`** — the trigger renders
+   as a `role="combobox"` button (now `data-testid="shot-status-select-trigger"`)
+   and options render in a portal `role="listbox"`. The test opens the trigger
+   and clicks `getByRole('option', { name: ... })`; `selectOption`/`inputValue`
+   would not work. Status labels: `todo`→"Draft", `in_progress`→"In Progress",
+   `complete`→"Shot", `on_hold`→"On Hold".
+2. **Autosave "Saving…/Saved" is per-editor, not page-level** — status/Date/
+   Location/Talent/Tags save silently (status is optimistic; only a toast on
+   failure). The `Saving…`/`Saved` indicator only renders inside the
+   Description/Notes editors while they are mounted. The status test therefore
+   proves persistence by **reloading**; the autosave indicator is covered via the
+   already-instrumented Notes editor (`notes-read-mode`/`notes-input`/
+   `notes-save-indicator`).
+3. **`canEdit = canManageShots(role) && !isMobile`** — at desktop (the fixtures
+   set 1280×720) a producer is an editor (cells show edit affordances) while a
+   viewer is read-only (`ReadOnlyMetaValue`: "Not set"/"0 assigned"). The
+   read-only summary group uses `viewerPage`; the editing group uses
+   `producerPage`.
+
+RBAC: shots are a **flat** `clients/{clientId}/shots/{id}` collection gated by
+`clientMatches + isAuthed` only, so the producer needs no project members doc.
+The viewer (also `clientId: 'test-client'`) can read the shot, BUT
+`ShotDetailPage` → `useShotDetailBundle` also subscribes to the project's
+**`lanes`** subcollection, whose read rule requires
+`hasProjectRole(...,['producer','crew','warehouse','viewer'])` or
+`producerCanAccessProject` (producer-global only). A viewer's global role
+satisfies neither, and `useShotDetailBundle` folds the resulting `lanes.error`
+into a **fatal** page error — so the detail page would blank out for a viewer.
+(Adversarial verify caught this; `useShotDetailBundle.test.ts` documents the
+lanes-error-is-fatal behavior.) Fix mirrors the warehouse-on-pulls pattern:
+`seedShotsCrudScenario` now accepts a `viewerUid` and writes a project
+`members/<uid>` doc (role `viewer`), wired from `global.setup.ts`. Membership
+does NOT make the viewer an editor — the UI's `canEdit`/`canManageShots` keys off
+the user's GLOBAL role (`rbac.ts`), so the viewer still renders the read-only
+path. (Latent product note: a non-member viewer cannot open a shot detail page in
+production for the same reason — out of scope for this E2E PR, tracked separately.)
+
+App-source changes are behavior-free testability hooks only:
+`data-testid="shot-status-select-trigger"` on `ShotStatusSelect`'s trigger, a
+`testId` prop on `MetaEditorCard` (passed as `meta-date`/`meta-location`/
+`meta-talent` in `ShotDetailPage`), and `data-testid="tags-section"` on the Tags
+wrapper. The only seed change is the additive viewer member doc above — no shot
+data was modified.
 
 ## Emulator seed (added 2026-06-05)
 
@@ -169,7 +239,6 @@ image contentType <10MB — no project-membership doc required (unlike pulls).
 | Spec | Category | Failure | Fix needed |
 |---|---|---|---|
 | `a11y.spec.ts` | App a11y | 93+ genuine WCAG AA contrast violations (e.g. muted `#71717a` on `#f4f4f5` = 4.39 vs 4.5) | Fix app contrast tokens (touches brand palette — product/design decision) or adjust the assertion threshold |
-| `sidebar-summary.spec.ts` | False premise / stale UI | Targets a shot **edit modal** (`role="dialog"`) with an `aside[data-testid="sidebar-summary"]` + Basics/Logistics tabs + "No date scheduled"/"No location" strings — **none of which exist** in current source. Editing now happens on the detail **page** (`ShotDetailPage.tsx`). Essentially every selector is stale. (NOT the interactive-login helper — that's fixed.) | Ground-up rewrite against `ShotDetailPage` (producerPage fixture + `SEED_SHOT_AURORA`/`SEED_SHOT_EDITABLE`): status select + autosave Saving/Saved, Date/Location "Not set" empty states, Tags. The seed currently lacks date/location/tags data, so assert empty states or extend the seed. |
 | `visual.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines on the CI runner image |
 | `e2e/richtext-bubble.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines |
 | `diagnose-sticky.spec.js` | Scratch | Ad-hoc sticky-toolbar diagnostic (1-min timeout); pre-dates and is unrelated to the now-fixed login helper | Delete it, or convert to a real assertion |
@@ -225,8 +294,12 @@ fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
    `domcontentloaded` + real `signOut` control) and `auth.spec.ts` un-quarantined.
    Scouting revealed `sidebar-summary` was NEVER a login-helper victim — it is a
    **false-premise spec** (targets a removed shot edit modal); it is now item 5.
-5. **Rewrite `sidebar-summary`** — ground-up against `ShotDetailPage` (it targets
-   a removed edit-modal sidebar; see the quarantine table for the real shape).
+5. ~~**Rewrite `sidebar-summary`** — ground-up against `ShotDetailPage` (it targets
+   a removed edit-modal sidebar).~~ **Done 2026-06-06**: rewritten against
+   `ShotDetailPage` using the storageState viewer/producer fixtures + the existing
+   seed (read-only summary on `SEED_SHOT_AURORA`; status mutation + reload
+   persistence + Notes autosave on `SEED_SHOT_EDITABLE`). Un-quarantined. See
+   "Sidebar-summary rewrite" above.
 6. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
 7. **Visual baselines** — regenerate on the CI runner image; un-quarantines
    `visual` + `richtext-bubble`.

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -301,7 +301,12 @@ async function globalSetup(config: FullConfig) {
   // helper guards against a double initializeApp.
   console.log('Seeding Firestore fixtures (shots-crud)...');
   try {
-    await seedShotsCrudScenario();
+    // Pass the viewer uid so the seed grants it project membership: the shot
+    // detail page subscribes to the project's lanes, whose read rule requires
+    // hasProjectRole(...,'viewer') (a viewer's global role satisfies neither
+    // isAdmin nor producerCanAccessProject), so without it the detail page
+    // errors out for a viewer (sidebar-summary's read-only group).
+    await seedShotsCrudScenario({ viewerUid: roleUids.viewer });
     // Seed the pulls-crud fixture AFTER shots-crud — seedPullsCrudScenario
     // assumes the seed project (created by seedShotsCrudScenario) already exists.
     // Pass the warehouse uid so the seed can grant it project membership: pull

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -425,8 +425,23 @@ export async function clearShotsCrudData(): Promise<void> {
  * Seed the deterministic fixture the shots-crud spec reads: one team-visible
  * project + the app-shaped shots declared in seedConstants.ts. Cleared first so
  * the dataset is identical on every run (the emulator persists across a run).
+ *
+ * VIEWER ACCESS: pass `viewerUid` to grant the viewer test user project
+ * membership (a doc at `.../projects/<id>/members/<uid>` with role 'viewer').
+ * The shot detail page (ShotDetailPage → useShotDetailBundle) subscribes to the
+ * project's `lanes` subcollection, whose firestore.rules read gate is
+ * `hasProjectRole(...,['producer','crew','warehouse','viewer'])` OR
+ * producerCanAccessProject (producer-global only). A viewer's GLOBAL role
+ * satisfies neither, so without this member doc the lanes read is denied,
+ * useShotDetailBundle folds that into a fatal page error, and the detail page
+ * never renders for a viewer. Producer needs no member doc — its global role
+ * satisfies producerCanAccessProject on a team project. Granting membership does
+ * NOT make the viewer an editor: the UI's canEdit/canManageShots uses the
+ * user's GLOBAL role (rbac.ts), so the viewer still renders the read-only path.
  */
-export async function seedShotsCrudScenario(): Promise<void> {
+export async function seedShotsCrudScenario(
+  opts: { viewerUid?: string } = {},
+): Promise<void> {
   await clearShotsCrudData();
 
   await createTestProject({
@@ -445,6 +460,21 @@ export async function seedShotsCrudScenario(): Promise<void> {
       shotNumber: String(order),
     });
     order += 1;
+  }
+
+  // Grant the viewer user project membership so firestore.rules permits it to
+  // read the project's lanes (and project doc) — see the VIEWER ACCESS note
+  // above. Keyed by uid because hasProjectRole resolves members/<request.auth.uid>.
+  if (opts.viewerUid) {
+    await getDb()
+      .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/members`)
+      .doc(opts.viewerUid)
+      .set({
+        role: 'viewer',
+        clientId: CLIENT_ID,
+        projectId: SEED_PROJECT_ID,
+        addedAt: new Date(),
+      });
   }
 }
 

--- a/tests/sidebar-summary.spec.ts
+++ b/tests/sidebar-summary.spec.ts
@@ -115,19 +115,22 @@ test.describe('Shot detail editing', () => {
     const trigger = producerPage.getByTestId('shot-status-select-trigger');
     await trigger.click();
     await producerPage.getByRole('option', { name: 'In Progress' }).click();
-    await expect(trigger).toHaveText(/In Progress/);
+    await expect(trigger).toHaveText(/In Progress/); // optimistic UI updated
 
-    // Reload proves the write reached Firestore (not just optimistic UI).
-    await producerPage.reload();
-    await expect(
-      producerPage.getByTestId('shot-status-select-trigger'),
-    ).toHaveText(/In Progress/);
+    // Prove the write actually reached Firestore — not just the optimistic label,
+    // which ShotStatusSelect sets BEFORE it awaits updateShotWithVersion. Reload
+    // until the committed value reads back, so a slow emulator commit can't lose
+    // the race against a single reload fired while the write is still in flight.
+    // (`trigger` is a lazy locator — it re-resolves against the reloaded page.)
+    await expect(async () => {
+      await producerPage.reload();
+      await expect(trigger).toHaveText(/In Progress/, { timeout: 5000 });
+    }).toPass({ timeout: 20000 });
 
     // Reset to the seeded baseline so reruns / other readers see status:'todo'.
-    const triggerAfter = producerPage.getByTestId('shot-status-select-trigger');
-    await triggerAfter.click();
+    await trigger.click();
     await producerPage.getByRole('option', { name: 'Draft' }).click();
-    await expect(triggerAfter).toHaveText(/Draft/);
+    await expect(trigger).toHaveText(/Draft/);
   });
 
   test('producer sees the autosave indicator reach "Saved" when editing notes', async ({

--- a/tests/sidebar-summary.spec.ts
+++ b/tests/sidebar-summary.spec.ts
@@ -1,225 +1,158 @@
-import { test, expect } from '@playwright/test';
-import { TEST_CREDENTIALS } from './fixtures/auth';
-import { authenticateTestUser, setupFirebaseEmulators } from './helpers/auth';
+import { test, expect } from './fixtures/auth';
+import {
+  SEED_PROJECT_ID,
+  SEED_SHOT_AURORA,
+  SEED_SHOT_EDITABLE,
+} from './helpers/seedConstants';
 
 /**
- * Test suite for Shot Edit modal's sidebar summary (status, schedule, tags) with autosave.
+ * Shot detail "summary" E2E — REWRITTEN 2026-06-06 (was a false-premise spec).
  *
- * PREREQUISITES:
- * 1. Firebase emulators must be running:
- *    firebase emulators:start --only auth,firestore,functions,storage
- * 2. Set environment variable: VITE_USE_FIREBASE_EMULATORS=1
- * 3. Dev server must be running on port 5173
+ * The original sidebar-summary.spec.ts targeted a REMOVED shot edit MODAL
+ * (`role="dialog"`) with an `aside[data-testid="sidebar-summary"]`, a native
+ * `<select>` status control, Status/Schedule/Tags sections, and Basics/Logistics
+ * `role="tab"` tabs. NONE of that exists anymore — the shot summary/edit
+ * experience is the detail PAGE (`ShotDetailPage` at `/projects/:id/shots/:sid`).
+ * This is a ground-up rewrite that hard-asserts the REAL summary surfaces against
+ * the Firestore emulator seed (see tests/helpers/seed.ts → seedShotsCrudScenario).
  *
- * To run these tests:
- *   VITE_USE_FIREBASE_EMULATORS=1 npx playwright test tests/sidebar-summary.spec.ts
+ * Verified against src-vnext (2026-06-06):
+ * - Status is a Radix Select (combobox trigger + portal listbox/options), NOT a
+ *   native `<select>`. Labels: todo→"Draft", in_progress→"In Progress",
+ *   complete→"Shot", on_hold→"On Hold". The trigger carries
+ *   `data-testid="shot-status-select-trigger"` and is `disabled` for read-only
+ *   roles (`canDoOperational = canManageShots(role)`).
+ * - Date/Location/Talent render in MetaEditorCard cells
+ *   (`data-testid` meta-date/meta-location/meta-talent). For a READ-ONLY role
+ *   (viewer, `canEdit=false`) they show ReadOnlyMetaValue: Date "Not set",
+ *   Location "Not set", Talent "0 assigned". For an EDITOR (producer desktop,
+ *   `canEdit=true`) the same cells render edit affordances instead.
+ * - Tags: `SectionLabel` "Tags" + `TagEditor`; an empty TagEditor button shows
+ *   "Add tags…" (real ellipsis U+2026).
+ * - Autosave "Saving…"/"Saved" is NOT shown for status/meta/tags — those save
+ *   silently (status is optimistic; only a toast on failure). The indicator
+ *   surfaces only in the Notes/Description editors while editing
+ *   (`data-testid` notes-save-indicator / save-indicator). Status persistence is
+ *   therefore proven by reloading the page, not by a "Saved" indicator.
+ * - Seed: every SEED_SHOT is created with only {title, status:'todo'} — no date,
+ *   location, or tags — so the summary asserts EMPTY states. The read-only group
+ *   uses `viewerPage` + SEED_SHOT_AURORA (never mutated). The editing group uses
+ *   `producerPage` + SEED_SHOT_EDITABLE, whose STATUS field is owned only by this
+ *   spec (shots-crud only renames EDITABLE's title); it resets status afterward.
  *
- * NOTE: These tests are skipped in CI unless VITE_USE_FIREBASE_EMULATORS is set
+ * There are intentionally NO `if (await x.isVisible())` guards: every assertion
+ * fails loudly if the seed or a selector regresses.
  */
-test.describe('Shot Edit Modal - Sidebar Summary', () => {
-  // Skip these tests in CI unless emulators are configured
-  test.skip(!process.env.VITE_USE_FIREBASE_EMULATORS, 'Requires Firebase emulators');
 
-  test.beforeEach(async ({ page }) => {
-    // Setup Firebase emulators
-    await setupFirebaseEmulators(page);
+const detailUrl = (shotId: string) =>
+  `/projects/${SEED_PROJECT_ID}/shots/${shotId}`;
 
-    // Authenticate as a test user
-    const producer = TEST_CREDENTIALS.producer;
-    await authenticateTestUser(page, {
-      email: producer.email,
-      password: producer.password,
-      role: producer.role,
-      clientId: 'test-client'
-    });
+// ── READ-ONLY SUMMARY (viewer → canEdit=false → ReadOnlyMetaValue) ───────────
+test.describe('Shot detail summary (read-only)', () => {
+  test('viewer sees status badge and empty Date/Location/Talent meta', async ({
+    viewerPage,
+  }) => {
+    await viewerPage.goto(detailUrl(SEED_SHOT_AURORA.id));
+
+    // "Back to Shots" only renders on the detail page — confirms we did not land
+    // on NotFoundPage (i.e. the seeded shot is readable). Fails without the seed.
+    await expect(
+      viewerPage.getByRole('button', { name: /back to shots/i }),
+    ).toBeVisible();
+    await expect(
+      viewerPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // Seeded status (todo) renders as the "Draft" badge in the status control.
+    await expect(
+      viewerPage.getByTestId('shot-status-select-trigger'),
+    ).toHaveText(/Draft/);
+
+    // Empty meta — AURORA has date:null, locationId:null, 0 talent.
+    await expect(viewerPage.getByTestId('meta-date')).toContainText('Not set');
+    await expect(viewerPage.getByTestId('meta-location')).toContainText(
+      'Not set',
+    );
+    await expect(viewerPage.getByTestId('meta-talent')).toContainText(
+      '0 assigned',
+    );
   });
 
-  test('displays sidebar summary and handles status change with autosave', async ({ page }) => {
-    // Wait for the shots page to be visible (adjust selector based on actual page structure)
-    // This assumes we're authenticated and can see the shots list
-    const shotsContainer = page.locator('[data-testid="shots-container"], main, [role="main"]').first();
-    await expect(shotsContainer).toBeVisible({ timeout: 10000 });
+  test('viewer sees the Tags section with an empty tag editor', async ({
+    viewerPage,
+  }) => {
+    await viewerPage.goto(detailUrl(SEED_SHOT_AURORA.id));
+    await expect(
+      viewerPage.getByRole('button', { name: /back to shots/i }),
+    ).toBeVisible();
 
-    // Look for an existing shot card or button to open the edit modal
-    // Try multiple selectors to find a shot
-    const shotCard = page.locator('[data-testid="shot-card"], [role="article"], button:has-text("Shot")').first();
+    // Scope to the Tags section (TagEditor's popover renders its own "Tags"
+    // heading when open — closed here for a read-only viewer, but scoping keeps
+    // the section-label assertion robust). Assert the label + empty-state button.
+    const tagsSection = viewerPage.getByTestId('tags-section');
+    await expect(tagsSection.getByText('Tags', { exact: true })).toBeVisible();
+    await expect(tagsSection.getByText('Add tags…')).toBeVisible();
+  });
+});
 
-    // If no shot exists, look for a "Create Shot" or similar button
-    const createShotButton = page.locator('button:has-text("Create"), button:has-text("New Shot"), [aria-label*="shot" i]').first();
+// ── EDITING (producer → canEdit=true). Serial: mutates the shared EDITABLE shot.
+test.describe('Shot detail editing', () => {
+  test.describe.configure({ mode: 'serial' });
 
-    // Try to click an existing shot first
-    const shotExists = await shotCard.count() > 0;
-    if (shotExists) {
-      await shotCard.click();
-    } else {
-      // Create a new shot if none exist
-      await createShotButton.click();
+  test('producer changes status via the select and it persists across reload', async ({
+    producerPage,
+  }) => {
+    await producerPage.goto(detailUrl(SEED_SHOT_EDITABLE.id));
+    await expect(
+      producerPage.getByRole('button', { name: /back to shots/i }),
+    ).toBeVisible();
 
-      // Fill in minimal required fields to create a shot
-      const nameInput = page.locator('input[name="name"], input[placeholder*="name" i]').first();
-      await nameInput.fill('Test Shot for Sidebar');
+    // Drive to "In Progress" without first hard-asserting the seeded "Draft":
+    // this keeps the test idempotent across a mid-mutation retry (if a prior
+    // attempt left EDITABLE in_progress, selecting it again is a no-op and the
+    // assertions still hold). The seeded "Draft" baseline is covered by the
+    // read-only AURORA test. Status is a Radix Select (NOT a native <select>).
+    const trigger = producerPage.getByTestId('shot-status-select-trigger');
+    await trigger.click();
+    await producerPage.getByRole('option', { name: 'In Progress' }).click();
+    await expect(trigger).toHaveText(/In Progress/);
 
-      // Submit the form
-      const submitButton = page.locator('button:has-text("Save"), button:has-text("Create"), button[type="submit"]').first();
-      await submitButton.click();
+    // Reload proves the write reached Firestore (not just optimistic UI).
+    await producerPage.reload();
+    await expect(
+      producerPage.getByTestId('shot-status-select-trigger'),
+    ).toHaveText(/In Progress/);
 
-      // Wait for the shot to be created and modal to appear
-      await page.waitForTimeout(1000);
-    }
-
-    // Wait for the Shot Edit modal to be visible
-    const modal = page.locator('[role="dialog"]');
-    await expect(modal).toBeVisible({ timeout: 5000 });
-
-    // Verify the modal heading
-    const modalHeading = modal.locator('h2');
-    await expect(modalHeading).toBeVisible();
-
-    // Verify the sidebar summary is visible
-    const sidebar = modal.locator('aside, [data-testid="sidebar-summary"]');
-    await expect(sidebar).toBeVisible();
-
-    // Check that the Status section exists
-    const statusSection = sidebar.locator('text=Status').first();
-    await expect(statusSection).toBeVisible();
-
-    // Check that a status badge is displayed
-    const statusBadge = sidebar.locator('[class*="badge"], [role="status"]').first();
-    await expect(statusBadge).toBeVisible();
-
-    // Check that the status select dropdown exists
-    const statusSelect = sidebar.locator('select').first();
-    await expect(statusSelect).toBeVisible();
-
-    // Check Schedule section with calendar icon and date info
-    const scheduleSection = sidebar.locator('text=Schedule').first();
-    await expect(scheduleSection).toBeVisible();
-
-    // Check Tags section
-    const tagsSection = sidebar.locator('text=Tags').first();
-    await expect(tagsSection).toBeVisible();
-
-    // Now change the status to trigger autosave
-    const currentStatus = await statusSelect.inputValue();
-
-    // Select a different status
-    const statusOptions = await statusSelect.locator('option').all();
-    const newStatusOption = statusOptions.find(async (option) => {
-      const value = await option.getAttribute('value');
-      return value !== currentStatus;
-    });
-
-    if (newStatusOption) {
-      const newStatusValue = await newStatusOption.getAttribute('value');
-      await statusSelect.selectOption(newStatusValue || '');
-
-      // Wait for autosave indication - look for "Saving..." text
-      const savingIndicator = page.locator('text=/Saving|saving/i');
-
-      // The autosave status might appear briefly, so we use a shorter timeout
-      try {
-        await expect(savingIndicator).toBeVisible({ timeout: 2000 });
-      } catch (e) {
-        // Autosave might be too fast to catch, that's okay
-        console.log('Autosave was too fast to capture "Saving..." state');
-      }
-
-      // Wait for "Saved" confirmation
-      const savedIndicator = page.locator('text=/Saved|saved/i');
-      await expect(savedIndicator).toBeVisible({ timeout: 5000 });
-
-      // Verify the status badge updated
-      const updatedBadge = sidebar.locator('[class*="badge"], [role="status"]').first();
-      await expect(updatedBadge).toBeVisible();
-
-      // Switch to a different tab (e.g., Logistics) while staying in the modal
-      const logisticsTab = modal.locator('button[role="tab"]:has-text("Logistics"), button:has-text("Logistics")').first();
-      const logisticsTabExists = await logisticsTab.count() > 0;
-
-      if (logisticsTabExists) {
-        await logisticsTab.click();
-
-        // Verify we're on the Logistics tab (aria-selected="true")
-        await expect(logisticsTab).toHaveAttribute('aria-selected', 'true');
-
-        // Verify that the Basics tab still shows saved state
-        const basicsTab = modal.locator('button[role="tab"]:has-text("Basics"), button:has-text("Basics")').first();
-
-        // Check if the Basics tab has saved status indicator
-        const basicsSavedStatus = basicsTab.locator('text=/Saved|saved/i');
-        await expect(basicsSavedStatus).toBeVisible({ timeout: 5000 });
-      }
-    }
-
-    // Close the modal
-    const closeButton = modal.locator('button[aria-label="Close"], button:has-text("×")').first();
-    await closeButton.click();
-
-    // Verify modal is closed
-    await expect(modal).not.toBeVisible({ timeout: 2000 });
+    // Reset to the seeded baseline so reruns / other readers see status:'todo'.
+    const triggerAfter = producerPage.getByTestId('shot-status-select-trigger');
+    await triggerAfter.click();
+    await producerPage.getByRole('option', { name: 'Draft' }).click();
+    await expect(triggerAfter).toHaveText(/Draft/);
   });
 
-  test('displays schedule and location information', async ({ page }) => {
-    // Navigate and open modal (similar to above)
-    await page.waitForTimeout(1000);
+  test('producer sees the autosave indicator reach "Saved" when editing notes', async ({
+    producerPage,
+  }) => {
+    await producerPage.goto(detailUrl(SEED_SHOT_EDITABLE.id));
+    await expect(
+      producerPage.getByRole('button', { name: /back to shots/i }),
+    ).toBeVisible();
 
-    const shotsContainer = page.locator('[data-testid="shots-container"], main, [role="main"]').first();
-    const shotCard = page.locator('[data-testid="shot-card"], [role="article"], button:has-text("Shot")').first();
+    // Status/meta/tags save silently; the Notes editor is the real Saving…/Saved
+    // surface (already instrumented with notes-read-mode / notes-input /
+    // notes-save-indicator). Enter edit mode, type, and assert the indicator
+    // settles on "Saved" while the editor is still mounted (it unmounts on blur).
+    await producerPage.getByTestId('notes-read-mode').click();
+    const input = producerPage.getByTestId('notes-input');
+    await expect(input).toBeVisible();
+    await input.fill(`E2E autosave ${Date.now()}`);
 
-    const shotExists = await shotCard.count() > 0;
-    if (shotExists) {
-      await shotCard.click();
-    } else {
-      // Skip if no shots available
-      test.skip();
-    }
-
-    const modal = page.locator('[role="dialog"]');
-    await expect(modal).toBeVisible({ timeout: 5000 });
-
-    const sidebar = modal.locator('aside, [data-testid="sidebar-summary"]');
-
-    // Check for calendar icon (schedule)
-    const calendarIcon = sidebar.locator('svg').first();
-    await expect(calendarIcon).toBeVisible();
-
-    // Check for date text (either "No date scheduled" or an actual date)
-    const dateText = sidebar.locator('text=/No date|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday/i').first();
-    await expect(dateText).toBeVisible();
-
-    // Check for location icon (map pin)
-    const locationIcon = sidebar.locator('svg').nth(1);
-    await expect(locationIcon).toBeVisible();
-
-    // Check for location text (either "No location" or an actual location)
-    const locationText = sidebar.locator('text=/No location|location/i').first();
-    await expect(locationText).toBeVisible();
-  });
-
-  test('shows tag list in sidebar', async ({ page }) => {
-    // Navigate and open modal
-    await page.waitForTimeout(1000);
-
-    const shotCard = page.locator('[data-testid="shot-card"], [role="article"], button:has-text("Shot")').first();
-    const shotExists = await shotCard.count() > 0;
-
-    if (!shotExists) {
-      test.skip();
-    }
-
-    await shotCard.click();
-
-    const modal = page.locator('[role="dialog"]');
-    await expect(modal).toBeVisible({ timeout: 5000 });
-
-    const sidebar = modal.locator('aside, [data-testid="sidebar-summary"]');
-
-    // Check for Tags section
-    const tagsSection = sidebar.locator('text=Tags').first();
-    await expect(tagsSection).toBeVisible();
-
-    // Check for either "No tags yet" message or actual tags
-    const tagsContent = sidebar.locator('text=/No tags|tag/i').first();
-    await expect(tagsContent).toBeVisible();
+    // The indicator is non-idle (debounce 1.5s → "Saving…" → "Saved" held ~2s →
+    // unmounts) only while the editor stays mounted. First confirm autosave fired
+    // (either transient state), then that it settled on "Saved" — a generous
+    // timeout absorbs a slow CI emulator write within the ~2s "Saved" window.
+    const indicator = producerPage.getByTestId('notes-save-indicator');
+    await expect(indicator).toHaveText(/Saving…|Saved/);
+    await expect(indicator).toHaveText(/Saved/, { timeout: 15000 });
   });
 });


### PR DESCRIPTION
## What & why

`tests/sidebar-summary.spec.ts` was a **false-premise** spec — it drove a removed shot **edit modal** (`role="dialog"`) with an `aside[data-testid="sidebar-summary"]`, a native `<select>` status control, Status/Schedule/Tags sections, and Basics/Logistics tabs. None of that exists; the shot summary/edit experience is the detail **page** (`ShotDetailPage` at `/projects/:id/shots/:sid`). This rewrites it ground-up against the real page + the existing Firestore emulator seed, following the `shots-crud.spec.ts` storageState pattern (un-quarantines E2E backlog #5).

Built via the proven scout → build → adversarial-verify dynamic workflow (same shape as #424/#425/#426).

## Tests (4, no `if(isVisible())` guards)

**Read-only summary** (`viewerPage` + `SEED_SHOT_AURORA`, `canEdit=false` → `ReadOnlyMetaValue`):
- status badge "Draft" · `meta-date`/`meta-location` "Not set" · `meta-talent` "0 assigned"
- Tags section label + empty `TagEditor` ("Add tags…"), scoped to `tags-section`

**Editing** (serial, `producerPage` + `SEED_SHOT_EDITABLE`):
- change status via the Radix Select → assert + **reload-persists** (proves the write hit Firestore) → reset to `todo`
- Notes autosave indicator reaches "Saved"

## Corrects three stale handoff assumptions (verified vs `src-vnext`)
1. Status is a **Radix Select** (combobox + portal options), not a native `<select>` → `getByRole('option')`, never `selectOption`.
2. Autosave "Saving…/Saved" is **per-editor** (Notes/Description), not page-level — status/meta/tags save silently/optimistically. Status persistence is proven by reload.
3. `canEdit = canManageShots(role) && !isMobile` — viewer is read-only, producer (desktop) is editor.

## Blocker found by adversarial verify (and fixed)
`ShotDetailPage` → `useShotDetailBundle` subscribes to the project **`lanes`** subcollection, whose read rule needs `hasProjectRole(...,'viewer')` — a viewer's global role satisfies neither `isAdmin` nor `producerCanAccessProject`, and `lanes.error` is **fatal**, so the page blanked out for a viewer (`useShotDetailBundle.test.ts` documents the fatal behavior). Fixed by seeding a **viewer project member doc** in `seedShotsCrudScenario` (mirrors the warehouse-on-pulls pattern in #424). Membership does **not** make the viewer an editor — the UI's `canEdit`/`canManageShots` keys off the user's **global** role.

> Latent product note (out of scope, tracked separately): a non-member viewer can't open a shot detail page in production for the same reason.

## App-source changes — behavior-free testability hooks only
- `data-testid="shot-status-select-trigger"` on `ShotStatusSelect`'s trigger
- `testId` prop on `MetaEditorCard` → `meta-date`/`meta-location`/`meta-talent`
- `data-testid="tags-section"` on the Tags wrapper

Plus: removed `sidebar-summary` from `playwright.config.ts` `testIgnore`; updated `tests/QUARANTINE.md`. The shared seed's **shot data is unchanged** (only the additive viewer member doc).

## Test plan
- [ ] CI `ui-checks` (chromium, Firestore emulator on Java 21) is the real gate — emulators can't run locally (Java 8). Expect the 4 new tests green alongside the existing smoke/shots-crud/pulls/hero/auth suites.
- [x] `tsc` (no new errors in changed files) + `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)