### PR TITLE
feat(auth/rules): effective-role source + /shots write-rule hardening (redesign Phase 5b-I)

### DIFF
--- a/.github/workflows/ui-checks.yml
+++ b/.github/workflows/ui-checks.yml
@@ -55,6 +55,23 @@ jobs:
           echo "Storage emulator ready"
           echo "Firebase emulators started (PID: $EMULATOR_PID)"
 
+      - name: Rules unit tests (emulator)
+        run: |
+          set -o pipefail
+          NO_COLOR=1 CI=1 FIRESTORE_EMULATOR_HOST=localhost:8080 \
+            npx vitest run ".rules.test.ts" 2>&1 | tee rules-tests.log
+          # Guard against green-by-skip: the rules suites self-skip (and still
+          # report a passing skip-notice test) when FIRESTORE_EMULATOR_HOST is
+          # not visible, so require a non-zero passed count AND zero skipped.
+          summary=$(grep -E '^[[:space:]]*Tests[[:space:]]' rules-tests.log | tail -1)
+          echo "Rules test summary: ${summary}"
+          if [ -z "${summary}" ] \
+            || ! echo "${summary}" | grep -qE '[1-9][0-9]* passed' \
+            || echo "${summary}" | grep -q 'skipped'; then
+            echo "Rules tests did not all execute (zero passed or some skipped) — failing."
+            exit 1
+          fi
+
       - name: Build & Preview (Vite)
         run: |
           if [ -f vite.config.ts ] || [ -f vite.config.js ]; then

--- a/firestore.rules
+++ b/firestore.rules
@@ -906,11 +906,16 @@ service cloud.firestore {
 
       // Wildcard catch-all for any other project sub-collections
       // Includes 'crew' for consistency with explicit sub-resource rules above.
+      // members is excluded from the write arm: overlapping matches OR
+      // together, so without the exclusion any team-visible-project producer
+      // could write arbitrary members docs through this rule, bypassing the
+      // explicit members rules (admin-only management + creation-time self-add).
       match /{collectionId}/{docId} {
         allow read: if clientMatches(clientId) &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||
            hasProjectRole(projectId, ['producer', 'crew', 'warehouse', 'viewer']));
         allow create, update, delete: if clientMatches(clientId) &&
+          collectionId != 'members' &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||
            hasProjectRole(projectId, ['producer', 'warehouse']));
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -93,6 +93,26 @@ service cloud.firestore {
         roles.hasAny([normalizedRole]);
     }
 
+    // Shots are CLIENT-scoped — projectId is a doc FIELD (mapShot.ts, '' fallback),
+    // not a path segment. Normalizes a missing/non-string projectId to '' so no
+    // get()/exists() ever sees a malformed path; '' routes to the legacy arm in
+    // shotProjectRole() below.
+    function shotProjectId(data) {
+      return ('projectId' in data && data.projectId is string) ? data.projectId : '';
+    }
+
+    // Project-scoped write arm for /shots and shot sub-resources. Callers pass
+    // the per-verb projectId source through shotProjectId():
+    // request.resource.data on create, resource.data on update/delete.
+    // Empty projectId (legacy shots): admin / global producer only — there is
+    // no project doc to scope against.
+    function shotProjectRole(clientId, projectId, roles) {
+      return isAdmin() ||
+        (projectId != ''
+          ? (producerCanAccessProject(clientId, projectId) || hasProjectRole(projectId, roles))
+          : hasGlobalRole(['producer']));
+    }
+
     function isSystemAdmin() {
       return request.auth != null &&
         exists(/databases/$(database)/documents/systemAdmins/$(request.auth.token.email)) &&
@@ -168,12 +188,20 @@ service cloud.firestore {
         (isAdmin() || isProducer()) &&
         resource.data.clientId == userClient();
 
+      // Create is project-scoped: a non-admin must hold producer access on the
+      // share's projectId (team-visible via producerCanAccessProject, or an
+      // explicit producer members doc) — a global claim alone cannot mint an
+      // enabled public share for an arbitrary project.
       allow create: if isAuthed() &&
-        (isAdmin() || isProducer()) &&
         request.resource.data.clientId == userClient() &&
         request.resource.data.projectId is string &&
         (request.resource.data.shotIds == null || request.resource.data.shotIds is list) &&
-        request.resource.data.enabled is bool;
+        request.resource.data.enabled is bool &&
+        (isAdmin() ||
+          (isProducer() &&
+           request.resource.data.projectId != '' &&
+           (producerCanAccessProject(userClient(), request.resource.data.projectId) ||
+            hasProjectRole(request.resource.data.projectId, ['producer']))));
 
       allow update, delete: if isAuthed() &&
         (isAdmin() || isProducer()) &&
@@ -406,7 +434,41 @@ service cloud.firestore {
 
 	    match /clients/{clientId}/shots/{docId} {
 	      allow read: if clientMatches(clientId);
-	      allow create, update, delete: if clientMatches(clientId) && isAuthed();
+
+	      // Create: project role on the incoming projectId, plus a global-producer
+	      // lane — createProjectFromRequest writes project + member + shot in ONE
+	      // transaction and rules get()/exists() see pre-transaction state, so the
+	      // membership arms cannot pass there (mirrors the projects create rule).
+	      // Role list ['producer','crew'] diverges from lanes (:806) intentionally:
+	      // crew writes shots (5e); warehouse shot-write was never UI-granted and
+	      // is revoked at 5f.
+	      allow create: if clientMatches(clientId) && (
+	        hasGlobalRole(['producer']) ||
+	        shotProjectRole(clientId, shotProjectId(request.resource.data), ['producer', 'crew'])
+	      );
+
+	      // Update: project role against the pre-image projectId; projectId is
+	      // immutable here — moves go through the arm below.
+	      // Batch budget: isAdmin() short-circuits before any get(), so the
+	      // admin-only client-wide batches (productMergeWrites.updateShotReferences,
+	      // spanning many projects per chunk) stay within the 20-access limit.
+	      // Single-project batches (BATCH_CHUNK_SIZE=250) touch 2 unique docs.
+	      allow update: if clientMatches(clientId) &&
+	        shotProjectId(request.resource.data) == shotProjectId(resource.data) &&
+	        shotProjectRole(clientId, shotProjectId(resource.data), ['producer', 'crew']);
+
+	      // Project-move (shotLifecycleActions.ts moveShotToProject): admins, or
+	      // global producers holding a project-scoped role on the TARGET projectId.
+	      allow update: if clientMatches(clientId) && (
+	        isAdmin() ||
+	        (hasGlobalRole(['producer']) &&
+	         shotProjectRole(clientId, shotProjectId(request.resource.data), ['producer']))
+	      );
+
+	      // Delete: pre-image projectId only — request.resource.data does not
+	      // exist on delete.
+	      allow delete: if clientMatches(clientId) &&
+	        shotProjectRole(clientId, shotProjectId(resource.data), ['producer', 'crew']);
 
       // Comments - subcollection of shots for collaboration
       match /comments/{commentId} {
@@ -431,11 +493,19 @@ service cloud.firestore {
           resource.data.createdBy == request.auth.uid;
       }
 
-      // Versions - immutable document snapshots for version history
+      // Versions - immutable document snapshots for version history.
+      // Create carries the same project arm as the parent shot: snapshots copy
+      // full shot data, so a denied shot-writer must not mint them. projectId
+      // comes from the parent shot doc (get is cached per request; version
+      // writes never ride in batches with shot writes).
       match /versions/{versionId} {
         allow read: if clientMatches(clientId);
         allow create: if clientMatches(clientId) && isAuthed() &&
-          request.resource.data.createdBy == request.auth.uid;
+          request.resource.data.createdBy == request.auth.uid &&
+          shotProjectRole(
+            clientId,
+            shotProjectId(get(/databases/$(database)/documents/clients/$(clientId)/shots/$(docId)).data),
+            ['producer', 'crew']);
         allow update, delete: if false; // Versions are immutable
       }
 
@@ -642,12 +712,17 @@ service cloud.firestore {
           // Self-membership: allow producers to add themselves when creating a project.
           // Validates: own UID only, must set addedBy to self, role must be 'producer',
           // and only the expected fields are written (no extra data injection).
+          // Creation-time only: getAfter sees the same-transaction project write
+          // (CreateProjectDialog.tsx, requestWrites.ts createProjectFromRequest),
+          // so the project's createdBy must be the caller — a producer cannot
+          // self-mint membership on someone else's project.
           allow create: if clientMatches(clientId)
             && isProducer()
             && memberId == request.auth.uid
             && request.resource.data.addedBy == request.auth.uid
             && request.resource.data.role == 'producer'
-            && request.resource.data.keys().hasOnly(['role', 'addedAt', 'addedBy']);
+            && request.resource.data.keys().hasOnly(['role', 'addedAt', 'addedBy'])
+            && getAfter(/databases/$(database)/documents/clients/$(clientId)/projects/$(projectId)).data.createdBy == request.auth.uid;
         }
 
 	      // Project departments and positions (project-scoped role taxonomy)

--- a/firestore.rules
+++ b/firestore.rules
@@ -191,7 +191,8 @@ service cloud.firestore {
       // Create is project-scoped: a non-admin must hold producer access on the
       // share's projectId (team-visible via producerCanAccessProject, or an
       // explicit producer members doc) — a global claim alone cannot mint an
-      // enabled public share for an arbitrary project.
+      // enabled public share for an arbitrary project. Only the admin arm may
+      // create a share with an empty projectId (legacy/unscoped shares).
       allow create: if isAuthed() &&
         request.resource.data.clientId == userClient() &&
         request.resource.data.projectId is string &&
@@ -459,6 +460,11 @@ service cloud.firestore {
 
 	      // Project-move (shotLifecycleActions.ts moveShotToProject): admins, or
 	      // global producers holding a project-scoped role on the TARGET projectId.
+	      // The arm checks the TARGET only — a producer can move a shot OUT of a
+	      // private project (accepted: shot reads are client-wide regardless of
+	      // project visibility). It also matches non-move updates; that is
+	      // intentional — its access requirement is equal or stricter than the
+	      // arm above, never wider.
 	      allow update: if clientMatches(clientId) && (
 	        isAdmin() ||
 	        (hasGlobalRole(['producer']) &&
@@ -498,6 +504,8 @@ service cloud.firestore {
       // full shot data, so a denied shot-writer must not mint them. projectId
       // comes from the parent shot doc (get is cached per request; version
       // writes never ride in batches with shot writes).
+      // isAuthed() is belt-and-suspenders: createdBy compares against
+      // request.auth.uid and must never evaluate it on null auth.
       match /versions/{versionId} {
         allow read: if clientMatches(clientId);
         allow create: if clientMatches(clientId) && isAuthed() &&

--- a/src-vnext/features/requests/lib/requestWrites.ts
+++ b/src-vnext/features/requests/lib/requestWrites.ts
@@ -169,6 +169,10 @@ export async function createProjectFromRequest(
       clientId: params.clientId,
       status: "active",
       shootDates: params.shootDates ?? [],
+      // Required by the members self-create carve-out (firestore.rules): the
+      // same-transaction member doc below is only allowed when the project's
+      // createdBy is the caller. CreateProjectDialog already writes it.
+      createdBy: params.createdBy,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     })

--- a/src-vnext/features/shots/__tests__/shots.rules.test.ts
+++ b/src-vnext/features/shots/__tests__/shots.rules.test.ts
@@ -1,0 +1,473 @@
+// @vitest-environment node
+/**
+ * Firestore rules characterization tests for /clients/{clientId}/shots and
+ * its adjacent write surfaces (project members self-create, shotShares,
+ * shot versions, the create-project-from-request transaction shape).
+ *
+ * These pins capture TODAY'S permissive behavior — every test asserts
+ * SUCCESS against the current rules. When the shots write rules harden,
+ * the pins flip to assertFails in the same commit so the diff IS the
+ * reviewable behavior change.
+ *
+ * Write shapes mirror the real client writers byte-for-byte:
+ *   - shot create: CreateShotDialog.tsx
+ *   - shot update: updateShotWithVersion.ts
+ *   - shot move: shotLifecycleActions.ts moveShotToProject
+ *   - version create: shotVersioning.ts createShotVersionSnapshot
+ *   - member self-create: adminWrites.ts addProjectMember
+ *   - share create: ShotsShareDialog.tsx Firestore fallback
+ *   - project-from-request batch: requestWrites.ts createProjectFromRequest
+ *
+ * Requires the Firestore emulator. When `FIRESTORE_EMULATOR_HOST` is not
+ * set, the suite is skipped so `CI=1 npm test -- --run` stays green on
+ * developer machines without a running emulator. CI (ui-checks.yml) starts
+ * the emulator on port 8080 and sets the host, so these tests run there.
+ */
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing"
+import {
+  collection,
+  deleteDoc,
+  doc,
+  serverTimestamp,
+  setDoc,
+  Timestamp,
+  updateDoc,
+  writeBatch,
+} from "firebase/firestore"
+
+const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST
+const skipSuite = !EMULATOR_HOST
+const describeOrSkip = skipSuite ? describe.skip : describe
+
+const PROJECT_ID = "demo-shots-rules"
+const RULES_PATH = resolve(__dirname, "../../../../firestore.rules")
+
+const CLIENT_ID = "unbound-merino"
+
+const VIEWER_UID = "viewer-uid"
+const CREW_UID = "crew-uid"
+const PRODUCER_UID = "producer-uid"
+const OWNER_UID = "owner-uid"
+
+// Seeded projects: one with an explicit visibility field, one without
+// (a missing visibility field counts as team-visible), plus a move target.
+const PROJ_TEAM = "proj-team"
+const PROJ_UNSET = "proj-unset"
+const PROJ_TARGET = "proj-target"
+
+const REQUEST_ID = "req-1"
+
+// Seeded shots, one per mutation pin so tests stay order-independent.
+const SHOT_VIEWER_UPDATE = "shot-viewer-update"
+const SHOT_VIEWER_DELETE = "shot-viewer-delete"
+const SHOT_CREW_UPDATE = "shot-crew-update"
+const SHOT_CREW_DELETE = "shot-crew-delete"
+const SHOT_MOVE = "shot-move"
+const SHOT_VERSIONS = "shot-versions"
+
+/** Shot create payload — mirrors CreateShotDialog.tsx handleCreate. */
+function makeShotCreate(projectId: string, createdBy: string) {
+  return {
+    title: "Hero look",
+    description: null,
+    projectId,
+    clientId: CLIENT_ID,
+    status: "todo",
+    talent: [],
+    products: [],
+    sortOrder: Date.now(),
+    shotNumber: 1,
+    date: null,
+    deleted: false,
+    notes: null,
+    referenceLinks: [],
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+    createdBy,
+  }
+}
+
+/** Seed-side shot doc (rules-disabled writes use concrete timestamps). */
+function makeSeedShot(projectId: string) {
+  return {
+    title: "Seeded shot",
+    description: null,
+    projectId,
+    clientId: CLIENT_ID,
+    status: "todo",
+    talent: [],
+    products: [],
+    sortOrder: 1,
+    shotNumber: 1,
+    date: null,
+    deleted: false,
+    notes: null,
+    referenceLinks: [],
+    createdAt: Timestamp.now(),
+    updatedAt: Timestamp.now(),
+    createdBy: OWNER_UID,
+  }
+}
+
+/** Version doc — mirrors shotVersioning.ts createShotVersionSnapshot. */
+function makeVersionDoc(createdBy: string) {
+  return {
+    snapshot: {
+      title: "Seeded shot",
+      description: null,
+      status: "todo",
+      shotNumber: 1,
+      date: null,
+      talent: [],
+      talentIds: [],
+      products: [],
+      locationId: null,
+      locationName: null,
+      laneId: null,
+      notes: null,
+      notesAddendum: null,
+      heroImage: null,
+      looks: [],
+      activeLookId: null,
+      tags: [],
+      referenceLinks: [],
+    },
+    createdBy,
+    createdByName: "Viewer User",
+    createdByAvatar: null,
+    changeType: "update",
+    changedFields: ["title"],
+    createdAt: serverTimestamp(),
+  }
+}
+
+let testEnv: RulesTestEnvironment | null = null
+
+function viewerDb() {
+  return testEnv!
+    .authenticatedContext(VIEWER_UID, { role: "viewer", clientId: CLIENT_ID })
+    .firestore()
+}
+
+function crewDb() {
+  return testEnv!
+    .authenticatedContext(CREW_UID, { role: "crew", clientId: CLIENT_ID })
+    .firestore()
+}
+
+function producerDb() {
+  return testEnv!
+    .authenticatedContext(PRODUCER_UID, { role: "producer", clientId: CLIENT_ID })
+    .firestore()
+}
+
+describeOrSkip("firestore.rules — shots write surfaces (characterization pins)", () => {
+  beforeAll(async () => {
+    if (!EMULATOR_HOST) return
+    const [host, portStr] = EMULATOR_HOST.split(":")
+    const port = Number(portStr || "8080")
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: {
+        host,
+        port,
+        rules: readFileSync(RULES_PATH, "utf8"),
+      },
+    })
+
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore()
+
+      await setDoc(doc(db, "clients", CLIENT_ID), { name: "Unbound Merino" })
+
+      // Project with an explicit visibility field (CreateProjectDialog shape).
+      await setDoc(doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM), {
+        name: "Team Project",
+        clientId: CLIENT_ID,
+        status: "active",
+        visibility: "team",
+        shootDates: [],
+        createdBy: OWNER_UID,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+
+      // Project WITHOUT a visibility field (the common live state).
+      await setDoc(doc(db, "clients", CLIENT_ID, "projects", PROJ_UNSET), {
+        name: "Unset Visibility Project",
+        clientId: CLIENT_ID,
+        status: "active",
+        shootDates: [],
+        createdBy: OWNER_UID,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+
+      await setDoc(doc(db, "clients", CLIENT_ID, "projects", PROJ_TARGET), {
+        name: "Move Target Project",
+        clientId: CLIENT_ID,
+        status: "active",
+        shootDates: [],
+        createdBy: OWNER_UID,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+
+      for (const shotId of [
+        SHOT_VIEWER_UPDATE,
+        SHOT_VIEWER_DELETE,
+        SHOT_CREW_UPDATE,
+        SHOT_CREW_DELETE,
+        SHOT_MOVE,
+        SHOT_VERSIONS,
+      ]) {
+        await setDoc(
+          doc(db, "clients", CLIENT_ID, "shots", shotId),
+          makeSeedShot(PROJ_TEAM),
+        )
+      }
+
+      // Submitted shot request (submitShotRequest shape) for the
+      // create-project-from-request transaction pin.
+      await setDoc(doc(db, "clients", CLIENT_ID, "shotRequests", REQUEST_ID), {
+        clientId: CLIENT_ID,
+        status: "submitted",
+        priority: "normal",
+        title: "Requested shot",
+        description: null,
+        referenceUrls: null,
+        references: null,
+        deadline: null,
+        notes: null,
+        submittedBy: OWNER_UID,
+        submittedByName: null,
+        relatedFamilyIds: null,
+        notifyUserIds: null,
+        submittedAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+    })
+  })
+
+  afterAll(async () => {
+    if (testEnv) {
+      await testEnv.cleanup()
+    }
+  })
+
+  // --- (a) viewer-claim shot writes pass under the isAuthed-only rule ---
+
+  it("[a1] viewer-claim CAN create a shot", async () => {
+    const db = viewerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-viewer-create"),
+        makeShotCreate(PROJ_TEAM, VIEWER_UID),
+      ),
+    )
+  })
+
+  it("[a2] viewer-claim CAN update a shot", async () => {
+    const db = viewerDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_VIEWER_UPDATE), {
+        title: "Viewer edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: VIEWER_UID,
+      }),
+    )
+  })
+
+  it("[a3] viewer-claim CAN delete a shot", async () => {
+    const db = viewerDb()
+    await assertSucceeds(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_VIEWER_DELETE)),
+    )
+  })
+
+  // --- (b) crew-claim NON-member (no members doc anywhere) shot writes ---
+
+  it("[b1] crew-claim non-member CAN create a shot", async () => {
+    const db = crewDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-crew-create"),
+        makeShotCreate(PROJ_UNSET, CREW_UID),
+      ),
+    )
+  })
+
+  it("[b2] crew-claim non-member CAN update a shot", async () => {
+    const db = crewDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_CREW_UPDATE), {
+        title: "Crew edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: CREW_UID,
+      }),
+    )
+  })
+
+  it("[b3] crew-claim non-member CAN delete a shot", async () => {
+    const db = crewDb()
+    await assertSucceeds(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_CREW_DELETE)),
+    )
+  })
+
+  // --- (c) members self-create carve-out ---
+
+  it("[c] producer-claim CAN self-create a producer members doc on an existing project they did not create", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(
+          db,
+          "clients",
+          CLIENT_ID,
+          "projects",
+          PROJ_TEAM,
+          "members",
+          PRODUCER_UID,
+        ),
+        {
+          role: "producer",
+          addedAt: serverTimestamp(),
+          addedBy: PRODUCER_UID,
+        },
+      ),
+    )
+  })
+
+  // --- (d) createProjectFromRequest transaction shape ---
+
+  it("[d] producer-claim createProjectFromRequest batch (project + member + shot + request update) SUCCEEDS", async () => {
+    const db = producerDb()
+    const projectRef = doc(collection(db, "clients", CLIENT_ID, "projects"))
+    const shotRef = doc(collection(db, "clients", CLIENT_ID, "shots"))
+    const memberRef = doc(
+      db,
+      "clients",
+      CLIENT_ID,
+      "projects",
+      projectRef.id,
+      "members",
+      PRODUCER_UID,
+    )
+    const requestRef = doc(db, "clients", CLIENT_ID, "shotRequests", REQUEST_ID)
+
+    const batch = writeBatch(db)
+    batch.set(projectRef, {
+      name: "Absorbed Project",
+      clientId: CLIENT_ID,
+      status: "active",
+      shootDates: [],
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+    batch.set(memberRef, {
+      role: "producer",
+      addedAt: serverTimestamp(),
+      addedBy: PRODUCER_UID,
+    })
+    batch.set(shotRef, {
+      title: "Requested shot",
+      description: "",
+      projectId: projectRef.id,
+      clientId: CLIENT_ID,
+      status: "todo",
+      deleted: false,
+      date: null,
+      talent: [],
+      products: [],
+      sortOrder: Date.now(),
+      sourceRequestId: REQUEST_ID,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+      createdBy: PRODUCER_UID,
+    })
+    batch.update(requestRef, {
+      status: "absorbed",
+      triagedBy: PRODUCER_UID,
+      triagedAt: serverTimestamp(),
+      absorbedIntoProjectId: projectRef.id,
+      absorbedAsShotId: shotRef.id,
+      updatedAt: serverTimestamp(),
+    })
+
+    await assertSucceeds(batch.commit())
+  })
+
+  // --- (e) project-move ---
+
+  it("[e] producer-claim CAN update a shot's projectId to a different project", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MOVE), {
+        projectId: PROJ_TARGET,
+        laneId: null,
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  // --- (f) shotShares (top-level collection) ---
+
+  it("[f] producer-claim CAN create an enabled shotShares doc with an arbitrary projectId string", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      setDoc(doc(db, "shotShares", "share-token-characterization-1"), {
+        clientId: CLIENT_ID,
+        projectId: "some-project-the-producer-never-touched",
+        shotIds: null,
+        enabled: true,
+        title: "All shots",
+        expiresAt: null,
+        createdAt: serverTimestamp(),
+        createdBy: PRODUCER_UID,
+        projectName: "Some Project",
+        resolvedShots: [],
+        columnConfig: ["title", "talent", "products"],
+      }),
+    )
+  })
+
+  // --- (g) versions subcollection ---
+
+  it("[g] viewer-claim CAN create a versions doc under a shot", async () => {
+    const db = viewerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(
+          db,
+          "clients",
+          CLIENT_ID,
+          "shots",
+          SHOT_VERSIONS,
+          "versions",
+          "version-1",
+        ),
+        makeVersionDoc(VIEWER_UID),
+      ),
+    )
+  })
+})
+
+// Ensure the skip notice is visible in test output so developers know why
+// zero rules tests ran locally.
+if (skipSuite) {
+  describe("firestore.rules — shots write surfaces (skipped)", () => {
+    it("skipped: set FIRESTORE_EMULATOR_HOST to run rules unit tests", () => {
+      expect(skipSuite).toBe(true)
+    })
+  })
+}

