### PR TITLE
fix(app): auto-reload once on stale lazy-chunk load failure

### DIFF
--- a/src-vnext/main.tsx
+++ b/src-vnext/main.tsx
@@ -4,6 +4,9 @@ import * as Sentry from "@sentry/react"
 import "../tokens.css"
 import "./index.css"
 import { App } from "@/app/App"
+import { installChunkReloadHandler } from "@/shared/lib/chunkReload"
+
+installChunkReloadHandler()
 
 interface BootError {
   readonly type?: string

--- a/src-vnext/shared/lib/chunkReload.test.ts
+++ b/src-vnext/shared/lib/chunkReload.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { handlePreloadError, installChunkReloadHandler } from "./chunkReload"
+
+const GUARD_KEY = "sb:chunk-reload-at"
+
+function makeEvent(): Event {
+  const event = new Event("vite:preloadError", { cancelable: true })
+  vi.spyOn(event, "preventDefault")
+  return event
+}
+
+describe("handlePreloadError", () => {
+  const reload = vi.fn()
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    sessionStorage.clear()
+    vi.useFakeTimers()
+    vi.setSystemTime(1_700_000_000_000)
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload },
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    })
+    reload.mockReset()
+  })
+
+  it("reloads once on the first preload error and swallows the event", () => {
+    const event = makeEvent()
+    handlePreloadError(event)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(sessionStorage.getItem(GUARD_KEY)).toBe("1700000000000")
+  })
+
+  it("does not reload again within the loop window — error propagates to the boundary", () => {
+    handlePreloadError(makeEvent())
+    reload.mockClear()
+
+    vi.setSystemTime(1_700_000_000_000 + 30_000)
+    const second = makeEvent()
+    handlePreloadError(second)
+
+    expect(reload).not.toHaveBeenCalled()
+    expect(second.preventDefault).not.toHaveBeenCalled()
+  })
+
+  it("reloads again once the loop window has elapsed", () => {
+    handlePreloadError(makeEvent())
+    reload.mockClear()
+
+    vi.setSystemTime(1_700_000_000_000 + 61_000)
+    handlePreloadError(makeEvent())
+
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it("still reloads when sessionStorage is unavailable", () => {
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied")
+    })
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("denied")
+    })
+
+    const event = makeEvent()
+    handlePreloadError(event)
+
+    expect(reload).toHaveBeenCalledTimes(1)
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe("installChunkReloadHandler", () => {
+  it("registers the handler for vite:preloadError", () => {
+    const addEventListener = vi.spyOn(window, "addEventListener")
+    installChunkReloadHandler()
+
+    expect(addEventListener).toHaveBeenCalledWith("vite:preloadError", handlePreloadError)
+    addEventListener.mockRestore()
+    window.removeEventListener("vite:preloadError", handlePreloadError)
+  })
+})

