### PR TITLE
fix(shots): resolve per-SKU launch date in product quick-view popover

### DIFF
--- a/src-vnext/features/shots/components/ProductQuickViewPopover.test.tsx
+++ b/src-vnext/features/shots/components/ProductQuickViewPopover.test.tsx
@@ -1,0 +1,119 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { ProductAssignment, ProductFamily, ProductSku } from "@/shared/types"
+
+// ---------------------------------------------------------------------------
+// Mocks — the popover loads a family doc and a sku doc; stub both per-test.
+// ---------------------------------------------------------------------------
+
+let mockFamily: Partial<ProductFamily> | null = null
+let mockSku: Partial<ProductSku> | null = null
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useProductFamilyDoc: () => ({ data: mockFamily, loading: false }),
+  useProductSkuDoc: () => ({ data: mockSku, loading: false }),
+}))
+
+vi.mock("@/shared/hooks/useStorageUrl", () => ({
+  useStorageUrl: () => undefined,
+}))
+
+import { ProductQuickViewPopover } from "./ProductQuickViewPopover"
+
+// ---------------------------------------------------------------------------
+// Helpers — production-shaped fixtures: a family with its own date, plus
+// colorway SKUs that may or may not carry a per-SKU override.
+// ---------------------------------------------------------------------------
+
+function ts(iso: string): Timestamp {
+  return Timestamp.fromDate(new Date(`${iso}T00:00:00Z`))
+}
+
+const FAMILY_LAUNCH = "2026-03-10"
+const SKU_LAUNCH = "2026-03-25"
+
+function assignment(skuId: string): ProductAssignment {
+  return {
+    familyId: "fam1",
+    familyName: "Women's Merino Scoop Bralette",
+    skuId,
+    colourName: "Black",
+  } as ProductAssignment
+}
+
+async function renderPopover() {
+  const user = userEvent.setup()
+  render(
+    <MemoryRouter>
+      <ProductQuickViewPopover assignment={assignment("sku-black")}>
+        <button type="button">trigger</button>
+      </ProductQuickViewPopover>
+    </MemoryRouter>,
+  )
+  // The quick-view content only mounts when the popover is open; open it and
+  // wait for the family name to confirm the content has rendered.
+  await user.click(screen.getByText("trigger"))
+  await screen.findByText("Women's Merino Scoop Bralette")
+}
+
+describe("ProductQuickViewPopover launch date resolution", () => {
+  beforeEach(() => {
+    mockFamily = null
+    mockSku = null
+  })
+
+  it("(a) shows the per-SKU launch date when the SKU has its own, with no inherited badge", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette", earliestLaunchDate: ts(FAMILY_LAUNCH) }
+    mockSku = { id: "sku-black", name: "Black", launchDate: ts(SKU_LAUNCH) }
+
+    await renderPopover()
+
+    expect(screen.getByText(SKU_LAUNCH)).toBeInTheDocument()
+    expect(screen.queryByText(FAMILY_LAUNCH)).not.toBeInTheDocument()
+    expect(screen.queryByText("inherited")).not.toBeInTheDocument()
+  })
+
+  it("(b) falls back to the family earliestLaunchDate when the SKU has none, and shows the inherited badge", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette", earliestLaunchDate: ts(FAMILY_LAUNCH) }
+    mockSku = { id: "sku-black", name: "Black" } // no per-SKU launchDate
+
+    await renderPopover()
+
+    expect(screen.getByText(FAMILY_LAUNCH)).toBeInTheDocument()
+    expect(screen.getByText("inherited")).toBeInTheDocument()
+  })
+
+  it("(b2) falls back to family.launchDate when earliestLaunchDate is absent", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette", launchDate: ts(FAMILY_LAUNCH) }
+    mockSku = { id: "sku-black", name: "Black" }
+
+    await renderPopover()
+
+    expect(screen.getByText(FAMILY_LAUNCH)).toBeInTheDocument()
+    expect(screen.getByText("inherited")).toBeInTheDocument()
+  })
+
+  it("(c) renders no launch row (and no badge) when neither SKU nor family has a date", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette" }
+    mockSku = { id: "sku-black", name: "Black" }
+
+    await renderPopover()
+
+    expect(screen.queryByText("Launch")).not.toBeInTheDocument()
+    expect(screen.queryByText("inherited")).not.toBeInTheDocument()
+  })
+
+  it("(d) the inherited flag is true ONLY on fallback — explicit SKU date wins and is not marked inherited", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette", earliestLaunchDate: ts(FAMILY_LAUNCH) }
+    mockSku = { id: "sku-black", name: "Black", launchDate: ts(SKU_LAUNCH) }
+
+    await renderPopover()
+
+    expect(screen.getByText(SKU_LAUNCH)).toBeInTheDocument()
+    expect(screen.queryByText("inherited")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/ProductQuickViewPopover.test.tsx
+++ b/src-vnext/features/shots/components/ProductQuickViewPopover.test.tsx
@@ -12,10 +12,14 @@ import type { ProductAssignment, ProductFamily, ProductSku } from "@/shared/type
 
 let mockFamily: Partial<ProductFamily> | null = null
 let mockSku: Partial<ProductSku> | null = null
+let lastSkuLookupId: string | null = null
 
 vi.mock("@/features/shots/hooks/usePickerData", () => ({
   useProductFamilyDoc: () => ({ data: mockFamily, loading: false }),
-  useProductSkuDoc: () => ({ data: mockSku, loading: false }),
+  useProductSkuDoc: (_familyId: string | null, skuId: string | null) => {
+    lastSkuLookupId = skuId
+    return { data: mockSku, loading: false }
+  },
 }))
 
 vi.mock("@/shared/hooks/useStorageUrl", () => ({
@@ -45,11 +49,11 @@ function assignment(skuId: string): ProductAssignment {
   } as ProductAssignment
 }
 
-async function renderPopover() {
+async function renderPopover(a: ProductAssignment = assignment("sku-black")) {
   const user = userEvent.setup()
   render(
     <MemoryRouter>
-      <ProductQuickViewPopover assignment={assignment("sku-black")}>
+      <ProductQuickViewPopover assignment={a}>
         <button type="button">trigger</button>
       </ProductQuickViewPopover>
     </MemoryRouter>,
@@ -64,6 +68,7 @@ describe("ProductQuickViewPopover launch date resolution", () => {
   beforeEach(() => {
     mockFamily = null
     mockSku = null
+    lastSkuLookupId = null
   })
 
   it("(a) shows the per-SKU launch date when the SKU has its own, with no inherited badge", async () => {
@@ -113,6 +118,19 @@ describe("ProductQuickViewPopover launch date resolution", () => {
 
     await renderPopover()
 
+    expect(screen.getByText(SKU_LAUNCH)).toBeInTheDocument()
+    expect(screen.queryByText("inherited")).not.toBeInTheDocument()
+  })
+
+  it("(e) resolves the SKU via legacy colourId when skuId is absent", async () => {
+    mockFamily = { id: "fam1", styleName: "Bralette", earliestLaunchDate: ts(FAMILY_LAUNCH) }
+    mockSku = { id: "colour-black", name: "Black", launchDate: ts(SKU_LAUNCH) }
+    // Legacy assignment: SKU doc id lives in colourId, no skuId.
+    const legacy = { familyId: "fam1", familyName: "Women's Merino Scoop Bralette", colourId: "colour-black", colourName: "Black" } as ProductAssignment
+
+    await renderPopover(legacy)
+
+    expect(lastSkuLookupId).toBe("colour-black")
     expect(screen.getByText(SKU_LAUNCH)).toBeInTheDocument()
     expect(screen.queryByText("inherited")).not.toBeInTheDocument()
   })

--- a/src-vnext/features/shots/components/ProductQuickViewPopover.tsx
+++ b/src-vnext/features/shots/components/ProductQuickViewPopover.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import { Link } from "react-router-dom"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { Button } from "@/ui/button"
-import { useProductFamilyDoc } from "@/features/shots/hooks/usePickerData"
+import { useProductFamilyDoc, useProductSkuDoc } from "@/features/shots/hooks/usePickerData"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
 import { formatDateOnly } from "@/features/shots/lib/dateOnly"
 import { ExternalLink } from "lucide-react"
@@ -40,6 +40,10 @@ function QuickViewContent({ assignment }: { readonly assignment: ProductAssignme
     needsLookup && assignment.familyId ? assignment.familyId : assignment.familyId
 
   const { data: family } = useProductFamilyDoc(familyIdForLookup ?? null)
+  const { data: sku } = useProductSkuDoc(
+    assignment.familyId ?? null,
+    assignment.skuId ?? null,
+  )
 
   const imageSrc =
     assignment.thumbUrl ??
@@ -52,7 +56,12 @@ function QuickViewContent({ assignment }: { readonly assignment: ProductAssignme
   const colourName = assignment.colourName ?? assignment.skuName
   const styleNumber = family?.styleNumbers?.[0] ?? family?.styleNumber
 
-  const launchDate = formatDateOnly(family?.earliestLaunchDate ?? family?.launchDate)
+  // Per-SKU launch date wins; otherwise fall back to the family date and mark
+  // the value as inherited so the UI can show a quiet badge.
+  const familyLaunch = family?.earliestLaunchDate ?? family?.launchDate ?? null
+  const resolvedLaunch = sku?.launchDate ?? familyLaunch
+  const launchInherited = !sku?.launchDate && !!familyLaunch
+  const launchDate = formatDateOnly(resolvedLaunch)
 
   const sampleCount = family?.sampleCount
 
@@ -75,7 +84,17 @@ function QuickViewContent({ assignment }: { readonly assignment: ProductAssignme
           {launchDate && (
             <div className="flex items-center justify-between gap-2">
               <span className="text-2xs text-[var(--color-text-subtle)]">Launch</span>
-              <span className="text-2xs text-[var(--color-text-secondary)]">{launchDate}</span>
+              <span className="flex items-center gap-1 text-2xs text-[var(--color-text-secondary)]">
+                {launchDate}
+                {launchInherited && (
+                  <span
+                    className="rounded-sm bg-[var(--color-surface-subtle)] px-1 text-2xs text-[var(--color-text-subtle)]"
+                    title="Inherited from the product family"
+                  >
+                    inherited
+                  </span>
+                )}
+              </span>
             </div>
           )}
           {sampleCount != null && (

--- a/src-vnext/features/shots/components/ProductQuickViewPopover.tsx
+++ b/src-vnext/features/shots/components/ProductQuickViewPopover.tsx
@@ -40,9 +40,12 @@ function QuickViewContent({ assignment }: { readonly assignment: ProductAssignme
     needsLookup && assignment.familyId ? assignment.familyId : assignment.familyId
 
   const { data: family } = useProductFamilyDoc(familyIdForLookup ?? null)
+  // Legacy/colour-keyed assignments carry the SKU doc id in colourId, not
+  // skuId (mirrors ProductAssignmentPicker's lookup) — fall back so the
+  // per-SKU launch date still resolves for them.
   const { data: sku } = useProductSkuDoc(
     assignment.familyId ?? null,
-    assignment.skuId ?? null,
+    assignment.skuId ?? assignment.colourId ?? null,
   )
 
   const imageSrc =

--- a/src-vnext/features/shots/hooks/usePickerData.ts
+++ b/src-vnext/features/shots/hooks/usePickerData.ts
@@ -92,6 +92,7 @@ function mapSku(id: string, data: Record<string, unknown>): ProductSku {
     skuCode: asString(data["skuCode"]) ?? asString(data["sku"]),
     imagePath: asString(data["imagePath"]),
     colorKey: asString(data["colorKey"]),
+    launchDate: (data["launchDate"] as ProductSku["launchDate"]) ?? null,
     deleted: asBoolean(data["deleted"]),
   }
 }


### PR DESCRIPTION
## What

The per-colorway **quick-view popover** on the shots surface showed the **family** launch date for every colorway, ignoring any per-SKU `launchDate` override.

Re-diagnosed against current source (the V2 plan named `mapShot.ts` + `ShotProductCard.tsx`, both **stale** — `mapShot.ts` has no launch-date logic and `ShotProductCard.tsx` doesn't exist). Two independent scouts confirmed: the shot card, table, sort, and filter are **already** per-SKU correct via `computeShotReadiness`; the popover was the **only** unfixed render site.

## Changes (3 files)

- **`ProductQuickViewPopover.tsx`** — load the SKU doc; resolve `sku.launchDate ?? family.earliestLaunchDate ?? family.launchDate`; show a quiet **"inherited"** badge only when falling back to the family date.
- **`usePickerData.ts` (`mapSku`)** — map the `launchDate` field. It was dropped in `mapSku`, so `useProductSkuDoc` always returned `launchDate=undefined` — without this, the popover fix would be a **silent no-op**. (`useHeroProductData`'s `mapSkuDoc` already maps it; this brings the picker hook in line.)
- **`ProductQuickViewPopover.test.tsx`** (new) — 5 tests: per-SKU wins (no badge), family fallback + badge (both `earliestLaunchDate` and `launchDate`), no-date no-row, explicit-date no-badge.

No data-model change.

## Verification

- Unit test green (5/5). Adversarial verify did a revert-and-fail check: reverting the resolution expression fails 4/5 tests, so the test is **non-vacuous**.
- Regression sweep: the `mapSku` change is purely additive (`launchDate` is an existing optional `ProductSku` field); the readiness/sort/filter path is fed by `useHeroProductData` (already mapped `launchDate`), so it's unaffected.
- Local Java 8 cannot run the emulator suite — **the CI `ui-checks` job is the final arbiter.**

## Notes / follow-ups (not in this PR)

- **`ProductAssignmentPicker` chip** also reads a launch date and its SKU lookup is gated on `needsImageLookup`, so it can still show the family date for thumbed assignments. Left out of scope to keep this slice minimal + independently revertable; the `mapSku` fix here is a prerequisite for fixing it later.
- **Family-fallback divergence (latent, minor):** the popover falls back `earliestLaunchDate ?? launchDate`; `computeShotReadiness` uses `earliestLaunchDate` only. They diverge only if a family sets `launchDate` but not `earliestLaunchDate` (unlikely with real data, which writes both together). Worth a future consolidation onto one helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)