--- a/src-vnext/features/shots/__tests__/shots.rules.test.ts
+++ b/src-vnext/features/shots/__tests__/shots.rules.test.ts
@@ -1,13 +1,14 @@
 // @vitest-environment node
 /**
- * Firestore rules characterization tests for /clients/{clientId}/shots and
- * its adjacent write surfaces (project members self-create, shotShares,
- * shot versions, the create-project-from-request transaction shape).
+ * Firestore rules tests for /clients/{clientId}/shots and its adjacent write
+ * surfaces (project members self-create, shotShares, shot versions, the
+ * create-project-from-request transaction shape).
  *
- * These pins capture TODAY'S permissive behavior — every test asserts
- * SUCCESS against the current rules. When the shots write rules harden,
- * the pins flip to assertFails in the same commit so the diff IS the
- * reviewable behavior change.
+ * History: commit 1 pinned TODAY'S permissive behavior (everything
+ * assertSucceeds under the isAuthed-only /shots rule). This commit hardens
+ * the rules and flips the pins in the SAME diff, so the assertSucceeds →
+ * assertFails flips ARE the reviewable behavior change. Each flipped test
+ * carries a comment naming the rule arm that now decides it.
  *
  * Write shapes mirror the real client writers byte-for-byte:
  *   - shot create: CreateShotDialog.tsx
@@ -17,6 +18,7 @@
  *   - member self-create: adminWrites.ts addProjectMember
  *   - share create: ShotsShareDialog.tsx Firestore fallback
  *   - project-from-request batch: requestWrites.ts createProjectFromRequest
+ *   - project + self-member batch: CreateProjectDialog.tsx handleCreate
  *
  * Requires the Firestore emulator. When `FIRESTORE_EMULATOR_HOST` is not
  * set, the suite is skipped so `CI=1 npm test -- --run` stays green on
@@ -28,6 +30,7 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
 import {
+  assertFails,
   assertSucceeds,
   initializeTestEnvironment,
   type RulesTestEnvironment,
@@ -54,23 +57,42 @@ const CLIENT_ID = "unbound-merino"
 
 const VIEWER_UID = "viewer-uid"
 const CREW_UID = "crew-uid"
+const MEMBER_CREW_UID = "member-crew-uid"
+const MEMBER_VIEWER_UID = "member-viewer-uid"
 const PRODUCER_UID = "producer-uid"
 const OWNER_UID = "owner-uid"
 
 // Seeded projects: one with an explicit visibility field, one without
-// (a missing visibility field counts as team-visible), plus a move target.
+// (a missing visibility field counts as team-visible), a move target, and
+// a private project (creator-only) owned by someone else.
 const PROJ_TEAM = "proj-team"
 const PROJ_UNSET = "proj-unset"
 const PROJ_TARGET = "proj-target"
+const PROJ_PRIVATE = "proj-private"
 
 const REQUEST_ID = "req-1"
 
-// Seeded shots, one per mutation pin so tests stay order-independent.
+// Matches the real client-side bulk write chunk (BATCH_CHUNK_SIZE) so the
+// 250-update batch test proves the rule-eval get() budget at production size.
+const BATCH_SIZE = 250
+
+// Seeded shots, one per mutation test so tests stay order-independent.
 const SHOT_VIEWER_UPDATE = "shot-viewer-update"
 const SHOT_VIEWER_DELETE = "shot-viewer-delete"
 const SHOT_CREW_UPDATE = "shot-crew-update"
 const SHOT_CREW_DELETE = "shot-crew-delete"
+const SHOT_MEMBER_CREW_UPDATE = "shot-member-crew-update"
+const SHOT_MEMBER_CREW_DELETE = "shot-member-crew-delete"
+const SHOT_MEMBER_VIEWER_UPDATE = "shot-member-viewer-update"
+const SHOT_PRODUCER_UNSET_UPDATE = "shot-producer-unset-update"
+const SHOT_PRODUCER_TEAM_DELETE = "shot-producer-team-delete"
+const SHOT_PRIVATE_UPDATE = "shot-private-update"
+const SHOT_PRIVATE_DELETE = "shot-private-delete"
+const SHOT_EMPTY_PRODUCER_UPDATE = "shot-empty-producer-update"
+const SHOT_EMPTY_PRODUCER_DELETE = "shot-empty-producer-delete"
+const SHOT_EMPTY_CREW_UPDATE = "shot-empty-crew-update"
 const SHOT_MOVE = "shot-move"
+const SHOT_MOVE_CREW = "shot-move-crew"
 const SHOT_VERSIONS = "shot-versions"
 
 /** Shot create payload — mirrors CreateShotDialog.tsx handleCreate. */
@@ -141,11 +163,28 @@ function makeVersionDoc(createdBy: string) {
       referenceLinks: [],
     },
     createdBy,
-    createdByName: "Viewer User",
+    createdByName: "Test User",
     createdByAvatar: null,
     changeType: "update",
     changedFields: ["title"],
     createdAt: serverTimestamp(),
+  }
+}
+
+/** shotShares doc — mirrors ShotsShareDialog.tsx Firestore fallback. */
+function makeShareDoc(projectId: string) {
+  return {
+    clientId: CLIENT_ID,
+    projectId,
+    shotIds: null,
+    enabled: true,
+    title: "All shots",
+    expiresAt: null,
+    createdAt: serverTimestamp(),
+    createdBy: PRODUCER_UID,
+    projectName: "Some Project",
+    resolvedShots: [],
+    columnConfig: ["title", "talent", "products"],
   }
 }
 
@@ -163,13 +202,25 @@ function crewDb() {
     .firestore()
 }
 
