### PR TITLE
feat(shots): unified two-column shot editor behind featureUnifiedShotEditor (redesign Phase 5a)

### DIFF
--- a/src-vnext/features/shots/components/HeroImageSection.tsx
+++ b/src-vnext/features/shots/components/HeroImageSection.tsx
@@ -26,12 +26,7 @@ interface HeroImageSectionProps {
   readonly shot: Shot
   readonly shotId: string
   readonly canUpload: boolean
-  /**
-   * Visual-only container variant. "natural" renders the hero at the image's
-   * NATIVE aspect ratio (portrait-friendly, height-capped, never a forced
-   * widescreen crop) for the 5a unified editor — Ted's approval condition,
-   * 2026-06-09. Default "fixed" keeps the legacy container byte-identical.
-   */
+  /** "natural" renders the hero at the image's native aspect ratio (height-capped); default "fixed" keeps the legacy container. */
   readonly frame?: "fixed" | "natural"
 }
 

--- a/src-vnext/features/shots/components/HeroImageSection.tsx
+++ b/src-vnext/features/shots/components/HeroImageSection.tsx
@@ -26,6 +26,13 @@ interface HeroImageSectionProps {
   readonly shot: Shot
   readonly shotId: string
   readonly canUpload: boolean
+  /**
+   * Visual-only container variant. "natural" renders the hero at the image's
+   * NATIVE aspect ratio (portrait-friendly, height-capped, never a forced
+   * widescreen crop) for the 5a unified editor — Ted's approval condition,
+   * 2026-06-09. Default "fixed" keeps the legacy container byte-identical.
+   */
+  readonly frame?: "fixed" | "natural"
 }
 
 export function HeroImageSection({
@@ -33,6 +40,7 @@ export function HeroImageSection({
   shot,
   shotId,
   canUpload,
+  frame = "fixed",
 }: HeroImageSectionProps) {
   const { clientId, user } = useAuth()
   const fileRef = useRef<HTMLInputElement>(null)
@@ -77,12 +85,22 @@ export function HeroImageSection({
   return (
     <div className="flex flex-col gap-2">
       {resolvedHeroUrl ? (
-        <div className="relative overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-subtle)]">
-          <div className="h-[clamp(210px,30vh,320px)] w-full">
+        <div
+          className={
+            frame === "natural"
+              ? "relative w-fit max-w-full overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-subtle)]"
+              : "relative overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-subtle)]"
+          }
+        >
+          <div className={frame === "natural" ? "max-h-[460px]" : "h-[clamp(210px,30vh,320px)] w-full"}>
             <img
               src={resolvedHeroUrl}
               alt="Hero"
-              className="h-full w-full object-contain"
+              className={
+                frame === "natural"
+                  ? "block h-auto max-h-[460px] w-auto max-w-full object-contain"
+                  : "h-full w-full object-contain"
+              }
             />
           </div>
           {canUpload && !uploading && (

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -29,6 +29,16 @@ interface SceneDetailSheetProps {
    * enter a duplicate sceneNumber. Excludes the currently-edited lane.
    */
   readonly siblingLanes?: ReadonlyArray<Lane>
+  /**
+   * REQUIRED capability prop (default-deny — no `= true` fallback). Mirrors
+   * the /lanes write rule (firestore.rules: admin || producer || warehouse;
+   * warehouse keeps lane-write until 5f per locked Q3). The app resolves
+   * roles from the GLOBAL claim today (no per-project role is resolvable
+   * client-side), so callers gate on the global role. When false, the four
+   * fields render as read-only display values — no inputs, no saves, no
+   * color picker.
+   */
+  readonly canEditScene: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -51,6 +61,7 @@ export function SceneDetailSheet({
   clientId,
   shotCount,
   siblingLanes,
+  canEditScene,
 }: SceneDetailSheetProps) {
   // Local state for form fields
   const [name, setName] = useState("")
@@ -242,15 +253,24 @@ export function SceneDetailSheet({
             >
               Scene Name
             </label>
-            <Input
-              id="scene-detail-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              onBlur={handleNameBlur}
-              onKeyDown={handleNameKeyDown}
-              placeholder="e.g., Beach Lifestyle"
-              data-testid="scene-name-input"
-            />
+            {canEditScene ? (
+              <Input
+                id="scene-detail-name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                onBlur={handleNameBlur}
+                onKeyDown={handleNameKeyDown}
+                placeholder="e.g., Beach Lifestyle"
+                data-testid="scene-name-input"
+              />
+            ) : (
+              <p
+                className="text-sm text-[var(--color-text-secondary)]"
+                data-testid="scene-name-readonly"
+              >
+                {lane.name}
+              </p>
+            )}
           </div>
 
           {/* Scene Number */}
@@ -261,18 +281,27 @@ export function SceneDetailSheet({
             >
               Scene Number
             </label>
-            <Input
-              id="scene-detail-number"
-              type="number"
-              value={sceneNumber}
-              onChange={(e) => setSceneNumber(e.target.value)}
-              onBlur={handleSceneNumberBlur}
-              onKeyDown={handleSceneNumberKeyDown}
-              placeholder="e.g., 1"
-              min={1}
-              max={MAX_SCENE_NUMBER}
-              data-testid="scene-number-input"
-            />
+            {canEditScene ? (
+              <Input
+                id="scene-detail-number"
+                type="number"
+                value={sceneNumber}
+                onChange={(e) => setSceneNumber(e.target.value)}
+                onBlur={handleSceneNumberBlur}
+                onKeyDown={handleSceneNumberKeyDown}
+                placeholder="e.g., 1"
+                min={1}
+                max={MAX_SCENE_NUMBER}
+                data-testid="scene-number-input"
+              />
+            ) : (
+              <p
+                className="text-sm text-[var(--color-text-secondary)]"
+                data-testid="scene-number-readonly"
+              >
+                {lane.sceneNumber != null ? String(lane.sceneNumber) : "Not set"}
+              </p>
+            )}
           </div>
 
           {/* Color Picker — fieldset/legend for an accessible group label */}
@@ -280,24 +309,32 @@ export function SceneDetailSheet({
             <legend className="text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)] mb-1.5 block">
               Color
             </legend>
-            <div className="flex gap-2" data-testid="scene-color-picker">
-              {SCENE_COLORS.map((c) => (
-                <button
-                  key={c.key}
-                  type="button"
-                  onClick={() => handleColorSelect(c.key)}
-                  className={`h-7 w-7 rounded-full transition-all ${
-                    lane.color === c.key
-                      ? "ring-2 ring-white ring-offset-2 ring-offset-[var(--color-surface)]"
-                      : "hover:scale-110"
-                  }`}
-                  style={{ background: c.hex }}
-                  aria-label={`Color ${c.key}`}
-                  aria-pressed={lane.color === c.key}
-                  data-testid={`scene-color-${c.key}`}
-                />
-              ))}
-            </div>
+            {canEditScene ? (
+              <div className="flex gap-2" data-testid="scene-color-picker">
+                {SCENE_COLORS.map((c) => (
+                  <button
+                    key={c.key}
+                    type="button"
+                    onClick={() => handleColorSelect(c.key)}
+                    className={`h-7 w-7 rounded-full transition-all ${
+                      lane.color === c.key
+                        ? "ring-2 ring-white ring-offset-2 ring-offset-[var(--color-surface)]"
+                        : "hover:scale-110"
+                    }`}
+                    style={{ background: c.hex }}
+                    aria-label={`Color ${c.key}`}
+                    aria-pressed={lane.color === c.key}
+                    data-testid={`scene-color-${c.key}`}
+                  />
+                ))}
+              </div>
+            ) : (
+              <span
+                className="block h-7 w-7 rounded-full"
+                style={{ background: resolvedColor }}
+                data-testid="scene-color-readonly"
+              />
+            )}
           </fieldset>
 
           {/* Creative Direction */}
@@ -309,21 +346,32 @@ export function SceneDetailSheet({
               >
                 Creative Direction
               </label>
-              <span className="text-3xs text-[var(--color-text-subtle)]">
-                {direction.length}/{MAX_DIRECTION_CHARS}
-              </span>
+              {canEditScene && (
+                <span className="text-3xs text-[var(--color-text-subtle)]">
+                  {direction.length}/{MAX_DIRECTION_CHARS}
+                </span>
+              )}
             </div>
-            <Textarea
-              id="scene-detail-direction"
-              value={direction}
-              onChange={handleDirectionChange}
-              onBlur={handleDirectionBlur}
-              rows={3}
-              maxLength={MAX_DIRECTION_CHARS}
-              placeholder="Mood, lighting, style notes..."
-              className="resize-none text-sm"
-              data-testid="scene-direction-textarea"
-            />
+            {canEditScene ? (
+              <Textarea
+                id="scene-detail-direction"
+                value={direction}
+                onChange={handleDirectionChange}
+                onBlur={handleDirectionBlur}
+                rows={3}
+                maxLength={MAX_DIRECTION_CHARS}
+                placeholder="Mood, lighting, style notes..."
+                className="resize-none text-sm"
+                data-testid="scene-direction-textarea"
+              />
+            ) : (
+              <p
+                className="whitespace-pre-wrap text-sm text-[var(--color-text-secondary)]"
+                data-testid="scene-direction-readonly"
+              >
+                {lane.direction || "Not set"}
+              </p>
+            )}
           </div>
 
           {/* Production Notes */}
@@ -335,21 +383,32 @@ export function SceneDetailSheet({
               >
                 Production Notes
               </label>
-              <span className="text-3xs text-[var(--color-text-subtle)]">
-                {notes.length}/{MAX_NOTES_CHARS}
-              </span>
+              {canEditScene && (
+                <span className="text-3xs text-[var(--color-text-subtle)]">
+                  {notes.length}/{MAX_NOTES_CHARS}
+                </span>
+              )}
             </div>
-            <Textarea
-              id="scene-detail-notes"
-              value={notes}
-              onChange={handleNotesChange}
-              onBlur={handleNotesBlur}
-              rows={5}
-              maxLength={MAX_NOTES_CHARS}
-              placeholder="Setup, timing, special requirements..."
-              className="resize-none text-sm"
-              data-testid="scene-notes-textarea"
-            />
+            {canEditScene ? (
+              <Textarea
+                id="scene-detail-notes"
+                value={notes}
+                onChange={handleNotesChange}
+                onBlur={handleNotesBlur}
+                rows={5}
+                maxLength={MAX_NOTES_CHARS}
+                placeholder="Setup, timing, special requirements..."
+                className="resize-none text-sm"
+                data-testid="scene-notes-textarea"
+              />
+            ) : (
+              <p
+                className="whitespace-pre-wrap text-sm text-[var(--color-text-secondary)]"
+                data-testid="scene-notes-readonly"
+              >
+                {lane.notes || "Not set"}
+              </p>
+            )}
           </div>
 
           {/* Shot count */}

--- a/src-vnext/features/shots/components/SceneDetailSheet.tsx
+++ b/src-vnext/features/shots/components/SceneDetailSheet.tsx
@@ -24,20 +24,9 @@ interface SceneDetailSheetProps {
   readonly projectId: string
   readonly clientId: string | null
   readonly shotCount?: number
-  /**
-   * All other lanes in the project — used to validate that the user doesn't
-   * enter a duplicate sceneNumber. Excludes the currently-edited lane.
-   */
+  /** Other lanes in the project, for duplicate-sceneNumber validation (excludes the edited lane). */
   readonly siblingLanes?: ReadonlyArray<Lane>
-  /**
-   * REQUIRED capability prop (default-deny — no `= true` fallback). Mirrors
-   * the /lanes write rule (firestore.rules: admin || producer || warehouse;
-   * warehouse keeps lane-write until 5f per locked Q3). The app resolves
-   * roles from the GLOBAL claim today (no per-project role is resolvable
-   * client-side), so callers gate on the global role. When false, the four
-   * fields render as read-only display values — no inputs, no saves, no
-   * color picker.
-   */
+  /** Required capability gate mirroring the /lanes write rule; when false the fields render as read-only display values. */
   readonly canEditScene: boolean
 }
 

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -52,8 +52,20 @@ import { useEffect, useRef, useState } from "react"
 import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
 import { ActiveEditorsBar } from "@/features/shots/components/ActiveEditorsBar"
+import { isFeatureEnabled } from "@/shared/lib/flags"
+import { ShotDetailPageUnified } from "@/features/shots/components/ShotDetailPageUnified"
 
 export default function ShotDetailPage() {
+  // Phase 5a fork B: flag-on renders the unified two-column composition;
+  // flag-off keeps the legacy render below byte-identical.
+  // Legacy branch is gated, NOT deleted; retirement at 5c.
+  if (isFeatureEnabled("featureUnifiedShotEditor")) {
+    return <ShotDetailPageUnified />
+  }
+  return <ShotDetailPageLegacy />
+}
+
+function ShotDetailPageLegacy() {
   const { sid } = useParams<{ sid: string }>()
   const navigate = useNavigate()
   const { shot, laneById, loading, error } = useShotDetailBundle(sid)

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -56,9 +56,8 @@ import { isFeatureEnabled } from "@/shared/lib/flags"
 import { ShotDetailPageUnified } from "@/features/shots/components/ShotDetailPageUnified"
 
 export default function ShotDetailPage() {
-  // Phase 5a fork B: flag-on renders the unified two-column composition;
-  // flag-off keeps the legacy render below byte-identical.
-  // Legacy branch is gated, NOT deleted; retirement at 5c.
+  // featureUnifiedShotEditor fork: flag-on renders the unified composition.
+  // Legacy branch is gated, NOT deleted; full retirement happens at flag removal.
   if (isFeatureEnabled("featureUnifiedShotEditor")) {
     return <ShotDetailPageUnified />
   }

--- a/src-vnext/features/shots/components/ShotDetailPage.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPage.tsx
@@ -64,6 +64,11 @@ export default function ShotDetailPage() {
   const canDoOperational = canManageShots(role)
   const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
   const canShare = role === "admin" || role === "producer"
+  // Scene/lane writes are gated to admin/producer/warehouse to match the
+  // Firestore rule on /lanes (warehouse keeps lane-write until 5f per locked
+  // Q3). Project-level roles are not resolvable client-side today, so this
+  // gates on the global claim role (ShotListPage canManageLanes parity).
+  const canEditScene = role === "admin" || role === "producer" || role === "warehouse"
   const [shareOpen, setShareOpen] = useState(false)
   const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
   const [sceneSheetShotCount, setSceneSheetShotCount] = useState<number | undefined>(
@@ -427,6 +432,7 @@ export default function ShotDetailPage() {
           projectId={shot.projectId}
           clientId={clientId}
           shotCount={sceneSheetShotCount}
+          canEditScene={canEditScene}
         />
 
       </div>

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -1,0 +1,658 @@
+// Phase 5a — unified two-column shot editor (flag-on composition).
+//
+// Rendered by the ShotDetailPage fork B when `featureUnifiedShotEditor` is on.
+// This is a RE-COMPOSITION of the existing section components to DESIGN.md law
+// (scan-path order, de-carded left column, editorial meta line, typographic
+// colorway centerpiece, Ivy Presto shot name + iconic period) — all writes go
+// through the same save() -> updateShotWithVersion closure the legacy page
+// uses. Approved comp: mockups/s26-5a-unified-editor-comp.html.
+//
+// Dependency law: this file imports NOTHING from ThreePanel* (5c deletes those
+// files independently). STATUS_CYCLE is re-defined locally by design.
+// Capability props are REQUIRED and default-deny on every section.
+import { useParams, useNavigate, useSearchParams } from "react-router-dom"
+import { Breadcrumbs } from "@/shared/components/Breadcrumbs"
+import {
+  collection,
+  getCountFromServer,
+  query,
+  where,
+} from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { shotsPath } from "@/shared/lib/paths"
+import { LoadingState } from "@/shared/components/LoadingState"
+import { DetailPageSkeleton } from "@/shared/components/Skeleton"
+import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
+import { InlineEdit } from "@/shared/components/InlineEdit"
+import { useShotDetailBundle } from "@/features/shots/hooks/useShotDetailBundle"
+import { ShotStatusSelect } from "@/features/shots/components/ShotStatusSelect"
+import { ShotStatusTapRow } from "@/features/shots/components/ShotStatusTapRow"
+import { TalentPicker } from "@/features/shots/components/TalentPicker"
+import { LocationPicker } from "@/features/shots/components/LocationPicker"
+import { NotesSection } from "@/features/shots/components/NotesSection"
+import { HeroImageSection } from "@/features/shots/components/HeroImageSection"
+import { ActiveLookCoverReferencesPanel } from "@/features/shots/components/ActiveLookCoverReferencesPanel"
+import { ShotCommentsSection } from "@/features/shots/components/ShotCommentsSection"
+import { ShotVersionHistorySection } from "@/features/shots/components/ShotVersionHistorySection"
+import { TagEditor } from "@/features/shots/components/TagEditor"
+import { ShotLifecycleActionsMenu } from "@/features/shots/components/ShotLifecycleActionsMenu"
+import { ShotReferenceLinksSection } from "@/features/shots/components/ShotReferenceLinksSection"
+import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
+import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
+import { ShotDetailSidebar } from "@/features/shots/components/ShotDetailSidebar"
+import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import { formatDateOnly, parseDateOnly } from "@/features/shots/lib/dateOnly"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { canManageShots } from "@/shared/lib/rbac"
+import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { textPreview } from "@/shared/lib/textPreview"
+import {
+  SectionLabel,
+  ReadOnlyMetaValue,
+  DescriptionEditor,
+  DateEditor,
+} from "@/features/shots/components/ShotDetailShared"
+import { Button } from "@/ui/button"
+import { ArrowLeft } from "lucide-react"
+import { toast } from "sonner"
+import { useEffect, useRef, useState } from "react"
+import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
+import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
+import { ActiveEditorsBar } from "@/features/shots/components/ActiveEditorsBar"
+import type { ShotFirestoreStatus, ShotLook } from "@/shared/types"
+
+// Re-defined locally — NEVER imported from ThreePanelLayout (build spec
+// security invariant 2; the ThreePanel files are deleted at 5c).
+const STATUS_CYCLE: ReadonlyArray<ShotFirestoreStatus> = [
+  "todo",
+  "in_progress",
+  "on_hold",
+  "complete",
+]
+
+// ---------------------------------------------------------------------------
+// Meta line segment (one editorial line replacing the three MetaEditorCards)
+// ---------------------------------------------------------------------------
+
+function MetaSegment({
+  label,
+  testId,
+  children,
+}: {
+  readonly label: string
+  readonly testId: string
+  readonly children: React.ReactNode
+}) {
+  return (
+    <span className="inline-flex min-w-0 items-baseline gap-1.5" data-testid={testId}>
+      <span className="text-3xs font-semibold uppercase tracking-wide text-[var(--color-text-subtle)]">
+        {label}
+      </span>
+      <span className="min-w-0">{children}</span>
+    </span>
+  )
+}
+
+function MetaDot() {
+  return (
+    <span aria-hidden="true" className="text-[var(--color-text-subtle)]">
+      &middot;
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Product colorway strip — pure-text typographic centerpiece (Ted's pick at
+// comp: PURE TEXT, read-only; writes stay in the right rail).
+// ---------------------------------------------------------------------------
+
+function ProductColorwayStrip({
+  looks,
+  activeLookId,
+}: {
+  readonly looks: ReadonlyArray<ShotLook>
+  readonly activeLookId: string | null | undefined
+}) {
+  const sorted = [...looks].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const productCount = sorted.reduce((acc, l) => acc + (l.products?.length ?? 0), 0)
+  const resolvedActiveId =
+    activeLookId && sorted.some((l) => l.id === activeLookId)
+      ? activeLookId
+      : sorted.length > 0
+        ? sorted[0]!.id
+        : null
+
+  return (
+    <section
+      className="border-t border-[var(--color-border)] pt-4"
+      data-testid="product-colorway-strip"
+    >
+      <div className="flex items-baseline gap-2">
+        <SectionLabel>Products</SectionLabel>
+        {sorted.length > 0 && (
+          <span className="text-2xs text-[var(--color-text-subtle)]">
+            {productCount} {productCount === 1 ? "item" : "items"} &middot; {sorted.length}{" "}
+            {sorted.length === 1 ? "look" : "looks"}
+          </span>
+        )}
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className="mt-1.5 text-sm text-[var(--color-text-muted)]">
+          No products yet. Add a look in the rail.
+        </p>
+      ) : (
+        sorted.map((look) => (
+          <div key={look.id} className="mt-3 first-of-type:mt-2">
+            <p className="text-2xs font-bold uppercase tracking-wider text-[var(--color-text-subtle)]">
+              {look.label || "Look"}
+              {look.id === resolvedActiveId ? <> &middot; Active</> : null}
+            </p>
+            {(look.products ?? []).length === 0 ? (
+              <p className="py-1 text-sm text-[var(--color-text-muted)]">
+                No products in this look.
+              </p>
+            ) : (
+              (look.products ?? []).map((p, i) => (
+                <div
+                  key={`${p.familyId}-${p.colourId ?? p.skuId ?? ""}-${i}`}
+                  className="flex flex-wrap items-baseline gap-x-2.5 py-1"
+                >
+                  <span className="text-base font-semibold text-[var(--color-text)]">
+                    {p.familyName ?? p.familyId}
+                  </span>
+                  {(p.colourName || p.size) && (
+                    <span className="text-sm text-[var(--color-text-secondary)]">
+                      {p.colourName && (
+                        <>
+                          &middot;{" "}
+                          <span className="font-semibold text-[var(--color-text)]">
+                            {p.colourName}
+                          </span>
+                        </>
+                      )}
+                      {p.size && <> &middot; {p.size}</>}
+                    </span>
+                  )}
+                  {p.skuName && (
+                    <span className="ml-auto text-2xs tabular-nums text-[var(--color-text-subtle)]">
+                      {p.skuName}
+                    </span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        ))
+      )}
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
+
+export function ShotDetailPageUnified() {
+  const { sid } = useParams<{ sid: string }>()
+  const navigate = useNavigate()
+  const { shot, lanes, laneById, loading, error } = useShotDetailBundle(sid)
+  const { role, clientId, user } = useAuth()
+  const { projectName } = useProjectScope()
+
+  // ONE device-authority read feeding named capability booleans with today's
+  // exact semantics (discharges the Phase-4 "OUT -> 5a" item). Mobile-crew
+  // edit is 5e — do NOT remove !isMobile here.
+  const isMobile = useIsMobile()
+  const canEdit = canManageShots(role) && !isMobile
+  const canDoOperational = canManageShots(role)
+  const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
+  // NEW 5a gate (Ted, 2026-06-09 — strict): uploads are admin/producer only;
+  // crew keep Firestore field edits but see NO upload buttons
+  // (storage.rules:72-75 denies crew writes — this aligns UI to rules).
+  const canUploadShotImages = (role === "admin" || role === "producer") && !isMobile
+  const canExport = !isMobile
+  const canShare = role === "admin" || role === "producer"
+  const canComment = canDoOperational
+  // Scene/lane writes are gated to admin/producer/warehouse to match the
+  // Firestore rule on /lanes (warehouse keeps lane-write until 5f per locked
+  // Q3). Project-level roles are not resolvable client-side today, so this
+  // gates on the global claim role (ShotListPage canManageLanes parity).
+  const canEditScene = role === "admin" || role === "producer" || role === "warehouse"
+
+  const [shareOpen, setShareOpen] = useState(false)
+  const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
+  const [sceneSheetShotCount, setSceneSheetShotCount] = useState<number | undefined>(
+    undefined,
+  )
+
+  // -- FAB integration: ?status_picker=1 (consume-only, 5i) and ?focus=notes --
+  const [searchParams, setSearchParamsFab] = useSearchParams()
+  const notesRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const sp = searchParams.get("status_picker")
+    const focus = searchParams.get("focus")
+    let consumed = false
+
+    if (sp === "1") {
+      // Status picker will be handled by ShotStatusTapRow (5i) — for now just consume param
+      consumed = true
+    }
+    if (focus === "notes" && notesRef.current) {
+      notesRef.current.scrollIntoView({ behavior: "smooth", block: "center" })
+      consumed = true
+    }
+    if (consumed) {
+      setSearchParamsFab((prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete("status_picker")
+        next.delete("focus")
+        return next
+      }, { replace: true })
+    }
+  }, [searchParams, setSearchParamsFab])
+
+  // Lazy one-shot count for SceneDetailSheet's "N shots in this scene" label.
+  useEffect(() => {
+    if (!sceneSheetOpen || !clientId || !shot?.laneId) {
+      setSceneSheetShotCount(undefined)
+      return
+    }
+    let cancelled = false
+    const run = async () => {
+      try {
+        const segs = shotsPath(clientId)
+        const q = query(
+          collection(db, segs[0]!, ...segs.slice(1)),
+          where("projectId", "==", shot.projectId),
+          where("laneId", "==", shot.laneId),
+          where("deleted", "==", false),
+        )
+        const snap = await getCountFromServer(q)
+        if (!cancelled) setSceneSheetShotCount(snap.data().count)
+      } catch (err) {
+        console.error("[ShotDetailPageUnified] scene count failed", err)
+        if (!cancelled) setSceneSheetShotCount(undefined)
+      }
+    }
+    void run()
+    return () => {
+      cancelled = true
+    }
+  }, [sceneSheetOpen, clientId, shot?.laneId, shot?.projectId])
+
+  // -- 1-4 status keys (ported from ThreePanel, role-gated) + Escape/Cmd+S --
+  // useKeyboardShortcuts already skips input/textarea/contentEditable targets.
+  const handleStatusKey = (index: number) => {
+    // Early-return unless canManageShots(role) — viewers no-op (build spec
+    // security invariant 2).
+    if (!canDoOperational) return
+    if (!shot || !clientId) return
+    const newStatus = STATUS_CYCLE[index]
+    if (!newStatus || shot.status === newStatus) return
+    void updateShotWithVersion({
+      clientId,
+      shotId: shot.id,
+      patch: { status: newStatus },
+      shot,
+      user,
+      source: "ShotDetailPageUnified:keyboard",
+    }).catch(() => {
+      toast.error("Failed to update status")
+    })
+  }
+
+  useKeyboardShortcuts([
+    { key: "Escape", handler: () => navigate(-1) },
+    { key: "s", meta: true, handler: () => { /* auto-save flushes on blur; this just prevents browser save dialog */ } },
+    { key: "1", handler: () => handleStatusKey(0) },
+    { key: "2", handler: () => handleStatusKey(1) },
+    { key: "3", handler: () => handleStatusKey(2) },
+    { key: "4", handler: () => handleStatusKey(3) },
+  ])
+
+  const save = async (fields: Record<string, unknown>): Promise<boolean> => {
+    if (!shot || !clientId) return false
+    try {
+      await updateShotWithVersion({
+        clientId,
+        shotId: shot.id,
+        patch: fields,
+        shot,
+        user,
+        source: "ShotDetailPageUnified",
+      })
+      return true
+    } catch {
+      toast.error("Failed to save changes")
+      return false
+    }
+  }
+
+  if (loading) return <LoadingState loading skeleton={<DetailPageSkeleton />} />
+  if (error) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-sm text-[var(--color-error)]">{error}</p>
+      </div>
+    )
+  }
+  if (!shot) {
+    return (
+      <div className="p-8 text-center">
+        <p className="text-sm text-[var(--color-text-muted)]">Shot not found.</p>
+      </div>
+    )
+  }
+
+  if (shot.deleted === true) {
+    navigate(`/projects/${shot.projectId}/shots`, { replace: true })
+    toast.info("This shot has been archived.")
+    return null
+  }
+
+  const safeDescription = textPreview(shot.description, Number.POSITIVE_INFINITY)
+  const talentCount = (shot.talentIds ?? shot.talent ?? []).length
+
+  return (
+    <ErrorBoundary>
+      <ActiveEditorsBar
+        clientId={clientId}
+        entityType="shots"
+        entityId={shot.id}
+      />
+      <div className="flex flex-col gap-5">
+        {/* ── Breadcrumb — preserves URL search so filter state survives going back to Shots ── */}
+        <Breadcrumbs
+          items={[
+            { label: "Projects", to: "/projects" },
+            {
+              label: projectName || "Project",
+              to: `/projects/${shot.projectId}/shots`,
+            },
+            {
+              label: "Shots",
+              to: `/projects/${shot.projectId}/shots${window.location.search}`,
+            },
+            { label: shot.shotNumber ? `#${shot.shotNumber}` : "Shot" },
+          ]}
+        />
+
+        {/* ── Top actions: back + Export/Share/lifecycle ── */}
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => navigate(-1)}
+            className="gap-1.5 text-[var(--color-text-muted)] hover:text-[var(--color-text)]"
+          >
+            <ArrowLeft className="h-3.5 w-3.5" />
+            Back to Shots
+          </Button>
+          <div className="ml-auto flex items-center gap-2">
+            {canExport && (
+              <Button
+                variant="outline"
+                onClick={() =>
+                  navigate(
+                    `/projects/${shot.projectId}/export?preset=shot-detail&shotId=${shot.id}`,
+                  )
+                }
+              >
+                Export
+              </Button>
+            )}
+            {canShare && !isMobile && (
+              <Button variant="outline" onClick={() => setShareOpen(true)}>
+                Share
+              </Button>
+            )}
+            {canManageLifecycle && <ShotLifecycleActionsMenu shot={shot} />}
+          </div>
+        </div>
+
+        {/* ── Masthead: shot# eyebrow + status badge, serif name + iconic period ── */}
+        <header className="flex flex-col gap-1.5">
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="inline-flex items-baseline gap-1 text-2xs font-bold uppercase tracking-wider text-[var(--color-text-subtle)]">
+              Shot
+              {canEdit ? (
+                <InlineEdit
+                  value={shot.shotNumber ?? ""}
+                  onSave={(shotNumber) => save({ shotNumber: shotNumber || null })}
+                  className="text-2xs font-bold tracking-wider"
+                  placeholder="#"
+                />
+              ) : (
+                shot.shotNumber && <span>#{shot.shotNumber}</span>
+              )}
+            </span>
+            {!isMobile && (
+              <ShotStatusSelect
+                shotId={shot.id}
+                currentStatus={shot.status}
+                shot={shot}
+                disabled={!canDoOperational}
+                variant="badge"
+              />
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-baseline text-3xl md:text-4xl">
+            {canEdit ? (
+              <InlineEdit
+                value={shot.title}
+                onSave={(title) => save({ title })}
+                className="text-3xl font-semibold leading-tight tracking-tight text-[var(--color-text)] [font-family:var(--font-serif)] md:text-4xl"
+                testId="shot-title-edit"
+              />
+            ) : (
+              <h1 className="text-3xl font-semibold leading-tight tracking-tight text-[var(--color-text)] [font-family:var(--font-serif)] md:text-4xl">
+                {shot.title || "Untitled Shot"}
+              </h1>
+            )}
+            {/* The iconic period — the ONLY red on this surface (Ted's pick at comp). */}
+            <span className="iconic-period" aria-hidden="true">
+              .
+            </span>
+          </div>
+
+          {/* Mobile: full-width status tap row (today's behavior, unchanged) */}
+          {isMobile && canDoOperational && <ShotStatusTapRow shot={shot} />}
+        </header>
+
+        {/* ── Scene context banner ── */}
+        <SceneContextBanner
+          laneId={shot.laneId}
+          laneById={laneById}
+          onViewScene={() => setSceneSheetOpen(true)}
+        />
+
+        <div className="grid items-start gap-8 xl:grid-cols-[minmax(0,1fr)_minmax(340px,400px)]">
+          {/* ── Left main column — de-carded, scan-path order ── */}
+          <div className="flex flex-col gap-5">
+            <section>
+              <SectionLabel>Description</SectionLabel>
+              <div className="mt-1.5 max-w-prose">
+                {canEdit ? (
+                  <DescriptionEditor
+                    value={safeDescription}
+                    onSave={async (description) => {
+                      const ok = await save({ description: description || null })
+                      if (!ok) throw new Error("Save failed")
+                    }}
+                  />
+                ) : (
+                  <p className="text-sm text-[var(--color-text-secondary)]">
+                    {safeDescription || "No description"}
+                  </p>
+                )}
+              </div>
+            </section>
+
+            <section>
+              <SectionLabel>Hero + References</SectionLabel>
+              <div className="mt-1.5 grid items-start gap-3 lg:grid-cols-[minmax(0,420px)_minmax(220px,1fr)]">
+                {/* Aspect-ratio flexible hero (Ted's approval condition):
+                    native image ratio, width-capped, height-capped — never a
+                    forced widescreen crop. */}
+                <div className="w-full max-w-[400px]">
+                  <HeroImageSection
+                    heroImage={shot.heroImage}
+                    shot={shot}
+                    shotId={shot.id}
+                    canUpload={canUploadShotImages}
+                    frame="natural"
+                  />
+                </div>
+                <ActiveLookCoverReferencesPanel
+                  shot={shot}
+                  canEdit={canUploadShotImages}
+                />
+              </div>
+            </section>
+
+            <ProductColorwayStrip
+              looks={shot.looks ?? []}
+              activeLookId={shot.activeLookId}
+            />
+
+            {/* ── ONE inline editorial meta line (Date / Location / Talent) ── */}
+            <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1.5 border-y border-[var(--color-border)] py-3.5 text-sm">
+              <MetaSegment label="Date" testId="meta-date">
+                {canEdit ? (
+                  <DateEditor
+                    value={formatDateOnly(shot.date)}
+                    onSave={(dateStr) => {
+                      if (!dateStr) {
+                        void save({ date: null })
+                        return
+                      }
+                      try {
+                        const ts = parseDateOnly(dateStr)
+                        void save({ date: ts })
+                      } catch {
+                        toast.error("Invalid date")
+                      }
+                    }}
+                  />
+                ) : (
+                  <ReadOnlyMetaValue value={formatDateOnly(shot.date) || "Not set"} />
+                )}
+              </MetaSegment>
+
+              <MetaDot />
+
+              <MetaSegment label="Location" testId="meta-location">
+                {canEdit ? (
+                  <span className="inline-flex min-w-[140px] max-w-[280px]">
+                    <LocationPicker
+                      selectedId={shot.locationId}
+                      selectedName={shot.locationName}
+                      onSave={(locationId, locationName) =>
+                        save({ locationId, locationName })
+                      }
+                      disabled={!canEdit}
+                      compact
+                      projectId={shot.projectId}
+                    />
+                  </span>
+                ) : (
+                  <ReadOnlyMetaValue value={shot.locationName?.trim() || "Not set"} />
+                )}
+              </MetaSegment>
+
+              <MetaDot />
+
+              <MetaSegment label="Talent" testId="meta-talent">
+                {canEdit ? (
+                  <span className="inline-flex min-w-[140px] max-w-[280px]">
+                    <TalentPicker
+                      selectedIds={shot.talentIds ?? shot.talent}
+                      onSave={(ids) => save({ talent: ids, talentIds: ids })}
+                      disabled={!canEdit}
+                      compact
+                      projectId={shot.projectId}
+                    />
+                  </span>
+                ) : (
+                  <ReadOnlyMetaValue value={`${talentCount} assigned`} />
+                )}
+              </MetaSegment>
+            </div>
+
+            <div ref={notesRef} className="flex flex-col gap-5">
+              <section>
+                <SectionLabel>Notes</SectionLabel>
+                <div className="mt-1.5">
+                  <NotesSection
+                    notes={shot.notes}
+                    notesAddendum={shot.notesAddendum}
+                    onSaveAddendum={async (value) => {
+                      const ok = await save({ notesAddendum: value || null })
+                      if (!ok) throw new Error("Failed to save addendum")
+                    }}
+                    canEditAddendum={canDoOperational}
+                  />
+                </div>
+              </section>
+
+              {/* Reference links live with Notes (Ted's pick at comp). */}
+              <ShotReferenceLinksSection
+                shotId={shot.id}
+                referenceLinks={shot.referenceLinks}
+                notesAddendum={shot.notesAddendum}
+                canEdit={canEdit}
+                onSaveReferenceLinks={async (next) => {
+                  const ok = await save({ referenceLinks: next })
+                  if (!ok) throw new Error("Failed to save reference links")
+                }}
+              />
+
+              <div data-testid="tags-section">
+                <SectionLabel>Tags</SectionLabel>
+                <TagEditor
+                  tags={shot.tags ?? []}
+                  onSave={(next) => save({ tags: next })}
+                  disabled={!canEdit}
+                />
+              </div>
+            </div>
+
+            <ShotCommentsSection shotId={shot.id} canComment={canComment} />
+
+            <ShotVersionHistorySection shot={shot} />
+          </div>
+
+          {/* ── Right sticky rail ── */}
+          <ShotDetailSidebar shot={shot} canEditLooks={canEdit} />
+        </div>
+
+        {canShare && (
+          <ShotsShareDialog
+            open={shareOpen}
+            onOpenChange={setShareOpen}
+            clientId={clientId}
+            projectId={shot.projectId}
+            projectName={projectName || "Project"}
+            user={user}
+            selectedShotIds={[shot.id]}
+          />
+        )}
+
+        <SceneDetailSheet
+          open={sceneSheetOpen}
+          onOpenChange={setSceneSheetOpen}
+          lane={shot.laneId ? laneById.get(shot.laneId) ?? null : null}
+          projectId={shot.projectId}
+          clientId={clientId}
+          shotCount={sceneSheetShotCount}
+          siblingLanes={lanes}
+          canEditScene={canEditScene}
+        />
+      </div>
+    </ErrorBoundary>
+  )
+}

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -1,15 +1,4 @@
-// Phase 5a — unified two-column shot editor (flag-on composition).
-//
-// Rendered by the ShotDetailPage fork B when `featureUnifiedShotEditor` is on.
-// This is a RE-COMPOSITION of the existing section components to DESIGN.md law
-// (scan-path order, de-carded left column, editorial meta line, typographic
-// colorway centerpiece, Ivy Presto shot name + iconic period) — all writes go
-// through the same save() -> updateShotWithVersion closure the legacy page
-// uses. Approved comp: mockups/s26-5a-unified-editor-comp.html.
-//
-// Dependency law: this file imports NOTHING from ThreePanel* (5c deletes those
-// files independently). STATUS_CYCLE is re-defined locally by design.
-// Capability props are REQUIRED and default-deny on every section.
+// Unified two-column shot editor — rendered by ShotDetailPage when `featureUnifiedShotEditor` is on.
 import { useParams, useNavigate, useSearchParams } from "react-router-dom"
 import { Breadcrumbs } from "@/shared/components/Breadcrumbs"
 import {
@@ -62,8 +51,7 @@ import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
 import { ActiveEditorsBar } from "@/features/shots/components/ActiveEditorsBar"
 import type { ShotFirestoreStatus, ShotLook } from "@/shared/types"
 
-// Re-defined locally — NEVER imported from ThreePanelLayout (build spec
-// security invariant 2; the ThreePanel files are deleted at 5c).
+// Local copy — no import from ThreePanelLayout.
 const STATUS_CYCLE: ReadonlyArray<ShotFirestoreStatus> = [
   "todo",
   "in_progress",
@@ -103,8 +91,7 @@ function MetaDot() {
 }
 
 // ---------------------------------------------------------------------------
-// Product colorway strip — pure-text typographic centerpiece (Ted's pick at
-// comp: PURE TEXT, read-only; writes stay in the right rail).
+// Product colorway strip — pure-text typographic centerpiece (read-only; writes stay in the right rail).
 // ---------------------------------------------------------------------------
 
 function ProductColorwayStrip({
@@ -201,16 +188,13 @@ export function ShotDetailPageUnified() {
   const { role, clientId, user } = useAuth()
   const { projectName } = useProjectScope()
 
-  // ONE device-authority read feeding named capability booleans with today's
-  // exact semantics (discharges the Phase-4 "OUT -> 5a" item). Mobile-crew
-  // edit is 5e — do NOT remove !isMobile here.
+  // ONE device-authority read feeding named capability booleans. Mobile edit
+  // enablement requires the rules backstop first — do NOT remove !isMobile here.
   const isMobile = useIsMobile()
   const canEdit = canManageShots(role) && !isMobile
   const canDoOperational = canManageShots(role)
   const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
-  // NEW 5a gate (Ted, 2026-06-09 — strict): uploads are admin/producer only;
-  // crew keep Firestore field edits but see NO upload buttons
-  // (storage.rules:72-75 denies crew writes — this aligns UI to rules).
+  // Uploads are admin/producer only — storage.rules denies crew writes.
   const canUploadShotImages = (role === "admin" || role === "producer") && !isMobile
   const canExport = !isMobile
   const canShare = role === "admin" || role === "producer"
@@ -227,7 +211,7 @@ export function ShotDetailPageUnified() {
     undefined,
   )
 
-  // -- FAB integration: ?status_picker=1 (consume-only, 5i) and ?focus=notes --
+  // -- FAB integration: ?status_picker=1 (consume-only) and ?focus=notes --
   const [searchParams, setSearchParamsFab] = useSearchParams()
   const notesRef = useRef<HTMLDivElement>(null)
 
@@ -453,7 +437,7 @@ export function ShotDetailPageUnified() {
                 {shot.title || "Untitled Shot"}
               </h1>
             )}
-            {/* The iconic period — the ONLY red on this surface (Ted's pick at comp). */}
+            {/* The iconic period — the single red accent on this surface. */}
             <span className="iconic-period" aria-hidden="true">
               .
             </span>
@@ -495,9 +479,7 @@ export function ShotDetailPageUnified() {
             <section>
               <SectionLabel>Hero + References</SectionLabel>
               <div className="mt-1.5 grid items-start gap-3 lg:grid-cols-[minmax(0,420px)_minmax(220px,1fr)]">
-                {/* Aspect-ratio flexible hero (Ted's approval condition):
-                    native image ratio, width-capped, height-capped — never a
-                    forced widescreen crop. */}
+                {/* Hero renders at the image's native ratio — no forced widescreen crop. */}
                 <div className="w-full max-w-[400px]">
                   <HeroImageSection
                     heroImage={shot.heroImage}
@@ -599,7 +581,7 @@ export function ShotDetailPageUnified() {
                 </div>
               </section>
 
-              {/* Reference links live with Notes (Ted's pick at comp). */}
+              {/* Reference links live with Notes. */}
               <ShotReferenceLinksSection
                 shotId={shot.id}
                 referenceLinks={shot.referenceLinks}

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -1,5 +1,5 @@
 // Unified two-column shot editor — rendered by ShotDetailPage when `featureUnifiedShotEditor` is on.
-import { useParams, useNavigate, useSearchParams } from "react-router-dom"
+import { useParams, useNavigate, useSearchParams, useLocation } from "react-router-dom"
 import { Breadcrumbs } from "@/shared/components/Breadcrumbs"
 import {
   collection,
@@ -211,8 +211,10 @@ export function ShotDetailPageUnified() {
     undefined,
   )
 
+  const { search: locationSearch } = useLocation()
+
   // -- FAB integration: ?status_picker=1 (consume-only) and ?focus=notes --
-  const [searchParams, setSearchParamsFab] = useSearchParams()
+  const [searchParams, setSearchParams] = useSearchParams()
   const notesRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -229,14 +231,14 @@ export function ShotDetailPageUnified() {
       consumed = true
     }
     if (consumed) {
-      setSearchParamsFab((prev) => {
+      setSearchParams((prev) => {
         const next = new URLSearchParams(prev)
         next.delete("status_picker")
         next.delete("focus")
         return next
       }, { replace: true })
     }
-  }, [searchParams, setSearchParamsFab])
+  }, [searchParams, setSearchParams])
 
   // Lazy one-shot count for SceneDetailSheet's "N shots in this scene" label.
   useEffect(() => {
@@ -331,12 +333,14 @@ export function ShotDetailPageUnified() {
     )
   }
 
+  // Legacy-parity guard; moves into a useEffect when the legacy branch retires.
   if (shot.deleted === true) {
     navigate(`/projects/${shot.projectId}/shots`, { replace: true })
     toast.info("This shot has been archived.")
     return null
   }
 
+  // Strips HTML; Infinity means sanitize without truncating (same call as the legacy page).
   const safeDescription = textPreview(shot.description, Number.POSITIVE_INFINITY)
   const talentCount = (shot.talentIds ?? shot.talent ?? []).length
 
@@ -358,7 +362,7 @@ export function ShotDetailPageUnified() {
             },
             {
               label: "Shots",
-              to: `/projects/${shot.projectId}/shots${window.location.search}`,
+              to: `/projects/${shot.projectId}/shots${locationSearch}`,
             },
             { label: shot.shotNumber ? `#${shot.shotNumber}` : "Shot" },
           ]}
@@ -437,6 +441,7 @@ export function ShotDetailPageUnified() {
                 {shot.title || "Untitled Shot"}
               </h1>
             )}
+            {/* Editorial serif masthead per docs/DESIGN.md — intentionally not .heading-page. */}
             {/* The iconic period — the single red accent on this surface. */}
             <span className="iconic-period" aria-hidden="true">
               .
@@ -480,7 +485,7 @@ export function ShotDetailPageUnified() {
               <SectionLabel>Hero + References</SectionLabel>
               <div className="mt-1.5 grid items-start gap-3 lg:grid-cols-[minmax(0,420px)_minmax(220px,1fr)]">
                 {/* Hero renders at the image's native ratio — no forced widescreen crop. */}
-                <div className="w-full max-w-[400px]">
+                <div className="w-full max-w-sm">
                   <HeroImageSection
                     heroImage={shot.heroImage}
                     shot={shot}

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -132,7 +132,7 @@ function ProductColorwayStrip({
       ) : (
         sorted.map((look) => (
           <div key={look.id} className="mt-3 first-of-type:mt-2">
-            <p className="text-2xs font-bold uppercase tracking-wider text-[var(--color-text-subtle)]">
+            <p className="label-meta">
               {look.label || "Look"}
               {look.id === resolvedActiveId ? <> &middot; Active</> : null}
             </p>

--- a/src-vnext/features/shots/components/ShotDetailSidebar.tsx
+++ b/src-vnext/features/shots/components/ShotDetailSidebar.tsx
@@ -1,0 +1,35 @@
+// Phase 5a — named right-rail component for the unified shot editor.
+//
+// Sticky at xl (minmax(340px,400px) column in the page grid), stacks below xl.
+// Hosts the Looks + Products workspace; reference uploads are hidden here by
+// design (showReferencesSection={false} — uploads live in the hero rail and
+// are gated by canUploadShotImages at the page level).
+import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
+import { SectionLabel } from "@/features/shots/components/ShotDetailShared"
+import type { Shot } from "@/shared/types"
+
+interface ShotDetailSidebarProps {
+  readonly shot: Shot
+  /**
+   * REQUIRED capability prop (default-deny — no optional/`= true` fallback).
+   * Gates all look/product writes in the rail (page canEdit semantics:
+   * canManageShots(role) && !isMobile).
+   */
+  readonly canEditLooks: boolean
+}
+
+export function ShotDetailSidebar({ shot, canEditLooks }: ShotDetailSidebarProps) {
+  return (
+    <div
+      className="flex flex-col gap-4 xl:sticky xl:top-4 xl:max-h-[calc(100vh-6rem)] xl:overflow-y-auto"
+      data-testid="shot-detail-sidebar"
+    >
+      <SectionLabel>Looks + Products</SectionLabel>
+      <ShotLooksSection
+        shot={shot}
+        canEdit={canEditLooks}
+        showReferencesSection={false}
+      />
+    </div>
+  )
+}

--- a/src-vnext/features/shots/components/ShotDetailSidebar.tsx
+++ b/src-vnext/features/shots/components/ShotDetailSidebar.tsx
@@ -1,20 +1,11 @@
-// Phase 5a — named right-rail component for the unified shot editor.
-//
-// Sticky at xl (minmax(340px,400px) column in the page grid), stacks below xl.
-// Hosts the Looks + Products workspace; reference uploads are hidden here by
-// design (showReferencesSection={false} — uploads live in the hero rail and
-// are gated by canUploadShotImages at the page level).
+// Right rail of the unified shot editor — sticky at xl, hosts Looks + Products.
 import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
 import { SectionLabel } from "@/features/shots/components/ShotDetailShared"
 import type { Shot } from "@/shared/types"
 
 interface ShotDetailSidebarProps {
   readonly shot: Shot
-  /**
-   * REQUIRED capability prop (default-deny — no optional/`= true` fallback).
-   * Gates all look/product writes in the rail (page canEdit semantics:
-   * canManageShots(role) && !isMobile).
-   */
+  /** Required capability gate for look/product writes in the rail. */
   readonly canEditLooks: boolean
 }
 

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -45,6 +45,7 @@ import { createLane, assignShotsToLane, ungroupAllShotsFromLane, deleteLane } fr
 import { Skeleton } from "@/ui/skeleton"
 import { useStuckLoading } from "@/shared/hooks/useStuckLoading"
 import { ThreePanelLayout } from "@/features/shots/components/ThreePanelLayout"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 
 export default function ShotListPage() {
   const { data: shots, loading, error } = useShots()
@@ -57,17 +58,27 @@ export default function ShotListPage() {
   const { data: locationRecords } = useLocations()
   const { data: productFamilies } = useProductFamilies()
 
+  // -- Phase 5a fork A: unified editor flag --
+  // Flag-on, desktop clicks NAVIGATE to the detail route (same as the
+  // non-desktop branch) and threePanelActive folds the flag into the single
+  // derived boolean so the three-panel early return is permanently false
+  // (gating only the early return would strand selection state and silently
+  // disable the 1/2 view shortcuts below).
+  const unifiedEditorEnabled = isFeatureEnabled("featureUnifiedShotEditor")
+
   // -- Three-panel state (desktop only) --
+  // Flag-off branch byte-identical — gated, NOT deleted; retirement at 5c
+  // (useShotListState.ts legacy-resolution precedent).
   const [selectedShotId, setSelectedShotId] = useState<string | null>(null)
-  const threePanelActive = isDesktop && selectedShotId !== null
+  const threePanelActive = !unifiedEditorEnabled && isDesktop && selectedShotId !== null
 
   const handleShotClick = useCallback((shotId: string) => {
-    if (isDesktop) {
+    if (!unifiedEditorEnabled && isDesktop) {
       setSelectedShotId(shotId)
     } else {
       navigate(`/projects/${projectId}/shots/${shotId}`)
     }
-  }, [isDesktop, navigate, projectId])
+  }, [unifiedEditorEnabled, isDesktop, navigate, projectId])
 
   // -- FAB integration: ?create=1 opens the dialog --
   const [searchParams, setSearchParamsFab] = useSearchParams()
@@ -949,6 +960,7 @@ export default function ShotListPage() {
         clientId={clientId}
         shotCount={editSceneShotCount}
         siblingLanes={lanes}
+        canEditScene={canManageLanes}
       />
 
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -58,7 +58,7 @@ export default function ShotListPage() {
   const { data: locationRecords } = useLocations()
   const { data: productFamilies } = useProductFamilies()
 
-  // -- Phase 5a fork A: unified editor flag --
+  // -- featureUnifiedShotEditor fork --
   // Flag-on, desktop clicks NAVIGATE to the detail route (same as the
   // non-desktop branch) and threePanelActive folds the flag into the single
   // derived boolean so the three-panel early return is permanently false
@@ -67,7 +67,7 @@ export default function ShotListPage() {
   const unifiedEditorEnabled = isFeatureEnabled("featureUnifiedShotEditor")
 
   // -- Three-panel state (desktop only) --
-  // Flag-off branch byte-identical — gated, NOT deleted; retirement at 5c
+  // Flag-off branch byte-identical — gated, NOT deleted; full retirement happens at flag removal
   // (useShotListState.ts legacy-resolution precedent).
   const [selectedShotId, setSelectedShotId] = useState<string | null>(null)
   const threePanelActive = !unifiedEditorEnabled && isDesktop && selectedShotId !== null

--- a/src-vnext/features/shots/components/ShotStatusSelect.tsx
+++ b/src-vnext/features/shots/components/ShotStatusSelect.tsx
@@ -23,6 +23,12 @@ interface ShotStatusSelectProps {
   readonly shot: Shot
   readonly disabled?: boolean
   readonly compact?: boolean
+  /**
+   * Visual-only variant. "badge" restyles the trigger as a status-token badge
+   * for the 5a unified editor masthead — same testid, same optimistic update
+   * + revert toast, same labels. Default keeps every legacy call site as-is.
+   */
+  readonly variant?: "default" | "badge"
 }
 
 export function ShotStatusSelect({
@@ -31,6 +37,7 @@ export function ShotStatusSelect({
   shot,
   disabled = false,
   compact = false,
+  variant = "default",
 }: ShotStatusSelectProps) {
   const { clientId, user } = useAuth()
   const [optimisticStatus, setOptimisticStatus] = useState<ShotFirestoreStatus | null>(null)
@@ -70,7 +77,13 @@ export function ShotStatusSelect({
     >
       <SelectTrigger
         data-testid="shot-status-select-trigger"
-        className={compact ? "h-7 w-[108px] px-2 text-xs" : "h-8 w-[128px]"}
+        className={
+          variant === "badge"
+            ? "h-7 w-auto gap-1 rounded-md border-0 bg-transparent px-1 shadow-none hover:bg-[var(--color-surface-subtle)]"
+            : compact
+              ? "h-7 w-[108px] px-2 text-xs"
+              : "h-8 w-[128px]"
+        }
       >
         <SelectValue>
           <StatusBadge

--- a/src-vnext/features/shots/components/ShotStatusSelect.tsx
+++ b/src-vnext/features/shots/components/ShotStatusSelect.tsx
@@ -23,11 +23,7 @@ interface ShotStatusSelectProps {
   readonly shot: Shot
   readonly disabled?: boolean
   readonly compact?: boolean
-  /**
-   * Visual-only variant. "badge" restyles the trigger as a status-token badge
-   * for the 5a unified editor masthead — same testid, same optimistic update
-   * + revert toast, same labels. Default keeps every legacy call site as-is.
-   */
+  /** "badge" restyles the trigger as a status-token badge; same testid, optimistic update, and labels. */
   readonly variant?: "default" | "badge"
 }
 

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -98,6 +98,11 @@ export function ThreePanelLayout({
   const canEdit = canManageShots(role) && !isMobile
   const canDoOperational = canManageShots(role)
   const canShare = role === "admin" || role === "producer"
+  // Scene/lane writes are gated to admin/producer/warehouse to match the
+  // Firestore rule on /lanes (warehouse keeps lane-write until 5f per locked
+  // Q3). Project-level roles are not resolvable client-side today, so this
+  // gates on the global claim role (ShotListPage canManageLanes parity).
+  const canEditScene = role === "admin" || role === "producer" || role === "warehouse"
   const [shareOpen, setShareOpen] = useState(false)
 
   // -- Scene sheet state (lifted from canvas + properties panels to avoid duplicates) --
@@ -153,6 +158,8 @@ export function ThreePanelLayout({
   // -- Status change via 1-4 keys --
   const handleStatusKey = useCallback(
     (index: number) => {
+      // Flag-independent 5a fix: status keys are role-gated (viewers no-op).
+      if (!canDoOperational) return
       if (!shot || !clientId) return
       const newStatus = STATUS_CYCLE[index]
       if (!newStatus || shot.status === newStatus) return
@@ -167,7 +174,7 @@ export function ThreePanelLayout({
         toast.error("Failed to update status")
       })
     },
-    [shot, clientId, user],
+    [canDoOperational, shot, clientId, user],
   )
 
   // -- Toggle-deselect: clicking the selected shot deselects --
@@ -334,6 +341,7 @@ export function ThreePanelLayout({
         clientId={clientId}
         shotCount={sceneSheetShotCount}
         siblingLanes={lanes}
+        canEditScene={canEditScene}
       />
     </div>
     </ErrorBoundary>

--- a/src-vnext/features/shots/components/ThreePanelLayout.tsx
+++ b/src-vnext/features/shots/components/ThreePanelLayout.tsx
@@ -158,7 +158,7 @@ export function ThreePanelLayout({
   // -- Status change via 1-4 keys --
   const handleStatusKey = useCallback(
     (index: number) => {
-      // Flag-independent 5a fix: status keys are role-gated (viewers no-op).
+      // Status keys are role-gated — viewers no-op.
       if (!canDoOperational) return
       if (!shot || !clientId) return
       const newStatus = STATUS_CYCLE[index]

--- a/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
@@ -63,6 +63,19 @@ describe("HeroImageSection frame variants", () => {
     expect(img.parentElement?.parentElement).toHaveClass("w-fit")
   })
 
+  it('"natural" frame keeps the Replace/Reset upload affordances when canUpload is true', () => {
+    render(
+      <HeroImageSection
+        heroImage={heroImage}
+        shot={baseShot}
+        shotId="shot-1"
+        canUpload={true}
+        frame="natural"
+      />,
+    )
+    expect(screen.getByRole("button", { name: /Replace/ })).toBeInTheDocument()
+  })
+
   it('"natural" frame does not change the empty state or upload gating', () => {
     render(
       <HeroImageSection

--- a/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { HeroImageSection } from "../HeroImageSection"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", user: { uid: "u1" }, role: "producer" }),
+}))
+
+vi.mock("@/shared/hooks/useStorageUrl", () => ({
+  useStorageUrl: (candidate: string | undefined) => candidate ?? null,
+}))
+
+vi.mock("@/shared/lib/uploadImage", () => ({
+  uploadHeroImage: vi.fn().mockResolvedValue({ path: "p", downloadURL: "u" }),
+  validateImageFileForUpload: vi.fn().mockReturnValue(null),
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
+}))
+
+const baseShot = {
+  id: "shot-1",
+  projectId: "p1",
+  clientId: "c1",
+  title: "Test Shot",
+  status: "todo" as const,
+  talent: [],
+  products: [],
+  sortOrder: 1,
+  deleted: false,
+} as unknown as Shot
+
+const heroImage = {
+  path: "clients/c1/shots/shot-1/hero.webp",
+  downloadURL: "https://example.test/hero.webp",
+} as Shot["heroImage"]
+
+describe("HeroImageSection frame variants", () => {
+  it('default "fixed" frame keeps the legacy fixed-height container', () => {
+    render(
+      <HeroImageSection heroImage={heroImage} shot={baseShot} shotId="shot-1" canUpload={false} />,
+    )
+    const img = screen.getByAltText("Hero")
+    expect(img).toHaveClass("h-full", "w-full", "object-contain")
+    expect(img.parentElement).toHaveClass("h-[clamp(210px,30vh,320px)]", "w-full")
+  })
+
+  it('"natural" frame renders the image at its native ratio, height-capped', () => {
+    render(
+      <HeroImageSection
+        heroImage={heroImage}
+        shot={baseShot}
+        shotId="shot-1"
+        canUpload={false}
+        frame="natural"
+      />,
+    )
+    const img = screen.getByAltText("Hero")
+    expect(img).toHaveClass("h-auto", "w-auto", "max-h-[460px]", "object-contain")
+    expect(img.parentElement).toHaveClass("max-h-[460px]")
+    expect(img.parentElement?.parentElement).toHaveClass("w-fit")
+  })
+
+  it('"natural" frame does not change the empty state or upload gating', () => {
+    render(
+      <HeroImageSection
+        heroImage={undefined}
+        shot={baseShot}
+        shotId="shot-1"
+        canUpload={true}
+        frame="natural"
+      />,
+    )
+    expect(screen.getByText("Add hero image")).toBeInTheDocument()
+    expect(screen.getByTestId("hero-image-file-input")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/SceneDetailSheet.test.tsx
@@ -46,6 +46,7 @@ describe("SceneDetailSheet", () => {
         lane={null}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
     expect(container.firstChild).toBeNull()
@@ -60,6 +61,7 @@ describe("SceneDetailSheet", () => {
         projectId="p1"
         clientId="c1"
         shotCount={4}
+        canEditScene
       />,
     )
 
@@ -81,6 +83,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
     expect(screen.getByTestId("scene-color-teal")).toBeInTheDocument()
@@ -99,6 +102,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -124,6 +128,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -143,6 +148,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -168,6 +174,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -191,6 +198,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -216,6 +224,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -238,6 +247,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -256,6 +266,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId={null}
+        canEditScene
       />,
     )
 
@@ -274,6 +285,7 @@ describe("SceneDetailSheet", () => {
         projectId="p1"
         clientId="c1"
         shotCount={1}
+        canEditScene
       />,
     )
     expect(screen.getByText("shot in this scene")).toBeInTheDocument()
@@ -289,6 +301,7 @@ describe("SceneDetailSheet", () => {
         lane={baseLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -306,6 +319,7 @@ describe("SceneDetailSheet", () => {
         lane={echoedLane}
         projectId="p1"
         clientId="c1"
+        canEditScene
       />,
     )
 
@@ -321,7 +335,7 @@ describe("SceneDetailSheet", () => {
 
     const onOpenChange = vi.fn()
     const { rerender } = render(
-      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" />,
+      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" canEditScene />,
     )
     expect((screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement).value).toBe(
       "direction A",
@@ -329,16 +343,87 @@ describe("SceneDetailSheet", () => {
 
     // Close the sheet
     rerender(
-      <SceneDetailSheet open={false} onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" />,
+      <SceneDetailSheet open={false} onOpenChange={onOpenChange} lane={laneA} projectId="p1" clientId="c1" canEditScene />,
     )
 
     // Re-open for a different lane
     rerender(
-      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneB} projectId="p1" clientId="c1" />,
+      <SceneDetailSheet open onOpenChange={onOpenChange} lane={laneB} projectId="p1" clientId="c1" canEditScene />,
     )
 
     expect((screen.getByTestId("scene-direction-textarea") as HTMLTextAreaElement).value).toBe(
       "direction B",
     )
+  })
+
+  describe("canEditScene={false} (read-only, flag-independent 5a fix)", () => {
+    it("renders the four fields as display values with no inputs", () => {
+      render(
+        <SceneDetailSheet
+          open
+          onOpenChange={vi.fn()}
+          lane={baseLane}
+          projectId="p1"
+          clientId="c1"
+          shotCount={4}
+          canEditScene={false}
+        />,
+      )
+
+      // Display values...
+      expect(screen.getByTestId("scene-name-readonly")).toHaveTextContent("Beach Lifestyle")
+      expect(screen.getByTestId("scene-number-readonly")).toHaveTextContent("3")
+      expect(screen.getByTestId("scene-direction-readonly")).toHaveTextContent(
+        "Golden hour, warm tones",
+      )
+      expect(screen.getByTestId("scene-notes-readonly")).toHaveTextContent("Bring reflector")
+
+      // ...and ZERO write affordances: no inputs, no textareas, no color buttons.
+      expect(screen.queryByTestId("scene-name-input")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("scene-number-input")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("scene-direction-textarea")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("scene-notes-textarea")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("scene-color-picker")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("scene-color-teal")).not.toBeInTheDocument()
+      expect(screen.getByTestId("scene-color-readonly")).toBeInTheDocument()
+
+      // Shot count footer still renders.
+      expect(screen.getByText("shots in this scene")).toBeInTheDocument()
+    })
+
+    it("shows 'Not set' for empty direction and notes", () => {
+      const bareLane: Lane = { ...baseLane, direction: undefined, notes: undefined }
+      render(
+        <SceneDetailSheet
+          open
+          onOpenChange={vi.fn()}
+          lane={bareLane}
+          projectId="p1"
+          clientId="c1"
+          canEditScene={false}
+        />,
+      )
+      expect(screen.getByTestId("scene-direction-readonly")).toHaveTextContent("Not set")
+      expect(screen.getByTestId("scene-notes-readonly")).toHaveTextContent("Not set")
+    })
+
+    it("never calls updateLane in read-only mode", async () => {
+      render(
+        <SceneDetailSheet
+          open
+          onOpenChange={vi.fn()}
+          lane={baseLane}
+          projectId="p1"
+          clientId="c1"
+          canEditScene={false}
+        />,
+      )
+
+      // Nothing to type into or click; assert no save path fired on mount or
+      // via the static color swatch.
+      fireEvent.click(screen.getByTestId("scene-color-readonly"))
+      await Promise.resolve()
+      expect(updateLane).not.toHaveBeenCalled()
+    })
   })
 })

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPage.desktop.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPage.desktop.test.tsx
@@ -1,0 +1,193 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a characterization pin (build spec, Test plan 1b).
+//
+// Pins TODAY's desktop-mode (isMobile=false) ShotDetailPage behavior, against
+// unchanged source. The legacy ShotDetailPage.test.tsx forces isMobile=true,
+// so none of the desktop affordances were pinned:
+//   - Export button present (device-gated only — viewer/crew still see it)
+//   - lifecycle menu gated admin/producer (present for producer, ABSENT for
+//     crew — this is the divergence from ThreePanelCanvasPanel's crew-inclusive
+//     gate that the 5a editor converges)
+//   - meta-date / meta-location / meta-talent testids present
+//   - tags-section present
+//   - shot-status-select-trigger present
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+vi.mock("@/features/shots/hooks/useShot", () => ({
+  useShot: vi.fn(),
+}))
+
+vi.mock("@/features/shots/hooks/useLanes", () => ({
+  useLanes: () => ({
+    data: [],
+    laneById: new Map(),
+    laneNameById: new Map(),
+    loading: false,
+    error: null,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, clientId: "c1", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+// Desktop mode — the branch the legacy ShotDetailPage.test.tsx never renders.
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useTalent: () => ({ data: [], loading: false, error: null }),
+  useLocations: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/shots/components/TalentPicker", () => ({
+  TalentPicker: () => <div>Talent</div>,
+}))
+
+vi.mock("@/features/shots/components/LocationPicker", () => ({
+  LocationPicker: () => <div>Location</div>,
+}))
+
+vi.mock("@/features/shots/components/NotesSection", () => ({
+  NotesSection: () => <div>Notes</div>,
+}))
+
+vi.mock("@/features/shots/components/HeroImageSection", () => ({
+  HeroImageSection: () => <div>Hero</div>,
+}))
+
+vi.mock("@/features/shots/components/ActiveLookCoverReferencesPanel", () => ({
+  ActiveLookCoverReferencesPanel: () => <div>CoverRefs</div>,
+}))
+
+vi.mock("@/features/shots/components/ShotLooksSection", () => ({
+  ShotLooksSection: () => <div>Looks</div>,
+}))
+
+vi.mock("@/features/shots/components/ShotCommentsSection", () => ({
+  ShotCommentsSection: () => <div>Comments</div>,
+}))
+
+vi.mock("@/features/shots/components/ShotVersionHistorySection", () => ({
+  ShotVersionHistorySection: () => <div>History</div>,
+}))
+
+vi.mock("@/features/shots/components/TagEditor", () => ({
+  TagEditor: () => <div>Tags</div>,
+}))
+
+// Behavior-free stub so the page-level admin/producer gate is what's asserted.
+vi.mock("@/features/shots/components/ShotLifecycleActionsMenu", () => ({
+  ShotLifecycleActionsMenu: () => (
+    <div data-testid="lifecycle-actions-stub">Lifecycle</div>
+  ),
+}))
+
+import { useShot } from "@/features/shots/hooks/useShot"
+import ShotDetailPage from "@/features/shots/components/ShotDetailPage"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    description: overrides.description,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    looks: overrides.looks,
+    activeLookId: overrides.activeLookId,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/p1/shots/s1"]}>
+      <Routes>
+        <Route path="/projects/:id/shots/:sid" element={<ShotDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockShot(overrides: Partial<Shot> = {}) {
+  ;(useShot as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: makeShot(overrides),
+    loading: false,
+    error: null,
+  })
+}
+
+describe("ShotDetailPage desktop mode (pre-5a pin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.role = "producer"
+  })
+
+  it("renders the desktop affordances for a producer", () => {
+    mockShot()
+
+    renderPage()
+
+    // Export is device-gated only (canExport = !isMobile).
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
+    // Lifecycle menu: admin/producer gate (canManageLifecycle).
+    expect(screen.getByTestId("lifecycle-actions-stub")).toBeInTheDocument()
+    // Status select trigger renders on desktop (!isMobile branch).
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeInTheDocument()
+    // Meta editor card testids.
+    expect(screen.getByTestId("meta-date")).toBeInTheDocument()
+    expect(screen.getByTestId("meta-location")).toBeInTheDocument()
+    expect(screen.getByTestId("meta-talent")).toBeInTheDocument()
+    // Tags section wrapper.
+    expect(screen.getByTestId("tags-section")).toBeInTheDocument()
+  })
+
+  it("hides the lifecycle menu for crew (today's admin/producer-only page gate)", () => {
+    authState.role = "crew"
+    mockShot()
+
+    renderPage()
+
+    // The detail page gates lifecycle to admin/producer — crew get NO menu
+    // here, even though ThreePanelCanvasPanel shows it to crew. 5a converges
+    // this; the pin makes the convergence an explicit red→green diff.
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    // Export stays visible — device-gated only, deliberate (spec invariant 10).
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
+    // Crew still see the status trigger (operational write, canDoOperational).
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -1,0 +1,353 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a — unit matrix for the unified two-column editor (flag-on).
+//
+// Renders through the ShotDetailPage default export with the flag mocked ON,
+// so the fork B entry is exercised too. Section components are stubbed to
+// emit their capability props (behavior-free), so what's asserted here is the
+// page-level capability wiring:
+//   - scan-path order (DESIGN.md law)
+//   - viewer mounts ZERO enabled write affordances
+//   - crew sees no upload/lifecycle affordances (strict convergence,
+//     Ted 2026-06-09) but keeps operational edits
+//   - 1-4 status keys: viewer no-op, producer writes via the local
+//     STATUS_CYCLE (never imported from ThreePanelLayout)
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+// Flag ON — fork B renders the unified composition.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) => flag === "featureUnifiedShotEditor",
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("@/features/shots/hooks/useShot", () => ({
+  useShot: vi.fn(),
+}))
+
+vi.mock("@/features/shots/hooks/useLanes", () => ({
+  useLanes: () => ({
+    data: [],
+    laneById: new Map(),
+    laneNameById: new Map(),
+    loading: false,
+    error: null,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, clientId: "c1", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+// Desktop mode.
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useTalent: () => ({ data: [], loading: false, error: null }),
+  useLocations: () => ({ data: [], loading: false, error: null }),
+}))
+
+// Capability-emitting stubs (behavior-free) — the page wiring is the subject.
+vi.mock("@/features/shots/components/HeroImageSection", () => ({
+  HeroImageSection: ({ canUpload }: { readonly canUpload: boolean }) => (
+    <div data-testid="hero-stub" data-can-upload={String(canUpload)}>
+      Hero
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ActiveLookCoverReferencesPanel", () => ({
+  ActiveLookCoverReferencesPanel: ({ canEdit }: { readonly canEdit: boolean }) => (
+    <div data-testid="cover-refs-stub" data-can-edit={String(canEdit)}>
+      CoverRefs
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ShotLooksSection", () => ({
+  ShotLooksSection: ({ canEdit }: { readonly canEdit: boolean }) => (
+    <div data-testid="looks-stub" data-can-edit={String(canEdit)}>
+      Looks
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/NotesSection", () => ({
+  NotesSection: ({ canEditAddendum }: { readonly canEditAddendum: boolean }) => (
+    <div data-testid="notes-stub" data-can-edit={String(canEditAddendum)}>
+      Notes
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ShotCommentsSection", () => ({
+  ShotCommentsSection: ({ canComment }: { readonly canComment: boolean }) => (
+    <div data-testid="comments-stub" data-can-comment={String(canComment)}>
+      Comments
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ShotReferenceLinksSection", () => ({
+  ShotReferenceLinksSection: ({ canEdit }: { readonly canEdit: boolean }) => (
+    <div data-testid="reference-links-stub" data-can-edit={String(canEdit)}>
+      Links
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/TagEditor", () => ({
+  TagEditor: ({ disabled }: { readonly disabled?: boolean }) => (
+    <div data-testid="tag-editor-stub" data-disabled={String(disabled === true)}>
+      Tags
+    </div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ShotVersionHistorySection", () => ({
+  ShotVersionHistorySection: () => <div data-testid="history-stub">History</div>,
+}))
+
+vi.mock("@/features/shots/components/ShotLifecycleActionsMenu", () => ({
+  ShotLifecycleActionsMenu: () => (
+    <div data-testid="lifecycle-actions-stub">Lifecycle</div>
+  ),
+}))
+
+vi.mock("@/features/shots/components/ShotsShareDialog", () => ({
+  ShotsShareDialog: () => null,
+}))
+
+vi.mock("@/features/shots/components/SceneDetailSheet", () => ({
+  SceneDetailSheet: () => null,
+}))
+
+vi.mock("@/features/shots/components/ActiveEditorsBar", () => ({
+  ActiveEditorsBar: () => null,
+}))
+
+import { useShot } from "@/features/shots/hooks/useShot"
+import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import ShotDetailPage from "@/features/shots/components/ShotDetailPage"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Active Merino T-Shirt",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber ?? "31",
+    description: overrides.description,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    looks: overrides.looks,
+    activeLookId: overrides.activeLookId,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/p1/shots/s1"]}>
+      <Routes>
+        <Route path="/projects/:id/shots/:sid" element={<ShotDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+function mockShot(overrides: Partial<Shot> = {}) {
+  ;(useShot as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: makeShot(overrides),
+    loading: false,
+    error: null,
+  })
+}
+
+/** Asserts each element precedes the next one in document order. */
+function expectDocumentOrder(elements: ReadonlyArray<HTMLElement>) {
+  for (let i = 0; i < elements.length - 1; i++) {
+    const a = elements[i]!
+    const b = elements[i + 1]!
+    expect(a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  }
+}
+
+describe("ShotDetailPageUnified (flag-on)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.role = "producer"
+  })
+
+  it("renders the scan-path order: description, hero, products, meta, notes, links, tags, comments, history, rail", () => {
+    mockShot({
+      looks: [
+        {
+          id: "l1",
+          label: "Primary",
+          order: 0,
+          products: [
+            { familyId: "f1", familyName: "Merino T-Shirt", colourName: "Ivory" },
+          ],
+        },
+      ],
+      activeLookId: "l1",
+    })
+
+    renderPage()
+
+    // Carryover testids/copy on the flag-on layout.
+    expect(screen.getByRole("button", { name: /Back to Shots/ })).toBeInTheDocument()
+    expect(screen.getByTestId("shot-title-edit")).toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeInTheDocument()
+
+    expectDocumentOrder([
+      screen.getByText("Description"),
+      screen.getByTestId("hero-stub"),
+      screen.getByTestId("product-colorway-strip"),
+      screen.getByTestId("meta-date"),
+      screen.getByTestId("meta-location"),
+      screen.getByTestId("meta-talent"),
+      screen.getByTestId("notes-stub"),
+      screen.getByTestId("reference-links-stub"),
+      screen.getByTestId("tags-section"),
+      screen.getByTestId("comments-stub"),
+      screen.getByTestId("history-stub"),
+      screen.getByTestId("shot-detail-sidebar"),
+    ])
+
+    // Colorway strip is the typographic centerpiece — product + colorway text.
+    expect(screen.getByText("Merino T-Shirt")).toBeInTheDocument()
+    expect(screen.getByText("Ivory")).toBeInTheDocument()
+  })
+
+  it("shows the zero-looks centerpiece state", () => {
+    mockShot({ looks: [] })
+
+    renderPage()
+
+    expect(
+      screen.getByText("No products yet. Add a look in the rail."),
+    ).toBeInTheDocument()
+  })
+
+  it("viewer mounts zero enabled write affordances", () => {
+    authState.role = "viewer"
+    mockShot()
+
+    renderPage()
+
+    // Title is a plain heading — no inline edit affordance.
+    expect(screen.queryByTestId("shot-title-edit")).not.toBeInTheDocument()
+    // Status trigger present but disabled (canDoOperational=false).
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeDisabled()
+    // No lifecycle, no uploads, no look/tag/notes/comment/link writes.
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "false")
+    expect(screen.getByTestId("cover-refs-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("looks-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("comments-stub")).toHaveAttribute("data-can-comment", "false")
+    expect(screen.getByTestId("reference-links-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("tag-editor-stub")).toHaveAttribute("data-disabled", "true")
+    // Read-only meta copy carried onto the segments (Date + Location empty).
+    expect(screen.getAllByText("Not set")).toHaveLength(2)
+    expect(screen.getByText("0 assigned")).toBeInTheDocument()
+    // Export stays visible — device-gated only, deliberate (spec invariant 10).
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
+    // Share is admin/producer only.
+    expect(screen.queryByRole("button", { name: "Share" })).not.toBeInTheDocument()
+  })
+
+  it("crew sees no upload or lifecycle affordances but keeps operational edits (strict convergence)", () => {
+    authState.role = "crew"
+    mockShot()
+
+    renderPage()
+
+    // Strict gates (Ted, 2026-06-09): uploads + lifecycle are admin/producer only.
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "false")
+    expect(screen.getByTestId("cover-refs-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Share" })).not.toBeInTheDocument()
+    // Crew keep Firestore field edits.
+    expect(screen.getByTestId("shot-status-select-trigger")).not.toBeDisabled()
+    expect(screen.getByTestId("shot-title-edit")).toBeInTheDocument()
+    expect(screen.getByTestId("looks-stub")).toHaveAttribute("data-can-edit", "true")
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "true")
+    expect(screen.getByTestId("comments-stub")).toHaveAttribute("data-can-comment", "true")
+    expect(screen.getByTestId("tag-editor-stub")).toHaveAttribute("data-disabled", "false")
+  })
+
+  it("1-4 status keys are a no-op for viewers", () => {
+    authState.role = "viewer"
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    fireEvent.keyDown(document.body, { key: "1" })
+    fireEvent.keyDown(document.body, { key: "2" })
+    fireEvent.keyDown(document.body, { key: "3" })
+    fireEvent.keyDown(document.body, { key: "4" })
+
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
+  })
+
+  it("1-4 status keys write for a producer via the unified editor source", () => {
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    fireEvent.keyDown(document.body, { key: "2" })
+
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(1)
+    expect(updateShotWithVersion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        patch: { status: "in_progress" },
+        source: "ShotDetailPageUnified:keyboard",
+      }),
+    )
+  })
+
+  it("1-4 keys skip the write when the status is unchanged", () => {
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    fireEvent.keyDown(document.body, { key: "1" })
+
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -19,6 +19,13 @@ import type { Shot } from "@/shared/types"
 
 const authState = vi.hoisted(() => ({ role: "producer" }))
 
+// Per-test lane state so the scene-banner member/non-member pair can flip
+// between a readable lane map and the non-member empty degrade.
+const laneState = vi.hoisted(() => ({
+  lanes: [] as unknown[],
+  laneById: new Map<string, unknown>(),
+}))
+
 // Flag ON — fork B renders the unified composition.
 vi.mock("@/shared/lib/flags", () => ({
   isFeatureEnabled: (flag: string) => flag === "featureUnifiedShotEditor",
@@ -34,8 +41,8 @@ vi.mock("@/features/shots/hooks/useShot", () => ({
 
 vi.mock("@/features/shots/hooks/useLanes", () => ({
   useLanes: () => ({
-    data: [],
-    laneById: new Map(),
+    data: laneState.lanes,
+    laneById: laneState.laneById,
     laneNameById: new Map(),
     loading: false,
     error: null,
@@ -209,6 +216,8 @@ describe("ShotDetailPageUnified (flag-on)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     authState.role = "producer"
+    laneState.lanes = []
+    laneState.laneById = new Map()
   })
 
   it("renders the scan-path order: description, hero, products, meta, notes, links, tags, comments, history, rail", () => {
@@ -308,6 +317,10 @@ describe("ShotDetailPageUnified (flag-on)", () => {
     expect(screen.getByTestId("looks-stub")).toHaveAttribute("data-can-edit", "true")
     expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "true")
     expect(screen.getByTestId("comments-stub")).toHaveAttribute("data-can-comment", "true")
+    expect(screen.getByTestId("reference-links-stub")).toHaveAttribute(
+      "data-can-edit",
+      "true",
+    )
     expect(screen.getByTestId("tag-editor-stub")).toHaveAttribute("data-disabled", "false")
   })
 
@@ -349,5 +362,116 @@ describe("ShotDetailPageUnified (flag-on)", () => {
     fireEvent.keyDown(document.body, { key: "1" })
 
     expect(updateShotWithVersion).not.toHaveBeenCalled()
+  })
+
+  // ── Per-role affordance matrix (build spec §Test plan item 2) ─────────────
+  // viewer/warehouse: ZERO enabled write affordances. crew: status + fields +
+  // comments yes; uploads/lifecycle/share no. producer/admin: all.
+
+  /** Every write affordance enabled — the admin/producer row of the matrix. */
+  function expectAllWriteAffordances() {
+    expect(screen.getByTestId("shot-title-edit")).toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).not.toBeDisabled()
+    expect(screen.getByTestId("lifecycle-actions-stub")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "true")
+    expect(screen.getByTestId("cover-refs-stub")).toHaveAttribute("data-can-edit", "true")
+    expect(screen.getByTestId("looks-stub")).toHaveAttribute("data-can-edit", "true")
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "true")
+    expect(screen.getByTestId("comments-stub")).toHaveAttribute("data-can-comment", "true")
+    expect(screen.getByTestId("reference-links-stub")).toHaveAttribute(
+      "data-can-edit",
+      "true",
+    )
+    expect(screen.getByTestId("tag-editor-stub")).toHaveAttribute("data-disabled", "false")
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
+  }
+
+  /** Zero enabled write affordances — the viewer/warehouse row of the matrix. */
+  function expectZeroWriteAffordances() {
+    expect(screen.queryByTestId("shot-title-edit")).not.toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeDisabled()
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Share" })).not.toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "false")
+    expect(screen.getByTestId("cover-refs-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("looks-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "false")
+    expect(screen.getByTestId("comments-stub")).toHaveAttribute("data-can-comment", "false")
+    expect(screen.getByTestId("reference-links-stub")).toHaveAttribute(
+      "data-can-edit",
+      "false",
+    )
+    expect(screen.getByTestId("tag-editor-stub")).toHaveAttribute("data-disabled", "true")
+    // Export stays visible — device-gated only, deliberate (spec invariant 10).
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
+  }
+
+  it("admin mounts every write affordance enabled", () => {
+    authState.role = "admin"
+    mockShot()
+
+    renderPage()
+
+    expectAllWriteAffordances()
+  })
+
+  it("producer mounts every write affordance enabled", () => {
+    authState.role = "producer"
+    mockShot()
+
+    renderPage()
+
+    expectAllWriteAffordances()
+  })
+
+  it("warehouse mounts zero enabled write affordances and the 1-4 keys no-op", () => {
+    authState.role = "warehouse"
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    expectZeroWriteAffordances()
+
+    // canManageShots(warehouse)=false — the status keys early-return too.
+    fireEvent.keyDown(document.body, { key: "2" })
+    fireEvent.keyDown(document.body, { key: "4" })
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
+  })
+
+  // ── Member vs non-member — only where lanes matter (scene banner) ─────────
+
+  it("non-member degrade: scene banner absent when laneById is empty even with a laneId", () => {
+    // useShotDetailBundle forces empty lane maps on a permission-denied lanes
+    // read (the non-member case) — the banner must simply not render.
+    mockShot({ laneId: "lane1" })
+
+    renderPage()
+
+    expect(screen.queryByTestId("scene-context-banner")).not.toBeInTheDocument()
+  })
+
+  it("member: scene banner renders when the shot's lane is readable", () => {
+    const now = Timestamp.fromMillis(Date.now())
+    const lane = {
+      id: "lane1",
+      name: "Terrace Scene",
+      projectId: "p1",
+      clientId: "c1",
+      sortOrder: 0,
+      color: "#7c3aed",
+      sceneNumber: 3,
+      createdAt: now,
+      updatedAt: now,
+      createdBy: "u1",
+    }
+    laneState.lanes = [lane]
+    laneState.laneById = new Map([["lane1", lane]])
+    mockShot({ laneId: "lane1" })
+
+    renderPage()
+
+    expect(screen.getByTestId("scene-context-banner")).toBeInTheDocument()
+    expect(screen.getByText("Terrace Scene")).toBeInTheDocument()
   })
 })

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -272,6 +272,29 @@ describe("ShotDetailPageUnified (flag-on)", () => {
     ).toBeInTheDocument()
   })
 
+  it("falls back to the first sorted look as Active when activeLookId is stale", () => {
+    mockShot({
+      looks: [
+        { id: "l2", label: "Alt", order: 1, products: [] },
+        { id: "l1", label: "Primary", order: 0, products: [] },
+      ],
+      activeLookId: "gone",
+    })
+
+    renderPage()
+
+    const strip = screen.getByTestId("product-colorway-strip")
+    const headers = Array.from(strip.querySelectorAll("p")).map((p) => p.textContent ?? "")
+    const primaryHeader = headers.find((t) => t.startsWith("Primary"))
+    const altHeader = headers.find((t) => t.startsWith("Alt"))
+    expect(primaryHeader).toContain("Active")
+    expect(altHeader).toBeDefined()
+    expect(altHeader).not.toContain("Active")
+    expect(headers.findIndex((t) => t.startsWith("Primary"))).toBeLessThan(
+      headers.findIndex((t) => t.startsWith("Alt")),
+    )
+  })
+
   it("viewer mounts zero enabled write affordances", () => {
     authState.role = "viewer"
     mockShot()

--- a/src-vnext/features/shots/components/__tests__/ShotDetailShared.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailShared.test.tsx
@@ -1,0 +1,79 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a characterization pin (build spec, Test plan 1e).
+//
+// Pins DescriptionEditor's flush-on-unmount contract, against unchanged
+// source — no test existed for this before. A pending debounced save (the
+// useAutoSave 1500ms window) MUST flush when the component unmounts (e.g.
+// back-button navigation mid-edit), and a clean unmount must not write.
+// 5a's autosave invariant: flush-on-blur AND flush-on-unmount preserved;
+// no layout branch may remount these editors mid-edit.
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { DescriptionEditor } from "@/features/shots/components/ShotDetailShared"
+
+function enterEditMode(displayText: string) {
+  fireEvent.click(screen.getByText(displayText))
+  return screen.getByTestId("description-input")
+}
+
+describe("DescriptionEditor flush-on-unmount (pre-5a pin)", () => {
+  it("flushes a pending debounced save when unmounted before the debounce fires", () => {
+    const onSave = vi.fn(() => Promise.resolve())
+    const { unmount } = render(
+      <DescriptionEditor value="Old description" onSave={onSave} />,
+    )
+
+    const input = enterEditMode("Old description")
+    fireEvent.change(input, { target: { value: "New description" } })
+
+    // Still inside the debounce window — nothing saved yet.
+    expect(onSave).not.toHaveBeenCalled()
+
+    unmount()
+
+    // The unmount cleanup flushes the pending save with the trimmed draft.
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith("New description")
+  })
+
+  it("trims the draft before the flushed save", () => {
+    const onSave = vi.fn(() => Promise.resolve())
+    const { unmount } = render(<DescriptionEditor value="" onSave={onSave} />)
+
+    const input = enterEditMode("Click to add...")
+    fireEvent.change(input, { target: { value: "  padded draft  " } })
+
+    unmount()
+
+    expect(onSave).toHaveBeenCalledTimes(1)
+    expect(onSave).toHaveBeenCalledWith("padded draft")
+  })
+
+  it("does not save on unmount when nothing changed", () => {
+    const onSave = vi.fn(() => Promise.resolve())
+    const { unmount } = render(
+      <DescriptionEditor value="Old description" onSave={onSave} />,
+    )
+
+    enterEditMode("Old description")
+    unmount()
+
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it("does not save on unmount when the draft was reverted to the original value", () => {
+    const onSave = vi.fn(() => Promise.resolve())
+    const { unmount } = render(
+      <DescriptionEditor value="Old description" onSave={onSave} />,
+    )
+
+    const input = enterEditMode("Old description")
+    fireEvent.change(input, { target: { value: "New description" } })
+    // Reverting to the original cancels the pending save (handleChange cancel branch).
+    fireEvent.change(input, { target: { value: "Old description" } })
+
+    unmount()
+
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
@@ -1,0 +1,155 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a characterization pin (build spec, Test plan 1a).
+//
+// Pins TODAY's desktop click behavior on ShotListPage, against unchanged
+// source: on desktop (useIsDesktop=true), clicking a shot SELECTS it into the
+// three-panel layout (ShotListPage.tsx handleShotClick desktop branch +
+// threePanelActive early return) and does NOT navigate to the detail route.
+// Nothing pinned this before — ShotListPage.test.tsx forces useIsDesktop=false.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/features/shots/hooks/useShots", () => ({
+  useShots: vi.fn(),
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useTalent: () => ({ data: [], loading: false, error: null }),
+  useLocations: () => ({ data: [], loading: false, error: null }),
+  useProductFamilies: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: "producer", clientId: "c1" }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+// Desktop: the branch the legacy ShotListPage.test.tsx never exercises.
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+vi.mock("@/features/shots/components/ShotStatusSelect", () => ({
+  ShotStatusSelect: ({ currentStatus }: { readonly currentStatus: string }) => (
+    <span>status:{currentStatus}</span>
+  ),
+}))
+
+vi.mock("@/features/shots/components/CreateShotDialog", () => ({
+  CreateShotDialog: () => null,
+}))
+
+vi.mock("@/features/pulls/components/CreatePullFromShotsDialog", () => ({
+  CreatePullFromShotsDialog: () => null,
+}))
+
+// Stub the three-panel layout: this pin is about ShotListPage's click routing,
+// not the panel internals.
+vi.mock("@/features/shots/components/ThreePanelLayout", () => ({
+  ThreePanelLayout: ({ selectedShotId }: { readonly selectedShotId: string }) => (
+    <div data-testid="three-panel-layout-stub">selected:{selectedShotId}</div>
+  ),
+}))
+
+import { useShots } from "@/features/shots/hooks/useShots"
+import ShotListPage from "@/features/shots/components/ShotListPage"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    referenceLinks: overrides.referenceLinks,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+function renderPage(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/projects/:id/shots" element={<ShotListPage />} />
+        <Route path="/projects/:id/shots/:sid" element={<div>Shot detail route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ShotListPage desktop click (three-panel pin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("selects the shot into the three-panel layout instead of navigating", () => {
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    // Sanity: three-panel not mounted before any selection.
+    expect(screen.queryByTestId("three-panel-layout-stub")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("Alpha"))
+
+    // Desktop click SELECTS (three-panel early return renders)...
+    expect(screen.getByTestId("three-panel-layout-stub")).toBeInTheDocument()
+    expect(screen.getByText("selected:a")).toBeInTheDocument()
+    // ...and does NOT navigate to the detail route.
+    expect(screen.queryByText("Shot detail route")).not.toBeInTheDocument()
+  })
+
+  it("replaces the list chrome while three-panel is active (early return)", () => {
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.getByRole("button", { name: /New Shot/ })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("Alpha"))
+
+    // The early return swaps the entire page body for ThreePanelLayout.
+    expect(screen.queryByRole("button", { name: /New Shot/ })).not.toBeInTheDocument()
+    expect(screen.getByTestId("three-panel-layout-stub")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
@@ -1,0 +1,157 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a fork A (build spec, "TWO coupled flag forks").
+//
+// Flag-ON counterpart of ShotListPage.desktopThreePanel.test.tsx: with
+// featureUnifiedShotEditor enabled, a desktop shot click NAVIGATES to the
+// detail route (same as the non-desktop branch) and the three-panel layout
+// never mounts (threePanelActive folds the flag, permanently false).
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+import type { FeatureFlags } from "@/shared/lib/flags"
+
+vi.mock("@/features/shots/hooks/useShots", () => ({
+  useShots: vi.fn(),
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useTalent: () => ({ data: [], loading: false, error: null }),
+  useLocations: () => ({ data: [], loading: false, error: null }),
+  useProductFamilies: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: "producer", clientId: "c1" }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+// Desktop: the branch that previously selected into three-panel.
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+// Flag mock: featureUnifiedShotEditor ON, everything else default-off.
+// featureSurfaceResolver stays false so useShotListState keeps the legacy
+// resolution path (the two flags are independent by spec).
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: keyof FeatureFlags) => flag === "featureUnifiedShotEditor",
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: false,
+    featureUnifiedShotEditor: true,
+  }),
+}))
+
+vi.mock("@/features/shots/components/ShotStatusSelect", () => ({
+  ShotStatusSelect: ({ currentStatus }: { readonly currentStatus: string }) => (
+    <span>status:{currentStatus}</span>
+  ),
+}))
+
+vi.mock("@/features/shots/components/CreateShotDialog", () => ({
+  CreateShotDialog: () => null,
+}))
+
+vi.mock("@/features/pulls/components/CreatePullFromShotsDialog", () => ({
+  CreatePullFromShotsDialog: () => null,
+}))
+
+// Stub the three-panel layout so the assertion "never mounts" is unambiguous.
+vi.mock("@/features/shots/components/ThreePanelLayout", () => ({
+  ThreePanelLayout: ({ selectedShotId }: { readonly selectedShotId: string }) => (
+    <div data-testid="three-panel-layout-stub">selected:{selectedShotId}</div>
+  ),
+}))
+
+import { useShots } from "@/features/shots/hooks/useShots"
+import ShotListPage from "@/features/shots/components/ShotListPage"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    referenceLinks: overrides.referenceLinks,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+function renderPage(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route path="/projects/:id/shots" element={<ShotListPage />} />
+        <Route path="/projects/:id/shots/:sid" element={<div>Shot detail route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ShotListPage desktop click (featureUnifiedShotEditor ON — fork A)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+  })
+
+  it("navigates to the detail route instead of selecting into three-panel", () => {
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    fireEvent.click(screen.getByText("Alpha"))
+
+    // Flag-on desktop click NAVIGATES (same as the non-desktop branch)...
+    expect(screen.getByText("Shot detail route")).toBeInTheDocument()
+    // ...and the three-panel layout never mounts.
+    expect(screen.queryByTestId("three-panel-layout-stub")).not.toBeInTheDocument()
+  })
+
+  it("keeps the list chrome mounted (no three-panel early return) before any click", () => {
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.getByRole("button", { name: /New Shot/ })).toBeInTheDocument()
+    expect(screen.queryByTestId("three-panel-layout-stub")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotStatusSelect.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotStatusSelect.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ShotStatusSelect } from "../ShotStatusSelect"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", user: { uid: "u1" }, role: "producer" }),
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
+}))
+
+const baseShot = {
+  id: "shot-1",
+  projectId: "p1",
+  clientId: "c1",
+  title: "Test Shot",
+  status: "todo" as const,
+  talent: [],
+  products: [],
+  sortOrder: 1,
+  deleted: false,
+} as unknown as Shot
+
+describe("ShotStatusSelect variants", () => {
+  it("default variant renders the legacy fixed-width trigger with the status badge", () => {
+    render(<ShotStatusSelect shotId="shot-1" currentStatus="todo" shot={baseShot} />)
+    const trigger = screen.getByTestId("shot-status-select-trigger")
+    expect(trigger).toHaveClass("w-[128px]")
+    expect(screen.getByText("Draft")).toBeInTheDocument()
+  })
+
+  it('"badge" variant restyles the trigger borderless while keeping the testid and label', () => {
+    render(
+      <ShotStatusSelect shotId="shot-1" currentStatus="in_progress" shot={baseShot} variant="badge" />,
+    )
+    const trigger = screen.getByTestId("shot-status-select-trigger")
+    expect(trigger).toHaveClass("border-0", "bg-transparent", "w-auto")
+    expect(trigger).not.toHaveClass("w-[128px]")
+    expect(screen.getByText("In Progress")).toBeInTheDocument()
+  })
+
+  it('"badge" variant still respects the disabled capability prop', () => {
+    render(
+      <ShotStatusSelect
+        shotId="shot-1"
+        currentStatus="todo"
+        shot={baseShot}
+        variant="badge"
+        disabled={true}
+      />,
+    )
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeDisabled()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ThreePanelCanvasPanel.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ThreePanelCanvasPanel.test.tsx
@@ -1,0 +1,128 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a characterization pin (build spec, Test plan 1d).
+//
+// Pins TODAY's ThreePanelCanvasPanel lifecycle gate, against unchanged source:
+// the lifecycle actions menu renders behind `canDoOperational`, which the
+// parent ThreePanelLayout derives from canManageShots(role) — so CREW see the
+// lifecycle menu here, while the detail page gates it admin/producer-only.
+// This is the divergence the 5a Editor phase converges (strict: lifecycle =
+// admin || producer, spec invariant 6). Red→green diff on this pin makes the
+// crew capability delta explicit in the PR.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import { canManageShots, ROLE } from "@/shared/lib/rbac"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: "crew", clientId: "c1", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/features/shots/components/HeroImageSection", () => ({
+  HeroImageSection: () => <div>Hero</div>,
+}))
+
+vi.mock("@/features/shots/components/ActiveLookCoverReferencesPanel", () => ({
+  ActiveLookCoverReferencesPanel: () => <div>CoverRefs</div>,
+}))
+
+vi.mock("@/features/shots/components/NotesSection", () => ({
+  NotesSection: () => <div>Notes</div>,
+}))
+
+vi.mock("@/features/shots/components/ShotReferenceLinksSection", () => ({
+  ShotReferenceLinksSection: () => <div>RefLinks</div>,
+}))
+
+vi.mock("@/features/shots/components/ProductSummaryStrip", () => ({
+  ProductSummaryStrip: () => <div>ProductStrip</div>,
+}))
+
+vi.mock("@/features/shots/components/ActiveEditorsBar", () => ({
+  ActiveEditorsBar: () => null,
+  CompactActiveEditors: () => null,
+}))
+
+// Behavior-free stub that records the disabled prop the panel passes today.
+vi.mock("@/features/shots/components/ShotLifecycleActionsMenu", () => ({
+  ShotLifecycleActionsMenu: ({ disabled }: { readonly disabled?: boolean }) => (
+    <div data-testid="lifecycle-actions-stub" data-disabled={String(disabled)}>
+      Lifecycle
+    </div>
+  ),
+}))
+
+import { ThreePanelCanvasPanel } from "@/features/shots/components/ThreePanelCanvasPanel"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+function renderPanel(props: {
+  readonly canEdit: boolean
+  readonly canDoOperational: boolean
+}) {
+  return render(
+    <MemoryRouter>
+      <ThreePanelCanvasPanel
+        shot={makeShot({})}
+        save={vi.fn(() => Promise.resolve(true))}
+        canEdit={props.canEdit}
+        canDoOperational={props.canDoOperational}
+        onClose={vi.fn()}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe("ThreePanelCanvasPanel lifecycle gate (pre-5a pin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders the lifecycle menu for CREW (canDoOperational gate, crew-inclusive today)", () => {
+    // The parent ThreePanelLayout computes canDoOperational = canManageShots(role),
+    // which INCLUDES crew — assert that premise so the pin can't silently drift.
+    expect(canManageShots(ROLE.CREW)).toBe(true)
+
+    renderPanel({ canEdit: true, canDoOperational: canManageShots(ROLE.CREW) })
+
+    const menu = screen.getByTestId("lifecycle-actions-stub")
+    expect(menu).toBeInTheDocument()
+    // Today's call site passes disabled={!canDoOperational} → enabled for crew.
+    expect(menu).toHaveAttribute("data-disabled", "false")
+  })
+
+  it("hides the lifecycle menu when canDoOperational is false (viewer)", () => {
+    expect(canManageShots(ROLE.VIEWER)).toBe(false)
+
+    renderPanel({ canEdit: false, canDoOperational: canManageShots(ROLE.VIEWER) })
+
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ThreePanelLayout.keyboard.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ThreePanelLayout.keyboard.test.tsx
@@ -1,13 +1,13 @@
 /// <reference types="@testing-library/jest-dom" />
 // Phase 5a characterization pin (build spec, Test plan 1c).
 //
-// Pins TODAY's ThreePanelLayout keyboard behavior EXACTLY, against unchanged
-// source:
+// Pins ThreePanelLayout keyboard behavior:
 //   - 1-4 keys write the matching STATUS_CYCLE status via updateShotWithVersion
-//     (source "ThreePanelLayout:keyboard"), EVEN for a viewer role. Yes, the
-//     hole: handleStatusKey has no role gate today. The Core phase adds the
-//     canDoOperational gate (flag-independent fix, spec invariant 3) and will
-//     flip the viewer pin below red→green.
+//     (source "ThreePanelLayout:keyboard") for roles with canDoOperational
+//     (canManageShots: admin/producer/crew). Viewers NO-OP — the Core 5a phase
+//     closed the previously-pinned ungated hole with the canDoOperational
+//     early return (flag-independent fix, spec invariant 3); the viewer pin
+//     below was flipped red→green to the new behavior in the same commit.
 //   - [ / ] move selection through the `shots` prop order via onSelectShot.
 //   - Escape calls onDeselect.
 //   - Deleted-shot guard: a soft-deleted selected shot deselects with a toast.
@@ -186,23 +186,20 @@ describe("ThreePanelLayout keyboard (pre-5a pin)", () => {
     expect(updateShotWithVersion).toHaveBeenCalledTimes(3)
   })
 
-  it("writes status for a VIEWER role too (today's ungated hole — 5a closes it)", () => {
+  it("NO-OPs all of 1-4 for a VIEWER role (canDoOperational gate, flag-independent 5a fix)", () => {
     authState.role = "viewer"
     mockSelectedShot({ status: "todo" })
     renderLayout()
 
+    pressKey("1")
     pressKey("2")
+    pressKey("3")
+    pressKey("4")
 
-    // Pin of REALITY, not intent: handleStatusKey has no role gate today, so
-    // a viewer keypress writes status. The 5a Core phase gates this on
-    // canDoOperational and updates this pin to assert the no-op.
-    expect(updateShotWithVersion).toHaveBeenCalledTimes(1)
-    expect(updateShotWithVersion).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        patch: { status: "in_progress" },
-        source: "ThreePanelLayout:keyboard",
-      }),
-    )
+    // handleStatusKey early-returns unless canDoOperational (canManageShots:
+    // admin/producer/crew). A viewer keypress must never reach
+    // updateShotWithVersion.
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
   })
 
   it("moves selection through the shots prop order with ] and [", () => {

--- a/src-vnext/features/shots/components/__tests__/ThreePanelLayout.keyboard.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ThreePanelLayout.keyboard.test.tsx
@@ -1,0 +1,248 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5a characterization pin (build spec, Test plan 1c).
+//
+// Pins TODAY's ThreePanelLayout keyboard behavior EXACTLY, against unchanged
+// source:
+//   - 1-4 keys write the matching STATUS_CYCLE status via updateShotWithVersion
+//     (source "ThreePanelLayout:keyboard"), EVEN for a viewer role. Yes, the
+//     hole: handleStatusKey has no role gate today. The Core phase adds the
+//     canDoOperational gate (flag-independent fix, spec invariant 3) and will
+//     flip the viewer pin below red→green.
+//   - [ / ] move selection through the `shots` prop order via onSelectShot.
+//   - Escape calls onDeselect.
+//   - Deleted-shot guard: a soft-deleted selected shot deselects with a toast.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+vi.mock("@/features/shots/hooks/useShot", () => ({
+  useShot: vi.fn(),
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn(() => Promise.resolve()),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, clientId: "c1", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useMediaQuery: () => false,
+  useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
+}))
+
+// Panels are not under test — keyboard handling lives in ThreePanelLayout.
+vi.mock("react-resizable-panels", () => ({
+  PanelGroup: ({ children }: { readonly children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  Panel: ({ children }: { readonly children?: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  PanelResizeHandle: () => null,
+}))
+
+vi.mock("@/features/shots/components/ThreePanelListPanel", () => ({
+  ThreePanelListPanel: () => <div data-testid="list-panel-stub" />,
+}))
+
+vi.mock("@/features/shots/components/ThreePanelCanvasPanel", () => ({
+  ThreePanelCanvasPanel: () => <div data-testid="canvas-panel-stub" />,
+}))
+
+vi.mock("@/features/shots/components/ThreePanelPropertiesPanel", () => ({
+  ThreePanelPropertiesPanel: () => <div data-testid="properties-panel-stub" />,
+}))
+
+vi.mock("@/features/shots/components/ShotsShareDialog", () => ({
+  ShotsShareDialog: () => null,
+}))
+
+vi.mock("@/features/shots/components/SceneDetailSheet", () => ({
+  SceneDetailSheet: () => null,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    info: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+import { useShot } from "@/features/shots/hooks/useShot"
+import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import { ThreePanelLayout } from "@/features/shots/components/ThreePanelLayout"
+import { toast } from "sonner"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+const SHOTS: ReadonlyArray<Shot> = [
+  makeShot({ id: "s1", title: "First", sortOrder: 0 }),
+  makeShot({ id: "s2", title: "Second", sortOrder: 1 }),
+  makeShot({ id: "s3", title: "Third", sortOrder: 2 }),
+]
+
+function mockSelectedShot(overrides: Partial<Shot> = {}) {
+  ;(useShot as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: makeShot({ id: "s2", title: "Second", ...overrides }),
+    loading: false,
+    error: null,
+  })
+}
+
+function renderLayout(props: {
+  readonly selectedShotId?: string
+  readonly onDeselect?: () => void
+  readonly onSelectShot?: (shotId: string) => void
+} = {}) {
+  return render(
+    <MemoryRouter>
+      <ThreePanelLayout
+        selectedShotId={props.selectedShotId ?? "s2"}
+        shots={SHOTS}
+        allShots={SHOTS}
+        showCreate
+        onDeselect={props.onDeselect ?? vi.fn()}
+        onSelectShot={props.onSelectShot ?? vi.fn()}
+      />
+    </MemoryRouter>,
+  )
+}
+
+function pressKey(key: string) {
+  fireEvent.keyDown(document.body, { key })
+}
+
+describe("ThreePanelLayout keyboard (pre-5a pin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.localStorage.clear()
+    authState.role = "producer"
+  })
+
+  it("writes the matching STATUS_CYCLE status for keys 2-4 and no-ops on the current status key", () => {
+    mockSelectedShot({ status: "todo" })
+    renderLayout()
+
+    pressKey("2")
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(1)
+    expect(updateShotWithVersion).toHaveBeenLastCalledWith({
+      clientId: "c1",
+      shotId: "s2",
+      patch: { status: "in_progress" },
+      shot: expect.objectContaining({ id: "s2", status: "todo" }),
+      user: { uid: "u1" },
+      source: "ThreePanelLayout:keyboard",
+    })
+
+    pressKey("3")
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(2)
+    expect(updateShotWithVersion).toHaveBeenLastCalledWith(
+      expect.objectContaining({ patch: { status: "on_hold" } }),
+    )
+
+    pressKey("4")
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(3)
+    expect(updateShotWithVersion).toHaveBeenLastCalledWith(
+      expect.objectContaining({ patch: { status: "complete" } }),
+    )
+
+    // "1" maps to "todo" — same as current status, so no write.
+    pressKey("1")
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(3)
+  })
+
+  it("writes status for a VIEWER role too (today's ungated hole — 5a closes it)", () => {
+    authState.role = "viewer"
+    mockSelectedShot({ status: "todo" })
+    renderLayout()
+
+    pressKey("2")
+
+    // Pin of REALITY, not intent: handleStatusKey has no role gate today, so
+    // a viewer keypress writes status. The 5a Core phase gates this on
+    // canDoOperational and updates this pin to assert the no-op.
+    expect(updateShotWithVersion).toHaveBeenCalledTimes(1)
+    expect(updateShotWithVersion).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        patch: { status: "in_progress" },
+        source: "ThreePanelLayout:keyboard",
+      }),
+    )
+  })
+
+  it("moves selection through the shots prop order with ] and [", () => {
+    mockSelectedShot()
+    const onSelectShot = vi.fn()
+    renderLayout({ selectedShotId: "s2", onSelectShot })
+
+    pressKey("]")
+    expect(onSelectShot).toHaveBeenCalledTimes(1)
+    expect(onSelectShot).toHaveBeenLastCalledWith("s3")
+
+    pressKey("[")
+    expect(onSelectShot).toHaveBeenCalledTimes(2)
+    expect(onSelectShot).toHaveBeenLastCalledWith("s1")
+  })
+
+  it("does not navigate past the ends of the shots order", () => {
+    mockSelectedShot({ id: "s3" })
+    const onSelectShot = vi.fn()
+    renderLayout({ selectedShotId: "s3", onSelectShot })
+
+    pressKey("]")
+    expect(onSelectShot).not.toHaveBeenCalled()
+  })
+
+  it("deselects on Escape", () => {
+    mockSelectedShot()
+    const onDeselect = vi.fn()
+    renderLayout({ onDeselect })
+
+    pressKey("Escape")
+    expect(onDeselect).toHaveBeenCalledTimes(1)
+  })
+
+  it("deselects with a toast when the selected shot is soft-deleted", () => {
+    mockSelectedShot({ deleted: true })
+    const onDeselect = vi.fn()
+    renderLayout({ onDeselect })
+
+    expect(toast.info).toHaveBeenCalledWith("This shot has been deleted")
+    expect(onDeselect).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src-vnext/features/shots/hooks/useShotDetailBundle.ts
+++ b/src-vnext/features/shots/hooks/useShotDetailBundle.ts
@@ -27,9 +27,16 @@ function normaliseError(err: ErrorLike): string | null {
 // project's lanes — these constants force the degraded empty state instead.
 const EMPTY_LANE_BY_ID: ReadonlyMap<string, Lane> = new Map()
 const EMPTY_LANE_NAME_BY_ID: ReadonlyMap<string, string> = new Map()
+const EMPTY_LANES: ReadonlyArray<Lane> = []
 
 export interface ShotDetailBundle {
   readonly shot: Shot | null
+  /**
+   * Ordered project lanes (sortOrder asc) — SceneDetailSheet's siblingLanes
+   * input for duplicate scene-number detection (5a unified editor). Empty on
+   * a swallowed permission-denied, same as laneById.
+   */
+  readonly lanes: ReadonlyArray<Lane>
   readonly laneById: ReadonlyMap<string, Lane>
   readonly laneNameById: ReadonlyMap<string, string>
   readonly loading: boolean
@@ -68,6 +75,7 @@ export function useShotDetailBundle(shotId: string | undefined): ShotDetailBundl
     // On a swallowed permission-denied, force the empty maps — useLanes may
     // still hold the previous project's lanes (the hook retains data on error),
     // and we must not surface stale scene context to a non-member.
+    lanes: lanesPermissionDenied ? EMPTY_LANES : lanes.data,
     laneById: lanesPermissionDenied ? EMPTY_LANE_BY_ID : lanes.laneById,
     laneNameById: lanesPermissionDenied ? EMPTY_LANE_NAME_BY_ID : lanes.laneNameById,
     loading: shot.loading || lanes.loading,

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -36,4 +36,38 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
     }
   })
+
+  it("defaults featureUnifiedShotEditor to false (Phase 5a is dark on main; CI build env never defines VITE_UNIFIED_SHOT_EDITOR)", () => {
+    expect(getFeatureFlags().featureUnifiedShotEditor).toBe(false)
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
+  })
+
+  it("VITE_UNIFIED_SHOT_EDITOR='1' or 'true' enables featureUnifiedShotEditor (featureSurfaceResolver env-parse precedent)", () => {
+    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "1")
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
+
+    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "true")
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
+
+    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "TRUE")
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
+  })
+
+  it("any other VITE_UNIFIED_SHOT_EDITOR value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", value)
+      expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
+    }
+  })
+
+  it("featureUnifiedShotEditor is independent of featureSurfaceResolver (separate rollbacks, never coupled)", () => {
+    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "1")
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
+
+    vi.unstubAllEnvs()
+    vi.stubEnv("VITE_SURFACE_RESOLVER", "1")
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -23,11 +23,22 @@ export interface FeatureFlags {
    * CI build env must never define it. No URL/localStorage override layer.
    */
   readonly featureSurfaceResolver: boolean
+  /**
+   * Phase 5a — unified two-column shot editor (ShotListPage fork A +
+   * ShotDetailPage fork B). Default OFF (flag-off path is byte-identical to
+   * pre-Phase-5a trunk). Enabled ONLY via `VITE_UNIFIED_SHOT_EDITOR=1` (or
+   * `true`) at build/dev time — e.g. the :5174 eyeball runs
+   * `VITE_UNIFIED_SHOT_EDITOR=1 npm run dev -- --port 5174`.
+   * CI build env must never define it. No URL/localStorage override layer.
+   * Independent of featureSurfaceResolver — never coupled (separate rollbacks).
+   */
+  readonly featureUnifiedShotEditor: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   featurePublishing: false,
   featureSurfaceResolver: false,
+  featureUnifiedShotEditor: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -50,6 +61,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureSurfaceResolver:
       DEFAULT_FLAGS.featureSurfaceResolver ||
       parseEnvFlag(import.meta.env.VITE_SURFACE_RESOLVER),
+    featureUnifiedShotEditor:
+      DEFAULT_FLAGS.featureUnifiedShotEditor ||
+      parseEnvFlag(import.meta.env.VITE_UNIFIED_SHOT_EDITOR),
   }
 }
 

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -11,6 +11,8 @@ import {
   SEED_SHOT_SPECTRA_INPROGRESS,
   SEED_SHOT_SPECTRA_ONHOLD,
   SEED_SHOT_SPECTRA_COMPLETE,
+  SEED_SHOT_RICH,
+  SEED_RICH_SHOT_FIELDS,
   SEED_PULL,
   SEED_PULL_ITEM,
 } from './seedConstants';
@@ -112,6 +114,16 @@ export async function createTestShot(projectId: string, data: {
   date?: Date | null;
   sortOrder?: number;
   shotNumber?: string | null;
+  /**
+   * RICH display fields (Phase 5a). Written ONLY when provided, so every
+   * pre-existing seeded shot's doc shape stays byte-identical. Shapes must
+   * mirror mapShot's normalizers (see SEED_RICH_SHOT_FIELDS).
+   */
+  notes?: string | null;
+  tags?: ReadonlyArray<{ id: string; label: string; color: string }>;
+  looks?: ReadonlyArray<Record<string, unknown>>;
+  activeLookId?: string | null;
+  heroImage?: { path: string; downloadURL: string };
 }): Promise<string> {
   const db = getDb();
   const col = db.collection(`clients/${CLIENT_ID}/shots`);
@@ -136,11 +148,17 @@ export async function createTestShot(projectId: string, data: {
     talent: data.talent || [],
     talentIds: data.talent || [],
     locationId: data.location ?? null,
-    notes: null,
+    notes: data.notes ?? null,
     referenceLinks: [],
     createdAt: new Date(),
     updatedAt: new Date(),
     createdBy: '',
+    // Conditional spreads: absent unless the caller provides them, so the
+    // base seed shots keep their original doc shape exactly.
+    ...(data.tags !== undefined ? { tags: data.tags } : {}),
+    ...(data.looks !== undefined ? { looks: data.looks } : {}),
+    ...(data.activeLookId !== undefined ? { activeLookId: data.activeLookId } : {}),
+    ...(data.heroImage !== undefined ? { heroImage: data.heroImage } : {}),
   });
 
   return shotRef.id;
@@ -513,6 +531,25 @@ export async function seedShotsCrudScenario(
     });
     order += 1;
   }
+
+  // RICH display shot (Phase 5a) — description, legacy notes HTML, tags, a
+  // data:-URI hero, and 2 looks with products/colorways/SKUs, so the unified
+  // editor's colorway strip is E2E-assertable post-flip. READ-ONLY: no spec
+  // may ever mutate it (see the ownership note on SEED_SHOT_RICH).
+  await createTestShot(SEED_PROJECT_ID, {
+    id: SEED_SHOT_RICH.id,
+    title: SEED_SHOT_RICH.title,
+    status: 'todo',
+    sortOrder: order,
+    shotNumber: String(order),
+    description: SEED_RICH_SHOT_FIELDS.description,
+    notes: SEED_RICH_SHOT_FIELDS.notes,
+    tags: SEED_RICH_SHOT_FIELDS.tags,
+    looks: SEED_RICH_SHOT_FIELDS.looks,
+    activeLookId: SEED_RICH_SHOT_FIELDS.activeLookId,
+    heroImage: SEED_RICH_SHOT_FIELDS.heroImage,
+  });
+  order += 1;
 
   // Grant the viewer user project membership so firestore.rules permits it to
   // read the project's lanes (and project doc) — see the VIEWER ACCESS note

--- a/tests/helpers/seedConstants.ts
+++ b/tests/helpers/seedConstants.ts
@@ -90,6 +90,94 @@ export const SEED_FILTER_SHOTS = [
   SEED_SHOT_SPECTRA_COMPLETE,
 ] as const;
 
+/**
+ * RICH — the dedicated DISPLAY shot for the 5a unified editor (Phase 5a build
+ * spec §Test plan item 3). READ-ONLY by contract: NO spec may EVER mutate this
+ * shot (shot-ownership map: AURORA read-only, EDITABLE status/notes/title,
+ * HERO hero-only, RICH display-only). It exists so the flag-on unified
+ * editor's typographic centerpiece (product + colorway names as text),
+ * legacy-notes render, tags, and hero are E2E-assertable after the default
+ * flip — and it is harmless flag-off:
+ *
+ * - Title token "Cascade" is unique (never "Aurora"/"Borealis"/"Spectra"/
+ *   "Helios"), so the shots-crud search test and the toolbar filter tests'
+ *   per-title assertions are unaffected.
+ * - status=todo adds one more todo shot; no spec asserts shot counts.
+ * - The hero downloadURL is a data: URI — resolveStoragePath passes URLs
+ *   through synchronously, so the <img> renders with zero Storage-emulator
+ *   coupling. The path deliberately does NOT include "/hero.webp", so the
+ *   manual "Reset" affordance never appears on this shot.
+ * - Tag labels avoid DEFAULT_SHOT_TAGS labels (e.g. "Men"), so mapShot's
+ *   canonicalizeTag leaves ids/colors exactly as seeded.
+ */
+export const SEED_SHOT_RICH = { id: 'e2e-shot-rich', title: 'Cascade Display Shot' } as const;
+
+/**
+ * The RICH shot's display fields, exported so post-flip specs can assert the
+ * exact tokens (colorway strip text, SKU names, tag labels, notes copy).
+ * Shapes mirror mapShot's normalizers: looks[].products use the app's
+ * ProductAssignment fields (British 'colourName'); tags need id+label+color.
+ */
+export const SEED_RICH_SHOT_FIELDS = {
+  description:
+    'Cascade hero look on the terrace at golden hour. Full-length, soft key from camera left.',
+  // Legacy notes are stored HTML (NotesSection renders them read-only).
+  notes: '<p>Steam the hoodie before the take. Cuff the trousers once.</p>',
+  tags: [
+    { id: 'e2e-rich-tag-editorial', label: 'Editorial', color: '#2563eb' },
+    { id: 'e2e-rich-tag-exterior', label: 'Exterior', color: '#16a34a' },
+  ],
+  heroImage: {
+    path: 'e2e/rich-hero.png',
+    downloadURL:
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACgAAAAyCAIAAACh0Q7HAAAANElEQVR42u3NMQ0AAAgDsDnhRgH+nSGDgyb9m+o5EbFYLBaLxWKxWCwWi8VisVgsFos/xwsiZOBegqip8gAAAABJRU5ErkJggg==',
+  },
+  activeLookId: 'e2e-rich-look-1',
+  looks: [
+    {
+      id: 'e2e-rich-look-1',
+      label: 'Terrace Look',
+      order: 0,
+      products: [
+        {
+          familyId: 'e2e-rich-family-hoodie',
+          familyName: 'Cascade Merino Hoodie',
+          colourId: 'e2e-rich-colour-glacier',
+          colourName: 'Glacier Blue',
+          skuId: 'e2e-rich-sku-hoodie-glacier-m',
+          skuName: 'CMH-GLB-M',
+          size: 'M',
+        },
+        {
+          familyId: 'e2e-rich-family-trouser',
+          familyName: 'Cascade Wool Trouser',
+          colourId: 'e2e-rich-colour-charcoal',
+          colourName: 'Charcoal',
+          skuId: 'e2e-rich-sku-trouser-charcoal-32',
+          skuName: 'CWT-CHR-32',
+          size: '32',
+        },
+      ],
+    },
+    {
+      id: 'e2e-rich-look-2',
+      label: 'Dusk Look',
+      order: 1,
+      products: [
+        {
+          familyId: 'e2e-rich-family-overshirt',
+          familyName: 'Cascade Overshirt',
+          colourId: 'e2e-rich-colour-ember',
+          colourName: 'Ember',
+          skuId: 'e2e-rich-sku-overshirt-ember-l',
+          skuName: 'COS-EMB-L',
+          size: 'L',
+        },
+      ],
+    },
+  ],
+} as const;
+
 /** All seeded shots, in seed order. */
 export const SEED_SHOTS = [
   SEED_SHOT_AURORA,


### PR DESCRIPTION
## Redesign Phase 5a — the unified two-column shot editor (flag-gated)

Implements the audited Phase 5a contract (8-agent adversarial audit, 2026-06-09; spec: `outputs/2026-06-09-phase5a-build-spec.md` in the workspace). Built to the Ted-approved working comp on real Q2-2026 No. 2-shaped data. **Flag default OFF — zero user-visible change at merge.**

### What this does
- **New flag `featureUnifiedShotEditor`** (`VITE_UNIFIED_SHOT_EDITOR`, env-only, default false) following the `featureSurfaceResolver` registry precedent exactly. Independent of the Phase 4 flag — the two rollbacks stay decoupled.
- **Fork A (ShotListPage):** flag-on, a desktop shot click navigates to the detail route instead of selecting into ThreePanel; `threePanelActive` folds the flag so the early return goes permanently inert. Flag-off branch byte-identical, commented `gated, NOT deleted; retirement at 5c`.
- **Fork B (ShotDetailPage):** flag-on renders the new `ShotDetailPageUnified` (+ `ShotDetailSidebar`); flag-off keeps the legacy 436-line render byte-identical.
- **The unified layout** (DESIGN.md law, approved at comp): shot# + status badge-trigger → Ivy Presto shot name + the red iconic period (the surface's single red) → Description first → aspect-flexible hero + reference rail (native image ratio, no forced widescreen — Ted's approval condition) → product colorway strip as a pure-text typographic centerpiece → Date/Location/Talent as ONE inline editorial meta line with per-segment editing (no dialogs) → Notes → reference links → Tags → Comments → collapsed version history. Right sticky rail: Looks + Products.
- **1–4 status keys** rehomed onto the unified editor, role-gated (viewer no-op, tested). `[`/`]` prev-next + in-editor quick-add are a NAMED deferred follow-up (decided before 5c).
- **Capability convergence (Ted-decided, strict):** lifecycle menu stays admin/producer (crew delta vs ThreePanel is deliberate); NEW `canUploadShotImages` = admin/producer only — crew no longer sees upload buttons that storage.rules always rejected.

### Two flag-independent security fixes (Ted-approved, the #432 normalizeRole precedent)
1. `ThreePanelLayout.handleStatusKey` gains the missing role gate — previously ANY desktop user including viewers could write shot status via the 1–4 keys (shots writes are `isAuthed()`-only until 5b). Characterization pin updated red→green in the same commit.
2. `SceneDetailSheet` gains a **required** `canEditScene` prop mirroring the lanes write rule — viewers/crew previously got an editable form whose every save failed against the rules.

### Test contract
- **First commit = characterization pins** written against unchanged source (desktop click→ThreePanel, detail-page desktop gates, ThreePanel keyboard incl. the pinned-then-fixed viewer hole, crew-lifecycle divergence, DescriptionEditor flush-on-unmount).
- Per-role affordance matrix on the unified editor (viewer/warehouse mount zero enabled write affordances).
- All load-bearing testids/copy carried verbatim onto the flag-on layout (`shot-title-edit`, `shot-status-select-trigger`, `meta-*`, `tags-section`, notes/hero testids, "Back to Shots") so ONE Playwright suite stays valid for both layouts.
- New RICH seed display shot (never mutated) so the colorway strip is E2E-assertable post-flip.
- The five detail-surface specs (shots-crud, sidebar-summary, hero-image, role-matrix, smoke) pass flag-off unchanged — **CI ui-checks is the arbiter** (local Java 8 cannot run emulators). Flag-on automated proof lands with the post-eyeball default-flip PR, which is the 5c entry gate.

### Verification
Lint 0 errors/0 warnings · build clean · 11 test files re-run independently post-build, all green (incl. pre-existing ShotListPage 24/24, ShotDetailPage 2/2). Adversarial verifier after every writer phase; flag-off byte-identical confirmed hunk-by-hunk except the two named fixes.

### Reviewer note
`docs/DESIGN.md` / `docs/PRODUCT.md` (the layout law this builds to) are intentionally NOT committed per standing constraint — flagged to Ted whether to commit them alongside this PR.

### Eyeball
`VITE_UNIFIED_SHOT_EDITOR=1 npm run dev -- --port 5174`

Do not merge without Ted's go.