### PR TITLE
feat(shots): flip featureUnifiedShotEditor default ON (redesign Phase 5a → 5c gate)

### DIFF
--- a/src-vnext/features/shots/components/__tests__/ShotDetailPage.desktop.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPage.desktop.test.tsx
@@ -50,6 +50,17 @@ vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsDesktop: () => true,
 }))
 
+// Pin the legacy (flag-off) detail body — the 5c rollback path. The real
+// featureUnifiedShotEditor default is ON since the default-flip PR.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: () => false,
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: false,
+    featureUnifiedShotEditor: false,
+  }),
+}))
+
 vi.mock("@/features/shots/hooks/usePickerData", () => ({
   useTalent: () => ({ data: [], loading: false, error: null }),
   useLocations: () => ({ data: [], loading: false, error: null }),

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPage.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPage.test.tsx
@@ -32,6 +32,17 @@ vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsMobile: () => true,
 }))
 
+// Pin the legacy (flag-off) detail body — the 5c rollback path. The real
+// featureUnifiedShotEditor default is ON since the default-flip PR.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: () => false,
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: false,
+    featureUnifiedShotEditor: false,
+  }),
+}))
+
 vi.mock("@/features/shots/hooks/usePickerData", () => ({
   useTalent: () => ({ data: [], loading: false, error: null }),
   useLocations: () => ({ data: [], loading: false, error: null }),

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
@@ -1,10 +1,12 @@
 /// <reference types="@testing-library/jest-dom" />
 // Phase 5a characterization pin (build spec, Test plan 1a).
 //
-// Pins TODAY's desktop click behavior on ShotListPage, against unchanged
-// source: on desktop (useIsDesktop=true), clicking a shot SELECTS it into the
-// three-panel layout (ShotListPage.tsx handleShotClick desktop branch +
-// threePanelActive early return) and does NOT navigate to the detail route.
+// Pins the flag-OFF ROLLBACK path on ShotListPage: with
+// featureUnifiedShotEditor forced off (the real default is ON since the
+// default-flip PR), a desktop shot click (useIsDesktop=true) SELECTS into the
+// three-panel layout (handleShotClick desktop branch + threePanelActive early
+// return) and does NOT navigate to the detail route. Stays alive until 5c
+// deletes the fallback. Flag-ON counterpart: ShotListPage.unifiedEditorFork.
 // Nothing pinned this before — ShotListPage.test.tsx forces useIsDesktop=false.
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
@@ -41,6 +43,18 @@ vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsMobile: () => false,
   useIsTablet: () => false,
   useIsDesktop: () => true,
+}))
+
+// Flag mock: featureUnifiedShotEditor OFF, everything else default-off.
+// The real default flipped ON in the default-flip PR; this pin forces it off
+// explicitly so the ThreePanel rollback path stays covered until 5c.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: () => false,
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: false,
+    featureUnifiedShotEditor: false,
+  }),
 }))
 
 vi.mock("@/features/shots/components/ShotStatusSelect", () => ({

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -37,37 +37,25 @@ describe("feature flags", () => {
     }
   })
 
-  it("defaults featureUnifiedShotEditor to false (Phase 5a is dark on main; CI build env never defines VITE_UNIFIED_SHOT_EDITOR)", () => {
-    expect(getFeatureFlags().featureUnifiedShotEditor).toBe(false)
-    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
-  })
-
-  it("VITE_UNIFIED_SHOT_EDITOR='1' or 'true' enables featureUnifiedShotEditor (featureSurfaceResolver env-parse precedent)", () => {
-    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "1")
-    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
-
-    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "true")
-    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
-
-    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "TRUE")
+  it("defaults featureUnifiedShotEditor to true (default-flip: desktop list clicks navigate to the unified editor; rollback = flip the default back)", () => {
+    expect(getFeatureFlags().featureUnifiedShotEditor).toBe(true)
     expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
   })
 
-  it("any other VITE_UNIFIED_SHOT_EDITOR value stays off (no URL/localStorage override layer)", () => {
-    for (const value of ["0", "false", "", "yes", "on"]) {
+  it("no VITE_UNIFIED_SHOT_EDITOR value turns the flag off (the env override is enable-only; rollback lives in the code default)", () => {
+    for (const value of ["1", "true", "TRUE", "0", "false", "", "yes", "on"]) {
       vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", value)
-      expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
+      expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
     }
   })
 
   it("featureUnifiedShotEditor is independent of featureSurfaceResolver (separate rollbacks, never coupled)", () => {
-    vi.stubEnv("VITE_UNIFIED_SHOT_EDITOR", "1")
+    // Unified editor default-on never drags the surface resolver along.
     expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
     expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
 
-    vi.unstubAllEnvs()
     vi.stubEnv("VITE_SURFACE_RESOLVER", "1")
     expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
-    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(false)
+    expect(isFeatureEnabled("featureUnifiedShotEditor")).toBe(true)
   })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -25,11 +25,11 @@ export interface FeatureFlags {
   readonly featureSurfaceResolver: boolean
   /**
    * Phase 5a — unified two-column shot editor (ShotListPage fork A +
-   * ShotDetailPage fork B). Default OFF (flag-off path is byte-identical to
-   * pre-Phase-5a trunk). Enabled ONLY via `VITE_UNIFIED_SHOT_EDITOR=1` (or
-   * `true`) at build/dev time — e.g. the :5174 eyeball runs
-   * `VITE_UNIFIED_SHOT_EDITOR=1 npm run dev -- --port 5174`.
-   * CI build env must never define it. No URL/localStorage override layer.
+   * ShotDetailPage fork B). Default ON since the default-flip PR (the 5c
+   * entry gate): desktop list clicks navigate to the unified editor route.
+   * ThreePanel stays in code as the instant rollback — flip this default
+   * back to false to restore it (the env override then re-applies; it is a
+   * no-op while the default is ON). Legacy paths are deleted at 5c.
    * Independent of featureSurfaceResolver — never coupled (separate rollbacks).
    */
   readonly featureUnifiedShotEditor: boolean
@@ -38,7 +38,7 @@ export interface FeatureFlags {
 const DEFAULT_FLAGS: FeatureFlags = {
   featurePublishing: false,
   featureSurfaceResolver: false,
-  featureUnifiedShotEditor: false,
+  featureUnifiedShotEditor: true,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */


### PR DESCRIPTION
## What

Flips `featureUnifiedShotEditor` from default-OFF to default-ON in `flags.ts`. This is the post-eyeball default-flip mini-PR named in the Phase 5a flag-flip checklist; its green `ui-checks` run — now building flag-ON and exercising the unified layout via the carried testids — is the Phase 5c entry gate.

## User-visible change

**Desktop list click navigates to the unified editor route.** ThreePanel becomes unreachable but stays in code as the instant rollback (flip the default back to `false` to restore it; legacy paths are deleted at 5c). Crew capability deltas at flip, as announced in #433: lifecycle menu is admin/producer-only and upload buttons are hidden for crew on the unified editor.

`featureSurfaceResolver` is a separate flag and stays OFF — the producer card→table default change does NOT happen in this PR.

## Test changes

- `flags.test.ts`: pins the new default-true; the `VITE_UNIFIED_SHOT_EDITOR` env override is enable-only, so no env value can turn the flag off — rollback lives in the code default.
- `ShotListPage.desktopThreePanel.test.tsx`, `ShotDetailPage.test.tsx`, `ShotDetailPage.desktop.test.tsx`: these flag-OFF characterization pins previously relied on the real default; they now force the flag off via explicit mocks so the ThreePanel/legacy-detail rollback path stays covered until 5c deletes the fallback. `ShotListPage.unifiedEditorFork.test.tsx` and `ShotDetailPageUnified.test.tsx` already carried explicit flag-ON mocks and are unchanged.

## Verification

- 7 affected vitest files re-run individually: 53/53 green (flags, both ShotListPage pins, both ShotDetailPage pins, ShotDetailPageUnified, ShotListPage).
- `npm run lint` 0 errors / 0 warnings; `npm run build` clean.
- CI `ui-checks` (job `test`) on this PR is the arbiter for the flag-ON Playwright suite (local emulators infeasible).