+function memberCrewDb() {
+  return testEnv!
+    .authenticatedContext(MEMBER_CREW_UID, { role: "crew", clientId: CLIENT_ID })
+    .firestore()
+}
+
+function memberViewerDb() {
+  return testEnv!
+    .authenticatedContext(MEMBER_VIEWER_UID, { role: "viewer", clientId: CLIENT_ID })
+    .firestore()
+}
+
 function producerDb() {
   return testEnv!
     .authenticatedContext(PRODUCER_UID, { role: "producer", clientId: CLIENT_ID })
     .firestore()
 }
 
-describeOrSkip("firestore.rules — shots write surfaces (characterization pins)", () => {
+describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => {
   beforeAll(async () => {
     if (!EMULATOR_HOST) return
     const [host, portStr] = EMULATOR_HOST.split(":")
@@ -221,12 +272,41 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
         updatedAt: Timestamp.now(),
       })
 
+      // Private project owned by someone else — producerCanAccessProject must
+      // NOT grant the global producer a lane here.
+      await setDoc(doc(db, "clients", CLIENT_ID, "projects", PROJ_PRIVATE), {
+        name: "Private Project",
+        clientId: CLIENT_ID,
+        status: "active",
+        visibility: "private",
+        shootDates: [],
+        createdBy: OWNER_UID,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now(),
+      })
+
+      // Members docs (app shape: role / addedAt / addedBy) — the
+      // hasProjectRole ALLOW arm fixtures.
+      await setDoc(
+        doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM, "members", MEMBER_CREW_UID),
+        { role: "crew", addedAt: Timestamp.now(), addedBy: OWNER_UID },
+      )
+      await setDoc(
+        doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM, "members", MEMBER_VIEWER_UID),
+        { role: "viewer", addedAt: Timestamp.now(), addedBy: OWNER_UID },
+      )
+
       for (const shotId of [
         SHOT_VIEWER_UPDATE,
         SHOT_VIEWER_DELETE,
         SHOT_CREW_UPDATE,
         SHOT_CREW_DELETE,
+        SHOT_MEMBER_CREW_UPDATE,
+        SHOT_MEMBER_CREW_DELETE,
+        SHOT_MEMBER_VIEWER_UPDATE,
+        SHOT_PRODUCER_TEAM_DELETE,
         SHOT_MOVE,
+        SHOT_MOVE_CREW,
         SHOT_VERSIONS,
       ]) {
         await setDoc(
@@ -234,6 +314,40 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
           makeSeedShot(PROJ_TEAM),
         )
       }
+
+      await setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", SHOT_PRODUCER_UNSET_UPDATE),
+        makeSeedShot(PROJ_UNSET),
+      )
+
+      for (const shotId of [SHOT_PRIVATE_UPDATE, SHOT_PRIVATE_DELETE]) {
+        await setDoc(
+          doc(db, "clients", CLIENT_ID, "shots", shotId),
+          makeSeedShot(PROJ_PRIVATE),
+        )
+      }
+
+      // Legacy shots: empty-string projectId (mapShot.ts '' fallback shape).
+      for (const shotId of [
+        SHOT_EMPTY_PRODUCER_UPDATE,
+        SHOT_EMPTY_PRODUCER_DELETE,
+        SHOT_EMPTY_CREW_UPDATE,
+      ]) {
+        await setDoc(
+          doc(db, "clients", CLIENT_ID, "shots", shotId),
+          makeSeedShot(""),
+        )
+      }
+
+      // 250 shots in one project for the batch get()-budget test.
+      const seedBatch = writeBatch(db)
+      for (let i = 0; i < BATCH_SIZE; i++) {
+        seedBatch.set(
+          doc(db, "clients", CLIENT_ID, "shots", `batch-shot-${i}`),
+          makeSeedShot(PROJ_TEAM),
+        )
+      }
+      await seedBatch.commit()
 
       // Submitted shot request (submitShotRequest shape) for the
       // create-project-from-request transaction pin.
@@ -263,11 +377,13 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     }
   })
 
-  // --- (a) viewer-claim shot writes pass under the isAuthed-only rule ---
+  // --- (a) viewer-claim shot writes — DENIED by the hardened /shots rule ---
+  // (flipped pins: viewer passes neither hasGlobalRole(['producer']) nor the
+  // shotProjectRole arm — no members doc, viewer not in ['producer','crew'])
 
