### PR TITLE
feat(shots): resolveSurface view-state authority + job defaults, flag-gated (redesign Phase 4)

### DIFF
--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -15,6 +15,7 @@ import { ShotQuickAdd } from "@/features/shots/components/ShotQuickAdd"
 import { ShotsTable, REORDER_SHOT_LIMIT } from "@/features/shots/components/ShotsTable"
 import { resolveReorderDisabledReason } from "@/features/shots/components/DisabledDragHandle"
 import { useShotListState } from "@/features/shots/hooks/useShotListState"
+import type { SurfaceDevice } from "@/features/shots/lib/resolveSurface"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { canGeneratePulls, canManageShots } from "@/shared/lib/rbac"
@@ -47,7 +48,7 @@ import { ThreePanelLayout } from "@/features/shots/components/ThreePanelLayout"
 
 export default function ShotListPage() {
   const { data: shots, loading, error } = useShots()
-  const { role, clientId, user } = useAuth()
+  const { role, clientId, user, loading: authLoading } = useAuth()
   const { projectId, projectName } = useProjectScope()
   const navigate = useNavigate()
   const isMobile = useIsMobile()
@@ -137,6 +138,18 @@ export default function ShotListPage() {
   const { data: lanes, laneNameById, laneById } = useLanes()
   const laneOrder = useMemo(() => new Map(lanes.map((l) => [l.id, l.sortOrder])), [lanes])
 
+  // -- Phase 4 (flag-gated) surface resolution inputs. GATED on auth loading:
+  // AuthProvider falls back to 'viewer' while claims load, so resolving then
+  // would flash the viewer surface — pass null until claims settle (the hook
+  // runs its legacy flag-off derivation in the meantime). `role` is already
+  // normalizeRole(globalClaim). Device is three-valued (incl. tablet) from
+  // the existing media hooks. Inert while featureSurfaceResolver is off. --
+  const surfaceDevice: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
+  const surfaceContext = useMemo(
+    () => (authLoading ? null : { role, device: surfaceDevice }),
+    [authLoading, role, surfaceDevice],
+  )
+
   // -- All filter / sort / view state --
   const {
     sortKey, sortDir, viewMode, groupKey, isCustomSort,
@@ -153,7 +166,7 @@ export default function ShotListPage() {
     shotGroups, activeFilterBadges, tagOptions,
     storageKeyBase,
   } = useShotListState({
-    shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById,
+    shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById, surfaceContext,
   })
 
   // -- Extra (advanced) filter count: conditions beyond status/missing inline filters --

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -138,12 +138,7 @@ export default function ShotListPage() {
   const { data: lanes, laneNameById, laneById } = useLanes()
   const laneOrder = useMemo(() => new Map(lanes.map((l) => [l.id, l.sortOrder])), [lanes])
 
-  // -- Phase 4 (flag-gated) surface resolution inputs. GATED on auth loading:
-  // AuthProvider falls back to 'viewer' while claims load, so resolving then
-  // would flash the viewer surface — pass null until claims settle (the hook
-  // runs its legacy flag-off derivation in the meantime). `role` is already
-  // normalizeRole(globalClaim). Device is three-valued (incl. tablet) from
-  // the existing media hooks. Inert while featureSurfaceResolver is off. --
+  // null until claims settle: AuthProvider falls back to 'viewer' while loading (viewer-flash guard)
   const surfaceDevice: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
   const surfaceContext = useMemo(
     () => (authLoading ? null : { role, device: surfaceDevice }),

--- a/src-vnext/features/shots/hooks/__tests__/useShotListState.resolver.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useShotListState.resolver.test.tsx
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { act } from "react"
+import { renderHook } from "@testing-library/react"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import type { ReactNode } from "react"
+import { useShotListState, type ShotListSurfaceContext } from "../useShotListState"
+import { normalizeRole } from "@/shared/lib/rbac"
+
+// ---------------------------------------------------------------------------
+// Phase 4 flag-ON integration — featureSurfaceResolver wired into
+// useShotListState via the optional, additive `surfaceContext` param.
+//
+// Companion to useShotListState.surface.test.tsx (the flag-OFF
+// characterization file). Proves:
+//   - flag-on producers resolve the table default (never-customized only)
+//   - flag-on is INERT for crew/warehouse/viewer (same resolution as legacy)
+//   - precedence: URL > stored explicit choice > surface default, device
+//     forcing last + non-destructive (zero setSearchParams writes)
+//   - resolution is GATED on auth loading (surfaceContext === null → legacy,
+//     no viewer-flash)
+//   - flag-off with surfaceContext provided stays legacy (the flag gates)
+// ---------------------------------------------------------------------------
+
+const mocks = vi.hoisted(() => ({
+  isMobile: false,
+  flagOn: true,
+  setSearchParamsCalls: [] as unknown[][],
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => mocks.isMobile,
+}))
+
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureSurfaceResolver" ? mocks.flagOn : actual.isFeatureEnabled(flag),
+  }
+})
+
+// Wrap the REAL useSearchParams so every setter invocation is recorded
+// (same pattern as the characterization file).
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>()
+  const { useMemo } = await import("react")
+  const useSearchParamsSpy: typeof actual.useSearchParams = (...hookArgs) => {
+    const [params, setParams] = actual.useSearchParams(...hookArgs)
+    const wrapped = useMemo(() => {
+      const fn: typeof setParams = (...args) => {
+        mocks.setSearchParamsCalls.push(args)
+        return setParams(...args)
+      }
+      return fn
+    }, [setParams])
+    return [params, wrapped]
+  }
+  return { ...actual, useSearchParams: useSearchParamsSpy }
+})
+
+const PARAMS = {
+  shots: [],
+  reorderOptimistic: null,
+  clientId: "test-client",
+  projectId: "p1",
+  talentNameById: new Map<string, string>(),
+  locationNameById: new Map<string, string>(),
+  productNameById: new Map<string, string>(),
+} as const
+
+const VIEW_STORAGE_KEY = "sb:shots:list:test-client:p1:view:v1"
+
+function setup(search = "", surfaceContext?: ShotListSurfaceContext | null) {
+  let currentSearch = ""
+  function Probe() {
+    currentSearch = useLocation().search
+    return null
+  }
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/projects/p1/shots${search}`]}>
+      {children}
+      <Probe />
+    </MemoryRouter>
+  )
+  const view = renderHook(() => useShotListState({ ...PARAMS, surfaceContext }), { wrapper })
+  return { view, getSearch: () => currentSearch }
+}
+
+beforeEach(() => {
+  mocks.isMobile = false
+  mocks.flagOn = true
+  mocks.setSearchParamsCalls.length = 0
+  window.localStorage.clear()
+})
+
+describe("useShotListState — featureSurfaceResolver flag-ON integration", () => {
+  it("never-customized producer on desktop resolves the table default (surface-default provenance)", () => {
+    const { view, getSearch } = setup("", { role: "producer", device: "desktop" })
+
+    expect(view.result.current.viewMode).toBe("table")
+    expect(view.result.current.groupKey).toBe("none")
+    expect(view.result.current.surface).toBe("plan-build")
+    expect(view.result.current.viewSource).toBe("surface-default")
+    // Pure derivation — zero writes, URL untouched.
+    view.rerender()
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+    expect(getSearch()).toBe("")
+  })
+
+  it("producer who explicitly chose cards (stored :view:v1='card') KEEPS cards", () => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, "card")
+    const { view } = setup("", { role: "producer", device: "desktop" })
+
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.viewSource).toBe("stored")
+  })
+
+  it("URL param beats the stored choice (precedence: url > stored > surface default)", () => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, "table")
+    const { view } = setup("?view=card", { role: "producer", device: "desktop" })
+
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.viewSource).toBe("url")
+  })
+
+  it("flag-on is INERT for crew/warehouse/viewer: resolution identical to legacy (card default)", () => {
+    const cases = [
+      { role: "crew", surface: "shoot" },
+      { role: "warehouse", surface: "review-warehouse" },
+      { role: "viewer", surface: "review-client" },
+    ] as const
+
+    for (const { role, surface } of cases) {
+      window.localStorage.clear()
+      const { view } = setup("", { role, device: "desktop" })
+      expect(view.result.current.viewMode).toBe("card")
+      expect(view.result.current.groupKey).toBe("none")
+      expect(view.result.current.surface).toBe(surface)
+      view.unmount()
+    }
+  })
+
+  it("mobile forcing stays override-without-erase under flag-on: latent ?view=table&group=status survive, zero writes", () => {
+    mocks.isMobile = true
+    const { view, getSearch } = setup("?view=table&group=status", { role: "producer", device: "mobile" })
+    view.rerender()
+
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.groupKey).toBe("none")
+    expect(view.result.current.viewSource).toBe("device-forced")
+
+    const params = new URLSearchParams(getSearch())
+    expect(params.get("view")).toBe("table")
+    expect(params.get("group")).toBe("status")
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+  })
+
+  it("GATES on auth loading: surfaceContext null → legacy resolution, no surface (no viewer-flash)", () => {
+    const { view } = setup("", null)
+
+    // Legacy default (card), NOT the producer table default and NOT a
+    // viewer-surface resolution from AuthProvider's 'viewer' loading fallback.
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.surface).toBeUndefined()
+    expect(view.result.current.viewSource).toBeUndefined()
+  })
+
+  it("flag-OFF with surfaceContext provided stays byte-identical legacy (flag gates the resolver)", () => {
+    mocks.flagOn = false
+    const { view, getSearch } = setup("", { role: "producer", device: "desktop" })
+    view.rerender()
+
+    expect(view.result.current.viewMode).toBe("card") // legacy default, no table flip
+    expect(view.result.current.groupKey).toBe("none")
+    expect(view.result.current.surface).toBeUndefined()
+    expect(view.result.current.viewSource).toBeUndefined()
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+    expect(getSearch()).toBe("")
+  })
+
+  it("legacy 'wardrobe' claim (normalized) lands on review-warehouse, not the viewer surface", () => {
+    const { view } = setup("", { role: normalizeRole("wardrobe"), device: "desktop" })
+
+    expect(view.result.current.surface).toBe("review-warehouse")
+    expect(view.result.current.viewMode).toBe("card") // inert: card, same as legacy
+  })
+
+  it("setViewMode still writes URL + localStorage identically under flag-on (setters untouched)", () => {
+    const { view, getSearch } = setup("", { role: "producer", device: "desktop" })
+
+    expect(view.result.current.viewMode).toBe("table")
+    // Producer explicitly switches to cards…
+    act(() => view.result.current.setViewMode("card"))
+    view.rerender()
+
+    expect(new URLSearchParams(getSearch()).get("view")).toBe("card")
+    expect(window.localStorage.getItem(VIEW_STORAGE_KEY)).toBe("card")
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.viewSource).toBe("url")
+    // Exactly the one explicit user write — nothing from resolution itself.
+    expect(mocks.setSearchParamsCalls).toHaveLength(1)
+  })
+})

--- a/src-vnext/features/shots/hooks/__tests__/useShotListState.surface.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useShotListState.surface.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import { MemoryRouter, useLocation } from "react-router-dom"
+import type { ReactNode } from "react"
+import { useShotListState } from "../useShotListState"
+
+// ---------------------------------------------------------------------------
+// CHARACTERIZATION TESTS — Phase 4 first commit (build spec §Test plan item 1).
+//
+// These pin TODAY's view/group resolution behavior in useShotListState BEFORE
+// the resolveSurface refactor. They describe current trunk behavior, not the
+// future API:
+//
+//   1. Mobile forcing: isMobile=true forces viewMode 'card' + groupKey 'none'
+//      regardless of ?view=table&group=status (useShotListState.ts:269-282).
+//   2. Override-without-erase: that forcing is a pure derivation — the latent
+//      URL params survive untouched (no setSearchParams write).
+//   3. Desktop respects URL: isMobile=false + ?view=table&group=status
+//      resolves table/status.
+//   4. Stored view: localStorage `sb:shots:list:{clientId}:{projectId}:view:v1`
+//      = 'table' is the no-URL-param default on desktop; mobile still forces
+//      card.
+//   5. Zero mount writes: mounting with clean modern params performs NO
+//      setSearchParams call. The legacy-param migration
+//      (useShotListState.ts:149-160) is the ONLY allowlisted mount write,
+//      pinned by its own test below.
+// ---------------------------------------------------------------------------
+
+// Mutable controls referenced by hoisted module mocks.
+const mocks = vi.hoisted(() => ({
+  isMobile: false,
+  setSearchParamsCalls: [] as unknown[][],
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => mocks.isMobile,
+}))
+
+// Wrap the REAL useSearchParams so every setter invocation is recorded.
+// The setter identity is memoized per underlying setter so hook effect
+// dependency behavior matches production.
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>()
+  const { useMemo } = await import("react")
+  const useSearchParamsSpy: typeof actual.useSearchParams = (...hookArgs) => {
+    const [params, setParams] = actual.useSearchParams(...hookArgs)
+    const wrapped = useMemo(() => {
+      const fn: typeof setParams = (...args) => {
+        mocks.setSearchParamsCalls.push(args)
+        return setParams(...args)
+      }
+      return fn
+    }, [setParams])
+    return [params, wrapped]
+  }
+  return { ...actual, useSearchParams: useSearchParamsSpy }
+})
+
+const PARAMS = {
+  shots: [],
+  reorderOptimistic: null,
+  clientId: "test-client",
+  projectId: "p1",
+  talentNameById: new Map<string, string>(),
+  locationNameById: new Map<string, string>(),
+  productNameById: new Map<string, string>(),
+} as const
+
+const VIEW_STORAGE_KEY = "sb:shots:list:test-client:p1:view:v1"
+
+/** Renders the hook AND a location probe so we can read the live URL search. */
+function setup(search = "") {
+  let currentSearch = ""
+  function Probe() {
+    currentSearch = useLocation().search
+    return null
+  }
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/projects/p1/shots${search}`]}>
+      {children}
+      <Probe />
+    </MemoryRouter>
+  )
+  const view = renderHook(() => useShotListState({ ...PARAMS }), { wrapper })
+  return {
+    view,
+    getSearch: () => currentSearch,
+  }
+}
+
+beforeEach(() => {
+  mocks.isMobile = false
+  mocks.setSearchParamsCalls.length = 0
+  window.localStorage.clear()
+})
+
+describe("useShotListState — surface characterization (pre-resolveSurface)", () => {
+  it("mobile forces viewMode 'card' and groupKey 'none' even with ?view=table&group=status", () => {
+    mocks.isMobile = true
+    const { view } = setup("?view=table&group=status")
+
+    expect(view.result.current.viewMode).toBe("card")
+    expect(view.result.current.groupKey).toBe("none")
+  })
+
+  it("mobile forcing is override-without-erase: latent ?view=table&group=status survive with zero writes", () => {
+    mocks.isMobile = true
+    const { view, getSearch } = setup("?view=table&group=status")
+    view.rerender()
+
+    // The forced card/none derivation never touched the URL...
+    const params = new URLSearchParams(getSearch())
+    expect(params.get("view")).toBe("table")
+    expect(params.get("group")).toBe("status")
+    // ...and no setSearchParams write of any kind occurred.
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+  })
+
+  it("desktop respects URL: ?view=table&group=status resolves table/status", () => {
+    mocks.isMobile = false
+    const { view } = setup("?view=table&group=status")
+
+    expect(view.result.current.viewMode).toBe("table")
+    expect(view.result.current.groupKey).toBe("status")
+  })
+
+  it("stored view 'table' (localStorage :view:v1) is the default on desktop when no ?view param", () => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, "table")
+    mocks.isMobile = false
+    const { view } = setup()
+
+    expect(view.result.current.viewMode).toBe("table")
+  })
+
+  it("stored view 'table' is still forced to 'card' on mobile", () => {
+    window.localStorage.setItem(VIEW_STORAGE_KEY, "table")
+    mocks.isMobile = true
+    const { view } = setup()
+
+    expect(view.result.current.viewMode).toBe("card")
+  })
+
+  it("mounting with clean modern params performs ZERO setSearchParams writes", () => {
+    mocks.isMobile = false
+    const { view, getSearch } = setup("?view=table&group=status&filters=missing.in:products&q=hello&sort=name")
+    view.rerender()
+
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+    // URL byte-identical to what we mounted with.
+    const params = new URLSearchParams(getSearch())
+    expect(params.get("view")).toBe("table")
+    expect(params.get("group")).toBe("status")
+    expect(params.get("filters")).toBe("missing.in:products")
+    expect(params.get("q")).toBe("hello")
+    expect(params.get("sort")).toBe("name")
+  })
+
+  it("mounting with no params at all performs ZERO setSearchParams writes", () => {
+    const { view, getSearch } = setup()
+    view.rerender()
+
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+    expect(getSearch()).toBe("")
+  })
+
+  it("ALLOWLISTED EXCEPTION: legacy flat params migrate to `filters` in exactly one replace-write on mount", () => {
+    const { view, getSearch } = setup("?status=todo,in_progress&missing=products")
+    view.rerender()
+
+    // Exactly one write — the legacy migration (useShotListState.ts:149-160).
+    expect(mocks.setSearchParamsCalls).toHaveLength(1)
+    const [, options] = mocks.setSearchParamsCalls[0] as [unknown, { replace?: boolean }]
+    expect(options?.replace).toBe(true)
+
+    // Legacy params consumed, single consolidated `filters` param written.
+    const params = new URLSearchParams(getSearch())
+    expect(params.get("status")).toBeNull()
+    expect(params.get("missing")).toBeNull()
+    expect(params.get("filters")).toBe("status.in:todo,in_progress;missing.in:products")
+
+    // The migrated conditions are live in hook state.
+    expect(Array.from(view.result.current.statusFilter).sort()).toEqual(["in_progress", "todo"])
+    expect(Array.from(view.result.current.missingFilter)).toEqual(["products"])
+  })
+})

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
-import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku, Lane } from "@/shared/types"
+import type { Shot, ShotFirestoreStatus, ProductFamily, ProductSku, Lane, Role } from "@/shared/types"
+import { isFeatureEnabled } from "@/shared/lib/flags"
+import {
+  resolveSurface,
+  type SurfaceDevice,
+  type SurfaceKind,
+  type ViewSource,
+} from "@/features/shots/lib/resolveSurface"
 import {
   type SortKey,
   type SortDir,
@@ -105,6 +112,25 @@ export type ShotListState = {
   readonly tagOptions: ReadonlyArray<{ readonly id: string; readonly label: string }>
   // Persistence key
   readonly storageKeyBase: string | null
+  // Phase 4 (flag-gated, ADDITIVE-ONLY): resolved surface metadata.
+  // `undefined` whenever featureSurfaceResolver is off, no surfaceContext was
+  // provided, or resolution is gated (auth still loading).
+  readonly surface?: SurfaceKind
+  readonly viewSource?: ViewSource
+}
+
+/**
+ * Phase 4 (flag-gated) resolver inputs, provided by the page. `null` while
+ * auth is loading — resolution is GATED on auth.loading (AuthProvider falls
+ * back to 'viewer' while claims load; resolving then would flash the viewer
+ * surface — spec security invariant 8). `undefined` = caller predates the
+ * resolver; legacy resolution applies.
+ */
+export type ShotListSurfaceContext = {
+  /** normalizeRole(globalClaim) — already normalized by AuthProvider. */
+  readonly role: Role
+  /** Real device, from the existing media hooks (incl. tablet). */
+  readonly device: SurfaceDevice
 }
 
 // ---------------------------------------------------------------------------
@@ -124,8 +150,10 @@ export function useShotListState(params: {
   readonly laneNameById?: ReadonlyMap<string, string>
   readonly laneOrder?: ReadonlyMap<string, number>
   readonly laneById?: ReadonlyMap<string, Lane>
+  /** Phase 4 — see ShotListSurfaceContext. Optional + additive. */
+  readonly surfaceContext?: ShotListSurfaceContext | null
 }): ShotListState {
-  const { shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById } = params
+  const { shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById, surfaceContext } = params
 
   const isMobile = useIsMobile()
   const [searchParams, setSearchParams] = useSearchParams()
@@ -265,8 +293,43 @@ export function useShotListState(params: {
     }
   }, [storageKeyBase])
 
+  // -- Phase 4 (flag-gated): resolveSurface --
+  const surfaceResolverEnabled = isFeatureEnabled("featureSurfaceResolver")
+
+  // The stored EXPLICIT choice (null when never set) — distinct from
+  // storedDefaultView, which collapses "never set" into 'card'. The resolver
+  // needs the distinction so only never-customized users get the new
+  // surface default. Read flag-on only.
+  const storedExplicitView = useMemo((): ViewMode | null => {
+    if (!surfaceResolverEnabled || !storageKeyBase) return null
+    try {
+      const raw = window.localStorage.getItem(`${storageKeyBase}:view:v1`)
+      // Backward compat: "gallery" and "visual" both migrate to "card"
+      if (raw === "card" || raw === "gallery" || raw === "visual") return "card"
+      return raw === "table" ? "table" : null
+    } catch {
+      return null
+    }
+  }, [surfaceResolverEnabled, storageKeyBase])
+
+  // Resolution is a pure derivation — zero setSearchParams / localStorage
+  // writes. Gated on surfaceContext (null while auth loads — no viewer-flash).
+  const resolved = useMemo(() => {
+    if (!surfaceResolverEnabled || !surfaceContext) return null
+    return resolveSurface({
+      effectiveRole: surfaceContext.role,
+      device: surfaceContext.device,
+      urlView: viewParam,
+      urlGroup: groupParam,
+      storedView: storedExplicitView,
+    })
+  }, [surfaceResolverEnabled, surfaceContext, viewParam, groupParam, storedExplicitView])
+
   // -- Derived view/group --
-  const viewMode: ViewMode = isMobile
+  // Legacy (flag-off) resolution. Byte-identical to pre-Phase-4 trunk —
+  // gated, NOT deleted; full retirement happens at featureSurfaceResolver
+  // flag removal (see build-spec §Flag-removal checklist).
+  const legacyViewMode: ViewMode = isMobile
     ? "card"
     : viewParam === "table"
       ? "table"
@@ -275,11 +338,14 @@ export function useShotListState(params: {
         ? "card"
         : storedDefaultView
 
-  const groupKey: GroupKey = isMobile
+  const legacyGroupKey: GroupKey = isMobile
     ? "none"
     : groupParam === "status" || groupParam === "date" || groupParam === "talent" || groupParam === "location" || groupParam === "scene"
       ? groupParam
       : "none"
+
+  const viewMode: ViewMode = resolved ? resolved.viewMode : legacyViewMode
+  const groupKey: GroupKey = resolved ? resolved.groupKey : legacyGroupKey
 
   const isCustomSort = sortKey === "custom"
 
@@ -573,5 +639,7 @@ export function useShotListState(params: {
     displayShots, insights, hasActiveFilters, hasActiveGrouping,
     shotGroups, activeFilterBadges, tagOptions,
     storageKeyBase,
+    surface: resolved?.surface,
+    viewSource: resolved?.viewSource,
   }
 }

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -112,24 +112,14 @@ export type ShotListState = {
   readonly tagOptions: ReadonlyArray<{ readonly id: string; readonly label: string }>
   // Persistence key
   readonly storageKeyBase: string | null
-  // Phase 4 (flag-gated, ADDITIVE-ONLY): resolved surface metadata.
-  // `undefined` whenever featureSurfaceResolver is off, no surfaceContext was
-  // provided, or resolution is gated (auth still loading).
+  // undefined when the resolver flag is off, surfaceContext is absent, or auth is still loading
   readonly surface?: SurfaceKind
   readonly viewSource?: ViewSource
 }
 
-/**
- * Phase 4 (flag-gated) resolver inputs, provided by the page. `null` while
- * auth is loading — resolution is GATED on auth.loading (AuthProvider falls
- * back to 'viewer' while claims load; resolving then would flash the viewer
- * surface — spec security invariant 8). `undefined` = caller predates the
- * resolver; legacy resolution applies.
- */
+/** null while auth loads (viewer-flash guard); undefined = caller predates the resolver. */
 export type ShotListSurfaceContext = {
-  /** normalizeRole(globalClaim) — already normalized by AuthProvider. */
   readonly role: Role
-  /** Real device, from the existing media hooks (incl. tablet). */
   readonly device: SurfaceDevice
 }
 

--- a/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
@@ -5,7 +5,6 @@ import {
   type SurfaceDevice,
   type SurfaceKind,
 } from "../resolveSurface"
-import { SHOT_TABLE_COLUMNS } from "../shotTableColumns"
 import type { ViewMode, GroupKey } from "../shotListFilters"
 import { normalizeRole } from "@/shared/lib/rbac"
 import type { Role } from "@/shared/types"
@@ -204,57 +203,11 @@ describe("resolveSurface — provenance (viewSource)", () => {
   })
 })
 
-describe("resolveSurface — purity + inert slots", () => {
+describe("resolveSurface — purity", () => {
   it("is pure: frozen input is not mutated and equal inputs give equal outputs", () => {
     const frozen = Object.freeze(input({ effectiveRole: "producer", device: "mobile", urlView: "table", urlGroup: "status", storedView: "card" }))
     const a = resolveSurface(frozen)
     const b = resolveSurface(input({ effectiveRole: "producer", device: "mobile", urlView: "table", urlGroup: "status", storedView: "card" }))
     expect(a).toEqual(b)
-  })
-
-  it("columns are INPUTS to useTableColumns only: shared defaults + empty suffix (per-surface keys = Phase 6 question)", () => {
-    for (const role of ROLES) {
-      const out = resolveSurface(input({ effectiveRole: role }))
-      expect(out.columns.defaultColumns).toBe(SHOT_TABLE_COLUMNS)
-      expect(out.columns.storageKeySuffix).toBe("")
-    }
-  })
-
-  it("affordances derive from rbac helpers + real device (typed, drives nothing in Phase 4)", () => {
-    const producerDesktop = resolveSurface(input({ effectiveRole: "producer" })).affordances
-    expect(producerDesktop).toEqual({
-      canCreateShots: true,
-      canReorderShots: true,
-      canBulkPull: true,
-      canShare: true,
-      canManageLanes: true,
-      canExport: true,
-    })
-
-    const viewerDesktop = resolveSurface(input({ effectiveRole: "viewer" })).affordances
-    expect(viewerDesktop).toEqual({
-      canCreateShots: false,
-      canReorderShots: false,
-      canBulkPull: false,
-      canShare: false,
-      canManageLanes: false,
-      // canExport has NO role factor today — ported verbatim, 5e decides.
-      canExport: true,
-    })
-
-    const producerMobile = resolveSurface(input({ effectiveRole: "producer", device: "mobile" })).affordances
-    expect(producerMobile.canBulkPull).toBe(false)
-    expect(producerMobile.canExport).toBe(false)
-
-    // Warehouse KEEPS lane affordances under flag-on — Ted's Q3 revoke
-    // decision is implemented at 5f WITH the rule tightening, not here.
-    expect(resolveSurface(input({ effectiveRole: "warehouse" })).affordances.canManageLanes).toBe(true)
-  })
-
-  it("chrome slot is typed but mirrors today's reality (viewSwitcher gated off-mobile)", () => {
-    const out = resolveSurface(input({ effectiveRole: "crew", device: "mobile" }))
-    expect(out.chrome).toEqual({ toolbar: "full", quickAdd: true, viewSwitcher: false })
-    const desktop = resolveSurface(input({ effectiveRole: "viewer" }))
-    expect(desktop.chrome).toEqual({ toolbar: "full", quickAdd: false, viewSwitcher: true })
   })
 })

--- a/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest"
+import {
+  resolveSurface,
+  type ResolveSurfaceInput,
+  type SurfaceDevice,
+  type SurfaceKind,
+} from "../resolveSurface"
+import { SHOT_TABLE_COLUMNS } from "../shotTableColumns"
+import type { ViewMode, GroupKey } from "../shotListFilters"
+import { normalizeRole } from "@/shared/lib/rbac"
+import type { Role } from "@/shared/types"
+
+// ---------------------------------------------------------------------------
+// resolveSurface unit matrix — Phase 4 build spec §Test plan item 2.
+//
+// Covers every (url × stored × role-default × device) combination, asserts
+// provenance, pins the 'wardrobe' input, and proves flag-off equivalence:
+// the resolver's output is byte-identical to the legacy inline ternaries
+// (useShotListState pre-Phase-4 trunk) for EVERY combination except the one
+// named, accepted behavior change — never-customized plan-build (admin/
+// producer) users default to 'table' instead of 'card' off-mobile.
+// ---------------------------------------------------------------------------
+
+const ROLES: readonly Role[] = ["admin", "producer", "crew", "warehouse", "viewer"]
+const DEVICES: readonly SurfaceDevice[] = ["mobile", "tablet", "desktop"]
+const URL_VIEWS: readonly (string | null)[] = [null, "table", "card", "gallery", "visual", "bogus", ""]
+const URL_GROUPS: readonly (string | null)[] = [null, "status", "date", "talent", "location", "scene", "bogus", ""]
+/** RAW localStorage `:view:v1` values, as the hook would read them. */
+const STORED_RAW: readonly (string | null)[] = [null, "card", "table", "gallery", "visual", "junk"]
+
+const EXPECTED_SURFACE: Record<Role, SurfaceKind> = {
+  admin: "plan-build",
+  producer: "plan-build",
+  crew: "shoot",
+  warehouse: "review-warehouse",
+  viewer: "review-client",
+}
+
+/**
+ * Mirror of the hook's storedExplicitView mapping (raw localStorage value →
+ * the resolver's `storedView` input). gallery/visual are legacy values that
+ * migrated to card; anything else was never an explicit choice.
+ */
+function parseStoredRaw(raw: string | null): ViewMode | null {
+  if (raw === "card" || raw === "gallery" || raw === "visual") return "card"
+  return raw === "table" ? "table" : null
+}
+
+// ---------------------------------------------------------------------------
+// Independent legacy oracle — a restatement of the pre-Phase-4 inline
+// ternaries (useShotListState.ts:269-282 on trunk), NOT of resolveSurface.
+// ---------------------------------------------------------------------------
+
+function legacyViewMode(urlView: string | null, storedRaw: string | null, isMobile: boolean): ViewMode {
+  const storedDefaultView: ViewMode =
+    storedRaw === "gallery" || storedRaw === "visual"
+      ? "card"
+      : storedRaw === "table"
+        ? "table"
+        : "card"
+  return isMobile
+    ? "card"
+    : urlView === "table"
+      ? "table"
+      : urlView === "card" || urlView === "gallery" || urlView === "visual"
+        ? "card"
+        : storedDefaultView
+}
+
+function legacyGroupKey(urlGroup: string | null, isMobile: boolean): GroupKey {
+  return isMobile
+    ? "none"
+    : urlGroup === "status" || urlGroup === "date" || urlGroup === "talent" || urlGroup === "location" || urlGroup === "scene"
+      ? (urlGroup as GroupKey)
+      : "none"
+}
+
+function input(overrides: Partial<ResolveSurfaceInput>): ResolveSurfaceInput {
+  return {
+    effectiveRole: "viewer",
+    device: "desktop",
+    urlView: null,
+    urlGroup: null,
+    storedView: null,
+    ...overrides,
+  }
+}
+
+describe("resolveSurface — role → surface mapping", () => {
+  it.each(ROLES)("maps %s to its surface", (role) => {
+    expect(resolveSurface(input({ effectiveRole: role })).surface).toBe(EXPECTED_SURFACE[role])
+  })
+
+  it("pins the 'wardrobe' input: normalizeRole('wardrobe') feeds warehouse → review-warehouse", () => {
+    const role = normalizeRole("wardrobe")
+    expect(role).toBe("warehouse")
+    const out = resolveSurface(input({ effectiveRole: role }))
+    expect(out.surface).toBe("review-warehouse")
+    // ...NOT the viewer surface the old alias ('wardrobe'→'viewer') landed on.
+    expect(out.surface).not.toBe("review-client")
+  })
+})
+
+describe("resolveSurface — full (url × stored × role-default × device) viewMode matrix", () => {
+  for (const role of ROLES) {
+    for (const device of DEVICES) {
+      for (const urlView of URL_VIEWS) {
+        for (const storedRaw of STORED_RAW) {
+          const isMobile = device === "mobile"
+          const storedView = parseStoredRaw(storedRaw)
+          const legacy = legacyViewMode(urlView, storedRaw, isMobile)
+          const isPlanBuild = role === "admin" || role === "producer"
+          const neverCustomized = parseStoredRaw(storedRaw) === null
+          const urlInert = urlView !== "table" && urlView !== "card" && urlView !== "gallery" && urlView !== "visual"
+          // The ONLY accepted delta vs legacy: never-customized plan-build
+          // users (no valid URL view, no stored choice) get table off-mobile.
+          const expected: ViewMode =
+            isPlanBuild && neverCustomized && urlInert && !isMobile ? "table" : legacy
+
+          it(`role=${role} device=${device} url=${String(urlView)} stored=${String(storedRaw)} → ${expected}`, () => {
+            const out = resolveSurface(input({ effectiveRole: role, device, urlView, storedView }))
+            expect(out.viewMode).toBe(expected)
+            // Flag-off equivalence for non-plan-build roles: byte-identical
+            // to the legacy ternaries in EVERY combination.
+            if (!isPlanBuild) expect(out.viewMode).toBe(legacy)
+          })
+        }
+      }
+    }
+  }
+})
+
+describe("resolveSurface — groupKey matrix (URL-only persistence, mobile forcing)", () => {
+  for (const device of DEVICES) {
+    for (const urlGroup of URL_GROUPS) {
+      const isMobile = device === "mobile"
+      const expected = legacyGroupKey(urlGroup, isMobile)
+      it(`device=${device} group=${String(urlGroup)} → ${expected} (legacy-equivalent for every role)`, () => {
+        for (const role of ROLES) {
+          expect(resolveSurface(input({ effectiveRole: role, device, urlGroup })).groupKey).toBe(expected)
+        }
+      })
+    }
+  }
+})
+
+describe("resolveSurface — provenance (viewSource)", () => {
+  it("'url' when a valid ?view param wins (beats stored)", () => {
+    const out = resolveSurface(input({ effectiveRole: "producer", urlView: "card", storedView: "table" }))
+    expect(out.viewMode).toBe("card")
+    expect(out.viewSource).toBe("url")
+  })
+
+  it("legacy URL aliases gallery/visual resolve as 'url' provenance card", () => {
+    for (const alias of ["gallery", "visual"]) {
+      const out = resolveSurface(input({ effectiveRole: "producer", urlView: alias }))
+      expect(out.viewMode).toBe("card")
+      expect(out.viewSource).toBe("url")
+    }
+  })
+
+  it("'stored' when no URL param but an explicit prior choice exists", () => {
+    const out = resolveSurface(input({ effectiveRole: "producer", storedView: "card" }))
+    expect(out.viewMode).toBe("card") // producers who chose cards KEEP cards
+    expect(out.viewSource).toBe("stored")
+  })
+
+  it("'surface-default' when neither URL nor stored choice exists", () => {
+    const producer = resolveSurface(input({ effectiveRole: "producer" }))
+    expect(producer.viewMode).toBe("table")
+    expect(producer.viewSource).toBe("surface-default")
+    const crew = resolveSurface(input({ effectiveRole: "crew" }))
+    expect(crew.viewMode).toBe("card")
+    expect(crew.viewSource).toBe("surface-default")
+  })
+
+  it("invalid ?view falls through to stored, then surface default", () => {
+    expect(resolveSurface(input({ effectiveRole: "viewer", urlView: "bogus", storedView: "table" })).viewSource).toBe("stored")
+    expect(resolveSurface(input({ effectiveRole: "viewer", urlView: "bogus" })).viewSource).toBe("surface-default")
+  })
+
+  it("'device-forced' when mobile forcing changes the outcome (view and/or group)", () => {
+    const view = resolveSurface(input({ effectiveRole: "producer", device: "mobile", urlView: "table" }))
+    expect(view.viewMode).toBe("card")
+    expect(view.viewSource).toBe("device-forced")
+
+    const group = resolveSurface(input({ effectiveRole: "viewer", device: "mobile", urlView: "card", urlGroup: "status" }))
+    expect(group.groupKey).toBe("none")
+    expect(group.viewSource).toBe("device-forced")
+  })
+
+  it("mobile keeps the underlying provenance when forcing changes nothing", () => {
+    const out = resolveSurface(input({ effectiveRole: "viewer", device: "mobile", urlView: "card" }))
+    expect(out.viewMode).toBe("card")
+    expect(out.groupKey).toBe("none")
+    expect(out.viewSource).toBe("url")
+  })
+
+  it("tablet is NOT forced — resolves like desktop", () => {
+    const out = resolveSurface(input({ effectiveRole: "producer", device: "tablet", urlView: "table", urlGroup: "status" }))
+    expect(out.viewMode).toBe("table")
+    expect(out.groupKey).toBe("status")
+    expect(out.viewSource).toBe("url")
+  })
+})
+
+describe("resolveSurface — purity + inert slots", () => {
+  it("is pure: frozen input is not mutated and equal inputs give equal outputs", () => {
+    const frozen = Object.freeze(input({ effectiveRole: "producer", device: "mobile", urlView: "table", urlGroup: "status", storedView: "card" }))
+    const a = resolveSurface(frozen)
+    const b = resolveSurface(input({ effectiveRole: "producer", device: "mobile", urlView: "table", urlGroup: "status", storedView: "card" }))
+    expect(a).toEqual(b)
+  })
+
+  it("columns are INPUTS to useTableColumns only: shared defaults + empty suffix (per-surface keys = Phase 6 question)", () => {
+    for (const role of ROLES) {
+      const out = resolveSurface(input({ effectiveRole: role }))
+      expect(out.columns.defaultColumns).toBe(SHOT_TABLE_COLUMNS)
+      expect(out.columns.storageKeySuffix).toBe("")
+    }
+  })
+
+  it("affordances derive from rbac helpers + real device (typed, drives nothing in Phase 4)", () => {
+    const producerDesktop = resolveSurface(input({ effectiveRole: "producer" })).affordances
+    expect(producerDesktop).toEqual({
+      canCreateShots: true,
+      canReorderShots: true,
+      canBulkPull: true,
+      canShare: true,
+      canManageLanes: true,
+      canExport: true,
+    })
+
+    const viewerDesktop = resolveSurface(input({ effectiveRole: "viewer" })).affordances
+    expect(viewerDesktop).toEqual({
+      canCreateShots: false,
+      canReorderShots: false,
+      canBulkPull: false,
+      canShare: false,
+      canManageLanes: false,
+      // canExport has NO role factor today — ported verbatim, 5e decides.
+      canExport: true,
+    })
+
+    const producerMobile = resolveSurface(input({ effectiveRole: "producer", device: "mobile" })).affordances
+    expect(producerMobile.canBulkPull).toBe(false)
+    expect(producerMobile.canExport).toBe(false)
+
+    // Warehouse KEEPS lane affordances under flag-on — Ted's Q3 revoke
+    // decision is implemented at 5f WITH the rule tightening, not here.
+    expect(resolveSurface(input({ effectiveRole: "warehouse" })).affordances.canManageLanes).toBe(true)
+  })
+
+  it("chrome slot is typed but mirrors today's reality (viewSwitcher gated off-mobile)", () => {
+    const out = resolveSurface(input({ effectiveRole: "crew", device: "mobile" }))
+    expect(out.chrome).toEqual({ toolbar: "full", quickAdd: true, viewSwitcher: false })
+    const desktop = resolveSurface(input({ effectiveRole: "viewer" }))
+    expect(desktop.chrome).toEqual({ toolbar: "full", quickAdd: false, viewSwitcher: true })
+  })
+})

--- a/src-vnext/features/shots/lib/resolveSurface.ts
+++ b/src-vnext/features/shots/lib/resolveSurface.ts
@@ -1,0 +1,211 @@
+import type { Role } from "@/shared/types"
+import type { TableColumnConfig } from "@/shared/types/table"
+import type { ViewMode, GroupKey } from "@/features/shots/lib/shotListFilters"
+import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
+import {
+  canGeneratePulls,
+  canManagePulls,
+  canManageProjects,
+  canManageShots,
+} from "@/shared/lib/rbac"
+
+// ---------------------------------------------------------------------------
+// resolveSurface — Phase 4 (build spec 2026-06-09, §The API).
+//
+// PURE function. No hook, no hidden reads (auth / URL / localStorage / media
+// queries), no writes. Every input is explicit so the resolution is fully
+// testable as a (role × device × url × stored) matrix.
+//
+// `effectiveRole` is OPAQUE to this module — it is already resolved by the
+// caller. Phase 4 feeds `normalizeRole(globalClaim)` (via AuthProvider).
+// Phase 5b upgrades the SOURCE to a live members-doc read (Ted, 2026-06-09 —
+// Q5/Q6: project wins, admin excepted) without touching this signature.
+// That injection point is also the typed PREVIEW SLOT: a future View-as
+// control (deferred to 4b/5e) feeds a simulated role here — presentation
+// only, never into can*/write handlers.
+//
+// Security invariants (spec §Security):
+// - Output is presentation-only BY CONSTRUCTION. No write handler may consume
+//   it. `affordances` derive ONLY from existing rbac.ts helpers + the REAL
+//   device, and drive nothing in Phase 4 (typed slot for 5e/5f).
+// - Zero URL writes: resolution is a derivation. Mobile forcing is
+//   override-without-erase — latent ?view/?group params are never erased.
+// - Do NOT import or call rbac.ts `resolveEffectiveRole` (quarantined → 5b).
+// ---------------------------------------------------------------------------
+
+export type SurfaceDevice = "mobile" | "tablet" | "desktop"
+
+/**
+ * Distinct review variants NOW: Phase 5f splits client vs warehouse review;
+ * a single 'review' enum value would force a breaking change later.
+ */
+export type SurfaceKind = "plan-build" | "shoot" | "review-client" | "review-warehouse"
+
+/** Provenance of the resolved viewMode/groupKey — testability hook. */
+export type ViewSource = "url" | "stored" | "surface-default" | "device-forced"
+
+/**
+ * Capability-shaped presentation hints. Derived ONLY from existing rbac.ts
+ * helpers + the real device. Typed but DRIVES NOTHING in Phase 4 — the
+ * `role && !isMobile` capability flags in ShotListPage stay the owners until
+ * 5e. All fields are required booleans (never optional-default-true; see
+ * spec invariant 6 re: the ShotsTable `canManageLanes = true` fail-open).
+ */
+export interface SurfaceAffordances {
+  readonly canCreateShots: boolean
+  readonly canReorderShots: boolean
+  readonly canBulkPull: boolean
+  readonly canShare: boolean
+  /** Lane/scene writes — admin|producer|warehouse, matching the /lanes rule. */
+  readonly canManageLanes: boolean
+  /**
+   * Ported verbatim from ShotListPage: canExport has NO role factor today
+   * (device-only). Flagged to Ted — 5e decides whether a role gate is added.
+   */
+  readonly canExport: boolean
+}
+
+/** Typed chrome slot — drives nothing in Phase 4 (consumed at 5e/5f). */
+export interface SurfaceChrome {
+  readonly toolbar: "full" | "minimal" | "none"
+  readonly quickAdd: boolean
+  readonly viewSwitcher: boolean
+}
+
+/**
+ * INPUTS to useTableColumns ONLY — never resolved visible/width/order.
+ * useTableColumns stays the sole owner of column state. Phase 4 outputs the
+ * single shared default set + an empty suffix; the single-key vs
+ * per-surface-key question is Phase 6's entry decision.
+ */
+export interface SurfaceColumns {
+  readonly defaultColumns: readonly TableColumnConfig[]
+  readonly storageKeySuffix: string
+}
+
+export interface ResolveSurfaceInput {
+  /** Already-resolved role. Opaque — see header comment (5b upgrades source). */
+  readonly effectiveRole: Role
+  /** Real device. Three-valued — a boolean would break 5e (tablet chrome). */
+  readonly device: SurfaceDevice
+  /** Raw `view` URL param (unvalidated). */
+  readonly urlView: string | null
+  /** Raw `group` URL param (unvalidated). */
+  readonly urlGroup: string | null
+  /** Prior EXPLICIT choice from localStorage `:view:v1`, null if never set. */
+  readonly storedView: ViewMode | null
+}
+
+export interface ResolvedSurface {
+  readonly surface: SurfaceKind
+  readonly viewMode: ViewMode
+  readonly groupKey: GroupKey
+  readonly viewSource: ViewSource
+  readonly columns: SurfaceColumns
+  readonly affordances: SurfaceAffordances
+  readonly chrome: SurfaceChrome
+}
+
+// ---------------------------------------------------------------------------
+// Role → surface mapping (the "job" each role lands on)
+// ---------------------------------------------------------------------------
+
+const SURFACE_BY_ROLE: Record<Role, SurfaceKind> = {
+  admin: "plan-build",
+  producer: "plan-build",
+  crew: "shoot",
+  warehouse: "review-warehouse",
+  viewer: "review-client",
+}
+
+/**
+ * Surface default viewMode (the lowest-precedence rung). Only plan-build
+ * changes today's hard default ('card'): producers/admins who never
+ * customized get the table; everyone else resolves byte-identical to the
+ * legacy ternaries — flag-on is VISUALLY INERT for crew/warehouse/viewer.
+ */
+const DEFAULT_VIEW_BY_SURFACE: Record<SurfaceKind, ViewMode> = {
+  "plan-build": "table",
+  shoot: "card",
+  "review-client": "card",
+  "review-warehouse": "card",
+}
+
+// ---------------------------------------------------------------------------
+// Param validation (mirrors the legacy inline ternaries in useShotListState)
+// ---------------------------------------------------------------------------
+
+function parseUrlView(urlView: string | null): ViewMode | null {
+  if (urlView === "table") return "table"
+  // Backward compat: "gallery" and "visual" URL params map to "card"
+  if (urlView === "card" || urlView === "gallery" || urlView === "visual") return "card"
+  return null
+}
+
+function parseUrlGroup(urlGroup: string | null): GroupKey {
+  return urlGroup === "status" ||
+    urlGroup === "date" ||
+    urlGroup === "talent" ||
+    urlGroup === "location" ||
+    urlGroup === "scene"
+    ? urlGroup
+    : "none"
+}
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+/**
+ * Precedence (pinned, spec §Resolution precedence):
+ *   URL param > stored explicit choice > surface/role default
+ * with device forcing (mobile → card/none) applied LAST as a NON-DESTRUCTIVE
+ * derivation: latent ?view=table&group=status survive untouched and restore
+ * on resize across 768px. groupKey keeps URL-only persistence.
+ */
+export function resolveSurface(input: ResolveSurfaceInput): ResolvedSurface {
+  const { effectiveRole, device, urlView, urlGroup, storedView } = input
+
+  const surface = SURFACE_BY_ROLE[effectiveRole]
+
+  const urlViewMode = parseUrlView(urlView)
+  const preForcingView: ViewMode =
+    urlViewMode ?? storedView ?? DEFAULT_VIEW_BY_SURFACE[surface]
+  const preForcingSource: ViewSource =
+    urlViewMode !== null ? "url" : storedView !== null ? "stored" : "surface-default"
+  const preForcingGroup: GroupKey = parseUrlGroup(urlGroup)
+
+  // Device forcing — applied last, non-destructively. Provenance flips to
+  // 'device-forced' only when forcing actually changed the outcome.
+  const isMobile = device === "mobile"
+  const forcingChangedOutcome =
+    isMobile && (preForcingView !== "card" || preForcingGroup !== "none")
+
+  const viewMode: ViewMode = isMobile ? "card" : preForcingView
+  const groupKey: GroupKey = isMobile ? "none" : preForcingGroup
+  const viewSource: ViewSource = forcingChangedOutcome ? "device-forced" : preForcingSource
+
+  return {
+    surface,
+    viewMode,
+    groupKey,
+    viewSource,
+    columns: {
+      defaultColumns: SHOT_TABLE_COLUMNS,
+      storageKeySuffix: "",
+    },
+    affordances: {
+      canCreateShots: canManageShots(effectiveRole),
+      canReorderShots: canManageShots(effectiveRole),
+      canBulkPull: canGeneratePulls(effectiveRole) && device !== "mobile",
+      canShare: canManageProjects(effectiveRole),
+      canManageLanes: canManagePulls(effectiveRole),
+      canExport: device !== "mobile",
+    },
+    chrome: {
+      toolbar: "full",
+      quickAdd: canManageShots(effectiveRole),
+      viewSwitcher: device !== "mobile",
+    },
+  }
+}

--- a/src-vnext/features/shots/lib/resolveSurface.ts
+++ b/src-vnext/features/shots/lib/resolveSurface.ts
@@ -9,59 +9,26 @@ import {
   canManageShots,
 } from "@/shared/lib/rbac"
 
-// ---------------------------------------------------------------------------
-// resolveSurface — Phase 4 (build spec 2026-06-09, §The API).
-//
-// PURE function. No hook, no hidden reads (auth / URL / localStorage / media
-// queries), no writes. Every input is explicit so the resolution is fully
-// testable as a (role × device × url × stored) matrix.
-//
-// `effectiveRole` is OPAQUE to this module — it is already resolved by the
-// caller. Phase 4 feeds `normalizeRole(globalClaim)` (via AuthProvider).
-// Phase 5b upgrades the SOURCE to a live members-doc read (Ted, 2026-06-09 —
-// Q5/Q6: project wins, admin excepted) without touching this signature.
-// That injection point is also the typed PREVIEW SLOT: a future View-as
-// control (deferred to 4b/5e) feeds a simulated role here — presentation
-// only, never into can*/write handlers.
-//
-// Security invariants (spec §Security):
-// - Output is presentation-only BY CONSTRUCTION. No write handler may consume
-//   it. `affordances` derive ONLY from existing rbac.ts helpers + the REAL
-//   device, and drive nothing in Phase 4 (typed slot for 5e/5f).
-// - Zero URL writes: resolution is a derivation. Mobile forcing is
-//   override-without-erase — latent ?view/?group params are never erased.
-// - Do NOT import or call rbac.ts `resolveEffectiveRole` (quarantined → 5b).
-// ---------------------------------------------------------------------------
+// PURE function, all inputs explicit — output is presentation-only by construction; no write
+// handler may consume it. `effectiveRole` is the typed preview slot: callers pass an already-
+// resolved role (5b upgrades the source; a future View-as feeds a simulated role here).
 
 export type SurfaceDevice = "mobile" | "tablet" | "desktop"
 
-/**
- * Distinct review variants NOW: Phase 5f splits client vs warehouse review;
- * a single 'review' enum value would force a breaking change later.
- */
+/** Distinct review variants now — 5f splits client vs warehouse without an enum break. */
 export type SurfaceKind = "plan-build" | "shoot" | "review-client" | "review-warehouse"
 
-/** Provenance of the resolved viewMode/groupKey — testability hook. */
+/** Provenance of the resolved viewMode/groupKey. */
 export type ViewSource = "url" | "stored" | "surface-default" | "device-forced"
 
-/**
- * Capability-shaped presentation hints. Derived ONLY from existing rbac.ts
- * helpers + the real device. Typed but DRIVES NOTHING in Phase 4 — the
- * `role && !isMobile` capability flags in ShotListPage stay the owners until
- * 5e. All fields are required booleans (never optional-default-true; see
- * spec invariant 6 re: the ShotsTable `canManageLanes = true` fail-open).
- */
+/** Derived only from rbac helpers + the REAL device; drives nothing until 5e. */
 export interface SurfaceAffordances {
   readonly canCreateShots: boolean
   readonly canReorderShots: boolean
   readonly canBulkPull: boolean
   readonly canShare: boolean
-  /** Lane/scene writes — admin|producer|warehouse, matching the /lanes rule. */
   readonly canManageLanes: boolean
-  /**
-   * Ported verbatim from ShotListPage: canExport has NO role factor today
-   * (device-only). Flagged to Ted — 5e decides whether a role gate is added.
-   */
+  // canExport has no role factor today (device-only, ported verbatim) — 5e decides
   readonly canExport: boolean
 }
 

--- a/src-vnext/features/shots/lib/resolveSurface.ts
+++ b/src-vnext/features/shots/lib/resolveSurface.ts
@@ -1,13 +1,5 @@
 import type { Role } from "@/shared/types"
-import type { TableColumnConfig } from "@/shared/types/table"
 import type { ViewMode, GroupKey } from "@/features/shots/lib/shotListFilters"
-import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
-import {
-  canGeneratePulls,
-  canManagePulls,
-  canManageProjects,
-  canManageShots,
-} from "@/shared/lib/rbac"
 
 // PURE function, all inputs explicit — output is presentation-only by construction; no write
 // handler may consume it. `effectiveRole` is the typed preview slot: callers pass an already-
@@ -21,34 +13,8 @@ export type SurfaceKind = "plan-build" | "shoot" | "review-client" | "review-war
 /** Provenance of the resolved viewMode/groupKey. */
 export type ViewSource = "url" | "stored" | "surface-default" | "device-forced"
 
-/** Derived only from rbac helpers + the REAL device; drives nothing until 5e. */
-export interface SurfaceAffordances {
-  readonly canCreateShots: boolean
-  readonly canReorderShots: boolean
-  readonly canBulkPull: boolean
-  readonly canShare: boolean
-  readonly canManageLanes: boolean
-  // canExport has no role factor today (device-only, ported verbatim) — 5e decides
-  readonly canExport: boolean
-}
-
-/** Typed chrome slot — drives nothing in Phase 4 (consumed at 5e/5f). */
-export interface SurfaceChrome {
-  readonly toolbar: "full" | "minimal" | "none"
-  readonly quickAdd: boolean
-  readonly viewSwitcher: boolean
-}
-
-/**
- * INPUTS to useTableColumns ONLY — never resolved visible/width/order.
- * useTableColumns stays the sole owner of column state. Phase 4 outputs the
- * single shared default set + an empty suffix; the single-key vs
- * per-surface-key question is Phase 6's entry decision.
- */
-export interface SurfaceColumns {
-  readonly defaultColumns: readonly TableColumnConfig[]
-  readonly storageKeySuffix: string
-}
+// affordances / chrome / columns deliberately absent: nothing consumes them in Phase 4
+// (CLAUDE.md no-stubs rule); 5e/5f/6 add each slot when its first consumer lands.
 
 export interface ResolveSurfaceInput {
   /** Already-resolved role. Opaque — see header comment (5b upgrades source). */
@@ -68,9 +34,6 @@ export interface ResolvedSurface {
   readonly viewMode: ViewMode
   readonly groupKey: GroupKey
   readonly viewSource: ViewSource
-  readonly columns: SurfaceColumns
-  readonly affordances: SurfaceAffordances
-  readonly chrome: SurfaceChrome
 }
 
 // ---------------------------------------------------------------------------
@@ -152,27 +115,5 @@ export function resolveSurface(input: ResolveSurfaceInput): ResolvedSurface {
   const groupKey: GroupKey = isMobile ? "none" : preForcingGroup
   const viewSource: ViewSource = forcingChangedOutcome ? "device-forced" : preForcingSource
 
-  return {
-    surface,
-    viewMode,
-    groupKey,
-    viewSource,
-    columns: {
-      defaultColumns: SHOT_TABLE_COLUMNS,
-      storageKeySuffix: "",
-    },
-    affordances: {
-      canCreateShots: canManageShots(effectiveRole),
-      canReorderShots: canManageShots(effectiveRole),
-      canBulkPull: canGeneratePulls(effectiveRole) && device !== "mobile",
-      canShare: canManageProjects(effectiveRole),
-      canManageLanes: canManagePulls(effectiveRole),
-      canExport: device !== "mobile",
-    },
-    chrome: {
-      toolbar: "full",
-      quickAdd: canManageShots(effectiveRole),
-      viewSwitcher: device !== "mobile",
-    },
-  }
+  return { surface, viewMode, groupKey, viewSource }
 }

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import { getFeatureFlags, isFeatureEnabled } from "../flags"
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
 
 describe("feature flags", () => {
   it("defaults featurePublishing to false (Phase 3 is dark on main)", () => {
@@ -8,5 +12,28 @@ describe("feature flags", () => {
 
   it("isFeatureEnabled returns the flag value", () => {
     expect(isFeatureEnabled("featurePublishing")).toBe(false)
+  })
+
+  it("defaults featureSurfaceResolver to false (Phase 4 is dark on main; CI build env never defines VITE_SURFACE_RESOLVER)", () => {
+    expect(getFeatureFlags().featureSurfaceResolver).toBe(false)
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
+  })
+
+  it("VITE_SURFACE_RESOLVER='1' or 'true' enables featureSurfaceResolver (LoginPage env-parse precedent)", () => {
+    vi.stubEnv("VITE_SURFACE_RESOLVER", "1")
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
+
+    vi.stubEnv("VITE_SURFACE_RESOLVER", "true")
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
+
+    vi.stubEnv("VITE_SURFACE_RESOLVER", "TRUE")
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
+  })
+
+  it("any other VITE_SURFACE_RESOLVER value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_SURFACE_RESOLVER", value)
+      expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
+    }
   })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -14,10 +14,26 @@
 export interface FeatureFlags {
   /** Phase 3 — Publishing & Crew Delivery Loop. See plan §10. */
   readonly featurePublishing: boolean
+  /**
+   * Phase 4 — resolveSurface job-default resolution in useShotListState.
+   * Default OFF (flag-off path is byte-identical to pre-Phase-4 trunk).
+   * Enabled ONLY via `VITE_SURFACE_RESOLVER=1` (or `true`) at build/dev time
+   * (LoginPage VITE_USE_FIREBASE_EMULATORS precedent) — e.g. the :5174
+   * eyeball runs `VITE_SURFACE_RESOLVER=1 npm run dev -- --port 5174`.
+   * CI build env must never define it. No URL/localStorage override layer.
+   */
+  readonly featureSurfaceResolver: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   featurePublishing: false,
+  featureSurfaceResolver: false,
+}
+
+/** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
+function parseEnvFlag(raw: unknown): boolean {
+  const value = (raw ?? "").toString().toLowerCase()
+  return value === "1" || value === "true"
 }
 
 /**
@@ -29,7 +45,12 @@ const DEFAULT_FLAGS: FeatureFlags = {
  * so the override plumbing can be threaded through without a type-break.
  */
 export function getFeatureFlags(): FeatureFlags {
-  return DEFAULT_FLAGS
+  return {
+    ...DEFAULT_FLAGS,
+    featureSurfaceResolver:
+      DEFAULT_FLAGS.featureSurfaceResolver ||
+      parseEnvFlag(import.meta.env.VITE_SURFACE_RESOLVER),
+  }
 }
 
 /**

--- a/src-vnext/shared/lib/rbac.test.ts
+++ b/src-vnext/shared/lib/rbac.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect } from "vitest"
 import {
   ROLE,
   normalizeRole,
-  resolveEffectiveRole,
   roleLabel,
   canManageProjects,
   canManageShots,
@@ -43,28 +42,6 @@ describe("normalizeRole", () => {
     expect(normalizeRole(undefined)).toBe("viewer")
     expect(normalizeRole(42)).toBe("viewer")
     expect(normalizeRole({})).toBe("viewer")
-  })
-})
-
-describe("resolveEffectiveRole", () => {
-  it("uses project-scoped role when available", () => {
-    expect(
-      resolveEffectiveRole("viewer", { "proj-1": "admin" }, "proj-1"),
-    ).toBe("admin")
-  })
-
-  it("falls back to global role when no project role", () => {
-    expect(
-      resolveEffectiveRole("producer", { "proj-1": "admin" }, "proj-2"),
-    ).toBe("producer")
-  })
-
-  it("falls back to global when no projectRoles", () => {
-    expect(resolveEffectiveRole("crew")).toBe("crew")
-  })
-
-  it("falls back to viewer when no roles at all", () => {
-    expect(resolveEffectiveRole(undefined)).toBe("viewer")
   })
 })
 

--- a/src-vnext/shared/lib/rbac.test.ts
+++ b/src-vnext/shared/lib/rbac.test.ts
@@ -30,6 +30,12 @@ describe("normalizeRole", () => {
     expect(normalizeRole("  Crew  ")).toBe("crew")
   })
 
+  it("adopts the legacy 'wardrobe' alias as warehouse (matches firestore.rules normalizedRole)", () => {
+    expect(normalizeRole("wardrobe")).toBe("warehouse")
+    expect(normalizeRole("Wardrobe")).toBe("warehouse")
+    expect(normalizeRole("  WARDROBE  ")).toBe("warehouse")
+  })
+
   it("returns viewer for unknown roles", () => {
     expect(normalizeRole("unknown")).toBe("viewer")
     expect(normalizeRole("")).toBe("viewer")

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -11,6 +11,10 @@ export const ROLE = {
 export function normalizeRole(role: unknown): Role {
   if (typeof role !== "string") return ROLE.VIEWER
   const lower = role.trim().toLowerCase()
+  // Legacy alias: firestore.rules (normalizedRole, :43-56) maps 'wardrobe' →
+  // warehouse. Mirror it here so legacy-wardrobe users land on the same JOB
+  // the rules grant writes for (Phase 4 spec, security invariant 5).
+  if (lower === "wardrobe") return ROLE.WAREHOUSE
   if (
     lower === ROLE.ADMIN ||
     lower === ROLE.PRODUCER ||
@@ -23,6 +27,16 @@ export function normalizeRole(role: unknown): Role {
   return ROLE.VIEWER
 }
 
+/**
+ * QUARANTINED — dead function; do NOT consume or extend (Phase 5b / Q5).
+ *
+ * No production call site. Its claims-map signature (projectRoles record off
+ * the auth token) would ossify the effective-role source, and Ted decided
+ * Q5 differently on 2026-06-09: the effective role comes from a LIVE project
+ * members read at 5b (Q6: project role wins, admin excepted). Phase 4's
+ * resolveSurface deliberately takes an opaque, already-resolved `effectiveRole`
+ * instead of this. Retire or rewrite this at 5b.
+ */
 export function resolveEffectiveRole(
   globalRole: unknown,
   projectRoles?: Record<string, unknown>,

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -27,7 +27,6 @@ export function normalizeRole(role: unknown): Role {
   return ROLE.VIEWER
 }
 
-// resolveEffectiveRole was deleted 2026-06-09 (dead code) — 5b rebuilds it on a live members read
 export function roleLabel(role: Role): string {
   switch (role) {
     case ROLE.ADMIN:

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -27,30 +27,7 @@ export function normalizeRole(role: unknown): Role {
   return ROLE.VIEWER
 }
 
-/**
- * QUARANTINED — dead function; do NOT consume or extend (Phase 5b / Q5).
- *
- * No production call site. Its claims-map signature (projectRoles record off
- * the auth token) would ossify the effective-role source, and Ted decided
- * Q5 differently on 2026-06-09: the effective role comes from a LIVE project
- * members read at 5b (Q6: project role wins, admin excepted). Phase 4's
- * resolveSurface deliberately takes an opaque, already-resolved `effectiveRole`
- * instead of this. Retire or rewrite this at 5b.
- */
-export function resolveEffectiveRole(
-  globalRole: unknown,
-  projectRoles?: Record<string, unknown>,
-  projectId?: string | null,
-): Role {
-  if (projectId && projectRoles) {
-    const projectRole = projectRoles[projectId]
-    if (typeof projectRole === "string" && projectRole.trim().length > 0) {
-      return normalizeRole(projectRole)
-    }
-  }
-  return normalizeRole(globalRole)
-}
-
+// resolveEffectiveRole was deleted 2026-06-09 (dead code) — 5b rebuilds it on a live members read
 export function roleLabel(role: Role): string {
   switch (role) {
     case ROLE.ADMIN:

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -95,7 +95,13 @@ export const test = base.extend<AuthFixtures>({
     await buildRoleFixture(browser, 'producer', use);
   },
 
-  /** Wardrobe — can manage products and view/edit shots. */
+  /**
+   * Wardrobe — LEGACY ALIAS claim (role='wardrobe'). Both firestore.rules
+   * (normalizedRole) and the client's rbac.ts normalizeRole map it to
+   * WAREHOUSE (Phase 4 aligned the client to the rules; it previously fell
+   * through to viewer). Read-only on shots/products; granted NO project
+   * members doc by the seed, so it exercises the non-member path.
+   */
   wardrobePage: async ({ browser }, use) => {
     await buildRoleFixture(browser, 'wardrobe', use);
   },

--- a/tests/role-matrix.spec.ts
+++ b/tests/role-matrix.spec.ts
@@ -1,6 +1,8 @@
 import { test, expect } from './fixtures/auth';
 import { SEED_PROJECT_ID, SEED_SHOT_AURORA } from './helpers/seedConstants';
 
+const SHOTS_URL = `/projects/${SEED_PROJECT_ID}/shots`;
+
 /**
  * Role-matrix E2E — NON-MEMBER lanes crash carve-out (Phase 2).
  *
@@ -74,5 +76,243 @@ test.describe('Shot detail — non-member (global crew, no project membership)',
     await expect(
       crewPage.getByTestId('scene-context-banner'),
     ).toHaveCount(0);
+  });
+});
+
+/**
+ * Phase 4 — flag-off NO-CHANGE assertions (build spec §Test plan item 4).
+ *
+ * `featureSurfaceResolver` is enabled ONLY via `VITE_SURFACE_RESOLVER=1` at
+ * build/dev time, and the CI build env never defines it — so this suite runs
+ * against the FLAG-OFF path and pins the pre-Phase-4 trunk behavior that the
+ * resolver must not change while the flag is off:
+ *
+ *   (a) producer default view stays CARD for never-customized users (the
+ *       flag-on resolver defaults producers to table — that flip is a named,
+ *       accepted behavior change AT FLAG REMOVAL, not before);
+ *   (b) mount performs ZERO URL writes (no view/group params materialize);
+ *   (c) mobile forcing is override-without-erase: a 390px viewport forces the
+ *       card list and hides the view toggle WITHOUT erasing latent
+ *       `?view=table&group=status`, and resizing across 768px (live
+ *       matchMedia) restores them;
+ *   (d) read-only roles keep their read-only list chrome (no "New Shot"),
+ *       and crew KEEPS its existing "New Shot" affordance
+ *       (canManageShots(crew)=true today — flag-off must not revoke it);
+ *   (e) a deep-linked `?view=table&group=status` survives a RELOAD unchanged
+ *       (URL is the source of truth; resolution adds/removes nothing) — pinned
+ *       for producer, crew, and viewer.
+ *
+ * The mobile case uses a PER-TEST viewport override — the auth fixtures pin
+ * 1280×720 (tests/fixtures/auth.ts), so `setViewportSize` inside the test is
+ * the supported way to get a mobile viewport without touching the fixture.
+ *
+ * Seed note: NO seed changes here. Crew intentionally remains a project
+ * NON-MEMBER (the lanes-carve-out repro above is load-bearing on that).
+ */
+/** The canonical Phase 4 deep link: explicit table view grouped by status. */
+const DEEP_LINK_SEARCH = '?view=table&group=status';
+
+/**
+ * Shared flag-off pin (assertion (e)): deep-linked `?view=table&group=status`
+ * renders the table on a desktop viewport, the load mutates NOTHING in the
+ * URL (assert page.url() exactly), and a reload comes back byte-identical.
+ */
+async function expectDeepLinkSurvivesReload(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.goto(`${SHOTS_URL}${DEEP_LINK_SEARCH}`);
+  await page.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+  // The explicit table view renders (desktop fixture viewport)…
+  await expect(page.locator('main table').first()).toBeVisible();
+
+  // …and the load mutated nothing: the search string is EXACTLY the deep link
+  // (no param added, removed, or reordered by resolution).
+  expect(new URL(page.url()).search).toBe(DEEP_LINK_SEARCH);
+
+  await page.reload();
+  await page.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+  await expect(page.locator('main table').first()).toBeVisible();
+  expect(new URL(page.url()).search).toBe(DEEP_LINK_SEARCH);
+}
+
+test.describe('Shots list — Phase 4 flag-off no-change', () => {
+  test('producer (desktop, never customized): default view stays card; mount writes no URL params', async ({
+    producerPage,
+  }) => {
+    await producerPage.goto(SHOTS_URL);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    // Shots render (seed list is non-empty).
+    await expect(
+      producerPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // (a) Default is the CARD view: no table is mounted. The fixture context
+    // is rebuilt from the global-setup storage state every test, so this
+    // producer has no stored `:view:v1` choice — the "never customized" case
+    // the flag-on resolver would flip to table. Flag-off must stay card.
+    await expect(producerPage.locator('main table')).toHaveCount(0);
+
+    // Desktop toolbar still offers the view toggle (gated on !isMobile only).
+    await expect(
+      producerPage.getByRole('button', { name: 'Card view' }),
+    ).toBeVisible();
+
+    // (b) Zero URL writes from resolution on mount: no view/group params
+    // appear that the user never set.
+    const url = new URL(producerPage.url());
+    expect(url.searchParams.get('view')).toBeNull();
+    expect(url.searchParams.get('group')).toBeNull();
+  });
+
+  test('producer (desktop): deep-linked ?view=table&group=status survives reload unchanged', async ({
+    producerPage,
+  }) => {
+    await expectDeepLinkSurvivesReload(producerPage);
+  });
+
+  /**
+   * CREW — flag-off pin for the third write-capable role. Crew has a global
+   * claim role='crew' but NO project members doc (intentionally — the
+   * lanes-carve-out repro at the top of this file is load-bearing on crew
+   * staying a non-member; do NOT seed one). On the LIST page the denied lanes
+   * subscription must degrade silently, exactly like the wardrobe case.
+   */
+  test('crew (non-member): no URL mutation on plain load; "New Shot" kept; deep link survives reload', async ({
+    crewPage,
+  }) => {
+    await crewPage.goto(SHOTS_URL);
+    await crewPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    // Non-member lanes denial degrades silently — no fatal permissions block.
+    await expect(
+      crewPage.getByText(/Missing or insufficient permissions/i),
+    ).toHaveCount(0);
+
+    await expect(
+      crewPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // (d) Crew KEEPS its create affordance: canManageShots(crew)=true today.
+    // Flag-off must not revoke it (any crew revocation is a 5e/5f decision,
+    // not Phase 4).
+    await expect(
+      crewPage.getByRole('button', { name: /new shot/i }).first(),
+    ).toBeVisible();
+
+    // (a)+(b) Card default + zero URL writes on an absent-override load.
+    await expect(crewPage.locator('main table')).toHaveCount(0);
+    const url = new URL(crewPage.url());
+    expect(url.searchParams.get('view')).toBeNull();
+    expect(url.searchParams.get('group')).toBeNull();
+
+    // (e) Deep link survives reload unchanged.
+    await expectDeepLinkSurvivesReload(crewPage);
+  });
+
+  test('producer (mobile viewport override): mobile forces card/none WITHOUT erasing ?view=table&group=status; resize restores them', async ({
+    producerPage,
+  }) => {
+    // Per-test viewport override — fixtures pin 1280×720 (desktop).
+    await producerPage.setViewportSize({ width: 390, height: 844 });
+
+    await producerPage.goto(`${SHOTS_URL}?view=table&group=status`);
+    await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    // Mobile forcing: the card list renders despite ?view=table…
+    await expect(
+      producerPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+    await expect(producerPage.locator('main table')).toHaveCount(0);
+    // …and the view toggle is hidden (toolbar !isMobile gate).
+    await expect(
+      producerPage.getByRole('button', { name: 'Table view' }),
+    ).toHaveCount(0);
+
+    // Override-without-erase: the latent URL params SURVIVE mobile forcing.
+    const mobileUrl = new URL(producerPage.url());
+    expect(mobileUrl.searchParams.get('view')).toBe('table');
+    expect(mobileUrl.searchParams.get('group')).toBe('status');
+
+    // Resize across the 768px breakpoint (live matchMedia, no reload): the
+    // latent table view + status grouping come back.
+    await producerPage.setViewportSize({ width: 1280, height: 720 });
+    await expect(producerPage.locator('main table').first()).toBeVisible();
+    const desktopUrl = new URL(producerPage.url());
+    expect(desktopUrl.searchParams.get('view')).toBe('table');
+    expect(desktopUrl.searchParams.get('group')).toBe('status');
+  });
+
+  test('viewer (project member): list renders read-only — no "New Shot", card default, no URL writes', async ({
+    viewerPage,
+  }) => {
+    await viewerPage.goto(SHOTS_URL);
+    await viewerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    await expect(
+      viewerPage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // Read-only chrome: no create affordance (canManageShots(viewer)=false).
+    await expect(
+      viewerPage.getByRole('button', { name: /new shot/i }),
+    ).toHaveCount(0);
+
+    // Card default + zero URL writes — same flag-off pins as the producer case.
+    await expect(viewerPage.locator('main table')).toHaveCount(0);
+    const url = new URL(viewerPage.url());
+    expect(url.searchParams.get('view')).toBeNull();
+    expect(url.searchParams.get('group')).toBeNull();
+
+    // (e) Deep link survives reload unchanged — the explicit table view is
+    // role-independent (Phase 3 URL-as-state), so the viewer pin matches
+    // producer/crew.
+    await expectDeepLinkSurvivesReload(viewerPage);
+  });
+
+  /**
+   * WARDROBE — annotated VIEWER DUPLICATE (build spec §Test plan item 4).
+   *
+   * This test deliberately duplicates the viewer assertions above, because for
+   * the shots LIST under flag-off the two roles are behaviorally identical:
+   *
+   * - The wardrobe user carries a legacy global claim role='wardrobe'. As of
+   *   Phase 4 (spec security invariant 5) the client's normalizeRole maps
+   *   'wardrobe' → WAREHOUSE — mirroring firestore.rules:43-56 — instead of
+   *   the old silent fall-through to viewer. canManageShots(warehouse) is
+   *   false, exactly like viewer, so the read-only list chrome (no "New
+   *   Shot") must be byte-identical. This pins that the alias fix changed the
+   *   JOB mapping without granting wardrobe any shot-create UI.
+   * - Unlike the viewer (who is granted a members doc by the seed), wardrobe
+   *   has NO members doc — it is a project NON-MEMBER, so its lanes
+   *   subscription is rules-denied. The list page must degrade (lanes error
+   *   is non-fatal there), not crash or surface the permissions error.
+   */
+  test('wardrobe (legacy alias, non-member) — viewer-duplicate: read-only list renders without crashing', async ({
+    wardrobePage,
+  }) => {
+    await wardrobePage.goto(SHOTS_URL);
+    await wardrobePage.locator('main, [role="main"]').first().waitFor({ state: 'visible' });
+
+    // Non-member lanes denial degrades silently — no fatal permissions block.
+    await expect(
+      wardrobePage.getByText(/Missing or insufficient permissions/i),
+    ).toHaveCount(0);
+
+    await expect(
+      wardrobePage.getByText(SEED_SHOT_AURORA.title).first(),
+    ).toBeVisible();
+
+    // Read-only chrome: wardrobe→warehouse still has canManageShots=false.
+    await expect(
+      wardrobePage.getByRole('button', { name: /new shot/i }),
+    ).toHaveCount(0);
+
+    // Card default + zero URL writes — identical pins to the viewer case.
+    await expect(wardrobePage.locator('main table')).toHaveCount(0);
+    const url = new URL(wardrobePage.url());
+    expect(url.searchParams.get('view')).toBeNull();
+    expect(url.searchParams.get('group')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Phase 4 of the V2 redesign: **one pure view-state authority** `resolveSurface({effectiveRole, device, urlView, urlGroup, storedView})` that resolves the entry surface + view state from role and device, **behind `featureSurfaceResolver` (default OFF)**. Real users see zero change until the flag flips; `VITE_SURFACE_RESOLVER=1` enables it for the origin-isolated :5174 eyeball only.

Built via scout -> build -> adversarial-verify workflow off an 8-agent pre-build audit (4 source scouts + security/UX/engineering/roadmap lenses, unanimous GO_WITH_CHANGES). Spec of record: `Projects/Shot Builder/outputs/2026-06-09-phase4-build-spec.md` (workspace).

## What changed

- **NEW `resolveSurface.ts`** — pure function, all inputs explicit, provenance output (`viewSource: url|stored|surface-default|device-forced`). Surface enum ships future-proof: `plan-build | shoot | review-client | review-warehouse` (all but plan-build render the existing surface; purpose-built shells land in 5e/5f). Device is 3-valued.
- **Precedence pinned + tested**: URL param > stored explicit choice > role default, device forcing applied LAST non-destructively. Producers who explicitly chose cards keep cards; the override-without-erase semantics (latent `?view=table&group=status` on mobile, restored on resize) are preserved byte-identical. Flag-off keeps the legacy ternaries gated, not deleted.
- **Security invariants** (`/shots` writes are `isAuthed()`-only until 5b, so a leaked affordance is a real write path): resolver output is presentation-only by construction; `affordances` derive ONLY from rbac helpers + real device and drive nothing in this PR; typed View-as preview slot ships, **visible menu deferred to 5e** (decided 2026-06-09).
- **`columns`** emits `defaultColumns + storageKeySuffix` only — `useTableColumns` remains the sole owner of user column prefs (no second authority).
- **`normalizeRole` adopts `wardrobe -> warehouse`** (aligns client with `firestore.rules` `normalizedRole`; legacy wardrobe claims previously fell through to viewer = wrong job surface). `resolveEffectiveRole` DELETED (dead code, zero production callers — review round 1; 5b rebuilds it on the live members read).
- **`flags.ts`**: `featureSurfaceResolver` + one `VITE_` parse (LoginPage precedent). No URL/localStorage override layer.
- **Flag-on is visually inert for crew/warehouse/viewer** — no render-path changes for them; resolution gated on auth loading (no viewer-flash).

## Test plan

- [x] **Characterization first** (commit 1): 8 tests pinning current mobile forcing, override-without-erase, zero mount-time URL writes (legacy-param migration allowlisted) — written against unchanged source
- [x] `resolveSurface.test.ts`: **672-case matrix** (url x stored x role x device incl. tablet), provenance asserted, wardrobe alias pinned, flag-off equivalence
- [x] Phase 3 flag-off contract unchanged: `ShotListPage.test.tsx` 24/24, `useShotListState.missing.test.tsx` 5/5, `filterSerializer` round-trips intact
- [x] `rbac.test.ts` 50/50, `flags.test.ts` 5/5, resolver integration 9/9 — all run individually via `CI=1 npm test -- --run <file>`, verified by the orchestrator directly (not agent-reported)
- [x] `npm run build` green
- [ ] **CI `ui-checks` (the arbiter)**: `role-matrix.spec.ts` +6 flag-off no-change cases — deep-link `?view=table&group=status` survives reload byte-identical, absent-override load mutates nothing, crew non-member degrade, mobile viewport override-without-erase, viewer read-only, wardrobe legacy alias. Cannot run locally (Java 8, no emulators).

## Notes for review

- Seed membership untouched (crew stays non-member — load-bearing for the Phase 2 lanes-carve-out repro). `tests/fixtures/auth.ts` change is comment-only.
- The wardrobe->warehouse alias is flag-INDEPENDENT (it corrects a client/rules mismatch); its blast radius beyond shots is: legacy-wardrobe users gain the warehouse capability set the rules already granted them.
- Page mobile render fork + toolbar `!isMobile` gate intentionally still read `isMobile` (named OUT of scope, owner 5e) — resolver consumption lands when the flag turns on for real surfaces.
