### PR TITLE
feat(shots): port [ / ] prev-next + in-editor quick-add to the unified editor

### DIFF
--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -29,6 +29,8 @@ import { ShotReferenceLinksSection } from "@/features/shots/components/ShotRefer
 import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
 import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { ShotDetailSidebar } from "@/features/shots/components/ShotDetailSidebar"
+import { ShotDetailQuickAdd } from "@/features/shots/components/ShotDetailQuickAdd"
+import { readShotListNavOrder } from "@/features/shots/lib/shotListNavOrder"
 import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
 import { formatDateOnly, parseDateOnly } from "@/features/shots/lib/dateOnly"
 import { useAuth } from "@/app/providers/AuthProvider"
@@ -311,6 +313,21 @@ export function ShotDetailPageUnified() {
     })
   }
 
+  // -- [ / ] prev-next over the list page's visible order (ported from
+  // ThreePanel with list-ordering context). Clamps at the ends, no wrap —
+  // navigation-only, so no role gate (parity with the retired panel). Deep
+  // links and new tabs have no order snapshot and the keys no-op.
+  const handlePrevNext = (delta: -1 | 1) => {
+    if (!shot || !clientId) return
+    const orderIds = readShotListNavOrder(clientId, shot.projectId)
+    if (!orderIds) return
+    const currentIndex = orderIds.indexOf(shot.id)
+    if (currentIndex === -1) return
+    const targetId = orderIds[currentIndex + delta]
+    if (!targetId) return
+    navigate(`/projects/${shot.projectId}/shots/${targetId}`)
+  }
+
   useKeyboardShortcuts([
     { key: "Escape", handler: () => navigate(-1) },
     { key: "s", meta: true, handler: () => { /* auto-save flushes on blur; this just prevents browser save dialog */ } },
@@ -318,6 +335,8 @@ export function ShotDetailPageUnified() {
     { key: "2", handler: () => handleStatusKey(1) },
     { key: "3", handler: () => handleStatusKey(2) },
     { key: "4", handler: () => handleStatusKey(3) },
+    { key: "[", handler: () => handlePrevNext(-1) },
+    { key: "]", handler: () => handlePrevNext(1) },
   ])
 
   const save = async (fields: Record<string, unknown>): Promise<boolean> => {
@@ -638,7 +657,11 @@ export function ShotDetailPageUnified() {
           </div>
 
           {/* ── Right sticky rail ── */}
-          <ShotDetailSidebar shot={shot} canEditLooks={canEdit} />
+          <ShotDetailSidebar
+            shot={shot}
+            canEditLooks={canEdit}
+            footer={canDoOperational ? <ShotDetailQuickAdd /> : undefined}
+          />
         </div>
 
         {canShare && (

--- a/src-vnext/features/shots/components/ShotDetailQuickAdd.tsx
+++ b/src-vnext/features/shots/components/ShotDetailQuickAdd.tsx
@@ -1,0 +1,31 @@
+import { toast } from "sonner"
+import { useShots } from "@/features/shots/hooks/useShots"
+import { ShotQuickAdd } from "@/features/shots/components/ShotQuickAdd"
+import { SectionLabel } from "@/features/shots/components/ShotDetailShared"
+
+// In-editor quick-add (bottom of the right rail). Mounted only for
+// canDoOperational roles, so the project shots subscription — needed for
+// next-shot-number computation, same query the list page holds — never
+// starts for read-only viewers. Created shots append to the end of the
+// project list; the user stays on the current shot (Ted 2026-06-10).
+export function ShotDetailQuickAdd() {
+  const { data: shots, loading } = useShots()
+
+  // Numbering needs the loaded list — creating against an empty snapshot
+  // would mint duplicate shot numbers.
+  if (loading) return null
+
+  return (
+    <div data-testid="shot-detail-quick-add">
+      <SectionLabel>Quick add</SectionLabel>
+      <div className="mt-1.5">
+        <ShotQuickAdd
+          shots={shots}
+          onCreated={(_shotId, title) => {
+            toast.success("Shot created", { description: title })
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src-vnext/features/shots/components/ShotDetailSidebar.tsx
+++ b/src-vnext/features/shots/components/ShotDetailSidebar.tsx
@@ -1,4 +1,5 @@
 // Right rail of the unified shot editor — sticky at xl, hosts Looks + Products.
+import type { ReactNode } from "react"
 import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
 import { SectionLabel } from "@/features/shots/components/ShotDetailShared"
 import type { Shot } from "@/shared/types"
@@ -7,9 +8,11 @@ interface ShotDetailSidebarProps {
   readonly shot: Shot
   /** Required capability gate for look/product writes in the rail. */
   readonly canEditLooks: boolean
+  /** Bottom-of-rail slot (the in-editor quick-add; gated by the page). */
+  readonly footer?: ReactNode
 }
 
-export function ShotDetailSidebar({ shot, canEditLooks }: ShotDetailSidebarProps) {
+export function ShotDetailSidebar({ shot, canEditLooks, footer }: ShotDetailSidebarProps) {
   return (
     <div
       className="flex flex-col gap-4 xl:sticky xl:top-4 xl:max-h-[calc(100vh-6rem)] xl:overflow-y-auto"
@@ -21,6 +24,7 @@ export function ShotDetailSidebar({ shot, canEditLooks }: ShotDetailSidebarProps
         canEdit={canEditLooks}
         showReferencesSection={false}
       />
+      {footer}
     </div>
   )
 }

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -45,6 +45,7 @@ import { SceneHeader } from "@/features/shots/components/SceneHeader"
 import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { GroupIntoSceneDialog } from "@/features/shots/components/GroupIntoSceneDialog"
 import { createLane, assignShotsToLane, ungroupAllShotsFromLane, deleteLane } from "@/features/shots/lib/laneActions"
+import { writeShotListNavOrder } from "@/features/shots/lib/shotListNavOrder"
 import { Skeleton } from "@/ui/skeleton"
 import { useStuckLoading } from "@/shared/hooks/useStuckLoading"
 
@@ -62,12 +63,6 @@ export default function ShotListPage() {
   const { data: talentRecords } = useTalent()
   const { data: locationRecords } = useLocations()
   const { data: productFamilies } = useProductFamilies()
-
-  // Shot clicks always navigate to the unified editor route (Phase 5c —
-  // the ThreePanel selection fork is retired).
-  const handleShotClick = useCallback((shotId: string) => {
-    navigate(`/projects/${projectId}/shots/${shotId}`)
-  }, [navigate, projectId])
 
   // -- FAB integration: ?create=1 opens the dialog --
   const [searchParams, setSearchParamsFab] = useSearchParams()
@@ -176,6 +171,16 @@ export default function ShotListPage() {
   } = useShotListState({
     shots, reorderOptimistic, clientId, projectId, talentNameById, locationNameById, productNameById, familyById, skuById, laneNameById, laneOrder, laneById, surfaceContext,
   })
+
+  // Shot clicks navigate to the unified editor route (Phase 5c retired the
+  // ThreePanel selection fork), snapshotting the visible order so the
+  // editor's [ / ] keys walk the list exactly as the user saw it.
+  const handleShotClick = useCallback((shotId: string) => {
+    if (clientId) {
+      writeShotListNavOrder(clientId, projectId, displayShots.map((s) => s.id))
+    }
+    navigate(`/projects/${projectId}/shots/${shotId}`)
+  }, [navigate, projectId, clientId, displayShots])
 
   // -- Extra (advanced) filter count: conditions beyond status/missing inline filters --
   const extraFilterCount = useMemo(

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -173,8 +173,15 @@ vi.mock("@/features/shots/components/ActiveEditorsBar", () => ({
   ActiveEditorsBar: () => null,
 }))
 
+// Stubbed: the real component mounts the project shots subscription. The
+// page-level gate (canDoOperational) is the subject here.
+vi.mock("@/features/shots/components/ShotDetailQuickAdd", () => ({
+  ShotDetailQuickAdd: () => <div data-testid="quick-add-stub">QuickAdd</div>,
+}))
+
 import { useShot } from "@/features/shots/hooks/useShot"
 import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import { writeShotListNavOrder } from "@/features/shots/lib/shotListNavOrder"
 import ShotDetailPage from "@/features/shots/components/ShotDetailPage"
 
 function makeShot(overrides: Partial<Shot>): Shot {
@@ -238,6 +245,7 @@ function expectDocumentOrder(elements: ReadonlyArray<HTMLElement>) {
 describe("ShotDetailPageUnified", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    sessionStorage.clear()
     authState.role = "producer"
     effectiveState.role = null
     effectiveState.resolving = false
@@ -634,5 +642,74 @@ describe("ShotDetailPageUnified", () => {
 
     expect(screen.getByTestId("scene-context-banner")).toBeInTheDocument()
     expect(screen.getByText("Terrace Scene")).toBeInTheDocument()
+  })
+
+  // -- [ / ] prev-next over the list-order snapshot --
+
+  it("[ and ] navigate to the previous/next shot in the list-order snapshot", () => {
+    writeShotListNavOrder("c1", "p1", ["s0", "s1", "s2"])
+    mockShot()
+
+    renderPage()
+
+    fireEvent.keyDown(document.body, { key: "[" })
+    expect(navigateSpy).toHaveBeenLastCalledWith("/projects/p1/shots/s0")
+
+    fireEvent.keyDown(document.body, { key: "]" })
+    expect(navigateSpy).toHaveBeenLastCalledWith("/projects/p1/shots/s2")
+  })
+
+  it("[ and ] clamp at the snapshot ends (no wrap-around)", () => {
+    writeShotListNavOrder("c1", "p1", ["s1"])
+    mockShot()
+
+    renderPage()
+
+    fireEvent.keyDown(document.body, { key: "[" })
+    fireEvent.keyDown(document.body, { key: "]" })
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+
+  it("[ and ] no-op without a snapshot (deep link / new tab) or when the shot left the visible order", () => {
+    sessionStorage.clear()
+    mockShot()
+
+    renderPage()
+    fireEvent.keyDown(document.body, { key: "]" })
+    expect(navigateSpy).not.toHaveBeenCalled()
+
+    writeShotListNavOrder("c1", "p1", ["other1", "other2"])
+    fireEvent.keyDown(document.body, { key: "]" })
+    expect(navigateSpy).not.toHaveBeenCalled()
+  })
+
+  // -- in-editor quick-add gating (bottom of the right rail) --
+
+  it("producer: quick-add renders at the bottom of the rail", () => {
+    mockShot()
+
+    renderPage()
+
+    const rail = screen.getByTestId("shot-detail-sidebar")
+    const quickAdd = screen.getByTestId("quick-add-stub")
+    expect(rail.contains(quickAdd)).toBe(true)
+  })
+
+  it("viewer: quick-add does not mount", () => {
+    authState.role = "viewer"
+    mockShot()
+
+    renderPage()
+
+    expect(screen.queryByTestId("quick-add-stub")).not.toBeInTheDocument()
+  })
+
+  it("role resolving: quick-add does not mount (no write affordance during the gap)", () => {
+    effectiveState.resolving = true
+    mockShot()
+
+    renderPage()
+
+    expect(screen.queryByTestId("quick-add-stub")).not.toBeInTheDocument()
   })
 })

--- a/src-vnext/features/shots/lib/__tests__/shotListNavOrder.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/shotListNavOrder.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { readShotListNavOrder, writeShotListNavOrder } from "../shotListNavOrder"
+
+describe("shotListNavOrder", () => {
+  beforeEach(() => {
+    sessionStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("round-trips an ordered id list per client+project", () => {
+    writeShotListNavOrder("c1", "p1", ["s3", "s1", "s2"])
+
+    expect(readShotListNavOrder("c1", "p1")).toEqual(["s3", "s1", "s2"])
+  })
+
+  it("scopes the snapshot by client and project", () => {
+    writeShotListNavOrder("c1", "p1", ["s1"])
+
+    expect(readShotListNavOrder("c1", "p2")).toBeNull()
+    expect(readShotListNavOrder("c2", "p1")).toBeNull()
+  })
+
+  it("returns null when no snapshot exists", () => {
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+  })
+
+  it("rejects malformed payloads", () => {
+    sessionStorage.setItem("sb:shots:nav-order:c1:p1", "not json {")
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+
+    sessionStorage.setItem("sb:shots:nav-order:c1:p1", JSON.stringify({ ids: ["s1"] }))
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+
+    sessionStorage.setItem("sb:shots:nav-order:c1:p1", JSON.stringify([1, 2]))
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+
+    sessionStorage.setItem("sb:shots:nav-order:c1:p1", JSON.stringify([]))
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+  })
+
+  it("swallows storage errors on write and read", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("denied")
+    })
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied")
+    })
+
+    expect(() => writeShotListNavOrder("c1", "p1", ["s1"])).not.toThrow()
+    expect(readShotListNavOrder("c1", "p1")).toBeNull()
+  })
+})

--- a/src-vnext/features/shots/lib/shotListNavOrder.ts
+++ b/src-vnext/features/shots/lib/shotListNavOrder.ts
@@ -1,0 +1,37 @@
+// Per-tab handoff of the shots list's visible order (sort + filters applied)
+// to the editor's [ / ] prev-next keys. sessionStorage by design: each tab
+// carries the order its user last clicked through; deep links and new tabs
+// have no context and the keys no-op.
+const KEY_PREFIX = "sb:shots:nav-order"
+
+function navOrderKey(clientId: string, projectId: string): string {
+  return `${KEY_PREFIX}:${clientId}:${projectId}`
+}
+
+export function writeShotListNavOrder(
+  clientId: string,
+  projectId: string,
+  shotIds: ReadonlyArray<string>,
+): void {
+  try {
+    sessionStorage.setItem(navOrderKey(clientId, projectId), JSON.stringify(shotIds))
+  } catch {
+    // Storage unavailable — [ / ] simply stays inert in this tab.
+  }
+}
+
+export function readShotListNavOrder(
+  clientId: string,
+  projectId: string,
+): ReadonlyArray<string> | null {
+  try {
+    const raw = sessionStorage.getItem(navOrderKey(clientId, projectId))
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+    if (!parsed.every((id) => typeof id === "string")) return null
+    return parsed
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## Summary

The named follow-up to #436: ports the two affordances that died with ThreePanel into the unified editor, flag-free, per the locked decisions (port WITH list-ordering context · quick-add at the bottom of the right rail · stay on the current shot after create).

## How it works

**`[` / `]` prev-next with list-ordering context.** The detail route deliberately knows nothing about the list's sort/filter state — the list page owns it. On shot click, `ShotListPage` snapshots the visible `displayShots` order into a per-tab sessionStorage key (`sb:shots:nav-order:<clientId>:<projectId>`); the editor reads the snapshot per keypress and navigates to the neighbor id. Clamps at the ends, no wrap — exact ThreePanel parity. Navigation-only, so no role gate (also parity). Deep links and new tabs have no snapshot → the keys no-op. Plain `[`/`]` only — cmd+[ browser history is untouched (the shortcut hook requires exact modifier match).

**In-editor quick-add.** New `footer` slot on `ShotDetailSidebar` hosts `ShotDetailQuickAdd` (a thin wrapper over the surviving `ShotQuickAdd` — same numbering, same `N`-to-focus, same batch-paste). Gated by `canDoOperational` (`!roleResolving && canManageShots(role)`, the 5b pattern), which also means the project-shots subscription it needs for next-number computation only ever mounts for operational roles — viewers/warehouse never subscribe. Returns null while loading so numbering can't run against an empty snapshot. After create: toast, stay on the current shot (new shot appends to the project list end, same as the list page).

## Verification

- 76 tests green across the 4 touched/new test files: snapshot lib pins (round-trip, scoping, malformed payloads, storage-error swallow), editor `[`/`]` matrix (prev/next, clamp, no-snapshot + absent-shot no-ops), quick-add gating matrix (producer renders in-rail / viewer absent / resolving absent).
- Adversarial pre-PR review (code-reviewer agent): **PASS**, no blockers. Confirmed the `handleShotClick` relocation has all 4 consumers below the new definition, the quick-add role gate maps onto the hardened `/shots` CREATE arms (admin / global-producer / project producer-crew), and `useShots` mounts exactly once, gated. One pre-existing page-wide note (global-crew non-member sees write affordances that rules deny → permission-denied toast) is the same accepted property as the status keys — not introduced here.
- lint 0 warnings · vite build clean.

## Test plan

- [x] `shotListNavOrder.test.ts` 5/5 · `ShotDetailPageUnified.test.tsx` 24/24 · `ShotListPage.test.tsx` + `ShotQuickAdd.test.tsx` green
- [ ] CI ui-checks (job `test`) — the arbiter
- [ ] Optional :5174 eyeball (keys + rail quick-add on real-shaped data)
- [ ] Ted merge gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)