-  it("[a1] viewer-claim CAN create a shot", async () => {
+  it("[a1] viewer-claim CANNOT create a shot", async () => {
     const db = viewerDb()
-    await assertSucceeds(
+    await assertFails(
       setDoc(
         doc(db, "clients", CLIENT_ID, "shots", "shot-viewer-create"),
         makeShotCreate(PROJ_TEAM, VIEWER_UID),
@@ -275,9 +391,9 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
-  it("[a2] viewer-claim CAN update a shot", async () => {
+  it("[a2] viewer-claim CANNOT update a shot", async () => {
     const db = viewerDb()
-    await assertSucceeds(
+    await assertFails(
       updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_VIEWER_UPDATE), {
         title: "Viewer edited title",
         updatedAt: serverTimestamp(),
@@ -286,18 +402,20 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
-  it("[a3] viewer-claim CAN delete a shot", async () => {
+  it("[a3] viewer-claim CANNOT delete a shot", async () => {
     const db = viewerDb()
-    await assertSucceeds(
+    await assertFails(
       deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_VIEWER_DELETE)),
     )
   })
 
   // --- (b) crew-claim NON-member (no members doc anywhere) shot writes ---
+  // (flipped pins: the hasProjectRole arm requires a members doc; a global
+  // crew claim alone no longer writes shots — guarantee #1 for 5e)
 
-  it("[b1] crew-claim non-member CAN create a shot", async () => {
+  it("[b1] crew-claim non-member CANNOT create a shot", async () => {
     const db = crewDb()
-    await assertSucceeds(
+    await assertFails(
       setDoc(
         doc(db, "clients", CLIENT_ID, "shots", "shot-crew-create"),
         makeShotCreate(PROJ_UNSET, CREW_UID),
@@ -305,9 +423,9 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
-  it("[b2] crew-claim non-member CAN update a shot", async () => {
+  it("[b2] crew-claim non-member CANNOT update a shot", async () => {
     const db = crewDb()
-    await assertSucceeds(
+    await assertFails(
       updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_CREW_UPDATE), {
         title: "Crew edited title",
         updatedAt: serverTimestamp(),
@@ -316,18 +434,196 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
-  it("[b3] crew-claim non-member CAN delete a shot", async () => {
+  it("[b3] crew-claim non-member CANNOT delete a shot", async () => {
     const db = crewDb()
-    await assertSucceeds(
+    await assertFails(
       deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_CREW_DELETE)),
     )
   })
 
-  // --- (c) members self-create carve-out ---
+  // --- member-crew (members doc role 'crew') — the hasProjectRole ALLOW arm ---
 
-  it("[c] producer-claim CAN self-create a producer members doc on an existing project they did not create", async () => {
+  it("member-crew CAN create a shot on their project", async () => {
+    const db = memberCrewDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-member-crew-create"),
+        makeShotCreate(PROJ_TEAM, MEMBER_CREW_UID),
+      ),
+    )
+  })
+
+  it("member-crew CAN update a shot on their project", async () => {
+    const db = memberCrewDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MEMBER_CREW_UPDATE), {
+        title: "Member crew edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: MEMBER_CREW_UID,
+      }),
+    )
+  })
+
+  it("member-crew CAN delete a shot on their project", async () => {
+    const db = memberCrewDb()
+    await assertSucceeds(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MEMBER_CREW_DELETE)),
+    )
+  })
+
+  // --- member-VIEWER (members doc role 'viewer') — still no write arm ---
+
+  it("member-viewer CANNOT create a shot on their project", async () => {
+    const db = memberViewerDb()
+    await assertFails(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-member-viewer-create"),
+        makeShotCreate(PROJ_TEAM, MEMBER_VIEWER_UID),
+      ),
+    )
+  })
+
+  it("member-viewer CANNOT update a shot on their project", async () => {
+    const db = memberViewerDb()
+    await assertFails(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MEMBER_VIEWER_UPDATE), {
+        title: "Member viewer edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: MEMBER_VIEWER_UID,
+      }),
+    )
+  })
+
+  // --- non-member global producer — producerCanAccessProject lane ---
+
+  it("non-member producer CAN create a shot on a team-visible project", async () => {
     const db = producerDb()
     await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-producer-team-create"),
+        makeShotCreate(PROJ_TEAM, PRODUCER_UID),
+      ),
+    )
+  })
+
+  it("non-member producer CAN create a shot on a visibility-absent project", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-producer-unset-create"),
+        makeShotCreate(PROJ_UNSET, PRODUCER_UID),
+      ),
+    )
+  })
+
+  it("non-member producer CAN update a shot on a visibility-absent project", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_PRODUCER_UNSET_UPDATE), {
+        title: "Producer edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  it("non-member producer CAN delete a shot on a team-visible project", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_PRODUCER_TEAM_DELETE)),
+    )
+  })
+
+  it("non-member producer CANNOT update a shot on a private project", async () => {
+    const db = producerDb()
+    await assertFails(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_PRIVATE_UPDATE), {
+        title: "Producer edited title",
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  it("non-member producer CANNOT delete a shot on a private project", async () => {
+    const db = producerDb()
+    await assertFails(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_PRIVATE_DELETE)),
+    )
+  })
+
+  // Accepted-by-spec asymmetry: the unconditional hasGlobalRole(['producer'])
+  // CREATE lane (required by the createProjectFromRequest one-transaction flow,
+  // where rules see pre-transaction state) intentionally bypasses target-project
+  // visibility — a global producer can CREATE into a private project even
+  // though update/delete there are denied above.
+  it("non-member producer CAN create a shot on a private project (create-lane asymmetry, accepted-by-spec)", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "shots", "shot-producer-private-create"),
+        makeShotCreate(PROJ_PRIVATE, PRODUCER_UID),
+      ),
+    )
+  })
+
+  // --- empty-string projectId (legacy shots) — admin / global producer only ---
+
+  it("producer CAN update an empty-projectId shot (legacy arm)", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_EMPTY_PRODUCER_UPDATE), {
+        title: "Producer edited legacy shot",
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  it("producer CAN delete an empty-projectId shot (legacy arm)", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      deleteDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_EMPTY_PRODUCER_DELETE)),
+    )
+  })
+
+  it("member-crew CANNOT update an empty-projectId shot (legacy arm is producer-only)", async () => {
+    const db = memberCrewDb()
+    await assertFails(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_EMPTY_CREW_UPDATE), {
+        title: "Crew edited legacy shot",
+        updatedAt: serverTimestamp(),
+        updatedBy: MEMBER_CREW_UID,
+      }),
+    )
+  })
+
+  // --- 250-doc single-project batch (real BATCH_CHUNK_SIZE) ---
+  // Proves the rule-eval document-access budget: every update resolves the
+  // same project doc + the same members doc, so the whole batch touches 2
+  // unique documents — well under the 20-access limit for batched writes.
+
+  it("member-crew CAN commit a 250-update single-project batch", async () => {
+    const db = memberCrewDb()
+    const batch = writeBatch(db)
+    for (let i = 0; i < BATCH_SIZE; i++) {
+      batch.update(doc(db, "clients", CLIENT_ID, "shots", `batch-shot-${i}`), {
+        title: `Batch edited ${i}`,
+        updatedAt: serverTimestamp(),
+        updatedBy: MEMBER_CREW_UID,
+      })
+    }
+    await assertSucceeds(batch.commit())
+  })
+
+  // --- (c) members self-create carve-out ---
+  // (flipped pin: the carve-out now requires getAfter(project).createdBy ==
+  // request.auth.uid — self-minting membership on someone else's existing
+  // project is the self-elevation hole 5b closes)
+
+  it("[c] producer-claim CANNOT self-create a producer members doc on an existing project they did not create", async () => {
+    const db = producerDb()
+    await assertFails(
       setDoc(
         doc(
           db,
@@ -347,7 +643,48 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
+  // Carve-out positive path: project create + self-member in ONE batch
+  // (CreateProjectDialog.tsx handleCreate shape — createdBy set to self, so
+  // getAfter resolves the pending project write).
+  it("producer-claim CAN self-add as member when creating the project in the same batch", async () => {
+    const db = producerDb()
+    const projectRef = doc(collection(db, "clients", CLIENT_ID, "projects"))
+    const memberRef = doc(
+      db,
+      "clients",
+      CLIENT_ID,
+      "projects",
+      projectRef.id,
+      "members",
+      PRODUCER_UID,
+    )
+
+    const batch = writeBatch(db)
+    batch.set(projectRef, {
+      name: "Dialog Project",
+      clientId: CLIENT_ID,
+      status: "active",
+      visibility: "team",
+      shootDates: [],
+      createdBy: PRODUCER_UID,
+      createdAt: serverTimestamp(),
+      updatedAt: serverTimestamp(),
+    })
+    batch.set(memberRef, {
+      role: "producer",
+      addedAt: serverTimestamp(),
+      addedBy: PRODUCER_UID,
+    })
+
+    await assertSucceeds(batch.commit())
+  })
+
   // --- (d) createProjectFromRequest transaction shape ---
+  // MUST stay green: the shot create rides the hasGlobalRole(['producer'])
+  // CREATE lane (rules see pre-transaction state), and the member self-create
+  // carve-out resolves the same-transaction project write via getAfter.
+  // Project payload now includes createdBy — mirrors requestWrites.ts, which
+  // gained the field in this PR so the tightened carve-out covers this flow.
 
   it("[d] producer-claim createProjectFromRequest batch (project + member + shot + request update) SUCCEEDS", async () => {
     const db = producerDb()
@@ -370,6 +707,7 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
       clientId: CLIENT_ID,
       status: "active",
       shootDates: [],
+      createdBy: PRODUCER_UID,
       createdAt: serverTimestamp(),
       updatedAt: serverTimestamp(),
     })
@@ -407,6 +745,8 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
   })
 
   // --- (e) project-move ---
+  // Stays green: the project-move update arm (global producer + project role
+  // on the TARGET projectId; PROJ_TARGET is team-visible).
 
   it("[e] producer-claim CAN update a shot's projectId to a different project", async () => {
     const db = producerDb()
@@ -420,32 +760,59 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
     )
   })
 
-  // --- (f) shotShares (top-level collection) ---
-
-  it("[f] producer-claim CAN create an enabled shotShares doc with an arbitrary projectId string", async () => {
-    const db = producerDb()
-    await assertSucceeds(
-      setDoc(doc(db, "shotShares", "share-token-characterization-1"), {
-        clientId: CLIENT_ID,
-        projectId: "some-project-the-producer-never-touched",
-        shotIds: null,
-        enabled: true,
-        title: "All shots",
-        expiresAt: null,
-        createdAt: serverTimestamp(),
-        createdBy: PRODUCER_UID,
-        projectName: "Some Project",
-        resolvedShots: [],
-        columnConfig: ["title", "talent", "products"],
+  it("member-crew CANNOT change a shot's projectId (projectId immutability pin; move arm is admin/global-producer only)", async () => {
+    const db = memberCrewDb()
+    await assertFails(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MOVE_CREW), {
+        projectId: PROJ_TARGET,
+        laneId: null,
+        updatedAt: serverTimestamp(),
+        updatedBy: MEMBER_CREW_UID,
       }),
     )
   })
 
-  // --- (g) versions subcollection ---
+  // --- (f) shotShares (top-level collection) — project-scoped create ---
 
-  it("[g] viewer-claim CAN create a versions doc under a shot", async () => {
-    const db = viewerDb()
+  it("[f1] producer-claim CAN create a share for an existing team-visible project", async () => {
+    const db = producerDb()
     await assertSucceeds(
+      setDoc(
+        doc(db, "shotShares", "share-token-team-1"),
+        makeShareDoc(PROJ_TEAM),
+      ),
+    )
+  })
+
+  it("[f2] producer-claim CANNOT create a share whose projectId points at a nonexistent project", async () => {
+    // Flipped pin: producerCanAccessProject/hasProjectRole find no project or
+    // members doc — the arbitrary-projectId share mint is closed.
+    const db = producerDb()
+    await assertFails(
+      setDoc(
+        doc(db, "shotShares", "share-token-nonexistent-1"),
+        makeShareDoc("some-project-the-producer-never-touched"),
+      ),
+    )
+  })
+
+  it("[f3] producer-claim CANNOT create a share for a private project they are not a member of", async () => {
+    const db = producerDb()
+    await assertFails(
+      setDoc(
+        doc(db, "shotShares", "share-token-private-1"),
+        makeShareDoc(PROJ_PRIVATE),
+      ),
+    )
+  })
+
+  // --- (g) versions subcollection ---
+  // (flipped pin: versions CREATE now carries the same shotProjectRole arm as
+  // the parent shot — a denied shot-writer cannot snapshot shot data)
+
+  it("[g] viewer-claim CANNOT create a versions doc under a shot", async () => {
+    const db = viewerDb()
+    await assertFails(
       setDoc(
         doc(
           db,
@@ -457,6 +824,24 @@ describeOrSkip("firestore.rules — shots write surfaces (characterization pins)
           "version-1",
         ),
         makeVersionDoc(VIEWER_UID),
+      ),
+    )
+  })
+
+  it("member-crew CAN create a versions doc under a shot on their project", async () => {
+    const db = memberCrewDb()
+    await assertSucceeds(
+      setDoc(
+        doc(
+          db,
+          "clients",
+          CLIENT_ID,
+          "shots",
+          SHOT_VERSIONS,
+          "versions",
+          "version-2",
+        ),
+        makeVersionDoc(MEMBER_CREW_UID),
       ),
     )
   })

--- a/src-vnext/features/shots/__tests__/shots.rules.test.ts
+++ b/src-vnext/features/shots/__tests__/shots.rules.test.ts
@@ -643,6 +643,34 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
     )
   })
 
+  // The project-subcollection wildcard catch-all ORs with the explicit
+  // members rules, so members must be excluded from its write arm — these
+  // two pin the exclusion (without it, any team-visible-project producer
+  // writes arbitrary members docs through the wildcard).
+  it("producer-claim CANNOT grant ANOTHER user a members doc on a team project (wildcard write arm excludes members)", async () => {
+    const db = producerDb()
+    await assertFails(
+      setDoc(
+        doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM, "members", "some-other-uid"),
+        {
+          role: "producer",
+          addedAt: serverTimestamp(),
+          addedBy: PRODUCER_UID,
+        },
+      ),
+    )
+  })
+
+  it("producer-claim CANNOT update an existing members doc on a team project (wildcard write arm excludes members)", async () => {
+    const db = producerDb()
+    await assertFails(
+      updateDoc(
+        doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM, "members", MEMBER_CREW_UID),
+        { role: "producer" },
+      ),
+    )
+  })
+
   // Carve-out positive path: project create + self-member in ONE batch
   // (CreateProjectDialog.tsx handleCreate shape — createdBy set to self, so
   // getAfter resolves the pending project write).

--- a/src-vnext/features/shots/__tests__/shots.rules.test.ts
+++ b/src-vnext/features/shots/__tests__/shots.rules.test.ts
@@ -59,7 +59,9 @@ const VIEWER_UID = "viewer-uid"
 const CREW_UID = "crew-uid"
 const MEMBER_CREW_UID = "member-crew-uid"
 const MEMBER_VIEWER_UID = "member-viewer-uid"
+const MEMBER_PRIVATE_PRODUCER_UID = "member-private-producer-uid"
 const PRODUCER_UID = "producer-uid"
+const ADMIN_UID = "admin-uid"
 const OWNER_UID = "owner-uid"
 
 // Seeded projects: one with an explicit visibility field, one without
@@ -93,6 +95,10 @@ const SHOT_EMPTY_PRODUCER_DELETE = "shot-empty-producer-delete"
 const SHOT_EMPTY_CREW_UPDATE = "shot-empty-crew-update"
 const SHOT_MOVE = "shot-move"
 const SHOT_MOVE_CREW = "shot-move-crew"
+const SHOT_MOVE_INTO_PRIVATE = "shot-move-into-private"
+const SHOT_PRIVATE_MOVE_OUT = "shot-private-move-out"
+const SHOT_ADMIN_PRIVATE_UPDATE = "shot-admin-private-update"
+const SHOT_ADMIN_EMPTY_UPDATE = "shot-admin-empty-update"
 const SHOT_VERSIONS = "shot-versions"
 
 /** Shot create payload — mirrors CreateShotDialog.tsx handleCreate. */
@@ -172,7 +178,7 @@ function makeVersionDoc(createdBy: string) {
 }
 
 /** shotShares doc — mirrors ShotsShareDialog.tsx Firestore fallback. */
-function makeShareDoc(projectId: string) {
+function makeShareDoc(projectId: string, createdBy: string = PRODUCER_UID) {
   return {
     clientId: CLIENT_ID,
     projectId,
@@ -181,7 +187,7 @@ function makeShareDoc(projectId: string) {
     title: "All shots",
     expiresAt: null,
     createdAt: serverTimestamp(),
-    createdBy: PRODUCER_UID,
+    createdBy,
     projectName: "Some Project",
     resolvedShots: [],
     columnConfig: ["title", "talent", "products"],
@@ -217,6 +223,18 @@ function memberViewerDb() {
 function producerDb() {
   return testEnv!
     .authenticatedContext(PRODUCER_UID, { role: "producer", clientId: CLIENT_ID })
+    .firestore()
+}
+
+function memberPrivateProducerDb() {
+  return testEnv!
+    .authenticatedContext(MEMBER_PRIVATE_PRODUCER_UID, { role: "producer", clientId: CLIENT_ID })
+    .firestore()
+}
+
+function adminDb() {
+  return testEnv!
+    .authenticatedContext(ADMIN_UID, { role: "admin", clientId: CLIENT_ID })
     .firestore()
 }
 
@@ -295,6 +313,12 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
         doc(db, "clients", CLIENT_ID, "projects", PROJ_TEAM, "members", MEMBER_VIEWER_UID),
         { role: "viewer", addedAt: Timestamp.now(), addedBy: OWNER_UID },
       )
+      // Producer membership on the PRIVATE project — the hasProjectRole arm
+      // of the shotShares create rule.
+      await setDoc(
+        doc(db, "clients", CLIENT_ID, "projects", PROJ_PRIVATE, "members", MEMBER_PRIVATE_PRODUCER_UID),
+        { role: "producer", addedAt: Timestamp.now(), addedBy: OWNER_UID },
+      )
 
       for (const shotId of [
         SHOT_VIEWER_UPDATE,
@@ -307,6 +331,7 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
         SHOT_PRODUCER_TEAM_DELETE,
         SHOT_MOVE,
         SHOT_MOVE_CREW,
+        SHOT_MOVE_INTO_PRIVATE,
         SHOT_VERSIONS,
       ]) {
         await setDoc(
@@ -320,7 +345,12 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
         makeSeedShot(PROJ_UNSET),
       )
 
-      for (const shotId of [SHOT_PRIVATE_UPDATE, SHOT_PRIVATE_DELETE]) {
+      for (const shotId of [
+        SHOT_PRIVATE_UPDATE,
+        SHOT_PRIVATE_DELETE,
+        SHOT_PRIVATE_MOVE_OUT,
+        SHOT_ADMIN_PRIVATE_UPDATE,
+      ]) {
         await setDoc(
           doc(db, "clients", CLIENT_ID, "shots", shotId),
           makeSeedShot(PROJ_PRIVATE),
@@ -332,6 +362,7 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
         SHOT_EMPTY_PRODUCER_UPDATE,
         SHOT_EMPTY_PRODUCER_DELETE,
         SHOT_EMPTY_CREW_UPDATE,
+        SHOT_ADMIN_EMPTY_UPDATE,
       ]) {
         await setDoc(
           doc(db, "clients", CLIENT_ID, "shots", shotId),
@@ -788,6 +819,58 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
     )
   })
 
+  // The move arm checks producer access on the TARGET project only — moving
+  // a shot OUT of a private project is possible for any global producer.
+  // Accepted-by-spec: shots are client-readable regardless of project
+  // visibility, and the move path is admin/producer-gated lifecycle UI.
+  it("producer-claim CAN move a shot OUT of a private project (move arm checks the TARGET only — accepted asymmetry)", async () => {
+    const db = producerDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_PRIVATE_MOVE_OUT), {
+        projectId: PROJ_TEAM,
+        laneId: null,
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  it("producer-claim CANNOT move a shot INTO a private project (move arm requires producer access on the TARGET)", async () => {
+    const db = producerDb()
+    await assertFails(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_MOVE_INTO_PRIVATE), {
+        projectId: PROJ_PRIVATE,
+        laneId: null,
+        updatedAt: serverTimestamp(),
+        updatedBy: PRODUCER_UID,
+      }),
+    )
+  })
+
+  // Admin matrix: isAdmin() short-circuits every arm, including the private
+  // and empty-projectId shapes that deny everyone else.
+  it("admin CAN update a shot on a private project", async () => {
+    const db = adminDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_ADMIN_PRIVATE_UPDATE), {
+        title: "Admin edited private shot",
+        updatedAt: serverTimestamp(),
+        updatedBy: ADMIN_UID,
+      }),
+    )
+  })
+
+  it("admin CAN update an empty-projectId shot", async () => {
+    const db = adminDb()
+    await assertSucceeds(
+      updateDoc(doc(db, "clients", CLIENT_ID, "shots", SHOT_ADMIN_EMPTY_UPDATE), {
+        title: "Admin edited legacy shot",
+        updatedAt: serverTimestamp(),
+        updatedBy: ADMIN_UID,
+      }),
+    )
+  })
+
   it("member-crew CANNOT change a shot's projectId (projectId immutability pin; move arm is admin/global-producer only)", async () => {
     const db = memberCrewDb()
     await assertFails(
@@ -830,6 +913,16 @@ describeOrSkip("firestore.rules — shots write surfaces (hardened, 5b)", () => 
       setDoc(
         doc(db, "shotShares", "share-token-private-1"),
         makeShareDoc(PROJ_PRIVATE),
+      ),
+    )
+  })
+
+  it("[f4] producer MEMBER of a private project CAN create a share for it (hasProjectRole arm)", async () => {
+    const db = memberPrivateProducerDb()
+    await assertSucceeds(
+      setDoc(
+        doc(db, "shotShares", "share-token-private-member-1"),
+        makeShareDoc(PROJ_PRIVATE, MEMBER_PRIVATE_PRODUCER_UID),
       ),
     )
   })

--- a/src-vnext/features/shots/components/BulkActionBar.tsx
+++ b/src-vnext/features/shots/components/BulkActionBar.tsx
@@ -21,6 +21,7 @@ import {
   SHOT_STATUSES,
 } from "@/shared/lib/statusMappings"
 import { canManageShots } from "@/shared/lib/rbac"
+import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { useAvailableTags } from "@/features/shots/hooks/useAvailableTags"
 import {
   bulkUpdateShotStatus,
@@ -90,7 +91,9 @@ export function BulkActionBar({
       const count = await bulkUpdateShotStatus(clientId, Array.from(selectedIds), status, user)
       toast.success(`Updated status on ${count} shot${count === 1 ? "" : "s"}`)
     } catch (err) {
-      toast.error("Failed to update status", { description: err instanceof Error ? err.message : "Unknown error" })
+      toast.error("Failed to update status", {
+        description: shotWriteErrorDescription(err, err instanceof Error ? err.message : "Unknown error"),
+      })
     }
   }
 
@@ -101,7 +104,9 @@ export function BulkActionBar({
       toast.success(`Applied "${tag.label}" to ${count} shot${count === 1 ? "" : "s"}`)
       setTagPopoverOpen(false)
     } catch (err) {
-      toast.error("Failed to apply tag", { description: err instanceof Error ? err.message : "Unknown error" })
+      toast.error("Failed to apply tag", {
+        description: shotWriteErrorDescription(err, err instanceof Error ? err.message : "Unknown error"),
+      })
     }
   }
 
@@ -112,7 +117,9 @@ export function BulkActionBar({
       toast.success(`Set location on ${count} shot${count === 1 ? "" : "s"}`)
       setLocationPopoverOpen(false)
     } catch (err) {
-      toast.error("Failed to set location", { description: err instanceof Error ? err.message : "Unknown error" })
+      toast.error("Failed to set location", {
+        description: shotWriteErrorDescription(err, err instanceof Error ? err.message : "Unknown error"),
+      })
     }
   }
 
@@ -123,7 +130,9 @@ export function BulkActionBar({
       toast.success(`Added talent to ${count} shot${count === 1 ? "" : "s"}`)
       setTalentPopoverOpen(false)
     } catch (err) {
-      toast.error("Failed to add talent", { description: err instanceof Error ? err.message : "Unknown error" })
+      toast.error("Failed to add talent", {
+        description: shotWriteErrorDescription(err, err instanceof Error ? err.message : "Unknown error"),
+      })
     }
   }
 

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -33,7 +33,10 @@ import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersio
 import { formatDateOnly, parseDateOnly } from "@/features/shots/lib/dateOnly"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
-import { canManageShots } from "@/shared/lib/rbac"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
+import { canEditScene as canEditSceneForRole, canManageShots } from "@/shared/lib/rbac"
+import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
 import { textPreview } from "@/shared/lib/textPreview"
 import {
@@ -185,25 +188,36 @@ export function ShotDetailPageUnified() {
   const { sid } = useParams<{ sid: string }>()
   const navigate = useNavigate()
   const { shot, lanes, laneById, loading, error } = useShotDetailBundle(sid)
-  const { role, clientId, user } = useAuth()
+  const { role: globalRole, clientId, user } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). Write affordances render NOTHING while the first uncached
+  // member read for this project is in flight (resolving) — never the
+  // global-role guess.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectName } = useProjectScope()
 
   // ONE device-authority read feeding named capability booleans. Mobile edit
   // enablement requires the rules backstop first — do NOT remove !isMobile here.
+  // Backing rule for the shot writes below: hardened /shots
+  // (firestore.rules:435-472, ['producer','crew'] arms).
   const isMobile = useIsMobile()
-  const canEdit = canManageShots(role) && !isMobile
-  const canDoOperational = canManageShots(role)
-  const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
-  // Uploads are admin/producer only — storage.rules denies crew writes.
-  const canUploadShotImages = (role === "admin" || role === "producer") && !isMobile
+  const canEdit = !roleResolving && canManageShots(role) && !isMobile
+  const canDoOperational = !roleResolving && canManageShots(role)
+  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  // PINNED to the GLOBAL claim: storage.rules sees only the auth token
+  // (isProducerOrWardrobe, storage.rules:15-25 — no cross-service
+  // firestore.get()), so a project-promoted crew still cannot upload and the
+  // UI must not advertise it from the effective role.
+  const canUploadShotImages = (globalRole === "admin" || globalRole === "producer") && !isMobile
   const canExport = !isMobile
-  const canShare = role === "admin" || role === "producer"
+  // PINNED to the GLOBAL claim: /shotShares create requires a global producer
+  // claim (firestore.rules:193-204) — backend can't see a project promotion.
+  const canShare = globalRole === "admin" || globalRole === "producer"
   const canComment = canDoOperational
-  // Scene/lane writes are gated to admin/producer/warehouse to match the
-  // Firestore rule on /lanes (warehouse keeps lane-write until 5f per locked
-  // Q3). Project-level roles are not resolvable client-side today, so this
-  // gates on the global claim role (ShotListPage canManageLanes parity).
-  const canEditScene = role === "admin" || role === "producer" || role === "warehouse"
+  // Scene/lane writes consolidate on rbac.canEditScene, which mirrors the
+  // /lanes rule (firestore.rules:880-882, :901-904 — already project-aware;
+  // warehouse keeps lane-write until 5f per locked Q3).
+  const canEditScene = !roleResolving && canEditSceneForRole(role)
 
   const [shareOpen, setShareOpen] = useState(false)
   const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
@@ -273,7 +287,8 @@ export function ShotDetailPageUnified() {
   // useKeyboardShortcuts already skips input/textarea/contentEditable targets.
   const handleStatusKey = (index: number) => {
     // Early-return unless canManageShots(role) — viewers no-op (build spec
-    // security invariant 2).
+    // security invariant 2). canDoOperational is false while roleResolving,
+    // so no write can fire during the effective-role gap.
     if (!canDoOperational) return
     if (!shot || !clientId) return
     const newStatus = STATUS_CYCLE[index]
@@ -285,8 +300,10 @@ export function ShotDetailPageUnified() {
       shot,
       user,
       source: "ShotDetailPageUnified:keyboard",
-    }).catch(() => {
-      toast.error("Failed to update status")
+    }).catch((err) => {
+      toast.error("Failed to update status", {
+        description: shotWriteErrorDescription(err),
+      })
     })
   }
 
@@ -300,6 +317,10 @@ export function ShotDetailPageUnified() {
   ])
 
   const save = async (fields: Record<string, unknown>): Promise<boolean> => {
+    // Reachable only from canEdit/canDoOperational affordances, which render
+    // nothing while roleResolving — the explicit guard keeps the invariant
+    // even if a future affordance forgets its gate.
+    if (roleResolving) return false
     if (!shot || !clientId) return false
     try {
       await updateShotWithVersion({
@@ -311,8 +332,10 @@ export function ShotDetailPageUnified() {
         source: "ShotDetailPageUnified",
       })
       return true
-    } catch {
-      toast.error("Failed to save changes")
+    } catch (err) {
+      toast.error("Failed to save changes", {
+        description: shotWriteErrorDescription(err),
+      })
       return false
     }
   }
@@ -379,6 +402,7 @@ export function ShotDetailPageUnified() {
             <ArrowLeft className="h-3.5 w-3.5" />
             Back to Shots
           </Button>
+          <EffectiveRoleChip />
           <div className="ml-auto flex items-center gap-2">
             {canExport && (
               <Button

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -18,7 +18,10 @@ import { useShotListState } from "@/features/shots/hooks/useShotListState"
 import type { SurfaceDevice } from "@/features/shots/lib/resolveSurface"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
-import { canGeneratePulls, canManageShots } from "@/shared/lib/rbac"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
+import { canEditScene, canGeneratePulls, canManageShots } from "@/shared/lib/rbac"
+import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { useIsMobile, useIsDesktop } from "@/shared/hooks/useMediaQuery"
 import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
 import { Button } from "@/ui/button"
@@ -49,7 +52,11 @@ import { isFeatureEnabled } from "@/shared/lib/flags"
 
 export default function ShotListPage() {
   const { data: shots, loading, error } = useShots()
-  const { role, clientId, user, loading: authLoading } = useAuth()
+  const { role: globalRole, clientId, user, loading: authLoading } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6) for the shots-surface write affordances below. `resolving`
+  // is true only during the first uncached member read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId, projectName } = useProjectScope()
   const navigate = useNavigate()
   const isMobile = useIsMobile()
@@ -127,18 +134,26 @@ export default function ShotListPage() {
     })
   }, [])
 
-  // -- Role-based flags --
-  const showCreate = canManageShots(role)
-  const canReorder = canManageShots(role)
-  const canBulkPull = canGeneratePulls(role) && !isMobile
-  const canRepair = (role === "admin" || role === "producer") && !isMobile
-  const canShare = role === "admin" || role === "producer"
+  // -- Role-based flags (5b: effective role + resolving gate) --
+  // Write affordances render NOTHING while the first member read is in
+  // flight (roleResolving) — never the global-role guess (the surfaceContext
+  // null-while-authLoading idiom). Backing rule for the shot writes:
+  // hardened /shots (firestore.rules:435-472, ['producer','crew'] arms).
+  const showCreate = !roleResolving && canManageShots(role)
+  const canReorder = !roleResolving && canManageShots(role)
+  const canBulkPull = !roleResolving && canGeneratePulls(role) && !isMobile
+  const canRepair = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  // PINNED to the GLOBAL claim: /shotShares create requires a global producer
+  // claim (firestore.rules:193-204) — the backend cannot see a project
+  // promotion, so the UI must not advertise Share from the effective role.
+  const canShare = globalRole === "admin" || globalRole === "producer"
   const canExport = !isMobile
-  const canManageLifecycle = (role === "admin" || role === "producer") && !isMobile
-  // Scene/lane writes (edit, delete, ungroup) are gated to admin/producer/warehouse
-  // to match the Firestore rule on /lanes. Crew users see the scene grouping UI
+  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  // Scene/lane writes (edit, delete, ungroup) consolidate on canEditScene
+  // (rbac.ts), which mirrors the /lanes rule (firestore.rules:880-882,
+  // :901-904 — already project-aware). Crew users see the scene grouping UI
   // read-only — no kebab menu, no edit sheet access from the table header.
-  const canManageLanes = role === "admin" || role === "producer" || role === "warehouse"
+  const canManageLanes = !roleResolving && canEditScene(role)
 
   // -- Lookup maps (computed from picker data, passed to list state hook) --
   const talentNameById = useMemo(() => new Map(talentRecords.map((t) => [t.id, t.name])), [talentRecords])
@@ -149,11 +164,16 @@ export default function ShotListPage() {
   const { data: lanes, laneNameById, laneById } = useLanes()
   const laneOrder = useMemo(() => new Map(lanes.map((l) => [l.id, l.sortOrder])), [lanes])
 
-  // null until claims settle: AuthProvider falls back to 'viewer' while loading (viewer-flash guard)
+  // null until claims settle: AuthProvider falls back to 'viewer' while loading
+  // (viewer-flash guard). 5b extends the same gate to the first uncached
+  // member-doc read (roleResolving) so resolveSurface never consumes the
+  // global-role guess; once settled, surfaceContext.role carries the
+  // EFFECTIVE role — resolveSurface's input contract is byte-unchanged (the
+  // opaque effectiveRole param is 5e's View-as interposition seam).
   const surfaceDevice: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
   const surfaceContext = useMemo(
-    () => (authLoading ? null : { role, device: surfaceDevice }),
-    [authLoading, role, surfaceDevice],
+    () => (authLoading || roleResolving ? null : { role, device: surfaceDevice }),
+    [authLoading, roleResolving, role, surfaceDevice],
   )
 
   // -- All filter / sort / view state --
@@ -359,6 +379,7 @@ export default function ShotListPage() {
         title="Shots"
         actions={
           <div className="flex items-center gap-2">
+            <EffectiveRoleChip />
             {canExport && (
               <Button variant="outline" onClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}>
                 Export
@@ -655,7 +676,11 @@ export default function ShotListPage() {
             onReorder={(reordered, range) => {
               setMobileOptimistic(reordered)
               persistShotOrder(reordered, clientId!, range)
-                .catch(() => toast.error("Failed to save shot order."))
+                .catch((err) =>
+                  toast.error("Failed to save shot order.", {
+                    description: shotWriteErrorDescription(err),
+                  }),
+                )
                 .finally(() => setMobileOptimistic(null))
             }}
             laneById={laneById}
@@ -671,7 +696,11 @@ export default function ShotListPage() {
                     toast.success("Shot removed from scene")
                   }
                 })
-                .catch(() => toast.error("Failed to assign scene"))
+                .catch((err) =>
+                  toast.error("Failed to assign scene", {
+                    description: shotWriteErrorDescription(err),
+                  }),
+                )
             }}
             groups={hasActiveGrouping ? shotGroups : null}
             collapsedScenes={collapsedScenes}
@@ -685,7 +714,11 @@ export default function ShotListPage() {
               if (clientId) {
                 void ungroupAllShotsFromLane({ shots, laneId: key, projectId, clientId })
                   .then((n) => toast.success(`${n} shots ungrouped`))
-                  .catch(() => toast.error("Failed to ungroup scene"))
+                  .catch((err) =>
+                    toast.error("Failed to ungroup scene", {
+                      description: shotWriteErrorDescription(err),
+                    }),
+                  )
               }
             } : undefined}
           />
@@ -715,7 +748,11 @@ export default function ShotListPage() {
                         if (clientId) {
                           void ungroupAllShotsFromLane({ shots, laneId: group.key, projectId, clientId })
                             .then((n) => toast.success(`${n} shots ungrouped`))
-                            .catch(() => toast.error("Failed to ungroup scene"))
+                            .catch((err) =>
+                              toast.error("Failed to ungroup scene", {
+                                description: shotWriteErrorDescription(err),
+                              }),
+                            )
                         }
                       } : undefined}
                       onDelete={canManageLanes ? () => {

--- a/src-vnext/features/shots/components/ShotStatusTapRow.tsx
+++ b/src-vnext/features/shots/components/ShotStatusTapRow.tsx
@@ -6,6 +6,7 @@ import {
   getShotStatusLabel,
 } from "@/shared/lib/statusMappings"
 import type { Shot, ShotFirestoreStatus } from "@/shared/types"
+import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { toast } from "sonner"
 
 interface ShotStatusTapRowProps {
@@ -52,10 +53,13 @@ export function ShotStatusTapRow({ shot, disabled = false }: ShotStatusTapRowPro
         source: "ShotStatusTapRow",
       })
       setOptimistic(null)
-    } catch {
+    } catch (err) {
       setOptimistic(null)
       toast.error("Failed to update status", {
-        description: `Reverted to ${getShotStatusLabel(prev)}`,
+        description: shotWriteErrorDescription(
+          err,
+          `Reverted to ${getShotStatusLabel(prev)}`,
+        ),
       })
     }
   }

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -19,6 +19,14 @@ import type { Shot } from "@/shared/types"
 
 const authState = vi.hoisted(() => ({ role: "producer" }))
 
+// 5b effective-role state. role=null mirrors the global claim (the default
+// matrix shape: member role == global role), a string overrides it (project
+// downgrade/promotion rows), resolving=true pins the first-read gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
 // Per-test lane state so the scene-banner member/non-member pair can flip
 // between a readable lane map and the non-member empty degrade.
 const laneState = vi.hoisted(() => ({
@@ -56,6 +64,13 @@ vi.mock("@/app/providers/AuthProvider", () => ({
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
 }))
 
 // Desktop mode.
@@ -216,6 +231,8 @@ describe("ShotDetailPageUnified (flag-on)", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
     laneState.lanes = []
     laneState.laneById = new Map()
   })
@@ -460,6 +477,79 @@ describe("ShotDetailPageUnified (flag-on)", () => {
     fireEvent.keyDown(document.body, { key: "2" })
     fireEvent.keyDown(document.body, { key: "4" })
     expect(updateShotWithVersion).not.toHaveBeenCalled()
+  })
+
+  // ── 5b effective-role gates (resolving gap, downgrade, promotion) ─────────
+
+  it("renders no shot-write affordances while the effective role is resolving; global pins stay", () => {
+    effectiveState.resolving = true
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    // Shot writes render NOTHING during the first-read gap — never the
+    // global-role guess.
+    expect(screen.queryByTestId("shot-title-edit")).not.toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeDisabled()
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "false")
+
+    // 1-4 keys must not write during the gap.
+    fireEvent.keyDown(document.body, { key: "2" })
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
+
+    // PINNED gates read the GLOBAL claim (producer) and are unaffected:
+    // Share (/shotShares rule) + uploads (storage.rules sees only the claim).
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "true")
+  })
+
+  it("project downgrade (global producer, member viewer): shot writes collapse, global pins stay, quiet chip shows", () => {
+    effectiveState.role = "viewer"
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    // Effective-role gates collapse to the member role.
+    expect(screen.queryByTestId("shot-title-edit")).not.toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeDisabled()
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
+    expect(screen.getByTestId("notes-stub")).toHaveAttribute("data-can-edit", "false")
+    fireEvent.keyDown(document.body, { key: "2" })
+    expect(updateShotWithVersion).not.toHaveBeenCalled()
+
+    // PINNED to the global claim by their backing rules (UI-only downgrade —
+    // accepted shape, Ted 2026-06-10): Share + uploads stay for a global
+    // producer.
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "true")
+
+    // The quiet chip names the downgrade.
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
+  })
+
+  it("project promotion (global crew, member producer): shot writes enabled, pinned gates stay off, no chip", () => {
+    authState.role = "crew"
+    effectiveState.role = "producer"
+    mockShot({ status: "todo" })
+
+    renderPage()
+
+    // Effective producer: full shot-write affordances incl. lifecycle.
+    expect(screen.getByTestId("shot-title-edit")).toBeInTheDocument()
+    expect(screen.getByTestId("shot-status-select-trigger")).not.toBeDisabled()
+    expect(screen.getByTestId("lifecycle-actions-stub")).toBeInTheDocument()
+
+    // PINNED gates still read the GLOBAL crew claim: no Share (/shotShares
+    // requires a global producer claim), no uploads (storage.rules cannot
+    // see the members doc).
+    expect(screen.queryByRole("button", { name: "Share" })).not.toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "false")
+
+    // Chip shows downgrades only — a promotion renders nothing.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
   })
 
   // ── Member vs non-member — only where lanes matter (scene banner) ─────────

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.desktopThreePanel.test.tsx
@@ -32,6 +32,12 @@ vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: "producer", clientId: "c1" }),
 }))
 
+// 5b: pin the effective role to the global producer claim (member == global)
+// so the pre-5b affordance expectations in this file stay byte-identical.
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({ role: "producer", resolving: false }),
+}))
+
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
@@ -23,6 +23,21 @@ vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: "producer", clientId: "c1" }),
 }))
 