--- a/src-vnext/shared/lib/chunkReload.test.ts
+++ b/src-vnext/shared/lib/chunkReload.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { handlePreloadError, installChunkReloadHandler } from "./chunkReload"
-
-const GUARD_KEY = "sb:chunk-reload-at"
+import {
+  RELOAD_GUARD_KEY as GUARD_KEY,
+  handlePreloadError,
+  installChunkReloadHandler,
+} from "./chunkReload"
 
 function makeEvent(): Event {
   const event = new Event("vite:preloadError", { cancelable: true })

--- a/src-vnext/shared/lib/chunkReload.ts
+++ b/src-vnext/shared/lib/chunkReload.ts
@@ -1,0 +1,40 @@
+const RELOAD_GUARD_KEY = "sb:chunk-reload-at"
+const RELOAD_LOOP_WINDOW_MS = 60_000
+
+function readLastReloadAt(): number {
+  try {
+    return Number(sessionStorage.getItem(RELOAD_GUARD_KEY)) || 0
+  } catch {
+    return 0
+  }
+}
+
+function writeLastReloadAt(value: number): void {
+  try {
+    sessionStorage.setItem(RELOAD_GUARD_KEY, String(value))
+  } catch {
+    // Storage unavailable (private mode quota, etc.) — reload anyway; the
+    // window guard just won't persist, and the boundary remains the backstop.
+  }
+}
+
+/**
+ * Stale-chunk recovery: after a deploy, an already-open tab requesting a
+ * lazy route chunk gets the SPA-rewritten index.html instead of the old
+ * hashed file and throws (e.g. "Unexpected token '<'"). One automatic
+ * reload picks up the new build. The sessionStorage timestamp guard keeps
+ * a genuinely broken deploy from reload-looping — within the window the
+ * error propagates to ErrorBoundary, which already renders the
+ * chunk-aware "Reload required" fallback and reports to Sentry.
+ */
+export function handlePreloadError(event: Event): void {
+  const now = Date.now()
+  if (now - readLastReloadAt() < RELOAD_LOOP_WINDOW_MS) return
+  writeLastReloadAt(now)
+  event.preventDefault()
+  window.location.reload()
+}
+
+export function installChunkReloadHandler(): void {
+  window.addEventListener("vite:preloadError", handlePreloadError)
+}

--- a/src-vnext/shared/lib/chunkReload.ts
+++ b/src-vnext/shared/lib/chunkReload.ts
@@ -1,4 +1,4 @@
-const RELOAD_GUARD_KEY = "sb:chunk-reload-at"
+export const RELOAD_GUARD_KEY = "sb:chunk-reload-at"
 const RELOAD_LOOP_WINDOW_MS = 60_000
 
 function readLastReloadAt(): number {
@@ -18,15 +18,7 @@ function writeLastReloadAt(value: number): void {
   }
 }
 
-/**
- * Stale-chunk recovery: after a deploy, an already-open tab requesting a
- * lazy route chunk gets the SPA-rewritten index.html instead of the old
- * hashed file and throws (e.g. "Unexpected token '<'"). One automatic
- * reload picks up the new build. The sessionStorage timestamp guard keeps
- * a genuinely broken deploy from reload-looping — within the window the
- * error propagates to ErrorBoundary, which already renders the
- * chunk-aware "Reload required" fallback and reports to Sentry.
- */
+// Stale-chunk recovery: reload once to pick up the new build; within the guard window the error propagates to ErrorBoundary instead (no reload loop on a broken deploy).
 export function handlePreloadError(event: Event): void {
   const now = Date.now()
   if (now - readLastReloadAt() < RELOAD_LOOP_WINDOW_MS) return


### PR DESCRIPTION
## Summary

Tiny hardening prompted by today's prod Sentry event (`SyntaxError: Unexpected token '<'` at `/library/talent`, 2:12pm EDT): a tab opened before one of today's three deploys requested a lazy route chunk whose hashed filename no longer existed; Firebase's SPA rewrite served `index.html`, which the browser tried to parse as JS. `RouteBoundary` contained it and reported to Sentry (`handled=yes`), but the user had to reload manually.

This PR makes that recovery automatic: a `vite:preloadError` listener (installed in `main.tsx` before render) reloads the page **once** to pick up the new build.

## Loop safety

A `sb:chunk-reload-at` sessionStorage timestamp guards a 60s window: if a preload error fires again within it (i.e. the deploy itself is broken, not stale), the handler does nothing — the error propagates exactly as today to `ErrorBoundary`'s chunk-aware "Reload required" fallback and Sentry. Per-tab by design (each stale tab gets one silent recovery). If sessionStorage is unavailable, it still reloads and the boundary remains the backstop.

## Scope

+134 lines, 3 files: `shared/lib/chunkReload.ts`, its test, one import + call in `main.tsx`. No behavior change for fresh sessions; independent of PR #436 (branched off main).

## Test plan

- [x] 5 unit tests (`chunkReload.test.ts`): first-error reload + event swallow, in-window suppression with propagation, post-window re-arm, storage-unavailable fallback, listener registration — 5/5 green
- [x] lint 0 warnings · vite build clean
- [ ] CI green
- [ ] Ted merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)