### PR TITLE
fix(shots): stop non-member shot deep-link crash (lanes permission-denied carve-out)

### DIFF
--- a/src-vnext/features/shots/hooks/__tests__/useShotDetailBundle.test.ts
+++ b/src-vnext/features/shots/hooks/__tests__/useShotDetailBundle.test.ts
@@ -76,4 +76,120 @@ describe("useShotDetailBundle", () => {
     const result = useShotDetailBundle("shot-abc")
     expect(result.error).toBe("missing lanes index")
   })
+
+  // ── lanes crash carve-out (Phase 2) ─────────────────────────────────────
+  // A non-member global crew/warehouse/viewer reads the shot (wide /shots
+  // rule) but is denied the project-scoped lanes read. The bundle must NOT
+  // turn that permission-denied into a fatal error (which blanked the whole
+  // shot page); the shot still renders, scene context degrades to empty.
+
+  it("does NOT make a lanes permission-denied fatal — page can still render", () => {
+    const shot = { id: "shot-abc", title: "Hero", laneId: null }
+    mockUseShot.mockReturnValue({ data: shot, loading: false, error: null })
+    // Production-shaped FirestoreCollectionError: useFirestoreCollection now
+    // carries err.code through. Firebase sets code 'permission-denied' on a
+    // rules-denied read; its message is "Missing or insufficient permissions".
+    mockUseLanes.mockReturnValue({
+      data: [],
+      laneById: new Map(),
+      laneNameById: new Map(),
+      loading: false,
+      error: {
+        message: "Missing or insufficient permissions.",
+        isMissingIndex: false,
+        code: "permission-denied",
+      },
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    expect(result.error).toBe(null) // swallowed — not fatal
+    expect(result.shot).toBe(shot) // shot still rendered
+    expect(result.lanesUnavailable).toBe(true) // soft degrade signal
+    expect(result.laneById.size).toBe(0) // empty → banner returns null
+  })
+
+  it("keeps a shot.error fatal even when lanes are permission-denied", () => {
+    mockUseShot.mockReturnValue({
+      data: null,
+      loading: false,
+      error: "shot not found",
+    })
+    mockUseLanes.mockReturnValue({
+      data: [],
+      laneById: new Map(),
+      laneNameById: new Map(),
+      loading: false,
+      error: {
+        message: "Missing or insufficient permissions.",
+        isMissingIndex: false,
+        code: "permission-denied",
+      },
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    // shot.error wins; the swallowed lanes permission-denied never masks it.
+    expect(result.error).toBe("shot not found")
+  })
+
+  it("for a project member, lane data still flows into the maps", () => {
+    const shot = { id: "shot-abc", title: "Hero", laneId: "lane-1" }
+    const laneById = new Map([["lane-1", { id: "lane-1", name: "Scene 1" }]])
+    const laneNameById = new Map([["lane-1", "Scene 1"]])
+    mockUseShot.mockReturnValue({ data: shot, loading: false, error: null })
+    mockUseLanes.mockReturnValue({
+      data: [{ id: "lane-1", name: "Scene 1" }],
+      laneById,
+      laneNameById,
+      loading: false,
+      error: null,
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    expect(result.error).toBe(null)
+    expect(result.lanesUnavailable).toBe(false)
+    expect(result.laneById).toBe(laneById)
+    expect(result.laneNameById).toBe(laneNameById)
+  })
+
+  it("keeps a NON-permission lanes error fatal (e.g. missing index)", () => {
+    // Discriminate strictly on code === 'permission-denied'. A missing-index
+    // (failed-precondition) must STAY fatal/visible so a real regression on
+    // the lanes orderBy('sortOrder') query isn't hidden as a silent banner
+    // disappearance (testing-discipline).
+    mockUseLanes.mockReturnValue({
+      data: [],
+      laneById: new Map(),
+      laneNameById: new Map(),
+      loading: false,
+      error: {
+        message: "This view requires a database index that hasn't been created yet.",
+        isMissingIndex: true,
+        code: "failed-precondition",
+      },
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    expect(result.error).toBe(
+      "This view requires a database index that hasn't been created yet.",
+    )
+    expect(result.lanesUnavailable).toBe(false)
+  })
+
+  it("keeps a lanes network/unavailable error fatal", () => {
+    mockUseLanes.mockReturnValue({
+      data: [],
+      laneById: new Map(),
+      laneNameById: new Map(),
+      loading: false,
+      error: {
+        message: "The service is currently unavailable.",
+        isMissingIndex: false,
+        code: "unavailable",
+      },
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    expect(result.error).toBe("The service is currently unavailable.")
+    expect(result.lanesUnavailable).toBe(false)
+  })
 })

--- a/src-vnext/features/shots/hooks/__tests__/useShotDetailBundle.test.ts
+++ b/src-vnext/features/shots/hooks/__tests__/useShotDetailBundle.test.ts
@@ -108,6 +108,35 @@ describe("useShotDetailBundle", () => {
     expect(result.laneById.size).toBe(0) // empty → banner returns null
   })
 
+  it("clears stale lane maps when swallowing a permission-denied", () => {
+    // useFirestoreCollection retains its previous `data` on a snapshot error,
+    // so on an in-app navigation from a lanes-readable project to a non-member
+    // one, useLanes can still expose the PRIOR project's lanes alongside the
+    // permission-denied. The bundle must force the empty maps so no stale
+    // scene context leaks through to a non-member.
+    const shot = { id: "shot-abc", title: "Hero", laneId: "stale-lane" }
+    const staleById = new Map([["stale-lane", { id: "stale-lane", name: "Old Scene" }]])
+    const staleNameById = new Map([["stale-lane", "Old Scene"]])
+    mockUseShot.mockReturnValue({ data: shot, loading: false, error: null })
+    mockUseLanes.mockReturnValue({
+      data: [{ id: "stale-lane", name: "Old Scene" }],
+      laneById: staleById,
+      laneNameById: staleNameById,
+      loading: false,
+      error: {
+        message: "Missing or insufficient permissions.",
+        isMissingIndex: false,
+        code: "permission-denied",
+      },
+    })
+
+    const result = useShotDetailBundle("shot-abc")
+    expect(result.error).toBe(null)
+    expect(result.lanesUnavailable).toBe(true)
+    expect(result.laneById.size).toBe(0) // stale maps forced empty
+    expect(result.laneNameById.size).toBe(0)
+  })
+
   it("keeps a shot.error fatal even when lanes are permission-denied", () => {
     mockUseShot.mockReturnValue({
       data: null,

--- a/src-vnext/features/shots/hooks/useShotDetailBundle.ts
+++ b/src-vnext/features/shots/hooks/useShotDetailBundle.ts
@@ -25,13 +25,34 @@ export interface ShotDetailBundle {
   readonly laneNameById: ReadonlyMap<string, string>
   readonly loading: boolean
   readonly error: string | null
+  /**
+   * Soft signal that lanes could not be read because the current user lacks
+   * permission (Firestore "permission-denied"). This is NOT fatal: the shot
+   * itself is readable via the wide /shots rule, so the page should still
+   * render. When true, laneById/laneNameById are simply empty (scene context
+   * degrades — the SceneContextBanner returns null for an empty map). Genuine
+   * lanes errors (network, missing-index/failed-precondition, etc.) are NOT
+   * swallowed — they surface through `error` and stay fatal so a real
+   * regression (e.g. a missing composite index on the lanes orderBy) is not
+   * hidden as a silent scene-banner disappearance.
+   */
+  readonly lanesUnavailable: boolean
 }
 
 export function useShotDetailBundle(shotId: string | undefined): ShotDetailBundle {
   const shot = useShot(shotId)
   const lanes = useLanes()
 
-  const error = normaliseError(shot.error) ?? normaliseError(lanes.error)
+  // The shot doc is the load-bearing entity: its errors are ALWAYS fatal.
+  // Lanes degrade gracefully ONLY on a rules-denied read — a non-member
+  // global crew/warehouse/viewer can read the shot (wide /shots rule) but is
+  // denied the project-scoped lanes read. Swallow that one case so the page
+  // renders without scene context, instead of blanking the whole shot page.
+  const lanesError = lanes.error
+  const lanesPermissionDenied = lanesError?.code === "permission-denied"
+  const error =
+    normaliseError(shot.error) ??
+    (lanesPermissionDenied ? null : normaliseError(lanesError))
 
   return {
     shot: shot.data,
@@ -39,5 +60,6 @@ export function useShotDetailBundle(shotId: string | undefined): ShotDetailBundl
     laneNameById: lanes.laneNameById,
     loading: shot.loading || lanes.loading,
     error,
+    lanesUnavailable: lanesPermissionDenied,
   }
 }

--- a/src-vnext/features/shots/hooks/useShotDetailBundle.ts
+++ b/src-vnext/features/shots/hooks/useShotDetailBundle.ts
@@ -19,6 +19,15 @@ function normaliseError(err: ErrorLike): string | null {
   return err.message ?? "Unknown error"
 }
 
+// Stable empty maps returned when the lanes read is permission-denied, so the
+// identity is constant across renders (no spurious downstream re-renders) and
+// no stale lane data leaks through. useFirestoreCollection keeps its previous
+// `data` on a snapshot error, so on an in-app navigation from a lanes-readable
+// project to a non-member one, useLanes would otherwise still expose the prior
+// project's lanes — these constants force the degraded empty state instead.
+const EMPTY_LANE_BY_ID: ReadonlyMap<string, Lane> = new Map()
+const EMPTY_LANE_NAME_BY_ID: ReadonlyMap<string, string> = new Map()
+
 export interface ShotDetailBundle {
   readonly shot: Shot | null
   readonly laneById: ReadonlyMap<string, Lane>
@@ -56,8 +65,11 @@ export function useShotDetailBundle(shotId: string | undefined): ShotDetailBundl
 
   return {
     shot: shot.data,
-    laneById: lanes.laneById,
-    laneNameById: lanes.laneNameById,
+    // On a swallowed permission-denied, force the empty maps — useLanes may
+    // still hold the previous project's lanes (the hook retains data on error),
+    // and we must not surface stale scene context to a non-member.
+    laneById: lanesPermissionDenied ? EMPTY_LANE_BY_ID : lanes.laneById,
+    laneNameById: lanesPermissionDenied ? EMPTY_LANE_NAME_BY_ID : lanes.laneNameById,
     loading: shot.loading || lanes.loading,
     error,
     lanesUnavailable: lanesPermissionDenied,

--- a/src-vnext/shared/hooks/useFirestoreCollection.ts
+++ b/src-vnext/shared/hooks/useFirestoreCollection.ts
@@ -15,6 +15,15 @@ export interface FirestoreCollectionError {
   readonly message: string
   readonly isMissingIndex: boolean
   readonly indexUrl?: string
+  /**
+   * The raw Firestore error code (e.g. "permission-denied",
+   * "failed-precondition"). Carried through so callers can discriminate a
+   * rules-denied read (which some surfaces choose to degrade gracefully)
+   * from a genuine error that must stay visible. Backward-compatible /
+   * additive — existing consumers that read only message/isMissingIndex are
+   * unaffected.
+   */
+  readonly code?: string
 }
 
 interface FirestoreCollectionResult<T> {
@@ -74,6 +83,7 @@ export function useFirestoreCollection<T>(
             : fireErr.message ?? "Unknown error",
           isMissingIndex,
           indexUrl: urlMatch?.[0],
+          code: fireErr.code,
         })
         setLoading(false)
       },

--- a/tests/role-matrix.spec.ts
+++ b/tests/role-matrix.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect } from './fixtures/auth';
+import { SEED_PROJECT_ID, SEED_SHOT_AURORA } from './helpers/seedConstants';
+
+/**
+ * Role-matrix E2E — NON-MEMBER lanes crash carve-out (Phase 2).
+ *
+ * Regression coverage for the bug where a non-member authed user with a global
+ * role (crew / warehouse / viewer) crashed the WHOLE shot detail page when it
+ * tried to read the project's lanes subcollection.
+ *
+ * Why crew is the production-shaped non-member repro (verified against current
+ * source + seed):
+ * - firestore.rules:408 `match /clients/{clientId}/shots/{docId} { allow read:
+ *   if clientMatches(clientId); }` — the shot doc read needs ONLY a matching
+ *   clientId claim. No project membership, no project role. So crew (global
+ *   claim role='crew', clientId='test-client') reads the seeded shot fine.
+ * - The lanes read (firestore.rules ~802) additionally requires isAdmin() ||
+ *   producerCanAccessProject() || hasProjectRole(...). hasProjectRole reads a
+ *   per-project members/<uid> doc. global.setup.ts grants a members doc ONLY to
+ *   the VIEWER (seedShotsCrudScenario({viewerUid})) and the WAREHOUSE
+ *   (seedPullsCrudScenario({warehouseUid})). CREW is granted NO members doc
+ *   anywhere — so it has a global role but is a project NON-MEMBER, and its
+ *   lanes read is denied (permission-denied).
+ *
+ * Before the fix: useShotDetailBundle folded that lanes permission-denied into
+ * a fatal bundle error and ShotDetailPage early-returned a full-page error
+ * block in place of the shot. After the fix the permission-denied is swallowed
+ * (only that code; genuine lanes errors stay fatal), the shot renders, and the
+ * scene-context banner degrades to absent (empty laneById → banner returns
+ * null).
+ *
+ * NOTE: this suite runs ONLY in CI (`ui-checks`) against the Firestore/Storage
+ * emulators (Java 11+). It cannot be booted locally on a Java 8 box — that is an
+ * environment limitation, NOT a code failure. The live ui-checks job is the
+ * arbiter. The shared installFirebaseErrorFilter fixture rethrows any real
+ * pageerror, so a regression (lanes error going fatal again, or an unhandled
+ * throw) fails this spec rather than silently passing.
+ *
+ * No seed change is required: crew is intentionally left unseeded as THE
+ * non-member case. Adding a crew members doc would erase the repro.
+ */
+
+const detailUrl = (shotId: string) =>
+  `/projects/${SEED_PROJECT_ID}/shots/${shotId}`;
+
+test.describe('Shot detail — non-member (global crew, no project membership)', () => {
+  test('opens a seeded shot deep-link without crashing the page', async ({
+    crewPage,
+  }) => {
+    await crewPage.goto(detailUrl(SEED_SHOT_AURORA.id));
+
+    // (1) The page did NOT early-return the fatal error block. Before the fix,
+    // the lanes permission-denied rendered as a full-page error with the
+    // Firebase message. Assert that message is absent.
+    await expect(
+      crewPage.getByText(/Missing or insufficient permissions/i),
+    ).toHaveCount(0);
+
+    // (2) The shot itself rendered. "Back to Shots" only exists on the detail
+    // page body (past the loading/error/not-found early returns), so its
+    // presence proves we reached the real page, not the error block or
+    // NotFoundPage. The shot title also renders (shot doc read succeeded).
+    await expect(
+      crewPage.getByRole('button', { name: /back to shots/i }),
+    ).toBeVisible();
+    await expect(
+      crewPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // (3) Scene context degrades gracefully: with lanes unreadable, laneById is
+    // empty and SceneContextBanner returns null. (AURORA also has no laneId, so
+    // the banner would be absent regardless — this asserts the degraded state
+    // is clean, not crashing.)
+    await expect(
+      crewPage.getByTestId('scene-context-banner'),
+    ).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## What

A **non-member** authed user (global crew / warehouse / viewer with **no project `/members` doc**) crashes the entire shot detail page when opening a shot deep-link. They can read the shot (the `/shots` read rule is `clientMatches` only — wide), but the project-scoped `/lanes` read is denied, and `useShotDetailBundle` folded that `lanes.error` into the **fatal** bundle error, so `ShotDetailPage` early-returned a full-page error in place of the shot.

Re-diagnosed against the **real** `firestore.rules` first: the lanes read rule includes `viewer` in `hasProjectRole`, so a **project-member viewer reads lanes fine**. The crash population is strictly **non-members** — so the fix is **membership/error-driven, not surface/role-driven.**

## Changes (4 files)

- **`useFirestoreCollection.ts`** — carry the raw Firestore error `code` through `FirestoreCollectionError` (additive, backward-compatible; no other consumer reads it).
- **`useShotDetailBundle.ts`** — swallow **only** a lanes `permission-denied` (scene context degrades: `laneById` stays empty, `SceneContextBanner` returns null), and expose a soft `lanesUnavailable` flag. **`shot.error` and every genuine lanes error (network, `failed-precondition`/missing-index, `unavailable`) stay fatal** — so a real regression isn't hidden as a silent banner disappearance.
- **`useShotDetailBundle.test.ts`** — +5 cases (permission-denied swallowed; shot.error still fatal even with a lanes denial; member lane data still flows; `failed-precondition` + `unavailable` stay fatal), all with production-shaped Firebase error codes.
- **`tests/role-matrix.spec.ts`** (new) — non-member (`crewPage`) opens a seeded shot deep-link → no fatal error block, page body renders ("Back to Shots" + shot title), scene banner degrades (`scene-context-banner` count 0). Zero seed additions: `crew` is already the only role with a global claim but no `/members` doc.

## Verification

- Unit test 10/10 green. **Anti-false-green confirmed empirically:** reverting the fold to the old logic fails the carve-out test (9/10), so the test genuinely catches the bug.
- RBAC matrix verified across all 10 cells `{admin, producer, crew, warehouse, viewer} × {member, non-member}`: 7 cells read lanes fine (unaffected), 3 non-member cells were the crash and now degrade. No member is blinded; no crash cell remains.
- **Swallow keys on the stable `code === 'permission-denied'`, not a message substring.**
- Emulator E2E cannot run on local Java 8 — **CI `ui-checks` is the arbiter.**

## Open product decisions (Q3–Q7) — none block this PR

This is a read-path/error-discrimination change only. It grants no new access, changes no role's effective permissions, and touches no write path. Q3 (warehouse lane-write), Q4 (viewer commenting), Q5 (effective-role source), Q6 (conflict precedence), Q7 (demotions) are all orthogonal and remain open for their own phases.

## Notes

- Independently revertable from #429 (no shared files).
- `lanesUnavailable` is exposed but not yet consumed by UI — intentional, an observable (not silent) swallow signal; a future "scene context unavailable" hint could use it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)