+// 5b effective-role state. role=null mirrors the global claim (member ==
+// global, the default matrix shape); a string overrides it (downgrade rows);
+// resolving=true pins the first-read affordance gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? "producer",
+    resolving: effectiveState.resolving,
+  }),
+}))
+
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
@@ -95,6 +110,8 @@ describe("ShotListPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     window.localStorage.clear()
+    effectiveState.role = null
+    effectiveState.resolving = false
     ;(useTalent as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [],
       loading: false,
@@ -605,6 +622,42 @@ describe("ShotListPage", () => {
     const finalParams = new URLSearchParams(capturedSearch!)
     expect(finalParams.get("scene")).toBeNull()
     expect(finalParams.get("group")).toBe("scene")
+  })
+
+  // ── 5b effective-role gates ────────────────────────────────────────────────
+
+  it("renders no write affordances while the effective role is resolving; Share (global pin) stays", () => {
+    effectiveState.resolving = true
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    // Shot-write affordances render NOTHING during the first-read gap.
+    expect(screen.queryByRole("button", { name: /new shot/i })).not.toBeInTheDocument()
+    // canShare is PINNED to the global producer claim (/shotShares rule) —
+    // unaffected by the gap.
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+  })
+
+  it("project downgrade (global producer, member viewer): New Shot collapses, Share (global pin) stays, chip shows", () => {
+    effectiveState.role = "viewer"
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.queryByRole("button", { name: /new shot/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
   })
 
   it("renders note URLs as clickable links", () => {

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
@@ -30,6 +30,12 @@ vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: "producer", clientId: "c1" }),
 }))
 
+// 5b: pin the effective role to the global producer claim (member == global)
+// so the pre-5b affordance expectations in this file stay byte-identical.
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({ role: "producer", resolving: false }),
+}))
+
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),

--- a/src-vnext/features/shots/lib/__tests__/shotWriteError.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/shotWriteError.test.ts
@@ -1,0 +1,48 @@
+// Phase 5b — shared permission-denied branch for shot-write toasts.
+import { describe, it, expect } from "vitest"
+import { FirebaseError } from "firebase/app"
+import {
+  isShotPermissionDenied,
+  shotWriteErrorDescription,
+  SHOT_PERMISSION_DENIED_DESCRIPTION,
+} from "@/features/shots/lib/shotWriteError"
+
+describe("isShotPermissionDenied", () => {
+  it("matches a FirebaseError with code permission-denied", () => {
+    const err = new FirebaseError("permission-denied", "Missing or insufficient permissions.")
+    expect(isShotPermissionDenied(err)).toBe(true)
+  })
+
+  it("rejects other FirebaseError codes", () => {
+    expect(isShotPermissionDenied(new FirebaseError("unavailable", "down"))).toBe(false)
+  })
+
+  it("string-matches plain Errors carrying Firestore's message (ProjectActionsMenu precedent)", () => {
+    expect(
+      isShotPermissionDenied(new Error("FirebaseError: Missing or insufficient permissions.")),
+    ).toBe(true)
+    expect(isShotPermissionDenied(new Error("network down"))).toBe(false)
+  })
+
+  it("rejects non-Error values", () => {
+    expect(isShotPermissionDenied("permission-denied")).toBe(false)
+    expect(isShotPermissionDenied(null)).toBe(false)
+  })
+})
+
+describe("shotWriteErrorDescription", () => {
+  it("returns the 5b permission copy on a denial", () => {
+    const err = new FirebaseError("permission-denied", "Missing or insufficient permissions.")
+    expect(shotWriteErrorDescription(err, "fallback")).toBe(
+      SHOT_PERMISSION_DENIED_DESCRIPTION,
+    )
+    expect(SHOT_PERMISSION_DENIED_DESCRIPTION).toBe(
+      "You don't have permission to edit shots on this project.",
+    )
+  })
+
+  it("returns the caller fallback (or undefined) otherwise", () => {
+    expect(shotWriteErrorDescription(new Error("boom"), "fallback")).toBe("fallback")
+    expect(shotWriteErrorDescription(new Error("boom"))).toBeUndefined()
+  })
+})

--- a/src-vnext/features/shots/lib/shotWriteError.ts
+++ b/src-vnext/features/shots/lib/shotWriteError.ts
@@ -1,0 +1,29 @@
+import { FirebaseError } from "firebase/app"
+
+// Shared permission-denied branch for shot-write toast catch paths (5b role
+// chip + toast copy). One helper instead of per-catch copies — consumed by
+// ShotListPage, ShotDetailPageUnified, ShotStatusTapRow, BulkActionBar.
+export const SHOT_PERMISSION_DENIED_DESCRIPTION =
+  "You don't have permission to edit shots on this project."
+
+export function isShotPermissionDenied(err: unknown): boolean {
+  if (err instanceof FirebaseError) return err.code === "permission-denied"
+  // String-match fallback (ProjectActionsMenu.tsx precedent): some write
+  // paths surface plain Errors carrying only Firestore's message text.
+  return (
+    err instanceof Error &&
+    err.message.includes("Missing or insufficient permissions")
+  )
+}
+
+/**
+ * Toast description for a failed shot write: the 5b permission copy on a
+ * rules denial, otherwise the caller's fallback (which may be undefined to
+ * keep today's description-less toasts unchanged).
+ */
+export function shotWriteErrorDescription(
+  err: unknown,
+  fallback?: string,
+): string | undefined {
+  return isShotPermissionDenied(err) ? SHOT_PERMISSION_DENIED_DESCRIPTION : fallback
+}

--- a/src-vnext/shared/components/EffectiveRoleChip.tsx
+++ b/src-vnext/shared/components/EffectiveRoleChip.tsx
@@ -1,0 +1,25 @@
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { roleLabel, roleRank } from "@/shared/lib/rbac"
+
+// Quiet effective-role indicator (5b, Ted: YES, quiet). Renders in the
+// project-scoped header area ONLY when the effective role is LOWER than the
+// global claim (a per-project downgrade, e.g. a global producer holding a
+// crew member doc). Token colors, muted — no red (red has one job per
+// surface and this is not it), border stays 1px.
+export function EffectiveRoleChip() {
+  const { role: globalRole, loading: authLoading } = useAuth()
+  const { role, resolving } = useEffectiveRole()
+
+  if (authLoading || resolving) return null
+  if (roleRank(role) >= roleRank(globalRole)) return null
+
+  return (
+    <span
+      data-testid="effective-role-chip"
+      className="inline-flex items-center whitespace-nowrap rounded-full border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-2 py-0.5 text-2xs font-medium text-[var(--color-text-muted)]"
+    >
+      {roleLabel(role)} on this project
+    </span>
+  )
+}

--- a/src-vnext/shared/components/__tests__/EffectiveRoleChip.test.tsx
+++ b/src-vnext/shared/components/__tests__/EffectiveRoleChip.test.tsx
@@ -1,0 +1,68 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5b — quiet role chip: visible ONLY when effectiveRole < globalRole.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+const authState = vi.hoisted(() => ({ role: "producer", loading: false }))
+const effectiveState = vi.hoisted(() => ({ role: "producer", resolving: false }))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, loading: authState.loading }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role,
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
+
+describe("EffectiveRoleChip", () => {
+  beforeEach(() => {
+    authState.role = "producer"
+    authState.loading = false
+    effectiveState.role = "producer"
+    effectiveState.resolving = false
+  })
+
+  it("is hidden when the effective role equals the global role", () => {
+    render(<EffectiveRoleChip />)
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("shows the downgrade copy when the effective role is lower (producer→viewer)", () => {
+    effectiveState.role = "viewer"
+    render(<EffectiveRoleChip />)
+    const chip = screen.getByTestId("effective-role-chip")
+    expect(chip).toHaveTextContent("Viewer on this project")
+  })
+
+  it("shows the lateral-rank crew downgrade for a global producer (the live xana shape)", () => {
+    effectiveState.role = "crew"
+    render(<EffectiveRoleChip />)
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Crew on this project",
+    )
+  })
+
+  it("is hidden on an effective UPGRADE (crew global, producer member doc)", () => {
+    authState.role = "crew"
+    effectiveState.role = "producer"
+    render(<EffectiveRoleChip />)
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing while the effective role is resolving or auth is loading", () => {
+    effectiveState.role = "viewer"
+    effectiveState.resolving = true
+    const { rerender } = render(<EffectiveRoleChip />)
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+
+    effectiveState.resolving = false
+    authState.loading = true
+    rerender(<EffectiveRoleChip />)
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/shared/hooks/__tests__/useEffectiveRole.test.tsx
+++ b/src-vnext/shared/hooks/__tests__/useEffectiveRole.test.tsx
@@ -1,0 +1,253 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5b — unit matrix for the effective-role source (locked Q5/Q6).
+// useAuth / useOptionalProjectScope / useFirestoreDoc are mocked so each
+// resolution branch is pinned in isolation: admin exception, project-role-wins
+// (incl. downgrades), the three silent failure modes, and the session cache
+// that keeps `resolving` from re-opening on per-route provider remounts.
+// The useFirestoreDoc mock APPLIES the hook's real mapDoc to a raw record, so
+// the member-doc normalizeRole path (legacy 'wardrobe') is exercised for real.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+
+const authState = vi.hoisted(() => ({
+  role: "producer" as string,
+  user: { uid: "u1" } as { uid: string } | null,
+  clientId: "c1" as string | null,
+  loading: false,
+}))
+
+const scopeState = vi.hoisted(() => ({
+  scope: { projectId: "p1", projectName: "Project 1" } as {
+    projectId: string
+    projectName: string
+  } | null,
+}))
+
+const docState = vi.hoisted(() => ({
+  /** Raw member-doc record the mock feeds through the caller's mapDoc. */
+  raw: null as Record<string, unknown> | null,
+  loading: false,
+  error: null as string | null,
+  errorCode: null as string | null,
+  /** Stale record exposed as .data while error is set (real-hook behavior). */
+  stale: null as Record<string, unknown> | null,
+  calls: [] as Array<string[] | null>,
+}))
+
+const toastSpy = vi.hoisted(() => vi.fn())
+
+vi.mock("sonner", () => ({
+  toast: Object.assign(toastSpy, { success: vi.fn(), error: vi.fn(), info: vi.fn() }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    role: authState.role,
+    user: authState.user,
+    clientId: authState.clientId,
+    loading: authState.loading,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useOptionalProjectScope: () => scopeState.scope,
+}))
+
+vi.mock("@/shared/hooks/useFirestoreDoc", () => ({
+  useFirestoreDoc: (
+    path: string[] | null,
+    mapDoc?: (id: string, data: Record<string, unknown>) => unknown,
+  ) => {
+    docState.calls.push(path)
+    // Null path mirrors the real hook: no subscription, settled empty.
+    if (!path) return { data: null, loading: false, error: null, errorCode: null }
+    // Like the real hook, .data keeps the STALE record when error is set.
+    const raw = docState.error ? docState.stale : docState.raw
+    const data = raw && mapDoc ? mapDoc("u1", raw) : raw
+    return {
+      data,
+      loading: docState.loading,
+      error: docState.error,
+      errorCode: docState.errorCode,
+    }
+  },
+}))
+
+import {
+  useEffectiveRole,
+  resetEffectiveRoleCacheForTests,
+} from "@/shared/hooks/useEffectiveRole"
+
+function setMemberDoc(role: string | null) {
+  docState.raw = role ? { role } : null
+  docState.loading = false
+  docState.error = null
+  docState.errorCode = null
+  docState.stale = null
+}
+
+function setDocLoading() {
+  setMemberDoc(null)
+  docState.loading = true
+}
+
+function setDocError(errorCode: string, message = "boom") {
+  docState.loading = false
+  docState.error = message
+  docState.errorCode = errorCode
+}
+
+describe("useEffectiveRole", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetEffectiveRoleCacheForTests()
+    authState.role = "producer"
+    authState.user = { uid: "u1" }
+    authState.clientId = "c1"
+    authState.loading = false
+    scopeState.scope = { projectId: "p1", projectName: "Project 1" }
+    docState.calls = []
+    setMemberDoc(null)
+  })
+
+  it("global admin is NEVER downgraded and skips the member subscription (Q6 exception)", () => {
+    authState.role = "admin"
+    setMemberDoc("viewer")
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "admin", resolving: false })
+    // The hook never opened a member-doc read (null path only).
+    expect(docState.calls.every((p) => p === null)).toBe(true)
+  })
+
+  it("returns the global claim with no project scope (org pages, OnSetViewerPage)", () => {
+    scopeState.scope = null
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "producer", resolving: false })
+    expect(docState.calls.every((p) => p === null)).toBe(true)
+  })
+
+  it("member doc role WINS over the global claim, including a producer→viewer downgrade (Q6)", () => {
+    setMemberDoc("viewer")
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "viewer", resolving: false })
+    // Member path is uid-keyed under the scoped project (paths.ts).
+    expect(docState.calls[docState.calls.length - 1]).toEqual([
+      "clients",
+      "c1",
+      "projects",
+      "p1",
+      "members",
+      "u1",
+    ])
+  })
+
+  it("normalizes a legacy 'wardrobe' member doc to warehouse", () => {
+    setMemberDoc("wardrobe")
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "warehouse", resolving: false })
+  })
+
+  it("doc absent → global-claim fallback (member-less project)", () => {
+    authState.role = "crew"
+    setMemberDoc(null)
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "crew", resolving: false })
+  })
+
+  it("permission-denied → global-claim fallback, silent (non-member reading own path)", () => {
+    authState.role = "crew"
+    setDocError("permission-denied", "Missing or insufficient permissions.")
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "crew", resolving: false })
+  })
+
+  it("transient error with a session cache → last-known-resolved role, never stale .data", () => {
+    // First mount resolves a member 'viewer' role (cached).
+    setMemberDoc("viewer")
+    const first = renderHook(() => useEffectiveRole())
+    expect(first.result.current.role).toBe("viewer")
+    first.unmount()
+
+    // Listener now errors transiently — and useFirestoreDoc still exposes a
+    // stale elevated record as .data. The hook must use the CACHE, not .data.
+    setDocError("unavailable")
+    docState.stale = { role: "producer" }
+    const second = renderHook(() => useEffectiveRole())
+
+    expect(second.result.current).toEqual({ role: "viewer", resolving: false })
+  })
+
+  it("transient error with NO cache → global-claim fallback (fail toward fewer)", () => {
+    authState.role = "crew"
+    setDocError("unavailable")
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current).toEqual({ role: "crew", resolving: false })
+  })
+
+  it("resolving=true ONLY on the first uncached in-flight read", () => {
+    setDocLoading()
+
+    const { result } = renderHook(() => useEffectiveRole())
+
+    expect(result.current.resolving).toBe(true)
+    // While resolving the role value is the global claim, but consumers gate
+    // on `resolving` and must render no write affordances from it.
+    expect(result.current.role).toBe("producer")
+  })
+
+  it("session cache survives unmount/remount: no resolving gap on re-nav", () => {
+    setMemberDoc("crew")
+    const first = renderHook(() => useEffectiveRole())
+    expect(first.result.current).toEqual({ role: "crew", resolving: false })
+    first.unmount()
+
+    // Per-route ProjectScopeProvider remount re-opens the subscription
+    // (loading) — the cached role answers immediately, resolving stays false.
+    setDocLoading()
+    const second = renderHook(() => useEffectiveRole())
+
+    expect(second.result.current).toEqual({ role: "crew", resolving: false })
+  })
+
+  it("fires ONE downgrade toast when the resolved role transitions downward mid-session", () => {
+    setMemberDoc("producer")
+    const { rerender } = renderHook(() => useEffectiveRole())
+    expect(toastSpy).not.toHaveBeenCalled()
+
+    // Live member-doc edit downgrades the role on the open subscription.
+    setMemberDoc("viewer")
+    rerender()
+
+    expect(toastSpy).toHaveBeenCalledTimes(1)
+    expect(toastSpy).toHaveBeenCalledWith("Your role on this project changed.")
+
+    // Re-render with the same role: no repeat toast.
+    rerender()
+    expect(toastSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not toast on an upgrade or on the first resolution", () => {
+    setMemberDoc("crew")
+    const { rerender } = renderHook(() => useEffectiveRole())
+    expect(toastSpy).not.toHaveBeenCalled()
+
+    setMemberDoc("producer")
+    rerender()
+
+    expect(toastSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/shared/hooks/useEffectiveRole.ts
+++ b/src-vnext/shared/hooks/useEffectiveRole.ts
@@ -1,0 +1,137 @@
+import { useEffect } from "react"
+import { toast } from "sonner"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useOptionalProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useFirestoreDoc } from "@/shared/hooks/useFirestoreDoc"
+import { projectMemberDocPath } from "@/shared/lib/paths"
+import { normalizeRole, roleRank, ROLE } from "@/shared/lib/rbac"
+import type { Role } from "@/shared/types"
+
+// Phase 5b effective-role source (locked Q5/Q6): the role project-scoped
+// capability gates consume. A LIVE members/{uid} doc on the active project
+// WINS over the global claim — including downgrades. Global admin is the
+// single exception and it lives HERE, nowhere else.
+//
+// Failure semantics (each silent, fail-toward-fewer):
+//   1. permission-denied — a NON-member reading its own member path is
+//      denied by the members read rule (firestore.rules:706-709). Expected;
+//      fall back to the global claim. No error UI, no console noise (the
+//      lanes-carve-out swallow precedent, useShotDetailBundle.ts).
+//   2. doc-absent — member-less project (the normal live state for
+//      admin-created projects). Global-claim fallback, silent.
+//   3. transient/other error — last-known-resolved role for this project if
+//      one exists this session, else the global claim. NEVER read .data when
+//      error is set: useFirestoreDoc keeps stale data on error, and a removed
+//      user must not freeze at their old elevated role.
+//
+// `resolving` is true ONLY during the FIRST in-flight read for a projectId
+// with no session cache. ProjectScopeProvider mounts per-route (12 routes),
+// so subscriptions churn on every in-project nav — the module-level cache
+// keeps the affordance gap from re-opening each time.
+
+export interface EffectiveRoleResult {
+  readonly role: Role
+  readonly resolving: boolean
+}
+
+// Last RESOLVED effective role per `${uid}:${projectId}` for this session.
+const resolvedRoleCache = new Map<string, Role>()
+
+/** Test-only: clears the module-level session cache between specs. */
+export function resetEffectiveRoleCacheForTests(): void {
+  resolvedRoleCache.clear()
+}
+
+// Member docs store role as an untyped string (legacy 'wardrobe' must map to
+// warehouse) — run it through normalizeRole, same as the claims path.
+function mapMemberDoc(_id: string, data: Record<string, unknown>): { role: Role } {
+  return { role: normalizeRole(data["role"]) }
+}
+
+// Stable options object — permission-denied is the EXPECTED non-member
+// answer, not an error worth logging.
+const MEMBER_DOC_OPTIONS = { quietErrorCodes: ["permission-denied"] } as const
+
+function commitResolvedRole(key: string, role: Role): void {
+  const prev = resolvedRoleCache.get(key)
+  resolvedRoleCache.set(key, role)
+  if (prev !== undefined && roleRank(role) < roleRank(prev)) {
+    // Q6 mid-session downgrade: announce once, never silently collapse
+    // affordances. The synchronous cache update dedupes across the several
+    // mounted hook consumers — the first commit changes the cache, so later
+    // effects see prev === role and skip the toast.
+    toast("Your role on this project changed.")
+  }
+}
+
+export function useEffectiveRole(): EffectiveRoleResult {
+  const { role: globalRole, user, clientId, loading: authLoading } = useAuth()
+  const scope = useOptionalProjectScope()
+  const uid = user?.uid ?? null
+  const projectId = scope?.projectId ?? null
+
+  // Global admin is NEVER downgraded (locked Q6) — skip the member
+  // subscription entirely.
+  const isGlobalAdmin = globalRole === ROLE.ADMIN
+
+  const memberPath =
+    !isGlobalAdmin && !authLoading && uid && clientId && projectId
+      ? projectMemberDocPath(uid, projectId, clientId)
+      : null
+
+  const { data, loading, error, errorCode } = useFirestoreDoc<{ role: Role }>(
+    memberPath,
+    mapMemberDoc,
+    MEMBER_DOC_OPTIONS,
+  )
+
+  const key = uid && projectId ? `${uid}:${projectId}` : null
+  const cached = key ? resolvedRoleCache.get(key) : undefined
+
+  let role: Role
+  let resolving = false
+  // True only when we hold a SETTLED answer (member doc, doc-absent, or the
+  // expected permission-denied) — the states worth caching for the session.
+  let authoritative = false
+
+  if (isGlobalAdmin) {
+    role = ROLE.ADMIN
+  } else if (!projectId) {
+    // No ProjectScopeProvider (org pages; OnSetViewerPage mounts without the
+    // provider) — the global claim is the effective role.
+    role = globalRole
+  } else if (!memberPath) {
+    // Auth still settling / signed out: no read in flight, fall toward the
+    // session cache then the global claim.
+    role = cached ?? globalRole
+  } else if (error) {
+    if (errorCode === "permission-denied") {
+      role = globalRole
+      authoritative = true
+    } else {
+      role = cached ?? globalRole
+    }
+  } else if (loading) {
+    if (cached !== undefined) {
+      role = cached
+    } else {
+      role = globalRole
+      resolving = true
+    }
+  } else if (data) {
+    // PROJECT ROLE WINS, including downgrades (locked Q6).
+    role = data.role
+    authoritative = true
+  } else {
+    // Doc absent — member-less project, the normal live state.
+    role = globalRole
+    authoritative = true
+  }
+
+  useEffect(() => {
+    if (!key || !authoritative) return
+    commitResolvedRole(key, role)
+  }, [key, role, authoritative])
+
+  return { role, resolving }
+}

--- a/src-vnext/shared/hooks/useFirestoreDoc.ts
+++ b/src-vnext/shared/hooks/useFirestoreDoc.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { doc, onSnapshot } from "firebase/firestore"
 import { db } from "@/shared/lib/firebase"
 import {
@@ -10,15 +10,40 @@ interface FirestoreDocResult<T> {
   readonly data: T | null
   readonly loading: boolean
   readonly error: string | null
+  /**
+   * Raw Firestore error code (e.g. "permission-denied") — additive, mirrors
+   * useFirestoreCollection's FirestoreCollectionError.code so callers can
+   * discriminate a rules-denied read from a genuine error. Null when no
+   * error is set.
+   */
+  readonly errorCode: string | null
+}
+
+interface FirestoreDocOptions {
+  /**
+   * Error codes EXPECTED at this call site (e.g. a non-member reading its
+   * own members doc is rules-denied — useEffectiveRole). Suppresses the
+   * console.error for those codes ONLY; the error still surfaces through
+   * the result. Lanes-carve-out precedent: useShotDetailBundle.ts swallows
+   * permission-denied the same way for the lanes read.
+   */
+  readonly quietErrorCodes?: ReadonlyArray<string>
 }
 
 export function useFirestoreDoc<T>(
   pathSegments: string[] | null,
   mapDoc?: (id: string, data: Record<string, unknown>) => T,
+  options?: FirestoreDocOptions,
 ): FirestoreDocResult<T> {
   const [data, setData] = useState<T | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<string | null>(null)
+
+  // Ref so the snapshot error callback reads the latest options without
+  // retriggering the subscription effect (deps stay [pathKey]).
+  const optionsRef = useRef(options)
+  optionsRef.current = options
 
   const pathKey = pathSegments?.join("/") ?? ""
 
@@ -31,6 +56,7 @@ export function useFirestoreDoc<T>(
 
     setLoading(true)
     setError(null)
+    setErrorCode(null)
 
     const docRef = doc(db, pathSegments[0]!, ...pathSegments.slice(1))
     markSubscriptionMount(pathKey)
@@ -49,8 +75,12 @@ export function useFirestoreDoc<T>(
         setLoading(false)
       },
       (err) => {
-        console.error("[useFirestoreDoc]", err)
+        const code = (err as { code?: string }).code ?? null
+        if (!code || !optionsRef.current?.quietErrorCodes?.includes(code)) {
+          console.error("[useFirestoreDoc]", err)
+        }
         setError(err.message)
+        setErrorCode(code)
         setLoading(false)
       },
     )
@@ -61,5 +91,5 @@ export function useFirestoreDoc<T>(
     }
   }, [pathKey])
 
-  return { data, loading, error }
+  return { data, loading, error, errorCode }
 }

--- a/src-vnext/shared/lib/rbac.test.ts
+++ b/src-vnext/shared/lib/rbac.test.ts
@@ -12,6 +12,8 @@ import {
   isViewer,
   canSubmitShotRequest,
   canTriageShotRequests,
+  canEditScene,
+  roleRank,
 } from "./rbac"
 
 describe("normalizeRole", () => {
@@ -232,6 +234,45 @@ describe("permission checks", () => {
     it("viewer cannot triage shot requests", () => {
       expect(canTriageShotRequests("viewer")).toBe(false)
     })
+  })
+})
+
+describe("canEditScene", () => {
+  // Mirrors the /lanes rule role list (firestore.rules:880-882 create/update,
+  // :901-904 delete): admin || producer || warehouse. 5f's warehouse revoke
+  // edits this helper + the lanes rule lists together (two-line edit).
+  it("admin can edit scenes", () => {
+    expect(canEditScene("admin")).toBe(true)
+  })
+
+  it("producer can edit scenes", () => {
+    expect(canEditScene("producer")).toBe(true)
+  })
+
+  it("warehouse keeps lane-write until the 5f revoke (locked Q3)", () => {
+    expect(canEditScene("warehouse")).toBe(true)
+  })
+
+  it("crew cannot edit scenes (crew writes shots, not lanes)", () => {
+    expect(canEditScene("crew")).toBe(false)
+  })
+
+  it("viewer cannot edit scenes", () => {
+    expect(canEditScene("viewer")).toBe(false)
+  })
+})
+
+describe("roleRank", () => {
+  it("orders admin > producer > crew/warehouse > viewer", () => {
+    expect(roleRank("admin")).toBeGreaterThan(roleRank("producer"))
+    expect(roleRank("producer")).toBeGreaterThan(roleRank("crew"))
+    expect(roleRank("producer")).toBeGreaterThan(roleRank("warehouse"))
+    expect(roleRank("crew")).toBeGreaterThan(roleRank("viewer"))
+    expect(roleRank("warehouse")).toBeGreaterThan(roleRank("viewer"))
+  })
+
+  it("treats crew and warehouse as lateral (equal rank, no downgrade either way)", () => {
+    expect(roleRank("crew")).toBe(roleRank("warehouse"))
   })
 })
 

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -101,3 +101,32 @@ export function canTriageShotRequests(role: Role): boolean {
 export function canManageCasting(role: Role): boolean {
   return role === ROLE.ADMIN || role === ROLE.PRODUCER
 }
+
+// Scene/lane writes (create scene, edit, delete, ungroup). Mirrors the
+// /lanes rule, which is already project-aware: create/update at
+// firestore.rules:880-882 and delete at :901-904 both gate on isAdmin ||
+// producerCanAccessProject || hasProjectRole(projectId, ['producer',
+// 'warehouse']). Consumes the EFFECTIVE role (5b) — the two surviving
+// copies (ShotListPage canManageLanes, ShotDetailPageUnified canEditScene)
+// consolidate here. 5f's warehouse revoke is a two-line edit: remove
+// 'warehouse' from this helper AND from the lanes rule role lists.
+export function canEditScene(role: Role): boolean {
+  return role === ROLE.ADMIN || role === ROLE.PRODUCER || role === ROLE.WAREHOUSE
+}
+
+// Total order over roles for "is this a downgrade" comparisons (the 5b
+// effective-role chip + mid-session downgrade toast). admin > producer >
+// crew/warehouse > viewer. Crew and warehouse are LATERAL jobs (crew writes
+// shots, warehouse writes lanes/pulls) — they share a rank on purpose, so a
+// crew<->warehouse project override is neither a downgrade nor an upgrade.
+const ROLE_RANK: Record<Role, number> = {
+  [ROLE.ADMIN]: 4,
+  [ROLE.PRODUCER]: 3,
+  [ROLE.CREW]: 2,
+  [ROLE.WAREHOUSE]: 2,
+  [ROLE.VIEWER]: 1,
+}
+
+export function roleRank(role: Role): number {
+  return ROLE_RANK[role]
+}

--- a/storage.rules
+++ b/storage.rules
@@ -13,7 +13,15 @@ service firebase.storage {
       return request.auth != null && request.auth.token.role == 'admin';
     }
     function isProducerOrWardrobe() {
-      return request.auth != null && (request.auth.token.role == 'producer' || request.auth.token.role == 'wardrobe' || request.auth.token.role == 'admin');
+      // Accepts canonical 'warehouse' alongside legacy 'wardrobe' — backend
+      // invites mint 'warehouse' claims (functions/index.js). Lower-cased
+      // compare mirrors firestore.rules normalizedRole case folding.
+      return request.auth != null &&
+        request.auth.token.role is string &&
+        (request.auth.token.role.lower() == 'producer' ||
+         request.auth.token.role.lower() == 'wardrobe' ||
+         request.auth.token.role.lower() == 'warehouse' ||
+         request.auth.token.role.lower() == 'admin');
     }
 
     // Validation functions for file uploads

--- a/tests/fixtures/auth.ts
+++ b/tests/fixtures/auth.ts
@@ -43,6 +43,7 @@ type AuthFixtures = {
   wardrobePage: Page;
   warehousePage: Page;
   crewPage: Page;
+  memberCrewPage: Page;
   viewerPage: Page;
 };
 
@@ -68,7 +69,7 @@ function installFirebaseErrorFilter(page: Page): void {
 
 async function buildRoleFixture(
   browser: import('@playwright/test').Browser,
-  role: 'admin' | 'producer' | 'wardrobe' | 'warehouse' | 'crew' | 'viewer',
+  role: 'admin' | 'producer' | 'wardrobe' | 'warehouse' | 'crew' | 'memberCrew' | 'viewer',
   use: (page: Page) => Promise<void>,
 ): Promise<void> {
   const context = await browser.newContext({ storageState: storageStatePath(role) });
@@ -111,9 +112,21 @@ export const test = base.extend<AuthFixtures>({
     await buildRoleFixture(browser, 'warehouse', use);
   },
 
-  /** Crew — view shots, limited edit. */
+  /** Crew — view shots, limited edit. NON-member of the seed project by
+   * contract (role-matrix.spec.ts non-member repro — do not seed a members
+   * doc for it). */
   crewPage: async ({ browser }, use) => {
     await buildRoleFixture(browser, 'crew', use);
+  },
+
+  /**
+   * Member crew (5b) — global claim 'crew' PLUS a members doc role 'crew' on
+   * the seed project (seedShotsCrudScenario memberCrewUid). The identity that
+   * exercises the hardened /shots rule's hasProjectRole ALLOW arm and the
+   * effective-role member path end-to-end.
+   */
+  memberCrewPage: async ({ browser }, use) => {
+    await buildRoleFixture(browser, 'memberCrew', use);
   },
 
   /** Viewer — read-only access. */
@@ -151,6 +164,11 @@ export const TEST_CREDENTIALS = {
   crew: {
     email: 'crew@test.shotbuilder.app',
     password: 'test-password-crew-123',
+    role: 'crew',
+  },
+  memberCrew: {
+    email: 'crew-member@test.shotbuilder.app',
+    password: 'test-password-crew-member-123',
     role: 'crew',
   },
   viewer: {

--- a/tests/global.setup.ts
+++ b/tests/global.setup.ts
@@ -56,6 +56,17 @@ export const TEST_USERS = {
     role: 'crew',
     clientId: 'test-client',
   },
+  // 5b: SEPARATE crew identity that IS a seed-project member (members doc
+  // role 'crew' — see seedShotsCrudScenario). Exercises the hardened /shots
+  // rule's hasProjectRole allow arm end-to-end. The original `crew` fixture
+  // above stays a NON-member by contract (role-matrix.spec.ts repro) — never
+  // grant it a members doc.
+  memberCrew: {
+    email: 'crew-member@test.shotbuilder.app',
+    password: 'test-password-crew-member-123',
+    role: 'crew',
+    clientId: 'test-client',
+  },
   viewer: {
     email: 'viewer@test.shotbuilder.app',
     password: 'test-password-viewer-123',
@@ -306,7 +317,13 @@ async function globalSetup(config: FullConfig) {
     // hasProjectRole(...,'viewer') (a viewer's global role satisfies neither
     // isAdmin nor producerCanAccessProject), so without it the detail page
     // errors out for a viewer (sidebar-summary's read-only group).
-    await seedShotsCrudScenario({ viewerUid: roleUids.viewer });
+    // memberCrewUid: the 5b member-crew identity gets a 'crew' members doc so
+    // the hardened /shots rule's hasProjectRole arm is E2E-exercised. The
+    // plain crew uid is intentionally NOT passed (non-member by contract).
+    await seedShotsCrudScenario({
+      viewerUid: roleUids.viewer,
+      memberCrewUid: roleUids.memberCrew,
+    });
     // Seed the pulls-crud fixture AFTER shots-crud — seedPullsCrudScenario
     // assumes the seed project (created by seedShotsCrudScenario) already exists.
     // Pass the warehouse uid so the seed can grant it project membership: pull

--- a/tests/helpers/seed.ts
+++ b/tests/helpers/seed.ts
@@ -459,11 +459,25 @@ export async function clearShotsCrudData(): Promise<void> {
  * useShotDetailBundle folds that into a fatal page error, and the detail page
  * never renders for a viewer. Producer needs no member doc — its global role
  * satisfies producerCanAccessProject on a team project. Granting membership does
- * NOT make the viewer an editor: the UI's canEdit/canManageShots uses the
- * user's GLOBAL role (rbac.ts), so the viewer still renders the read-only path.
+ * NOT make the viewer an editor: the member doc's 'viewer' role IS the
+ * effective role under 5b (project role wins), which still renders the
+ * read-only path — same outcome as the pre-5b global-role gate.
+ *
+ * MEMBER-CREW ACCESS (5b): pass `memberCrewUid` to grant the DEDICATED
+ * crew-member test user (crew-member@test.shotbuilder.app, global claim
+ * 'crew') a members doc with role 'crew'. This identity exercises the
+ * hardened /shots rule's hasProjectRole ALLOW arm end-to-end (member crew
+ * creates a shot through the UI). It is a SEPARATE identity from the
+ * original crew fixture, whose members-doc ABSENCE is load-bearing
+ * (role-matrix.spec.ts non-member repro) — never grant that one a doc.
+ *
+ * Member docs use the APP shape ({role, addedAt, addedBy} —
+ * adminWrites.addProjectMember / CreateProjectDialog), not the legacy seed
+ * shape ({role, clientId, projectId, addedAt}): rules don't validate member
+ * fields on these paths, but the seed should mirror what production writes.
  */
 export async function seedShotsCrudScenario(
-  opts: { viewerUid?: string } = {},
+  opts: { viewerUid?: string; memberCrewUid?: string } = {},
 ): Promise<void> {
   await clearShotsCrudData();
 
@@ -554,15 +568,30 @@ export async function seedShotsCrudScenario(
   // Grant the viewer user project membership so firestore.rules permits it to
   // read the project's lanes (and project doc) — see the VIEWER ACCESS note
   // above. Keyed by uid because hasProjectRole resolves members/<request.auth.uid>.
+  // App-shaped doc ({role, addedAt, addedBy}); 'e2e-seed' marks the admin-SDK
+  // writer (production writes the adder's uid).
   if (opts.viewerUid) {
     await getDb()
       .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/members`)
       .doc(opts.viewerUid)
       .set({
         role: 'viewer',
-        clientId: CLIENT_ID,
-        projectId: SEED_PROJECT_ID,
         addedAt: new Date(),
+        addedBy: 'e2e-seed',
+      });
+  }
+
+  // 5b: the member-crew identity's members doc — the hasProjectRole ALLOW arm
+  // of the hardened /shots rule, exercised end-to-end (see MEMBER-CREW ACCESS
+  // note above). Do NOT add one for the original crew fixture.
+  if (opts.memberCrewUid) {
+    await getDb()
+      .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/members`)
+      .doc(opts.memberCrewUid)
+      .set({
+        role: 'crew',
+        addedAt: new Date(),
+        addedBy: 'e2e-seed',
       });
   }
 }
@@ -676,15 +705,16 @@ export async function seedPullsCrudScenario(
   // Grant the warehouse user project membership so firestore.rules permits it to
   // read + fulfill the pull (see the WAREHOUSE ACCESS note above). Keyed by uid
   // because hasProjectRole resolves the member doc at members/<request.auth.uid>.
+  // App-shaped doc ({role, addedAt, addedBy}) — see the member-doc shape note
+  // on seedShotsCrudScenario.
   if (opts.warehouseUid) {
     await db
       .collection(`clients/${CLIENT_ID}/projects/${SEED_PROJECT_ID}/members`)
       .doc(opts.warehouseUid)
       .set({
         role: 'warehouse',
-        clientId: CLIENT_ID,
-        projectId: SEED_PROJECT_ID,
         addedAt: now,
+        addedBy: 'e2e-seed',
       });
   }
 }

--- a/tests/role-matrix.spec.ts
+++ b/tests/role-matrix.spec.ts
@@ -194,9 +194,12 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
       crewPage.getByText(SEED_SHOT_AURORA.title).first(),
     ).toBeVisible();
 
-    // (d) Crew KEEPS its create affordance: canManageShots(crew)=true today.
-    // Flag-off must not revoke it (any crew revocation is a 5e/5f decision,
-    // not Phase 4).
+    // (d) Crew KEEPS its create affordance. Under 5b the mechanism changed
+    // but the pin holds: the non-member's own members-doc read is
+    // permission-denied, useEffectiveRole silently falls back to the GLOBAL
+    // claim ('crew'), and canManageShots(crew)=true. (The hardened /shots
+    // rule would deny the actual write for a non-member crew — the UI-side
+    // non-member revoke is sequenced with 5b-II/5c, rules backstop first.)
     await expect(
       crewPage.getByRole('button', { name: /new shot/i }).first(),
     ).toBeVisible();
@@ -314,5 +317,68 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
     const url = new URL(wardrobePage.url());
     expect(url.searchParams.get('view')).toBeNull();
     expect(url.searchParams.get('group')).toBeNull();
+  });
+});
+
+/**
+ * Phase 5b — effective-role member path + the hardened /shots ALLOW arm.
+ *
+ * crew-member@test.shotbuilder.app carries the SAME global claim as the
+ * non-member crew fixture ('crew') but ALSO holds a seed-project members doc
+ * with role 'crew' (seedShotsCrudScenario memberCrewUid — a SEPARATE
+ * identity; the original crew fixture's members-doc ABSENCE is load-bearing
+ * for the non-member repro at the top of this file).
+ *
+ * CI's emulator loads the repo's HARDENED firestore.rules, so the create
+ * below passes ONLY via the project-role arm: clientMatches && hasProjectRole
+ * (projectId, ['producer','crew']) (firestore.rules /shots create). A
+ * non-member crew claim satisfies no arm — this test is the end-to-end proof
+ * that the UI affordance and the rule now read the same source (the members
+ * doc), per the rules-vs-UI adversarial check.
+ */
+test.describe('Shots — member crew (5b effective role, hardened-rule allow arm)', () => {
+  test('member-crew creates a shot end-to-end through the UI', async ({
+    memberCrewPage,
+  }) => {
+    await memberCrewPage.goto(SHOTS_URL);
+    await memberCrewPage
+      .locator('main, [role="main"]')
+      .first()
+      .waitFor({ state: 'visible' });
+
+    // Member lanes/members reads are permitted (hasProjectRole includes
+    // crew on the read lists) — no permissions error anywhere on the page.
+    await expect(
+      memberCrewPage.getByText(/Missing or insufficient permissions/i),
+    ).toHaveCount(0);
+
+    // Card view so the created CARD (not just the success toast, which also
+    // renders the title) proves list membership — shots-crud precedent.
+    await memberCrewPage.getByRole('button', { name: 'Card view' }).click();
+
+    // The effective role resolves from the members doc ('crew') — the create
+    // affordance renders after the resolving gate settles.
+    const newShotButton = memberCrewPage.getByRole('button', { name: 'New Shot' });
+    await expect(newShotButton).toBeVisible();
+    await newShotButton.click();
+
+    const dialog = memberCrewPage.getByRole('dialog');
+    await expect(dialog).toBeVisible();
+
+    const title = `E2E Member Crew Shot ${Date.now()}`;
+    await dialog.getByTestId('shot-title-input').fill(title);
+    await dialog.getByRole('button', { name: 'Create', exact: true }).click();
+
+    // The write PASSED the hardened rule (hasProjectRole allow arm): the
+    // dialog closes and the card lands in the list. A rules denial would
+    // keep the dialog open / surface the permission toast instead.
+    await expect(dialog).not.toBeVisible();
+    await expect(
+      memberCrewPage.locator('[data-testid="shot-card"]', { hasText: title }),
+    ).toBeVisible();
+
+    // member role == global role (crew): the quiet downgrade chip must NOT
+    // render — it is downgrade-only.
+    await expect(memberCrewPage.getByTestId('effective-role-chip')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## What

Phase 5b-I of the redesign: the per-project **effective-role source** (live `members/{uid}` read — locked Q5) and **`/shots` write-rule hardening** (the rule is currently `isAuthed()`-only; the UI is the only shot-edit defense). Contract: the audited build spec (Session 15, 10-agent audit, all four lenses GO_WITH_CHANGES; Ted approved 2026-06-10).

## Staged commits — review the diffs in order

This PR lands in **three reviewable tranches** (characterization-first; local Java 8 cannot run emulators, so CI is the only place the rules tests execute):

1. **Characterization pins + CI rules lane** (this push): 11 pins assert TODAY's permissive behavior against the UNMODIFIED rules — viewer and non-member crew can create/update/delete shots; producer self-add members carve-out; the `createProjectFromRequest` one-transaction shape; project-move; `shotShares` create with arbitrary projectId; viewer versions-create. Plus a `ui-checks` step that finally EXECUTES rules tests against the emulator with a fail-if-zero-tests guard (the existing rules suite has been silently self-skipping in every CI workflow — green-by-skip).
2. **Rules hardening** (next push): `/shots` writes per-verb (`isAdmin() || producerCanAccessProject() || hasProjectRole(projectId,['producer','crew'])` with doc-field projectId sourcing + project-move pin + global-producer create lane), members self-add tightened to creation-time, `shotShares` create project-scoped, versions create hardened, storage.rules warehouse-string fix. The pin updates in that commit ARE the behavior change — review them as the contract.
3. **Client effective-role wiring**: `useEffectiveRole()` → `{role, resolving}` (admin exception inside the hook; silent global-claim fallback on denied/absent/error), quiet role chip, permission-denied toast branch, `canEditScene` consolidation (two surviving copies only), member-crew E2E fixture + role-matrix updates.

**Role-list note for reviewers:** the shots list `['producer','crew']` deliberately diverges from the lanes precedent `['producer','warehouse']` — crew must write shots for 5e (mobile-crew edit); warehouse is heading to read-only Review at 5f with its lane-write revoked (locked Q3). Not a copy mistake.

## Deploy posture

Merging this PR does NOT change production rules — no CI workflow deploys firestore.rules (deploy-live is hosting-only). The rules activate only via a manual, Ted-gated `firebase deploy --only firestore:rules` per the runbook in the spec. Live-data readiness was verified 2026-06-10 (read-only sample): all 10 production users are admin/producer-claim and pass the hardened rule on all 17 projects; no backfill required.

## Verification so far

- New rules test file self-skips cleanly without the emulator (`1 passed | 11 skipped`, exit 0) and lint passes (0/0).
- Every pinned write shape was adversarially verified field-for-field against the real client writers (CreateShotDialog, updateShotWithVersion, adminWrites, requestWrites, shotLifecycleActions, ShotsShareDialog, shotVersioning).
- The zero-tests guard was attacked with all four summary shapes (all-pass / pass+skip / all-skip / no-files) — only all-pass survives.