### PR TITLE
feat(rbac): wire project-scoped capability gates to the effective role (redesign Phase 5b-II)

### DIFF
--- a/src-vnext/app/routes/guards/RequireRole.tsx
+++ b/src-vnext/app/routes/guards/RequireRole.tsx
@@ -9,6 +9,12 @@ interface RequireRoleProps {
 }
 
 export function RequireRole({ children, allowed }: RequireRoleProps) {
+  // PINNED to the GLOBAL claim (5b): route guards are org-scope chrome with no
+  // project context (no ProjectScopeProvider above the router), so there is no
+  // effective role to resolve. The guarded backends are global-role rules:
+  // /shotRequests requires a global admin/producer claim (firestore.rules:409-433)
+  // and the admin collections /users (firestore.rules:539-543) +
+  // /pendingInvitations (firestore.rules:547-549) require a global admin claim.
   const { role, loading } = useAuth()
 
   if (loading) return null

--- a/src-vnext/features/admin/components/ProjectAccessTab.test.tsx
+++ b/src-vnext/features/admin/components/ProjectAccessTab.test.tsx
@@ -1,0 +1,207 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { ProjectMember } from "@/features/admin/hooks/useProjectMembers"
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    clientId: "c1",
+    role: "admin",
+    user: { uid: "admin-1", email: "admin@example.com", displayName: "Admin", photoURL: null },
+  }),
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({
+    data: [{ id: "p1", name: "Project One" }],
+    loading: false,
+    error: null,
+  }),
+}))
+
+const usersState = vi.hoisted(() => ({
+  users: [] as Array<{ id: string; email: string; displayName?: string | null; role: string }>,
+}))
+
+vi.mock("@/features/admin/hooks/useUsers", () => ({
+  useUsers: () => ({ data: usersState.users, loading: false, error: null }),
+}))
+
+const membersState = vi.hoisted(() => ({
+  members: [] as ProjectMember[],
+}))
+
+vi.mock("@/features/admin/hooks/useProjectMembers", () => ({
+  useProjectMembers: () => ({ data: membersState.members, loading: false, error: null }),
+}))
+
+vi.mock("@/features/admin/lib/adminWrites", () => ({
+  removeProjectMember: vi.fn(),
+}))
+
+vi.mock("@/features/admin/components/AddProjectMemberDialog", () => ({
+  AddProjectMemberDialog: () => null,
+}))
+
+// Mock the Radix Select primitive with a trivial native <select> so that
+// jsdom-driven tests can drive onValueChange without Radix's pointer-capture
+// polyfill. The real Select is exercised in e2e. (Same pattern as
+// CallOverridesEditor.test.tsx.)
+vi.mock("@/ui/select", async () => {
+  const React = await import("react")
+  interface SelectProps {
+    readonly children?: React.ReactNode
+    readonly value?: string
+    readonly onValueChange?: (value: string) => void
+  }
+  interface SelectItemProps {
+    readonly children?: React.ReactNode
+    readonly value: string
+  }
+  const MOCK_SELECT_ITEM_TYPE = Symbol.for("mock-select-item")
+  const Select = ({ children, value, onValueChange }: SelectProps) => {
+    const options: { value: string; label: string }[] = []
+    const visit = (node: React.ReactNode): void => {
+      React.Children.forEach(node, (child) => {
+        if (!React.isValidElement(child)) return
+        const elType = child.type as unknown
+        if (
+          typeof elType === "function" &&
+          (elType as { mockSelectItemTag?: symbol }).mockSelectItemTag === MOCK_SELECT_ITEM_TYPE
+        ) {
+          const props = child.props as SelectItemProps
+          const label = typeof props.children === "string" ? props.children : props.value
+          options.push({ value: props.value, label })
+          return
+        }
+        const props = child.props as { children?: React.ReactNode }
+        if (props?.children !== undefined) visit(props.children)
+      })
+    }
+    visit(children)
+    return React.createElement(
+      "select",
+      {
+        "data-testid": "mock-select",
+        "aria-label": "mock-select",
+        value: value ?? "",
+        onChange: (e: React.ChangeEvent<HTMLSelectElement>) =>
+          onValueChange?.(e.target.value),
+      },
+      React.createElement("option", { key: "__placeholder__", value: "" }, "placeholder"),
+      ...options.map((o) =>
+        React.createElement("option", { key: o.value, value: o.value }, o.label),
+      ),
+    )
+  }
+  const SelectItem = ({ children }: SelectItemProps) => React.createElement(React.Fragment, null, children)
+  ;(SelectItem as unknown as { mockSelectItemTag: symbol }).mockSelectItemTag = MOCK_SELECT_ITEM_TYPE
+  const Passthrough = ({ children }: { readonly children?: React.ReactNode }) =>
+    React.createElement(React.Fragment, null, children)
+  return {
+    Select,
+    SelectContent: Passthrough,
+    SelectTrigger: Passthrough,
+    SelectValue: Passthrough,
+    SelectItem,
+  }
+})
+
+import { ProjectAccessTab } from "@/features/admin/components/ProjectAccessTab"
+
+async function renderWithProjectSelected() {
+  const user = userEvent.setup()
+  render(<ProjectAccessTab />)
+  await user.selectOptions(screen.getByTestId("mock-select"), "p1")
+  return user
+}
+
+describe("ProjectAccessTab effective-access copy", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    usersState.users = []
+    membersState.members = []
+  })
+
+  it("shows downgrade copy when the member doc ranks below the global claim", async () => {
+    usersState.users = [
+      { id: "u1", email: "pat@example.com", displayName: "Pat", role: "producer" },
+    ]
+    membersState.members = [{ id: "u1", role: "viewer" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByTestId("project-access-effective-role")).toHaveTextContent(
+      "Effective here: Viewer (downgraded from global Producer)",
+    )
+  })
+
+  it("shows promote copy when the member doc ranks above the global claim", async () => {
+    usersState.users = [
+      { id: "u1", email: "cam@example.com", displayName: "Cam", role: "crew" },
+    ]
+    membersState.members = [{ id: "u1", role: "producer" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByTestId("project-access-effective-role")).toHaveTextContent(
+      "Effective here: Producer (promoted from global Crew)",
+    )
+  })
+
+  it("shows the admin exception for a globally-admin member (project role has no effect)", async () => {
+    usersState.users = [
+      { id: "u1", email: "ada@example.com", displayName: "Ada", role: "admin" },
+    ]
+    membersState.members = [{ id: "u1", role: "viewer" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByTestId("project-access-effective-role")).toHaveTextContent(
+      "Admin globally — project role has no effect",
+    )
+  })
+
+  it("renders no diagnostic when project and global roles agree", async () => {
+    usersState.users = [
+      { id: "u1", email: "pat@example.com", displayName: "Pat", role: "producer" },
+    ]
+    membersState.members = [{ id: "u1", role: "producer" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByText("Producer")).toBeInTheDocument()
+    expect(screen.queryByTestId("project-access-effective-role")).not.toBeInTheDocument()
+  })
+
+  it("treats crew<->warehouse as lateral (no downgrade/promote copy)", async () => {
+    usersState.users = [
+      { id: "u1", email: "wes@example.com", displayName: "Wes", role: "crew" },
+    ]
+    membersState.members = [{ id: "u1", role: "warehouse" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByText("Warehouse")).toBeInTheDocument()
+    expect(screen.queryByTestId("project-access-effective-role")).not.toBeInTheDocument()
+  })
+
+  it("normalizes a legacy 'wardrobe' member-doc role to Warehouse (matches useEffectiveRole)", async () => {
+    usersState.users = [
+      { id: "u1", email: "lee@example.com", displayName: "Lee", role: "producer" },
+    ]
+    membersState.members = [{ id: "u1", role: "wardrobe" }]
+
+    await renderWithProjectSelected()
+
+    expect(screen.getByText("Warehouse")).toBeInTheDocument()
+    expect(screen.getByTestId("project-access-effective-role")).toHaveTextContent(
+      "Effective here: Warehouse (downgraded from global Producer)",
+    )
+  })
+})

--- a/src-vnext/features/admin/components/ProjectAccessTab.tsx
+++ b/src-vnext/features/admin/components/ProjectAccessTab.tsx
@@ -6,7 +6,7 @@ import { useProjects } from "@/features/projects/hooks/useProjects"
 import { useUsers } from "@/features/admin/hooks/useUsers"
 import { useProjectMembers, type ProjectMember } from "@/features/admin/hooks/useProjectMembers"
 import { removeProjectMember } from "@/features/admin/lib/adminWrites"
-import { roleLabel } from "@/shared/lib/rbac"
+import { ROLE, normalizeRole, roleLabel, roleRank } from "@/shared/lib/rbac"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { Button } from "@/ui/button"
 import {
@@ -35,6 +35,26 @@ interface RemoveTarget {
   readonly projectName: string
 }
 
+// Admin diagnostic (5b-II, copy-level only): the member-doc role is what
+// useEffectiveRole resolves on project surfaces, so surface a quiet one-liner
+// when it differs from the user's global claim. No new reads — useUsers
+// already carries the global role. Returns null when the roles agree (or the
+// global role is unknown), so the row stays exactly as before.
+function effectiveAccessNote(projectRole: Role, globalRole: Role | null): string | null {
+  if (globalRole === null) return null
+  // Mirrors the useEffectiveRole admin exception (locked Q6): a global admin
+  // short-circuits to admin and never reads the member doc.
+  if (globalRole === ROLE.ADMIN) {
+    return "Admin globally — project role has no effect"
+  }
+  const projectRank = roleRank(projectRole)
+  const globalRank = roleRank(globalRole)
+  // crew<->warehouse is lateral (equal rank) — no copy, matching roleRank.
+  if (projectRank === globalRank) return null
+  const direction = projectRank < globalRank ? "downgraded" : "promoted"
+  return `Effective here: ${roleLabel(projectRole)} (${direction} from global ${roleLabel(globalRole)})`
+}
+
 function MemberTable({
   members,
   users,
@@ -44,7 +64,7 @@ function MemberTable({
   currentUserId,
 }: {
   readonly members: readonly ProjectMember[]
-  readonly users: ReadonlyArray<{ readonly id: string; readonly email: string; readonly displayName?: string | null }>
+  readonly users: ReadonlyArray<{ readonly id: string; readonly email: string; readonly displayName?: string | null; readonly role?: Role }>
   readonly projectName: string
   readonly projectId: string
   readonly clientId: string
@@ -56,10 +76,16 @@ function MemberTable({
   const enrichedMembers = useMemo(() => {
     return members.map((m) => {
       const user = users.find((u) => u.id === m.id)
+      // Both roles go through normalizeRole, matching the useEffectiveRole
+      // pipeline (legacy 'wardrobe' member docs label as Warehouse).
+      const projectRole = normalizeRole(m.role)
+      const globalRole = user ? normalizeRole(user.role) : null
       return {
         ...m,
         displayName: user?.displayName ?? null,
         email: user?.email ?? "Unknown",
+        projectRole,
+        effectiveNote: effectiveAccessNote(projectRole, globalRole),
       }
     })
   }, [members, users])
@@ -117,7 +143,15 @@ function MemberTable({
                   {m.email}
                 </td>
                 <td className="px-4 py-2.5 text-sm text-[var(--color-text-muted)]">
-                  {roleLabel(m.role as Role)}
+                  {roleLabel(m.projectRole)}
+                  {m.effectiveNote && (
+                    <div
+                      data-testid="project-access-effective-role"
+                      className="mt-0.5 text-xs text-[var(--color-text-subtle)]"
+                    >
+                      {m.effectiveNote}
+                    </div>
+                  )}
                 </td>
                 <td className="px-4 py-2.5 text-right">
                   {m.id !== currentUserId && (

--- a/src-vnext/features/assets/components/ProjectAssetsPage.tsx
+++ b/src-vnext/features/assets/components/ProjectAssetsPage.tsx
@@ -6,6 +6,8 @@ import { ListPageSkeleton } from "@/shared/components/Skeleton"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { useShots } from "@/features/shots/hooks/useShots"
 import { useTalent, useLocations, useProductFamilies } from "@/features/shots/hooks/usePickerData"
 import { useCrew } from "@/features/schedules/hooks/useCrew"
@@ -70,7 +72,12 @@ function countHeroImages(shots: readonly Shot[]): number {
 
 export default function ProjectAssetsPage() {
   const { projectId, projectName } = useProjectScope()
-  const { clientId, role } = useAuth()
+  const { clientId, role: globalRole } = useAuth()
+  // 5b-II effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). Write affordances stay disabled while the first uncached
+  // member read for this project is in flight (resolving) — never the
+  // global-role guess.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const isMobile = useIsMobile()
   const { data: shots, loading: shotsLoading, error: shotsError } = useShots()
   const { data: talent, loading: talentLoading, error: talentError } = useTalent()
@@ -87,7 +94,22 @@ export default function ProjectAssetsPage() {
   const error =
     shotsError || talentError || locationsError || familiesError || crewError
 
-  const canEdit = canManageProjects(role) && !isMobile && !!clientId
+  // -- Role-based flags (5b-II: effective role + resolving gate) --
+  // Effective-AND-global by design. These writes (projectAssetsWrites.ts)
+  // arrayUnion/arrayRemove projectIds on CLIENT-scoped library docs —
+  // /clients/{clientId}/talent (firestore.rules:363-365), /locations
+  // (:382-384), /crew (:402-408) — all GLOBAL admin||producer rules, NOT
+  // project-scoped. The effective arm handles project downgrades (locked Q6);
+  // the global arm mirrors the backend's isAdmin||isProducer check so a
+  // project-PROMOTED member (e.g. global crew with a producer members doc)
+  // never sees affordances the rules deny. UI excluding warehouse stays
+  // stricter-than-rule (pre-existing, fail-toward-fewer).
+  const canEdit =
+    !roleResolving &&
+    canManageProjects(role) &&
+    canManageProjects(globalRole) &&
+    !isMobile &&
+    !!clientId
 
   const heroCount = useMemo(() => countHeroImages(shots), [shots])
 
@@ -195,7 +217,7 @@ export default function ProjectAssetsPage() {
 
   return (
     <ErrorBoundary>
-      <PageHeader title="Assets" />
+      <PageHeader title="Assets" actions={<EffectiveRoleChip />} />
 
       <div className="grid gap-4 lg:grid-cols-3">
         <ProjectScopedAssetCard

--- a/src-vnext/features/assets/components/__tests__/ProjectAssetsPage.test.tsx
+++ b/src-vnext/features/assets/components/__tests__/ProjectAssetsPage.test.tsx
@@ -5,13 +5,30 @@ import { MemoryRouter } from "react-router-dom"
 import { Timestamp } from "firebase/firestore"
 import type { Shot } from "@/shared/types"
 
+// 5b-II effective-role mock: role=null means "mirror the global claim"
+// (default matrix), a string overrides it (downgrade/promotion rows),
+// resolving=true pins the first-uncached-member-read gap. authState lets
+// promotion rows flip the global claim too.
+const authState = vi.hoisted(() => ({ role: "producer" }))
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useProjectScope: () => ({ projectId: "p1", projectName: "Project One" }),
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project One" }),
 }))
 
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: () => ({ clientId: "c1", role: "producer" }),
+  useAuth: () => ({ clientId: "c1", role: authState.role }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
 }))
 
 vi.mock("@/shared/hooks/useMediaQuery", () => ({
@@ -97,9 +114,46 @@ function renderPage() {
   )
 }
 
+function mockDataHooks({
+  shots = [],
+  talent = [],
+}: {
+  readonly shots?: readonly Shot[]
+  readonly talent?: readonly Record<string, unknown>[]
+} = {}) {
+  ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: shots,
+    loading: false,
+    error: null,
+  })
+  ;(useTalent as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: talent,
+    loading: false,
+    error: null,
+  })
+  ;(useLocations as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: [],
+    loading: false,
+    error: null,
+  })
+  ;(useProductFamilies as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: [],
+    loading: false,
+    error: null,
+  })
+  ;(useCrew as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: [],
+    loading: false,
+    error: null,
+  })
+}
+
 describe("ProjectAssetsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
   })
 
   it("adds existing talent to a project via the Add dialog", async () => {
@@ -253,6 +307,89 @@ describe("ProjectAssetsPage", () => {
       agency: "CAA",
       notes: "",
     })
+  })
+
+  it("disables asset write affordances while the effective role is resolving", () => {
+    effectiveState.resolving = true
+    mockDataHooks({
+      shots: [makeShot({ talentIds: ["t1"] })],
+      talent: [{ id: "t1", name: "Used Talent", agency: "A", projectIds: ["p1"] }],
+    })
+
+    renderPage()
+
+    // Write affordances are never enabled from the global-role guess during
+    // the first uncached member read.
+    for (const button of screen.getAllByRole("button", { name: /^add$/i })) {
+      expect(button).toBeDisabled()
+    }
+    for (const button of screen.getAllByRole("button", { name: /^new$/i })) {
+      expect(button).toBeDisabled()
+    }
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled()
+    // The chip renders nothing while resolving.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("disables edits on a project downgrade (member doc wins over global claim) and shows the chip", () => {
+    effectiveState.role = "viewer"
+    mockDataHooks({
+      shots: [makeShot({ talentIds: ["t1"] })],
+      talent: [{ id: "t1", name: "Used Talent", agency: "A", projectIds: ["p1"] }],
+    })
+
+    renderPage()
+
+    for (const button of screen.getAllByRole("button", { name: /^add$/i })) {
+      expect(button).toBeDisabled()
+    }
+    for (const button of screen.getAllByRole("button", { name: /^new$/i })) {
+      expect(button).toBeDisabled()
+    }
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
+  })
+
+  it("disables edits on a project PROMOTION (global crew + producer members doc) — backend rules read only the global claim", () => {
+    // /clients/{clientId}/{talent,locations,crew} writes require the GLOBAL
+    // admin||producer claim (firestore.rules:363-365, :382-384, :402-408);
+    // the UI must not advertise what those rules deny.
+    authState.role = "crew"
+    effectiveState.role = "producer"
+    mockDataHooks({
+      shots: [makeShot({ talentIds: ["t1"] })],
+      talent: [{ id: "t1", name: "Used Talent", agency: "A", projectIds: ["p1"] }],
+    })
+
+    renderPage()
+
+    for (const button of screen.getAllByRole("button", { name: /^add$/i })) {
+      expect(button).toBeDisabled()
+    }
+    for (const button of screen.getAllByRole("button", { name: /^new$/i })) {
+      expect(button).toBeDisabled()
+    }
+    expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled()
+  })
+
+  it("falls back to the global claim when there is no project override", () => {
+    // effectiveState.role = null mirrors the global producer claim (the hook
+    // returns the global claim on null project scope / absent member doc).
+    mockDataHooks({
+      shots: [makeShot({ talentIds: ["t1"] })],
+      talent: [{ id: "t1", name: "Used Talent", agency: "A", projectIds: ["p1"] }],
+    })
+
+    renderPage()
+
+    for (const button of screen.getAllByRole("button", { name: /^add$/i })) {
+      expect(button).toBeEnabled()
+    }
+    expect(screen.getByRole("button", { name: "Remove" })).toBeEnabled()
+    // Equal roles render no chip.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
   })
 })
 

--- a/src-vnext/features/casting/components/CastingBoardPage.tsx
+++ b/src-vnext/features/casting/components/CastingBoardPage.tsx
@@ -13,7 +13,7 @@ import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
 import { useCastingBoard } from "@/features/casting/hooks/useCastingBoard"
 import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
-import { canManageCasting } from "@/shared/lib/rbac"
+import { canManageCasting, ROLE } from "@/shared/lib/rbac"
 import {
   addTalentToCastingBoard,
   updateCastingEntry,
@@ -66,7 +66,7 @@ export default function CastingBoardPage() {
   // a project promotion, so the UI must not advertise Share from the
   // effective role.
   const canShare =
-    (globalRole === "admin" || globalRole === "producer") && !isMobile
+    (globalRole === ROLE.ADMIN || globalRole === ROLE.PRODUCER) && !isMobile
   // PINNED to the GLOBAL claim: Book also backlinks
   // /clients/{clientId}/talent/{talentId}.projectIds, whose rule is
   // global-claim only (firestore.rules:363-365, isAdmin || isProducer —
@@ -75,9 +75,9 @@ export default function CastingBoardPage() {
   // skip the backlink — the board status update alone goes through the
   // project wildcard (firestore.rules:921-929).
   const canWriteTalentBacklink =
-    globalRole === "admin" ||
-    globalRole === "producer" ||
-    globalRole === "warehouse"
+    globalRole === ROLE.ADMIN ||
+    globalRole === ROLE.PRODUCER ||
+    globalRole === ROLE.WAREHOUSE
 
   // Local UI state
   const [search, setSearch] = useState("")

--- a/src-vnext/features/casting/components/CastingBoardPage.tsx
+++ b/src-vnext/features/casting/components/CastingBoardPage.tsx
@@ -8,6 +8,8 @@ import { EmptyState } from "@/shared/components/EmptyState"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
 import { useCastingBoard } from "@/features/casting/hooks/useCastingBoard"
 import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
@@ -41,13 +43,41 @@ type SortKey = "name" | "agency" | "status"
 
 export default function CastingBoardPage() {
   const { projectId, projectName } = useProjectScope()
-  const { clientId, role, user } = useAuth()
+  const { clientId, role: globalRole, user } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). Board-edit affordances render NOTHING while the first
+  // uncached member read for this project is in flight (resolving) — never
+  // the global-role guess.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const isMobile = useIsMobile()
 
   const { entries, loading, error } = useCastingBoard(projectId, clientId)
   const { data: talentLibrary, loading: talentLoading } = useTalentLibrary()
 
-  const canEdit = canManageCasting(role) && !isMobile
+  // -- Role-based flags (5b-II: effective role + resolving gate) --
+  // Board-edit affordances (Add Talent, status/book/remove, bulk bar, card
+  // edits). Backing rule: the castingBoard subcollection has no explicit
+  // match, so writes fall to the project wildcard (firestore.rules:921-929):
+  // isAdmin || producerCanAccessProject || hasProjectRole(['producer',
+  // 'warehouse']).
+  const canEdit = !roleResolving && canManageCasting(role) && !isMobile
+  // PINNED to the GLOBAL claim: /castingShares create requires a global
+  // admin/producer claim (firestore.rules:227-231) — the backend cannot see
+  // a project promotion, so the UI must not advertise Share from the
+  // effective role.
+  const canShare =
+    (globalRole === "admin" || globalRole === "producer") && !isMobile
+  // PINNED to the GLOBAL claim: Book also backlinks
+  // /clients/{clientId}/talent/{talentId}.projectIds, whose rule is
+  // global-claim only (firestore.rules:363-365, isAdmin || isProducer —
+  // admin/producer/warehouse). The Book batch is atomic, so a
+  // project-promoted member (global viewer/crew + member-doc producer) must
+  // skip the backlink — the board status update alone goes through the
+  // project wildcard (firestore.rules:921-929).
+  const canWriteTalentBacklink =
+    globalRole === "admin" ||
+    globalRole === "producer" ||
+    globalRole === "warehouse"
 
   // Local UI state
   const [search, setSearch] = useState("")
@@ -169,6 +199,7 @@ export default function CastingBoardPage() {
         projectId,
         userId: user.uid,
         talentId,
+        includeTalentBacklink: canWriteTalentBacklink,
       })
       toast.success("Talent booked")
     } catch (err) {
@@ -273,18 +304,23 @@ export default function CastingBoardPage() {
     )
   }
 
-  const actions = canEdit ? (
+  const actions = (
     <>
-      <Button variant="outline" size="sm" onClick={handleShare}>
-        <Share2 className="mr-1.5 h-3.5 w-3.5" />
-        Share
-      </Button>
-      <Button size="sm" onClick={() => setAddDialogOpen(true)}>
-        <Plus className="mr-1.5 h-3.5 w-3.5" />
-        Add Talent
-      </Button>
+      <EffectiveRoleChip />
+      {canShare && (
+        <Button variant="outline" size="sm" onClick={handleShare}>
+          <Share2 className="mr-1.5 h-3.5 w-3.5" />
+          Share
+        </Button>
+      )}
+      {canEdit && (
+        <Button size="sm" onClick={() => setAddDialogOpen(true)}>
+          <Plus className="mr-1.5 h-3.5 w-3.5" />
+          Add Talent
+        </Button>
+      )}
     </>
-  ) : undefined
+  )
 
   return (
     <ErrorBoundary>

--- a/src-vnext/features/casting/components/__tests__/CastingBoardPage.test.tsx
+++ b/src-vnext/features/casting/components/__tests__/CastingBoardPage.test.tsx
@@ -1,0 +1,228 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { fireEvent, render, screen } from "@testing-library/react"
+import type { CastingBoardEntry } from "@/shared/types"
+
+// 5b global-claim state, mutable so promotion rows can flip the global role.
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+// 5b effective-role state. role=null mirrors the global claim (member ==
+// global / no project scope, the default matrix shape); a string overrides
+// it (downgrade/promotion rows); resolving=true pins the first-read
+// affordance gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    role: authState.role,
+    clientId: "c1",
+    user: { uid: "u1" },
+    loading: false,
+  }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+  useIsDesktop: () => false,
+}))
+
+vi.mock("@/features/casting/hooks/useCastingBoard", () => ({
+  useCastingBoard: vi.fn(),
+}))
+
+vi.mock("@/features/library/hooks/useTalentLibrary", () => ({
+  useTalentLibrary: vi.fn(),
+}))
+
+vi.mock("@/features/casting/hooks/useCastingVoteAggregates", () => ({
+  useCastingVoteAggregates: () => ({ aggregates: new Map() }),
+}))
+
+vi.mock("@/features/casting/lib/castingWrites", () => ({
+  addTalentToCastingBoard: vi.fn(),
+  updateCastingEntry: vi.fn(),
+  bookCastingTalent: vi.fn(),
+  removeTalentFromCastingBoard: vi.fn(),
+  bulkUpdateCastingStatus: vi.fn(),
+}))
+
+vi.mock("@/features/casting/components/CastingCard", () => ({
+  CastingCard: ({
+    entry,
+    canEdit,
+    onBook,
+  }: {
+    readonly entry: CastingBoardEntry
+    readonly canEdit: boolean
+    readonly onBook: (talentId: string) => void
+  }) => (
+    <div data-testid="casting-card">
+      {entry.talentName}
+      {canEdit ? " (editable)" : ""}
+      {canEdit && (
+        <button type="button" onClick={() => onBook(entry.talentId)}>
+          Book
+        </button>
+      )}
+    </div>
+  ),
+}))
+
+vi.mock("@/features/casting/components/AddCastingTalentDialog", () => ({
+  AddCastingTalentDialog: () => null,
+}))
+
+vi.mock("@/features/casting/components/CastingShareDialog", () => ({
+  CastingShareDialog: () => null,
+}))
+
+vi.mock("@/features/casting/components/AdminTalentDetailSheet", () => ({
+  AdminTalentDetailSheet: () => null,
+}))
+
+import { useCastingBoard } from "@/features/casting/hooks/useCastingBoard"
+import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
+import { bookCastingTalent } from "@/features/casting/lib/castingWrites"
+import CastingBoardPage from "@/features/casting/components/CastingBoardPage"
+
+function makeEntry(overrides: Partial<CastingBoardEntry>): CastingBoardEntry {
+  return {
+    id: overrides.id ?? "t1",
+    talentId: overrides.talentId ?? "t1",
+    talentName: overrides.talentName ?? "Talent One",
+    talentAgency: overrides.talentAgency ?? null,
+    status: overrides.status ?? "shortlist",
+    notes: overrides.notes ?? null,
+    roleLabel: overrides.roleLabel ?? null,
+    sortOrder: overrides.sortOrder ?? 0,
+    addedBy: overrides.addedBy ?? "u1",
+    addedAt: overrides.addedAt,
+    updatedAt: overrides.updatedAt,
+  }
+}
+
+describe("CastingBoardPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
+    ;(useCastingBoard as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      entries: [makeEntry({})],
+      loading: false,
+      error: null,
+    })
+    ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [],
+      loading: false,
+      error: null,
+    })
+  })
+
+  it("renders edit + share affordances for a producer when the effective role mirrors the global claim (null-scope fallback shape)", () => {
+    render(<CastingBoardPage />)
+
+    expect(screen.getByRole("button", { name: /add talent/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    expect(screen.getByTestId("casting-card")).toHaveTextContent("Talent One (editable)")
+    // No downgrade — chip stays hidden
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders no board-edit affordances while the effective role is resolving; the global-pinned Share stays", () => {
+    effectiveState.resolving = true
+    render(<CastingBoardPage />)
+
+    expect(screen.queryByRole("button", { name: /add talent/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId("casting-card")).not.toHaveTextContent("(editable)")
+    // Share is pinned to the GLOBAL claim (/castingShares create,
+    // firestore.rules:227-231) and does not wait on the member read.
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    // Chip renders nothing while resolving
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("project downgrade: member-doc viewer beats the global producer claim for board edits; Share stays pinned and the chip shows", () => {
+    effectiveState.role = "viewer"
+    render(<CastingBoardPage />)
+
+    expect(screen.queryByRole("button", { name: /add talent/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId("casting-card")).not.toHaveTextContent("(editable)")
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent("Viewer on this project")
+  })
+
+  it("project promotion: member-doc producer enables board edits for a global viewer, but Share stays pinned to the global claim", () => {
+    authState.role = "viewer"
+    effectiveState.role = "producer"
+    render(<CastingBoardPage />)
+
+    expect(screen.getByRole("button", { name: /add talent/i })).toBeInTheDocument()
+    expect(screen.getByTestId("casting-card")).toHaveTextContent("Talent One (editable)")
+    // /castingShares create requires a GLOBAL admin/producer claim — the
+    // backend cannot see a project promotion.
+    expect(screen.queryByRole("button", { name: /share/i })).not.toBeInTheDocument()
+    // Promotion is not a downgrade — chip stays hidden
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("promotion Book path: a project-promoted member books WITHOUT the talent-doc backlink (global-claim-only rule, firestore.rules:363-365)", () => {
+    authState.role = "viewer"
+    effectiveState.role = "producer"
+    render(<CastingBoardPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Book" }))
+
+    // The talent projectIds backlink is GLOBAL-claim only; the atomic batch
+    // must skip it or the whole Book is permission-denied for this combo.
+    expect(bookCastingTalent).toHaveBeenCalledWith({
+      clientId: "c1",
+      projectId: "p1",
+      userId: "u1",
+      talentId: "t1",
+      includeTalentBacklink: false,
+    })
+  })
+
+  it("global-producer Book path: books WITH the talent-doc backlink", () => {
+    render(<CastingBoardPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "Book" }))
+
+    expect(bookCastingTalent).toHaveBeenCalledWith({
+      clientId: "c1",
+      projectId: "p1",
+      userId: "u1",
+      talentId: "t1",
+      includeTalentBacklink: true,
+    })
+  })
+
+  it("shows the empty-state Add Talent action only when board edits are allowed", () => {
+    ;(useCastingBoard as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      entries: [],
+      loading: false,
+      error: null,
+    })
+    effectiveState.role = "viewer"
+    render(<CastingBoardPage />)
+
+    expect(screen.getByText("No talent on the casting board")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /add talent/i })).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/casting/lib/castingWrites.ts
+++ b/src-vnext/features/casting/lib/castingWrites.ts
@@ -163,16 +163,25 @@ export async function bulkUpdateCastingStatus(args: {
 }
 
 /**
- * Book a talent: updates the casting entry status to "booked" and
- * adds the projectId to the talent doc's projectIds array.
+ * Book a talent: updates the casting entry status to "booked" and,
+ * when allowed, adds the projectId to the talent doc's projectIds array.
  */
 export async function bookCastingTalent(args: {
   readonly clientId: string
   readonly projectId: string
   readonly userId: string
   readonly talentId: string
+  /**
+   * Whether to include the /clients/{clientId}/talent/{talentId} projectIds
+   * backlink in the batch. That write is GLOBAL-claim only
+   * (firestore.rules:363-365, isAdmin || isProducer) while the board entry
+   * falls to the project wildcard — and the batch is atomic, so a
+   * project-promoted member (global viewer/crew + member-doc producer) must
+   * skip the backlink or the whole Book is permission-denied.
+   */
+  readonly includeTalentBacklink: boolean
 }): Promise<void> {
-  const { clientId, projectId, userId, talentId } = args
+  const { clientId, projectId, userId, talentId, includeTalentBacklink } = args
   const batch = writeBatch(db)
 
   // 1. Update casting entry status to "booked"
@@ -182,14 +191,17 @@ export async function bookCastingTalent(args: {
     updatedAt: serverTimestamp(),
   })
 
-  // 2. Add projectId to talent doc's projectIds array
-  const talentSegments = talentPath(clientId)
-  const talentRef = doc(db, talentSegments[0]!, ...talentSegments.slice(1), talentId)
-  batch.update(talentRef, {
-    projectIds: arrayUnion(projectId),
-    updatedAt: serverTimestamp(),
-    updatedBy: userId,
-  })
+  // 2. Add projectId to talent doc's projectIds array (global claims only —
+  // see includeTalentBacklink doc above)
+  if (includeTalentBacklink) {
+    const talentSegments = talentPath(clientId)
+    const talentRef = doc(db, talentSegments[0]!, ...talentSegments.slice(1), talentId)
+    batch.update(talentRef, {
+      projectIds: arrayUnion(projectId),
+      updatedAt: serverTimestamp(),
+      updatedBy: userId,
+    })
+  }
 
   await batch.commit()
 }

--- a/src-vnext/features/dashboard/components/ShootReadinessWidget.tsx
+++ b/src-vnext/features/dashboard/components/ShootReadinessWidget.tsx
@@ -50,6 +50,11 @@ function persistRequirementsFilter(value: boolean): void {
 export function ShootReadinessWidget() {
   const { items, loading } = useShootReadiness()
   const { role, clientId } = useAuth()
+  // PINNED to the GLOBAL claim (5b): this widget lives on the org dashboard,
+  // outside any ProjectScopeProvider — there is no project context to resolve
+  // an effective role against (useEffectiveRole's null-scope fallback would
+  // return the global claim anyway). The target project is chosen inside
+  // BulkAddToProjectDialog, after the affordance is shown.
   const canBulkAdd = canManageProjects(role)
   const {
     familyProjectMap,

--- a/src-vnext/features/library/components/CrewDetailPage.tsx
+++ b/src-vnext/features/library/components/CrewDetailPage.tsx
@@ -135,6 +135,10 @@ export default function CrewDetailPage() {
   const [deleting, setDeleting] = useState(false)
 
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): crew detail is an org-scope surface
+  // (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/crew writes require a global admin/producer claim
+  // (firestore.rules:402-405) — a project promotion never unlocks these.
   const canEdit = !isMobile && canManageCrew(role as Role)
 
   const handleFieldSave = async (field: string, value: string) => {

--- a/src-vnext/features/library/components/LibraryCrewPage.tsx
+++ b/src-vnext/features/library/components/LibraryCrewPage.tsx
@@ -27,6 +27,10 @@ export default function LibraryCrewPage() {
   const { role } = useAuth()
   const isMobile = useIsMobile()
   const navigate = useNavigate()
+  // PINNED to the GLOBAL claim (5b): the crew library is an org-scope
+  // surface (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/crew writes require a global admin/producer claim
+  // (firestore.rules:402-405) — a project promotion never unlocks these.
   const canCreate = canManageCrew(role)
   const canEdit = !isMobile && canCreate
 

--- a/src-vnext/features/library/components/LibraryLocationsPage.tsx
+++ b/src-vnext/features/library/components/LibraryLocationsPage.tsx
@@ -32,6 +32,10 @@ export default function LibraryLocationsPage() {
   const { data: locations, loading, error } = useLocationLibrary()
   const [query, setQuery] = useState("")
   const [createOpen, setCreateOpen] = useState(false)
+  // PINNED to the GLOBAL claim (5b): the locations library is an org-scope
+  // surface (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/locations writes require a global admin/producer
+  // claim (firestore.rules:382-384) — a project promotion never unlocks these.
   const canCreate = canManageLocations(role)
   const [viewMode, setViewMode] = usePersistedViewMode("sb:locations-view", "list", LOCATIONS_VIEW_MODES)
 

--- a/src-vnext/features/library/components/LibraryPalettePage.tsx
+++ b/src-vnext/features/library/components/LibraryPalettePage.tsx
@@ -156,6 +156,12 @@ function InlineHexEdit({
 export default function LibraryPalettePage() {
   const { clientId, role } = useAuth()
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): the palette is an org-scope surface
+  // (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/colorSwatches create/update require a global
+  // admin/producer claim (firestore.rules:629); delete is global admin-only
+  // (firestore.rules:630), which canDelete mirrors exactly. A project
+  // promotion never unlocks these.
   const canEdit = canManageProducts(role) && !isMobile
   const canDelete = role === ROLE.ADMIN && !isMobile
 

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -68,6 +68,10 @@ const TALENT_VIEW_OPTIONS = [
 export default function LibraryTalentPage() {
   const { clientId, role, user } = useAuth()
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): the talent library is an org-scope
+  // surface (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/talent writes require a global admin/producer claim
+  // (firestore.rules:363-365) — a project promotion never unlocks these.
   const canCreate = canManageTalent(role)
   const canEdit = canCreate && !isMobile
   const { data: talent, loading, error } = useTalentLibrary()

--- a/src-vnext/features/library/components/LocationDetailPage.tsx
+++ b/src-vnext/features/library/components/LocationDetailPage.tsx
@@ -34,6 +34,10 @@ export default function LocationDetailPage() {
   )
 
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): location detail is an org-scope surface
+  // (no ProjectScopeProvider, so no effective role applies) and
+  // /clients/{clientId}/locations writes require a global admin/producer
+  // claim (firestore.rules:382-384) — a project promotion never unlocks these.
   const canEdit = !isMobile && canManageLocations(role)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)

--- a/src-vnext/features/links/components/SharedLinksPage.tsx
+++ b/src-vnext/features/links/components/SharedLinksPage.tsx
@@ -39,6 +39,12 @@ export default function SharedLinksPage() {
   const { clientId, role } = useAuth()
 
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): share links live in the top-level
+  // /castingShares collection, whose management rules check only the global
+  // admin/producer claim — get/list (firestore.rules:223-225), create
+  // (:227-231), update/delete (:233-235). The backend cannot see a project
+  // promotion, so this page must not advertise edit affordances from the
+  // effective role.
   const canEdit = canManageCasting(role)
 
   const { links, loading, error } = useShareLinks(projectId, clientId)

--- a/src-vnext/features/products/components/ProductActivitySection.tsx
+++ b/src-vnext/features/products/components/ProductActivitySection.tsx
@@ -160,6 +160,11 @@ export function ProductActivitySection({
                         {deleted ? "Deleted" : comment.body}
                       </div>
                     </div>
+                    {/* PINNED to the GLOBAL claim (5b): removing someone
+                        else's comment is a soft-delete update allowed for
+                        author-or-ADMIN, where admin is the GLOBAL claim
+                        (productFamilies/comments firestore.rules:598-604);
+                        org backend, no project context. */}
                     {canEdit && !deleted && (mine || isAdmin(role)) && (
                       <Button
                         type="button"

--- a/src-vnext/features/products/components/ProductDetailPage.tsx
+++ b/src-vnext/features/products/components/ProductDetailPage.tsx
@@ -69,6 +69,11 @@ export default function ProductDetailPage() {
   const navigate = useNavigate()
   const { role, clientId, user } = useAuth()
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): org-scope product detail — write
+  // affordances (here and propagated as props to the Overview/Samples
+  // sections) are backed by global-role rules: productFamilies
+  // firestore.rules:566-574 (create/update :568 admin|producer, delete
+  // :569 admin). No project context exists on this page.
   const canEdit = !isMobile && canManageProducts(role)
   const [showDeleted, setShowDeleted] = useState(false)
   const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false)

--- a/src-vnext/features/products/components/ProductEditorPage.tsx
+++ b/src-vnext/features/products/components/ProductEditorPage.tsx
@@ -444,6 +444,10 @@ export default function ProductEditorPage() {
   const navigate = useNavigate()
   const { clientId, role, user } = useAuth()
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): org-scope product editor — every write
+  // it gates is a global-role rule: productFamilies firestore.rules:566-574,
+  // skus :571-574, samples :578-581, documents :584-586 (admin|producer
+  // arms). No project context exists to resolve an effective role against.
   const canEdit = !isMobile && canManageProducts(role)
 
   const mode: Mode = fid ? "edit" : "create"

--- a/src-vnext/features/products/components/ProductListPage.tsx
+++ b/src-vnext/features/products/components/ProductListPage.tsx
@@ -61,8 +61,18 @@ export default function ProductListPage() {
   const { data: families, loading, error } = useProductFamilies()
   const { role, user: currentUser, clientId } = useAuth()
   const isMobile = useIsMobile()
+  // PINNED to the GLOBAL claim (5b): org-scope products page, no project
+  // context — useEffectiveRole has no ProjectScopeProvider here and would
+  // return the global claim anyway. Backing rules are global-role checks:
+  // productFamilies create/update firestore.rules:568 (admin|producer),
+  // delete :569 (admin — backs showMerge, which deletes merged families).
   const canCreate = canManageProducts(role)
   const canEdit = !isMobile && canCreate
+  // PINNED to the GLOBAL claim (5b): bulk-add creates SHOTS in a project
+  // chosen inside the dialog (bulkCreateShotsFromProducts) — backed by the
+  // /shots create rule's global lanes (firestore.rules:446-449:
+  // hasGlobalRole(['producer']) or isAdmin() via shotProjectRole). No
+  // project scope exists on this org page to resolve an effective role.
   const canBulkAdd = canManageProjects(role)
   const showMerge = isAdmin(role) && !isMobile
   const [searchParams, setSearchParams] = useSearchParams()

--- a/src-vnext/features/products/components/ProductUpsertDialog.tsx
+++ b/src-vnext/features/products/components/ProductUpsertDialog.tsx
@@ -270,6 +270,10 @@ export function ProductUpsertDialog({
   const isMobile = useIsMobile()
   const navigate = useNavigate()
 
+  // PINNED to the GLOBAL claim (5b): products are an org-scope backend —
+  // productFamilies/skus create+update require a global admin|producer claim
+  // (firestore.rules:568, :571-574); there is no project context to promote
+  // from, so the effective role must not feed this gate.
   const canEdit = !isMobile && canManageProducts(role)
   const existingSkus = useMemo(() => (skus ?? []).filter((s) => s.deleted !== true), [skus])
 

--- a/src-vnext/features/products/components/ProductVersionHistorySection.tsx
+++ b/src-vnext/features/products/components/ProductVersionHistorySection.tsx
@@ -6,6 +6,7 @@ import { InlineEmpty } from "@/shared/components/InlineEmpty"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { canRestoreVersions } from "@/shared/lib/rbac"
 import { useProductVersions } from "@/features/products/hooks/useProductVersions"
 import { useProductSkus } from "@/features/products/hooks/useProducts"
 import { restoreProductVersion } from "@/features/products/lib/productVersioning"
@@ -112,9 +113,14 @@ export function ProductVersionHistorySection({
   const [restoreTarget, setRestoreTarget] = useState<ProductVersion | null>(null)
   const [restoring, setRestoring] = useState(false)
 
+  // PINNED to the GLOBAL claim: restore is a productFamilies update whose rule
+  // (firestore.rules:568) is isAdmin() || isProducer() — pure global claims, no
+  // project arm. Wiring the effective role here would advertise Restore to a
+  // project-promoted crew and then fail with permission-denied on the family
+  // update. !isMobile is a device concern, not RBAC.
   const canRestore = useMemo(() => {
     if (isMobile) return false
-    return role === "admin" || role === "producer"
+    return canRestoreVersions(role)
   }, [isMobile, role])
 
   const {

--- a/src-vnext/features/products/components/__tests__/ProductVersionHistorySection.test.tsx
+++ b/src-vnext/features/products/components/__tests__/ProductVersionHistorySection.test.tsx
@@ -1,0 +1,169 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { Timestamp } from "firebase/firestore"
+import type { ProductFamily, ProductVersion } from "@/shared/types"
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+const deviceState = vi.hoisted(() => ({ isMobile: false }))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => deviceState.isMobile,
+}))
+
+// PIN test harness: the section must consume useAuth's GLOBAL role — the
+// productFamilies update rule (firestore.rules:568) is isAdmin() ||
+// isProducer(), no project arm. authState drives the global claim;
+// effectiveState exists ONLY to prove a project promotion is ignored.
+const authState = vi.hoisted(() => ({ role: "producer" }))
+const effectiveState = vi.hoisted(() => ({ role: "producer", resolving: false }))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    clientId: "c1",
+    role: authState.role,
+    user: {
+      uid: "u1",
+      email: "alex@example.com",
+      displayName: "Alex Rivera",
+      photoURL: null,
+    },
+  }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role,
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/features/products/hooks/useProductVersions", () => ({
+  useProductVersions: vi.fn(),
+}))
+
+vi.mock("@/features/products/hooks/useProducts", () => ({
+  useProductSkus: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/products/lib/productVersioning", () => ({
+  restoreProductVersion: vi.fn(),
+}))
+
+import { useProductVersions } from "@/features/products/hooks/useProductVersions"
+import { ProductVersionHistorySection } from "@/features/products/components/ProductVersionHistorySection"
+
+function makeFamily(overrides: Partial<ProductFamily> = {}): ProductFamily {
+  return {
+    id: overrides.id ?? "f1",
+    styleName: overrides.styleName ?? "Test Family",
+    ...overrides,
+  }
+}
+
+function makeVersion(overrides: Partial<ProductVersion> = {}): ProductVersion {
+  return {
+    id: overrides.id ?? "v1",
+    snapshot: overrides.snapshot ?? { styleName: "Old name" },
+    createdAt: overrides.createdAt ?? Timestamp.fromMillis(Date.now()),
+    createdBy: overrides.createdBy ?? "u1",
+    createdByName: overrides.createdByName ?? "Alex Rivera",
+    createdByAvatar: overrides.createdByAvatar ?? null,
+    changeType: overrides.changeType ?? "update",
+    changedFields: overrides.changedFields ?? ["styleName"],
+  }
+}
+
+function mockVersions(versions: ProductVersion[]) {
+  ;(useProductVersions as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: versions,
+    loading: false,
+    error: null,
+  })
+}
+
+describe("ProductVersionHistorySection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    deviceState.isMobile = false
+    authState.role = "producer"
+    effectiveState.role = "producer"
+    effectiveState.resolving = false
+  })
+
+  it("shows Restore for a global producer on a non-create version", async () => {
+    const user = userEvent.setup()
+    mockVersions([makeVersion({ id: "v-1" })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.getByRole("button", { name: "Restore" })).toBeInTheDocument()
+  })
+
+  it("hides Restore for global crew and shows the read-only hint", async () => {
+    const user = userEvent.setup()
+    authState.role = "crew"
+    effectiveState.role = "crew"
+    mockVersions([makeVersion({ id: "v-1" })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+    expect(
+      screen.getByText("Restore is producer/admin desktop-only."),
+    ).toBeInTheDocument()
+  })
+
+  it("hides Restore for a global viewer", async () => {
+    const user = userEvent.setup()
+    authState.role = "viewer"
+    effectiveState.role = "viewer"
+    mockVersions([makeVersion({ id: "v-1" })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+  })
+
+  it("stays PINNED to the global claim: a project-promoted crew gets no Restore", async () => {
+    const user = userEvent.setup()
+    authState.role = "crew"
+    // Effective role says producer (project promotion) — the rule at
+    // firestore.rules:568 cannot see it, so the UI must not advertise Restore.
+    effectiveState.role = "producer"
+    mockVersions([makeVersion({ id: "v-1" })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+  })
+
+  it("hides Restore on mobile even for a producer", async () => {
+    const user = userEvent.setup()
+    deviceState.isMobile = true
+    mockVersions([makeVersion({ id: "v-1" })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+  })
+
+  it("never offers Restore on the create version", async () => {
+    const user = userEvent.setup()
+    mockVersions([makeVersion({ id: "v-1", changeType: "create", changedFields: [] })])
+
+    render(<ProductVersionHistorySection family={makeFamily()} />)
+    await user.click(screen.getByRole("button", { name: /version history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/projects/components/CreateProjectDialog.tsx
+++ b/src-vnext/features/projects/components/CreateProjectDialog.tsx
@@ -81,7 +81,12 @@ export function CreateProjectDialog({
         updatedAt: serverTimestamp(),
       })
 
-      // Auto-membership: non-admin creators get a member doc atomically
+      // Auto-membership: non-admin creators get a member doc atomically.
+      // PINNED to the GLOBAL claim (5b): create runs from org-chrome (no
+      // project exists yet, so no effective role). Backing rules: projects
+      // create (firestore.rules:688, global admin/producer) + the members
+      // creation-time self-add carve-out (firestore.rules:713-735, getAfter
+      // createdBy arm). Behavior branch, not an affordance gate.
       if (!isAdmin(role) && user) {
         const memberPath = projectMembersPath(projectRef.id, clientId)
         const memberRef = doc(db, memberPath[0]!, ...memberPath.slice(1), user.uid)

--- a/src-vnext/features/projects/components/EditProjectDialog.tsx
+++ b/src-vnext/features/projects/components/EditProjectDialog.tsx
@@ -67,6 +67,10 @@ export function EditProjectDialog({
   project,
 }: EditProjectDialogProps) {
   const { clientId, role } = useAuth()
+  // PINNED to the GLOBAL claim (5b): this dialog opens from the org dashboard
+  // (ProjectDashboard) with no ProjectScopeProvider mounted, so there is no
+  // effective role to consult. Backing rule: projects update
+  // (firestore.rules:691-702).
   const showVisibility = canManageProjects(role)
 
   const [name, setName] = useState("")

--- a/src-vnext/features/projects/components/ProjectActionsMenu.tsx
+++ b/src-vnext/features/projects/components/ProjectActionsMenu.tsx
@@ -23,6 +23,11 @@ interface ProjectActionsMenuProps {
 
 export function ProjectActionsMenu({ project, onEdit, onActionInteraction }: ProjectActionsMenuProps) {
   const { role, clientId } = useAuth()
+  // PINNED to the GLOBAL claim (5b): this menu renders on the org dashboard's
+  // ProjectCard with no ProjectScopeProvider mounted, so there is no effective
+  // role to consult. Backing rules: projects update (firestore.rules:691-702)
+  // and delete (firestore.rules:703-711) — global producer team-visible arm,
+  // private-creator arm, and explicit-member arm enforced server-side.
   const canManage = canManageProjects(role)
   const canDelete = canManage
 

--- a/src-vnext/features/projects/components/ProjectDashboard.tsx
+++ b/src-vnext/features/projects/components/ProjectDashboard.tsx
@@ -87,6 +87,12 @@ export default function ProjectDashboard() {
     }
   }, [])
 
+  // PINNED to the GLOBAL claim (5b): the dashboard is org-chrome — no
+  // ProjectScopeProvider is mounted, so there is no project to resolve an
+  // effective role against. Backing rule: projects create requires a global
+  // admin/producer claim (firestore.rules:688). The same pin covers the
+  // empty-state "Create Your First Project" action below (isAdmin(role) ||
+  // canManage).
   const canManage = canManageProjects(role)
   const showCreate = canManage
   const showActions = canManage && !isMobile

--- a/src-vnext/features/pulls/components/PullDetailPage.tsx
+++ b/src-vnext/features/pulls/components/PullDetailPage.tsx
@@ -11,6 +11,8 @@ import { usePull } from "@/features/pulls/hooks/usePull"
 import { updatePullField } from "@/features/pulls/lib/updatePull"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { canManagePulls, canFulfillPulls } from "@/shared/lib/rbac"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
 import {
@@ -40,12 +42,26 @@ export default function PullDetailPage() {
   const { pid } = useParams<{ pid: string }>()
   const navigate = useNavigate()
   const { data: pull, loading, error } = usePull(pid)
-  const { role, clientId } = useAuth()
+  const { clientId } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). `resolving` is true only during the first uncached
+  // member read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId } = useProjectScope()
   const isMobile = useIsMobile()
 
-  const canEdit = canManagePulls(role) && !isMobile
-  const canFulfill = canFulfillPulls(role)
+  // -- Role-based flags (5b-II: effective role + resolving gate) --
+  // Write affordances render NOTHING (or disabled controls) while the first
+  // member read is in flight (roleResolving) — never the global-role guess.
+  // Backing rule: project-scoped /pulls create/update/delete
+  // (firestore.rules:757-766, ['producer','warehouse'] arm). Note the Share
+  // toggle here is a pull-doc field write (shareEnabled/shareToken), NOT a
+  // /shotShares-style global-pinned collection — same /pulls rule applies.
+  const canEdit = !roleResolving && canManagePulls(role) && !isMobile
+  // Fulfillment updates are pull-doc updates under the same /pulls write arm.
+  // rbac.canFulfillPulls (admin||warehouse) is intentionally STRICTER than
+  // the rule (which also allows producer) — UI-stricter is fine.
+  const canFulfill = !roleResolving && canFulfillPulls(role)
 
   const save = async (fields: Record<string, unknown>) => {
     if (!pull || !clientId) return
@@ -138,6 +154,7 @@ export default function PullDetailPage() {
             )}
           </div>
           <div className="flex items-center gap-2">
+            <EffectiveRoleChip />
             <Select
               value={displayStatus}
               onValueChange={handleStatusChange}

--- a/src-vnext/features/pulls/components/PullListPage.tsx
+++ b/src-vnext/features/pulls/components/PullListPage.tsx
@@ -7,19 +7,28 @@ import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
 import { usePulls } from "@/features/pulls/hooks/usePulls"
 import { PullCard } from "@/features/pulls/components/PullCard"
 import { CreatePullDialog } from "@/features/pulls/components/CreatePullDialog"
-import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { canManagePulls } from "@/shared/lib/rbac"
 import { Button } from "@/ui/button"
 import { ClipboardList, Plus } from "lucide-react"
 
 export default function PullListPage() {
   const { data: pulls, loading, error } = usePulls()
-  const { role } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). `resolving` is true only during the first uncached
+  // member read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectName } = useProjectScope()
   const [createOpen, setCreateOpen] = useState(false)
 
-  const showCreate = canManagePulls(role)
+  // -- Role-based flags (5b-II: effective role + resolving gate) --
+  // The write affordance renders NOTHING while the first member read is in
+  // flight (roleResolving) — never the global-role guess. Backing rule:
+  // project-scoped /pulls create/update/delete (firestore.rules:757-766,
+  // ['producer','warehouse'] arm).
+  const showCreate = !roleResolving && canManagePulls(role)
 
   if (loading) {
     return <LoadingState loading skeleton={<ListPageSkeleton />} />
@@ -38,12 +47,15 @@ export default function PullListPage() {
       <PageHeader
         title="Pull Sheets"
         actions={
-          showCreate ? (
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus className="mr-2 h-4 w-4" />
-              New Pull Sheet
-            </Button>
-          ) : undefined
+          <div className="flex items-center gap-2">
+            <EffectiveRoleChip />
+            {showCreate && (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                New Pull Sheet
+              </Button>
+            )}
+          </div>
         }
       />
 

--- a/src-vnext/features/pulls/components/__tests__/PullDetailPage.test.tsx
+++ b/src-vnext/features/pulls/components/__tests__/PullDetailPage.test.tsx
@@ -1,0 +1,173 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { FulfillmentFirestoreStatus, Pull, PullItem } from "@/shared/types"
+
+vi.mock("@/features/pulls/hooks/usePull", () => ({
+  usePull: vi.fn(),
+}))
+
+vi.mock("@/features/pulls/lib/updatePull", () => ({
+  updatePullField: vi.fn(),
+}))
+
+// Mutable global claim so promotion rows can flip it (5b matrix shape).
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, clientId: "c1", loading: false }),
+}))
+
+// 5b effective-role state. role=null mirrors the global claim (member ==
+// global, the default matrix shape); a string overrides it (downgrade rows);
+// resolving=true pins the first-read affordance gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+  useIsDesktop: () => true,
+}))
+
+vi.mock("@/features/pulls/components/FulfillmentToggle", () => ({
+  FulfillmentToggle: ({ disabled }: { readonly disabled: boolean }) => (
+    <button data-testid="fulfillment-toggle" disabled={disabled}>
+      toggle
+    </button>
+  ),
+}))
+
+import { usePull } from "@/features/pulls/hooks/usePull"
+import PullDetailPage from "@/features/pulls/components/PullDetailPage"
+
+function makeItem(overrides: Partial<PullItem>): PullItem {
+  return {
+    familyId: overrides.familyId ?? "f1",
+    familyName: overrides.familyName ?? "Family 1",
+    sizes: overrides.sizes ?? [],
+    fulfillmentStatus:
+      overrides.fulfillmentStatus ?? ("pending" as FulfillmentFirestoreStatus),
+  }
+}
+
+function makePull(overrides: Partial<Pull>): Pull {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "pull1",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    name: overrides.name ?? "Pull 1",
+    shotIds: overrides.shotIds ?? [],
+    items: overrides.items ?? [makeItem({})],
+    status: overrides.status ?? "draft",
+    shareEnabled: overrides.shareEnabled ?? false,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  }
+}
+
+function setPull(pull: Pull | null) {
+  ;(usePull as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: pull,
+    loading: false,
+    error: null,
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/p1/pulls/pull1"]}>
+      <Routes>
+        <Route path="/projects/:id/pulls/:pid" element={<PullDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("PullDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
+    setPull(makePull({}))
+  })
+
+  it("shows edit affordances for a producer (effective role mirrors global)", () => {
+    renderPage()
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeEnabled()
+    // Producer is not a fulfiller (canFulfillPulls = admin || warehouse).
+    expect(screen.getByTestId("fulfillment-toggle")).toBeDisabled()
+    // Equal roles: no downgrade chip.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders no write affordances while the effective role is resolving", () => {
+    effectiveState.resolving = true
+    renderPage()
+    expect(screen.queryByRole("button", { name: /share/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeDisabled()
+    expect(screen.getByTestId("fulfillment-toggle")).toBeDisabled()
+    // Title falls back to the read-only heading, not the inline editor.
+    expect(screen.getByRole("heading", { name: "Pull 1" })).toBeInTheDocument()
+    // Chip is self-gating and also renders nothing while resolving.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("hides edit affordances on a per-project downgrade (member doc wins)", () => {
+    effectiveState.role = "viewer"
+    renderPage()
+    expect(screen.queryByRole("button", { name: /share/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeDisabled()
+    expect(screen.getByTestId("fulfillment-toggle")).toBeDisabled()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent("Viewer on this project")
+  })
+
+  it("enables fulfillment for a warehouse member doc over a producer claim", () => {
+    effectiveState.role = "warehouse"
+    renderPage()
+    // Warehouse can manage AND fulfill pulls.
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    expect(screen.getByTestId("fulfillment-toggle")).toBeEnabled()
+    // Warehouse ranks below producer, so the downgrade chip shows.
+    expect(screen.getByTestId("effective-role-chip")).toBeInTheDocument()
+  })
+
+  it("shows edit affordances on a per-project promotion (member doc wins)", () => {
+    authState.role = "viewer"
+    effectiveState.role = "producer"
+    renderPage()
+    expect(screen.getByRole("button", { name: /share/i })).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeEnabled()
+    // Upgrades render no chip.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the global claim when there is no member-doc override (null-scope shape)", () => {
+    // useEffectiveRole returns the global claim when no ProjectScopeProvider
+    // / member doc exists (hook-level behavior, unit-tested in
+    // useEffectiveRole.test.tsx). role=null mirrors that fallback here.
+    authState.role = "viewer"
+    effectiveState.role = null
+    renderPage()
+    expect(screen.queryByRole("button", { name: /share/i })).not.toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBeDisabled()
+  })
+})

--- a/src-vnext/features/pulls/components/__tests__/PullListPage.test.tsx
+++ b/src-vnext/features/pulls/components/__tests__/PullListPage.test.tsx
@@ -1,0 +1,130 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { Timestamp } from "firebase/firestore"
+import type { Pull } from "@/shared/types"
+
+vi.mock("@/features/pulls/hooks/usePulls", () => ({
+  usePulls: vi.fn(),
+}))
+
+// Mutable global claim so promotion rows can flip it (5b matrix shape).
+const authState = vi.hoisted(() => ({ role: "producer" }))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role, clientId: "c1", loading: false }),
+}))
+
+// 5b effective-role state. role=null mirrors the global claim (member ==
+// global, the default matrix shape); a string overrides it (downgrade rows);
+// resolving=true pins the first-read affordance gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+  useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
+}))
+
+vi.mock("@/features/pulls/components/PullCard", () => ({
+  PullCard: ({ pull }: { readonly pull: Pull }) => <div>pull:{pull.id}</div>,
+}))
+
+vi.mock("@/features/pulls/components/CreatePullDialog", () => ({
+  CreatePullDialog: () => null,
+}))
+
+import { usePulls } from "@/features/pulls/hooks/usePulls"
+import PullListPage from "@/features/pulls/components/PullListPage"
+
+function makePull(overrides: Partial<Pull>): Pull {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "pull1",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    name: overrides.name ?? "Pull 1",
+    shotIds: overrides.shotIds ?? [],
+    items: overrides.items ?? [],
+    status: overrides.status ?? "draft",
+    shareEnabled: overrides.shareEnabled ?? false,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  }
+}
+
+function setPulls(pulls: Pull[]) {
+  ;(usePulls as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: pulls,
+    loading: false,
+    error: null,
+  })
+}
+
+describe("PullListPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
+    setPulls([makePull({})])
+  })
+
+  it("shows the create affordance for a producer (effective role mirrors global)", () => {
+    render(<PullListPage />)
+    expect(screen.getByRole("button", { name: /new pull sheet/i })).toBeInTheDocument()
+    // Equal roles: no downgrade chip.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders no write affordances while the effective role is resolving", () => {
+    effectiveState.resolving = true
+    render(<PullListPage />)
+    expect(screen.queryByRole("button", { name: /new pull sheet/i })).not.toBeInTheDocument()
+    // Chip is self-gating and also renders nothing while resolving.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("hides the create affordance on a per-project downgrade (member doc wins)", () => {
+    effectiveState.role = "viewer"
+    render(<PullListPage />)
+    expect(screen.queryByRole("button", { name: /new pull sheet/i })).not.toBeInTheDocument()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent("Viewer on this project")
+  })
+
+  it("shows the create affordance on a per-project promotion (member doc wins)", () => {
+    authState.role = "viewer"
+    effectiveState.role = "warehouse"
+    render(<PullListPage />)
+    expect(screen.getByRole("button", { name: /new pull sheet/i })).toBeInTheDocument()
+    // Upgrades render no chip.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("falls back to the global claim when there is no member-doc override (null-scope shape)", () => {
+    // useEffectiveRole returns the global claim when no ProjectScopeProvider
+    // / member doc exists (hook-level behavior, unit-tested in
+    // useEffectiveRole.test.tsx). role=null mirrors that fallback here.
+    authState.role = "viewer"
+    effectiveState.role = null
+    render(<PullListPage />)
+    expect(screen.queryByRole("button", { name: /new pull sheet/i })).not.toBeInTheDocument()
+  })
+
+  it("hides the empty-state create action for read-only effective roles", () => {
+    effectiveState.role = "viewer"
+    setPulls([])
+    render(<PullListPage />)
+    expect(screen.getByText("No pull sheets yet")).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: /create pull sheet/i })).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/requests/components/RecipientPicker.tsx
+++ b/src-vnext/features/requests/components/RecipientPicker.tsx
@@ -42,6 +42,13 @@ export function RecipientPicker({ clientId, value, onChange }: RecipientPickerPr
     usersPath(clientId),
   )
 
+  // PINNED to GLOBAL role data (5b: not an effective-role gate). This filters
+  // OTHER users' /users-doc role fields to build the recipient list — it never
+  // reads the caller's role, so useEffectiveRole does not apply. Notifications
+  // target global team leads; a per-project member-doc promotion has no users-doc
+  // footprint for this filter to see. Caller capability is gated at the route:
+  // RequireRole(["admin","producer"]) wraps the request centre
+  // (src-vnext/app/routes/index.tsx:282), itself a global-claim (org-scope) gate.
   const eligibleUsers = useMemo(
     () => allUsers.filter((u) => u.role === "admin" || u.role === "producer"),
     [allUsers],

--- a/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
+++ b/src-vnext/features/schedules/components/CallSheetBuilderPage.tsx
@@ -8,6 +8,8 @@ import { DetailPageSkeleton } from "@/shared/components/Skeleton"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
 import { canManageSchedules } from "@/shared/lib/rbac"
 import { useCallSheetBundle } from "@/features/schedules/hooks/useCallSheetBundle"
@@ -52,7 +54,11 @@ function formatScheduleDate(date: import("@/shared/types").Schedule["date"]): st
 }
 
 export default function CallSheetBuilderPage() {
-  const { clientId, role } = useAuth()
+  const { clientId } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). `resolving` is true only during the first uncached
+  // member read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId, projectName } = useProjectScope()
   const isMobile = useIsMobile()
   const navigate = useNavigate()
@@ -60,17 +66,27 @@ export default function CallSheetBuilderPage() {
 
   const scheduleId = searchParams.get("scheduleId")
   const isPreviewParam = searchParams.get("preview") === "1"
-  const canManage = canManageSchedules(role)
+  // canManage drives every schedule/call-sheet write affordance on this page
+  // (builder vs preview fork, editors, dialog mounts). The page renders a
+  // skeleton while roleResolving, never the global-role guess. Backing
+  // rules: /schedules create/update (firestore.rules:796-799) and its
+  // subcollections — entries (:811-814), dayDetails (:822-824),
+  // talentCalls (:832-834), crewCalls (:842-844), clientCalls (:852-854),
+  // callSheet (:863-865) — all ['producer','warehouse'] project arms.
+  const canManage = !roleResolving && canManageSchedules(role)
 
   // Enforce preview mode for non-managers (read-only)
   useEffect(() => {
+    // Don't rewrite the URL on the resolving gap — a manager whose first
+    // member read is still in flight must not be locked into preview=1.
+    if (roleResolving) return
     if (canManage) return
     if (!scheduleId) return
     if (isPreviewParam) return
     const next = new URLSearchParams(searchParams)
     next.set("preview", "1")
     setSearchParams(next, { replace: true })
-  }, [canManage, isPreviewParam, scheduleId, searchParams, setSearchParams])
+  }, [roleResolving, canManage, isPreviewParam, scheduleId, searchParams, setSearchParams])
 
   // Mobile redirect (builder is desktop-only; preview is allowed)
   useEffect(() => {
@@ -150,6 +166,11 @@ export default function CallSheetBuilderPage() {
 
   // No schedule selected: show call sheet list for managers (desktop). Others must use a deep link.
   if (!scheduleId) {
+    // Skeleton while the first member read is in flight — the manager/
+    // non-manager fork below must never run on the global-role guess.
+    if (roleResolving) {
+      return <LoadingState loading skeleton={<DetailPageSkeleton />} />
+    }
     if (!canManage) {
       return (
         <ErrorBoundary>
@@ -169,8 +190,11 @@ export default function CallSheetBuilderPage() {
     )
   }
 
-  // Loading
-  if (scheduleLoading || dayDetailsLoading) {
+  // Loading — roleResolving included so the builder-vs-preview fork below
+  // renders a skeleton during the first uncached member read, never the
+  // global-role guess (no preview flash for managers, no editor flash for
+  // project-downgraded users).
+  if (scheduleLoading || dayDetailsLoading || roleResolving) {
     return <LoadingState loading skeleton={<DetailPageSkeleton />} />
   }
 
@@ -266,6 +290,7 @@ export default function CallSheetBuilderPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              <EffectiveRoleChip />
               <Button
                 variant="outline"
                 size="sm"
@@ -333,6 +358,7 @@ export default function CallSheetBuilderPage() {
               )}
             </div>
             <div className="flex items-center gap-2">
+              <EffectiveRoleChip />
               <Button
                 variant="outline"
                 size="sm"

--- a/src-vnext/features/schedules/components/CreateScheduleDialog.tsx
+++ b/src-vnext/features/schedules/components/CreateScheduleDialog.tsx
@@ -3,6 +3,7 @@ import { Timestamp } from "firebase/firestore"
 import { createSchedule } from "@/features/schedules/lib/scheduleWrites"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { canManageSchedules } from "@/shared/lib/rbac"
 import {
   Dialog,
@@ -26,7 +27,14 @@ export function CreateScheduleDialog({
   onOpenChange,
   onCreated,
 }: CreateScheduleDialogProps) {
-  const { clientId, role } = useAuth()
+  const { clientId } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). Defense-in-depth guard — the dialog is only mounted by
+  // canManage parents (ScheduleListPage), but the write guard below must
+  // not fall back to the global-role guess while the first member read is
+  // in flight. Backing rule: /schedules create/update
+  // (firestore.rules:796-799).
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId } = useProjectScope()
   const [name, setName] = useState("")
   const [date, setDate] = useState("")
@@ -35,7 +43,7 @@ export function CreateScheduleDialog({
 
   const handleCreate = async () => {
     const trimmedName = name.trim()
-    if (!trimmedName || !clientId || !canManageSchedules(role)) return
+    if (!trimmedName || !clientId || roleResolving || !canManageSchedules(role)) return
 
     setSaving(true)
     setError(null)

--- a/src-vnext/features/schedules/components/ScheduleCard.tsx
+++ b/src-vnext/features/schedules/components/ScheduleCard.tsx
@@ -28,6 +28,9 @@ function formatDate(date: Schedule["date"]): string {
 interface ScheduleCardProps {
   readonly schedule: Schedule
   readonly canManage: boolean
+  // Delete is rules-stricter than edit: /schedules delete arm is admin-only
+  // (firestore.rules:801).
+  readonly canDelete: boolean
   readonly onDelete: (schedule: Schedule) => void
   readonly onEdit: (schedule: Schedule) => void
 }
@@ -35,6 +38,7 @@ interface ScheduleCardProps {
 export function ScheduleCard({
   schedule,
   canManage,
+  canDelete,
   onDelete,
   onEdit,
 }: ScheduleCardProps) {
@@ -83,16 +87,18 @@ export function ScheduleCard({
                 <Pencil className="mr-2 h-4 w-4" />
                 Edit
               </DropdownMenuItem>
-              <DropdownMenuItem
-                className="text-[var(--color-error)]"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onDelete(schedule)
-                }}
-              >
-                <Trash2 className="mr-2 h-4 w-4" />
-                Delete
-              </DropdownMenuItem>
+              {canDelete && (
+                <DropdownMenuItem
+                  className="text-[var(--color-error)]"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onDelete(schedule)
+                  }}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </DropdownMenuItem>
+              )}
             </DropdownMenuContent>
           </DropdownMenu>
         )}

--- a/src-vnext/features/schedules/components/ScheduleListPage.tsx
+++ b/src-vnext/features/schedules/components/ScheduleListPage.tsx
@@ -38,7 +38,10 @@ export default function ScheduleListPage() {
   const canManage = !roleResolving && canManageSchedules(role)
   // Delete is rules-stricter than create/update: the /schedules delete arm
   // is admin-only (firestore.rules:801), so Delete gates on admin separately
-  // or a non-admin manager would hit permission-denied.
+  // or a non-admin manager would hit permission-denied. isAdmin on the
+  // EFFECTIVE role is safe: admin is never downgraded (the hook's admin
+  // exception) and a member doc can never mint 'admin', so this matches the
+  // rule's global-claim isAdmin() exactly.
   const canDelete = !roleResolving && isAdmin(role)
 
   const [createOpen, setCreateOpen] = useState(false)

--- a/src-vnext/features/schedules/components/ScheduleListPage.tsx
+++ b/src-vnext/features/schedules/components/ScheduleListPage.tsx
@@ -14,18 +14,32 @@ import { CreateScheduleDialog } from "@/features/schedules/components/CreateSche
 import { EditScheduleDialog } from "@/features/schedules/components/EditScheduleDialog"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
-import { canManageSchedules } from "@/shared/lib/rbac"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
+import { canManageSchedules, isAdmin } from "@/shared/lib/rbac"
 import { Button } from "@/ui/button"
 import { CalendarDays, Plus } from "lucide-react"
 import type { Schedule } from "@/shared/types"
 
 export default function ScheduleListPage() {
-  const { clientId, role } = useAuth()
+  const { clientId } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). `resolving` is true only during the first uncached
+  // member read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId } = useProjectScope()
   const { data: schedules, loading, error } = useSchedules(clientId, projectId)
   const navigate = useNavigate()
 
-  const canManage = canManageSchedules(role)
+  // Write affordances render NOTHING while the first member read is in
+  // flight (roleResolving) — never the global-role guess. Backing rule:
+  // /schedules create/update (firestore.rules:796-799, isAdmin ||
+  // producerCanAccessProject || hasProjectRole(['producer','warehouse'])).
+  const canManage = !roleResolving && canManageSchedules(role)
+  // Delete is rules-stricter than create/update: the /schedules delete arm
+  // is admin-only (firestore.rules:801), so Delete gates on admin separately
+  // or a non-admin manager would hit permission-denied.
+  const canDelete = !roleResolving && isAdmin(role)
 
   const [createOpen, setCreateOpen] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<Schedule | null>(null)
@@ -36,7 +50,7 @@ export default function ScheduleListPage() {
   }
 
   const handleDelete = async () => {
-    if (!deleteTarget || !clientId || !canManage) return
+    if (!deleteTarget || !clientId || !canDelete) return
     try {
       await deleteSchedule(clientId, projectId, deleteTarget.id)
       toast.success(`"${deleteTarget.name}" deleted`)
@@ -62,12 +76,15 @@ export default function ScheduleListPage() {
       <PageHeader
         title="Call Sheet"
         actions={
-          canManage ? (
-            <Button onClick={() => setCreateOpen(true)}>
-              <Plus className="mr-2 h-4 w-4" />
-              New Call Sheet
-            </Button>
-          ) : undefined
+          <div className="flex items-center gap-2">
+            <EffectiveRoleChip />
+            {canManage && (
+              <Button onClick={() => setCreateOpen(true)}>
+                <Plus className="mr-2 h-4 w-4" />
+                New Call Sheet
+              </Button>
+            )}
+          </div>
         }
       />
 
@@ -86,6 +103,7 @@ export default function ScheduleListPage() {
               key={schedule.id}
               schedule={schedule}
               canManage={canManage}
+              canDelete={canDelete}
               onDelete={setDeleteTarget}
               onEdit={setEditTarget}
             />

--- a/src-vnext/features/schedules/components/__tests__/CallSheetBuilderPage.test.tsx
+++ b/src-vnext/features/schedules/components/__tests__/CallSheetBuilderPage.test.tsx
@@ -34,7 +34,22 @@ const mockDayDetails: DayDetails = {
 // --- Provider mocks ---
 
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: () => ({ clientId: "client-1", role: "producer" }),
+  useAuth: () => ({ clientId: "client-1", role: "producer", loading: false }),
+}))
+
+// 5b: hoisted mutable effective-role state. role=null mirrors the global
+// claim (default matrix); a string overrides it (downgrade rows);
+// resolving=true pins the first-member-read gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? "producer",
+    resolving: effectiveState.resolving,
+  }),
 }))
 
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
@@ -43,10 +58,6 @@ vi.mock("@/app/providers/ProjectScopeProvider", () => ({
 
 vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsMobile: () => false,
-}))
-
-vi.mock("@/shared/lib/rbac", () => ({
-  canManageSchedules: () => true,
 }))
 
 // --- Data hook mocks ---
@@ -248,6 +259,11 @@ function renderPage() {
 
 // --- Tests ---
 
+beforeEach(() => {
+  effectiveState.role = null
+  effectiveState.resolving = false
+})
+
 describe("CallSheetBuilderPage — Section Order wiring", () => {
   beforeEach(() => {
     setSectionOrderMock.mockClear()
@@ -292,5 +308,49 @@ describe("CallSheetBuilderPage — Section Order wiring", () => {
       "dayDetails",
       "header",
     ])
+  })
+})
+
+describe("CallSheetBuilderPage — effective role wiring (5b)", () => {
+  it("renders the builder when the effective role mirrors the global producer claim", () => {
+    renderPage()
+
+    expect(
+      screen.getByRole("button", { name: /section order/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /export pdf/i })).toBeInTheDocument()
+    // No downgrade — the chip stays hidden.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders a skeleton (no builder, no preview) while the effective role is resolving", () => {
+    effectiveState.resolving = true
+    renderPage()
+
+    expect(screen.getByTestId("loading-state")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /section order/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /export pdf/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.queryByTestId("call-sheet-renderer")).not.toBeInTheDocument()
+  })
+
+  it("project downgrade to viewer renders read-only preview with the role chip; member doc wins over the global claim", () => {
+    effectiveState.role = "viewer"
+    renderPage()
+
+    // Read affordance (preview renderer) stays; write affordances are gone.
+    expect(screen.getByTestId("call-sheet-renderer")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /section order/i }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /export pdf/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
   })
 })

--- a/src-vnext/features/schedules/components/__tests__/CreateScheduleDialog.test.tsx
+++ b/src-vnext/features/schedules/components/__tests__/CreateScheduleDialog.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { CreateScheduleDialog } from "@/features/schedules/components/CreateScheduleDialog"
+
+// --- Write mock ---
+
+const createScheduleMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue("sched-new"),
+)
+
+vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
+  createSchedule: createScheduleMock,
+}))
+
+vi.mock("firebase/firestore", () => ({
+  Timestamp: {
+    fromDate: (date: Date) => ({ toDate: () => date }),
+  },
+}))
+
+// --- Provider mocks ---
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "client-1", role: "producer", loading: false }),
+}))
+
+// 5b: hoisted mutable effective-role state. role=null mirrors the global
+// claim (default matrix); a string overrides it (downgrade rows);
+// resolving=true pins the first-member-read gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? "producer",
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "proj-1", projectName: "Test Project" }),
+}))
+
+// --- Helpers ---
+
+function renderDialog() {
+  return render(
+    <CreateScheduleDialog open onOpenChange={vi.fn()} onCreated={vi.fn()} />,
+  )
+}
+
+async function fillNameAndSubmit() {
+  const user = userEvent.setup()
+  await user.type(screen.getByLabelText("Name"), "Day 1")
+  await user.click(screen.getByRole("button", { name: "Create" }))
+}
+
+// --- Tests ---
+
+describe("CreateScheduleDialog — effective role guard (5b)", () => {
+  beforeEach(() => {
+    createScheduleMock.mockClear()
+    effectiveState.role = null
+    effectiveState.resolving = false
+  })
+
+  it("creates the schedule when the effective role mirrors the global producer claim", async () => {
+    renderDialog()
+    await fillNameAndSubmit()
+
+    expect(createScheduleMock).toHaveBeenCalledTimes(1)
+    expect(createScheduleMock).toHaveBeenCalledWith("client-1", "proj-1", {
+      name: "Day 1",
+      date: null,
+    })
+  })
+
+  it("does not write while the effective role is resolving", async () => {
+    effectiveState.resolving = true
+    renderDialog()
+    await fillNameAndSubmit()
+
+    expect(createScheduleMock).not.toHaveBeenCalled()
+  })
+
+  it("does not write when the project member doc downgrades the role to viewer", async () => {
+    effectiveState.role = "viewer"
+    renderDialog()
+    await fillNameAndSubmit()
+
+    expect(createScheduleMock).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/schedules/components/__tests__/ScheduleListPage.test.tsx
+++ b/src-vnext/features/schedules/components/__tests__/ScheduleListPage.test.tsx
@@ -1,0 +1,225 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type React from "react"
+import ScheduleListPage from "@/features/schedules/components/ScheduleListPage"
+import type { Schedule } from "@/shared/types"
+
+// --- Mock data ---
+
+const mockSchedules: Schedule[] = [
+  {
+    id: "sched-1",
+    name: "Day 1",
+    date: { toDate: () => new Date("2026-04-01") } as never,
+    projectId: "proj-1",
+    clientId: "client-1",
+    status: "draft",
+    generalCall: "07:00",
+    wrapTime: null,
+    notes: null,
+    tracks: [],
+  },
+]
+
+// --- Provider mocks ---
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "client-1", role: "producer", loading: false }),
+}))
+
+// 5b: hoisted mutable effective-role state. role=null mirrors the global
+// claim (default matrix); a string overrides it (downgrade rows);
+// resolving=true pins the first-member-read gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? "producer",
+    resolving: effectiveState.resolving,
+  }),
+}))
+
+vi.mock("@/app/providers/ProjectScopeProvider", () => ({
+  useProjectScope: () => ({ projectId: "proj-1", projectName: "Test Project" }),
+}))
+
+// --- Data hook mocks ---
+
+vi.mock("@/features/schedules/hooks/useSchedules", () => ({
+  useSchedules: () => ({ data: mockSchedules, loading: false, error: null }),
+}))
+
+vi.mock("@/features/schedules/lib/scheduleWrites", () => ({
+  deleteSchedule: vi.fn().mockResolvedValue(undefined),
+}))
+
+// --- Child component stubs ---
+
+vi.mock("@/features/schedules/components/ScheduleCard", () => ({
+  ScheduleCard: ({
+    canManage,
+    canDelete,
+  }: {
+    readonly canManage: boolean
+    readonly canDelete: boolean
+  }) => (
+    <div
+      data-testid="schedule-card"
+      data-can-manage={String(canManage)}
+      data-can-delete={String(canDelete)}
+    />
+  ),
+}))
+
+vi.mock("@/features/schedules/components/CreateScheduleDialog", () => ({
+  CreateScheduleDialog: () => <div data-testid="create-schedule-dialog" />,
+}))
+
+vi.mock("@/features/schedules/components/EditScheduleDialog", () => ({
+  EditScheduleDialog: () => <div data-testid="edit-schedule-dialog" />,
+}))
+
+vi.mock("@/shared/components/ConfirmDialog", () => ({
+  ConfirmDialog: () => <div data-testid="confirm-dialog" />,
+}))
+
+vi.mock("@/shared/components/ErrorBoundary", () => ({
+  ErrorBoundary: ({ children }: { readonly children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock("@/shared/components/PageHeader", () => ({
+  PageHeader: ({
+    title,
+    actions,
+  }: {
+    readonly title: React.ReactNode
+    readonly actions?: React.ReactNode
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      <div>{actions}</div>
+    </div>
+  ),
+}))
+
+vi.mock("@/shared/components/EmptyState", () => ({
+  EmptyState: ({ title }: { readonly title: string }) => (
+    <div data-testid="empty-state">{title}</div>
+  ),
+}))
+
+vi.mock("@/shared/components/LoadingState", () => ({
+  LoadingState: ({ loading }: { readonly loading: boolean }) =>
+    loading ? <div data-testid="loading-state" /> : null,
+}))
+
+vi.mock("@/shared/components/Skeleton", () => ({
+  ListPageSkeleton: () => <div data-testid="list-skeleton" />,
+}))
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+// --- Helpers ---
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/proj-1/schedules"]}>
+      <ScheduleListPage />
+    </MemoryRouter>,
+  )
+}
+
+// --- Tests ---
+
+describe("ScheduleListPage — effective role wiring (5b)", () => {
+  beforeEach(() => {
+    effectiveState.role = null
+    effectiveState.resolving = false
+  })
+
+  it("shows manage affordances when the effective role mirrors the global producer claim", () => {
+    renderPage()
+
+    expect(
+      screen.getByRole("button", { name: /new call sheet/i }),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("schedule-card")).toHaveAttribute(
+      "data-can-manage",
+      "true",
+    )
+    // No downgrade — the chip stays hidden.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders no manage affordances while the effective role is resolving", () => {
+    effectiveState.resolving = true
+    renderPage()
+
+    expect(
+      screen.queryByRole("button", { name: /new call sheet/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId("schedule-card")).toHaveAttribute(
+      "data-can-manage",
+      "false",
+    )
+    // The chip self-gates while resolving.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("project downgrade to viewer hides manage affordances and shows the role chip", () => {
+    effectiveState.role = "viewer"
+    renderPage()
+
+    expect(
+      screen.queryByRole("button", { name: /new call sheet/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId("schedule-card")).toHaveAttribute(
+      "data-can-manage",
+      "false",
+    )
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
+  })
+
+  it("effective crew gets no manage affordances (schedules are producer/warehouse-gated)", () => {
+    // Member doc says crew: schedules are producer-only — still read-only.
+    effectiveState.role = "crew"
+    renderPage()
+
+    expect(
+      screen.queryByRole("button", { name: /new call sheet/i }),
+    ).not.toBeInTheDocument()
+    expect(screen.getByTestId("schedule-card")).toHaveAttribute(
+      "data-can-manage",
+      "false",
+    )
+  })
+
+  it("producer can manage but not delete (the /schedules delete arm is admin-only)", () => {
+    renderPage()
+
+    const card = screen.getByTestId("schedule-card")
+    expect(card).toHaveAttribute("data-can-manage", "true")
+    expect(card).toHaveAttribute("data-can-delete", "false")
+  })
+
+  it("admin gets the delete affordance", () => {
+    effectiveState.role = "admin"
+    renderPage()
+
+    expect(screen.getByTestId("schedule-card")).toHaveAttribute(
+      "data-can-delete",
+      "true",
+    )
+  })
+})

--- a/src-vnext/features/shots/components/ShotCommentsSection.tsx
+++ b/src-vnext/features/shots/components/ShotCommentsSection.tsx
@@ -52,6 +52,12 @@ export function ShotCommentsSection({
   const [saving, setSaving] = useState(false)
   const [deleteId, setDeleteId] = useState<string | null>(null)
 
+  // The comments create rule is isAuthed + createdBy-self (firestore.rules
+  // comments block), so this double gate (effective-role canComment prop AND
+  // global-claim canManageShots) is UI-stricter than the backend — safe
+  // (fail-toward-fewer). Collapsing onto the effective-role prop alone is a
+  // 5f decision (Q4 viewer commenting) — tracked in the 5b spec deferred
+  // register; do not rewire here.
   const writeEnabled = useMemo(() => {
     if (!canComment) return false
     if (!clientId) return false

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -191,8 +191,10 @@ export function ShotDetailPageUnified() {
   const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectName } = useProjectScope()
 
-  // ONE device-authority read feeding named capability booleans. Mobile edit
-  // enablement requires the rules backstop first — do NOT remove !isMobile here.
+  // ONE device-authority read feeding named capability booleans. The rules
+  // backstop shipped at 5b-I — mobile edit enablement is now Phase 5e's job
+  // (mobile-crew edit / Shoot surface). Do NOT remove !isMobile here; 5e
+  // removes it deliberately behind its own surface gating.
   // Backing rule for the shot writes below: hardened /shots
   // (firestore.rules:435-472, ['producer','crew'] arms).
   const isMobile = useIsMobile()
@@ -204,6 +206,10 @@ export function ShotDetailPageUnified() {
   // firestore.get()), so a project-promoted crew still cannot upload and the
   // UI must not advertise it from the effective role.
   const canUploadShotImages = (globalRole === "admin" || globalRole === "producer") && !isMobile
+  // NO role gate, by locked decision: export is device-only. The export
+  // backend rules (exportTemplates firestore.rules:641-651, exportReports
+  // :868-877) don't gate this affordance; the per-share export toggle is 5f.
+  // Do not add an effective-role (or any role) source here.
   const canExport = !isMobile
   // PINNED to the GLOBAL claim: /shotShares create requires a global producer
   // claim (firestore.rules:193-204) — backend can't see a project promotion.

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -124,6 +124,10 @@ export default function ShotListPage() {
   // claim (firestore.rules:193-204) — the backend cannot see a project
   // promotion, so the UI must not advertise Share from the effective role.
   const canShare = globalRole === "admin" || globalRole === "producer"
+  // NO role gate, by locked decision: export is device-only. The export
+  // backend rules (exportTemplates firestore.rules:641-651, exportReports
+  // :868-877) don't gate this affordance; the per-share export toggle is 5f.
+  // Do not add an effective-role (or any role) source here.
   const canExport = !isMobile
   const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && !isMobile
   // Scene/lane writes (edit, delete, ungroup) consolidate on canEditScene

--- a/src-vnext/features/shots/components/ShotLooksSection.tsx
+++ b/src-vnext/features/shots/components/ShotLooksSection.tsx
@@ -85,6 +85,13 @@ export function ShotLooksSection({
   readonly showReferencesSection?: boolean
 }) {
   const { clientId, user, role } = useAuth()
+  // PINNED to the GLOBAL claim (the canManageProducts(role) half): catalog
+  // writes hit the org-scoped products backend — productFamilies
+  // (firestore.rules:566-574) and skus (:571-574) require a global
+  // isAdmin()||isProducer(), so a project promotion cannot grant catalog
+  // writes and the UI must not advertise them from the effective role. The
+  // canEdit prop half IS effective-role-driven by the parent
+  // (ShotDetailPageUnified → ShotDetailSidebar).
   const canManageCatalog = canEdit && canManageProducts(role)
   const looks = useMemo(
     () => (shot.looks ? [...shot.looks].sort((a, b) => (a.order ?? 0) - (b.order ?? 0)) : []),

--- a/src-vnext/features/shots/components/ShotVersionHistorySection.tsx
+++ b/src-vnext/features/shots/components/ShotVersionHistorySection.tsx
@@ -5,7 +5,9 @@ import { toast } from "sonner"
 import { InlineEmpty } from "@/shared/components/InlineEmpty"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { canRestoreVersions } from "@/shared/lib/rbac"
 import { useShotVersions } from "@/features/shots/hooks/useShotVersions"
 import { restoreShotVersion } from "@/features/shots/lib/shotVersioning"
 import { Button } from "@/ui/button"
@@ -33,7 +35,14 @@ function changeTypeLabel(type: ShotVersion["changeType"]): string {
 }
 
 export function ShotVersionHistorySection({ shot }: { readonly shot: Shot }) {
-  const { clientId, role, user } = useAuth()
+  const { clientId, user } = useAuth()
+  // 5b effective role: restore is a project-scoped shot write — shot update
+  // (firestore.rules:457-472) + version create (:511-516) both carry
+  // shotProjectRole arms, so the member doc WINS over the global claim
+  // (locked Q5/Q6). The Restore affordance renders NOTHING while the first
+  // uncached member read is in flight (roleResolving) — never the global-role
+  // guess. !isMobile is a device concern, not RBAC — it stays here.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const isMobile = useIsMobile()
   const [open, setOpen] = useState(false)
   const [restoreTarget, setRestoreTarget] = useState<ShotVersion | null>(null)
@@ -41,8 +50,8 @@ export function ShotVersionHistorySection({ shot }: { readonly shot: Shot }) {
 
   const canRestore = useMemo(() => {
     if (isMobile) return false
-    return role === "admin" || role === "producer"
-  }, [isMobile, role])
+    return !roleResolving && canRestoreVersions(role)
+  }, [isMobile, roleResolving, role])
 
   const {
     data: versions,
@@ -84,7 +93,7 @@ export function ShotVersionHistorySection({ shot }: { readonly shot: Shot }) {
 
       {open && (
         <div className="border-t border-[var(--color-border)] p-4">
-          {!canRestore && (
+          {!roleResolving && !canRestore && (
             <div className="mb-3 text-xs text-[var(--color-text-subtle)]">
               Restore is producer/admin desktop-only.
             </div>

--- a/src-vnext/features/shots/components/TagManagementPage.tsx
+++ b/src-vnext/features/shots/components/TagManagementPage.tsx
@@ -34,6 +34,8 @@ import { isTagColorKey, type TagColorKey } from "@/shared/lib/tagColors"
 import { findCanonicalTag, normalizeTagLabel } from "@/shared/lib/tagDedup"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { useShots } from "@/features/shots/hooks/useShots"
 import { canManageShots } from "@/shared/lib/rbac"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
@@ -128,10 +130,19 @@ function buildTagLibrary(shots: readonly Shot[]): readonly TagEntry[] {
 }
 
 export default function TagManagementPage() {
-  const { clientId, role } = useAuth()
+  const { clientId } = useAuth()
+  // 5b effective role: the project members doc WINS over the global claim
+  // (locked Q5/Q6). `resolving` is true only during the first uncached member
+  // read for this project.
+  const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectId, projectName } = useProjectScope()
   const isMobile = useIsMobile()
-  const canEdit = canManageShots(role) && !isMobile
+  // Tag rename/merge/recolor/delete batch-update shot docs
+  // (tagManagementWrites.ts) → hardened /shots update arm
+  // (firestore.rules:457-466, project-scoped ['producer','crew']). Write
+  // affordances render NOTHING while the first member read is in flight
+  // (roleResolving) — never the global-role guess.
+  const canEdit = !roleResolving && canManageShots(role) && !isMobile
   const navigate = useNavigate()
 
   const { data: shots, loading, error } = useShots()
@@ -341,12 +352,15 @@ export default function TagManagementPage() {
       <PageHeader
         title="Tags"
         actions={
-          canEdit && mergeIds.length >= 2 ? (
-            <Button variant="outline" onClick={() => setMergeOpen(true)} className="gap-2">
-              <Merge className="h-4 w-4" />
-              Merge ({mergeIds.length})
-            </Button>
-          ) : null
+          <div className="flex items-center gap-2">
+            <EffectiveRoleChip />
+            {canEdit && mergeIds.length >= 2 ? (
+              <Button variant="outline" onClick={() => setMergeOpen(true)} className="gap-2">
+                <Merge className="h-4 w-4" />
+                Merge ({mergeIds.length})
+              </Button>
+            ) : null}
+          </div>
         }
       />
 

--- a/src-vnext/features/shots/components/__tests__/ShotVersionHistorySection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotVersionHistorySection.test.tsx
@@ -26,6 +26,21 @@ vi.mock("@/app/providers/AuthProvider", () => ({
   }),
 }))
 
+// 5b: the section consumes the EFFECTIVE role (member doc wins over the
+// global claim). role: null mirrors the global claim; a string overrides it
+// (downgrade rows); resolving=true pins the first-uncached-read gap.
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? "producer",
+    resolving: effectiveState.resolving,
+  }),
+}))
+
 vi.mock("@/features/shots/hooks/useShotVersions", () => ({
   useShotVersions: vi.fn(),
 }))
@@ -85,6 +100,8 @@ function makeVersion(overrides: Partial<ShotVersion>): ShotVersion {
 describe("ShotVersionHistorySection", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    effectiveState.role = null
+    effectiveState.resolving = false
   })
 
   it("shows empty state when no versions exist", async () => {
@@ -126,6 +143,74 @@ describe("ShotVersionHistorySection", () => {
       currentShot: shot,
       user: expect.objectContaining({ uid: "u1" }),
     })
+  })
+
+  it("renders no Restore affordance (and no hint) while the effective role is resolving", async () => {
+    const user = userEvent.setup()
+    effectiveState.resolving = true
+    ;(useShotVersions as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeVersion({ id: "v-1" })],
+      loading: false,
+      error: null,
+    })
+
+    render(<ShotVersionHistorySection shot={makeShot({})} />)
+    await user.click(screen.getByRole("button", { name: /history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+    // The read-only hint stays hidden too — never flash copy off the
+    // global-role guess during the first uncached member read.
+    expect(
+      screen.queryByText("Restore is producer/admin desktop-only."),
+    ).not.toBeInTheDocument()
+  })
+
+  it("hides Restore for a project-downgraded role (effective viewer)", async () => {
+    const user = userEvent.setup()
+    effectiveState.role = "viewer"
+    ;(useShotVersions as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeVersion({ id: "v-1" })],
+      loading: false,
+      error: null,
+    })
+
+    render(<ShotVersionHistorySection shot={makeShot({})} />)
+    await user.click(screen.getByRole("button", { name: /history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+    expect(
+      screen.getByText("Restore is producer/admin desktop-only."),
+    ).toBeInTheDocument()
+  })
+
+  it("hides Restore for effective crew (UI intentionally narrower than the shot rules)", async () => {
+    const user = userEvent.setup()
+    effectiveState.role = "crew"
+    ;(useShotVersions as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeVersion({ id: "v-1" })],
+      loading: false,
+      error: null,
+    })
+
+    render(<ShotVersionHistorySection shot={makeShot({})} />)
+    await user.click(screen.getByRole("button", { name: /history/i }))
+
+    expect(screen.queryByRole("button", { name: "Restore" })).not.toBeInTheDocument()
+  })
+
+  it("shows Restore for an effective producer (project promotion path)", async () => {
+    const user = userEvent.setup()
+    effectiveState.role = "producer"
+    ;(useShotVersions as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeVersion({ id: "v-1" })],
+      loading: false,
+      error: null,
+    })
+
+    render(<ShotVersionHistorySection shot={makeShot({})} />)
+    await user.click(screen.getByRole("button", { name: /history/i }))
+
+    expect(screen.getByRole("button", { name: "Restore" })).toBeInTheDocument()
   })
 })
 

--- a/src-vnext/features/shots/components/__tests__/TagManagementPage.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/TagManagementPage.test.tsx
@@ -6,8 +6,24 @@ import { MemoryRouter } from "react-router-dom"
 import { Timestamp } from "firebase/firestore"
 import type { Shot } from "@/shared/types"
 
+// 5b test convention: hoisted mutable state — effectiveState.role null means
+// "mirror the global claim" (default matrix), a string overrides it
+// (downgrade rows), resolving=true pins the first-read gap.
+const authState = vi.hoisted(() => ({ role: "producer" }))
+const effectiveState = vi.hoisted(() => ({
+  role: null as string | null,
+  resolving: false,
+}))
+
 vi.mock("@/app/providers/AuthProvider", () => ({
-  useAuth: () => ({ clientId: "c1", role: "producer" }),
+  useAuth: () => ({ clientId: "c1", role: authState.role }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({
+    role: effectiveState.role ?? authState.role,
+    resolving: effectiveState.resolving,
+  }),
 }))
 
 vi.mock("@/app/providers/ProjectScopeProvider", () => ({
@@ -73,9 +89,26 @@ function renderPage() {
   )
 }
 
+function setShots(shots: readonly Shot[]) {
+  ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: shots,
+    loading: false,
+    error: null,
+  })
+}
+
+const taggedShot = () =>
+  makeShot({
+    id: "s1",
+    tags: [{ id: "tag-1", label: "Outdoor", color: "blue" }],
+  })
+
 describe("TagManagementPage", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    authState.role = "producer"
+    effectiveState.role = null
+    effectiveState.resolving = false
   })
 
   it("renames a tag across shots from the Details panel", async () => {
@@ -120,4 +153,70 @@ describe("TagManagementPage", () => {
     })
   })
 
+  it("renders tag-write affordances when the effective role mirrors the global producer claim", async () => {
+    const user = userEvent.setup()
+    setShots([taggedShot()])
+
+    renderPage()
+
+    // Merge checkboxes render only for canEdit roles.
+    expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(0)
+
+    await user.click(screen.getAllByText("Outdoor")[0]!)
+    expect(screen.getByRole("button", { name: /delete/i })).toBeEnabled()
+
+    // No per-project downgrade → the chip renders nothing.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("renders no tag-write affordances while the effective role is resolving", async () => {
+    const user = userEvent.setup()
+    effectiveState.resolving = true
+    setShots([taggedShot()])
+
+    renderPage()
+
+    // The first uncached member read is in flight: never show the
+    // global-role guess.
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0)
+
+    await user.click(screen.getAllByText("Outdoor")[0]!)
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled()
+
+    // The chip is also quiet while resolving.
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  it("hides tag-write affordances when the project member doc downgrades a global producer to viewer", async () => {
+    const user = userEvent.setup()
+    effectiveState.role = "viewer"
+    setShots([taggedShot()])
+
+    renderPage()
+
+    expect(screen.queryAllByRole("checkbox")).toHaveLength(0)
+
+    await user.click(screen.getAllByText("Outdoor")[0]!)
+    expect(screen.getByRole("button", { name: /delete/i })).toBeDisabled()
+
+    // The downgrade is surfaced quietly in the header.
+    expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+      "Viewer on this project",
+    )
+  })
+
+  it("keeps tag-write affordances when the member doc promotes a global viewer to producer", () => {
+    authState.role = "viewer"
+    effectiveState.role = "producer"
+    setShots([taggedShot()])
+
+    renderPage()
+
+    // Project role WINS over the global claim, including upgrades (locked
+    // Q5/Q6) — the /shots update arm is project-scoped, so the affordance
+    // is honest here (unlike the pinned global-rule surfaces).
+    expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(0)
+    // Upgrades render no chip (downgrade-only indicator).
+    expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
 })

--- a/src-vnext/shared/components/AppShell.tsx
+++ b/src-vnext/shared/components/AppShell.tsx
@@ -28,6 +28,11 @@ export function AppShell() {
   const { data: project } = useProject(projectId ?? null)
   const projectName = project?.name
 
+  // PINNED to the GLOBAL claim (5b): the request badge is org-scope chrome and
+  // its subscription reads /shotRequests, which requires a global
+  // admin/producer claim (firestore.rules:410-412) — a project-level promotion
+  // cannot grant it, so the badge (and the read) must not consult the
+  // effective role.
   const canSeeRequestBadge = role === ROLE.ADMIN || role === ROLE.PRODUCER
   const { count: submittedRequestCount } = useSubmittedRequestCount(
     canSeeRequestBadge ? clientId : null,

--- a/src-vnext/shared/components/CommandPalette.tsx
+++ b/src-vnext/shared/components/CommandPalette.tsx
@@ -117,6 +117,11 @@ function CommandPaletteInner({
   }
 
   const showEmpty = query.trim() && grouped && !hasAnyResults(grouped)
+  // PINNED to the GLOBAL claim (5b): the palette is org-scope chrome (mounted
+  // in AppShell, available on every route regardless of project context) and
+  // its admin actions target /admin, whose backing collections /users
+  // (firestore.rules:539-543) and /pendingInvitations (firestore.rules:547-549)
+  // require the global admin claim — never a project-level role.
   const isAdmin = role === ROLE.ADMIN
 
   return (

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -67,6 +67,10 @@ export function buildNavConfig(projectId?: string, role?: string): NavConfig {
       { type: "item", item: { label: "Dashboard", to: "/projects", iconName: "layout-grid" } },
     ]
 
+    // PINNED to the GLOBAL claim (5b): this branch only renders on org-scope
+    // routes (no projectId, no ProjectScopeProvider), so `role` here is the
+    // global claim by construction. Backing rule: /shotRequests read requires a
+    // global admin/producer claim (firestore.rules:410-412).
     if (role === ROLE.ADMIN || role === ROLE.PRODUCER) {
       entries.push({
         type: "item",
@@ -86,6 +90,10 @@ export function buildNavConfig(projectId?: string, role?: string): NavConfig {
       },
     )
 
+    // PINNED to the GLOBAL claim (5b): Admin nav is org-scope chrome — the
+    // /admin surface reads /users (firestore.rules:539-543) and
+    // /pendingInvitations (firestore.rules:547-549), both gated on the global
+    // admin claim; a project-level role can never grant or revoke it.
     if (role === ROLE.ADMIN) {
       entries.push(
         { type: "divider" },

--- a/src-vnext/shared/lib/rbac.test.ts
+++ b/src-vnext/shared/lib/rbac.test.ts
@@ -9,10 +9,8 @@ import {
   canGeneratePulls,
   canManagePulls,
   canFulfillPulls,
-  isViewer,
-  canSubmitShotRequest,
-  canTriageShotRequests,
   canEditScene,
+  canRestoreVersions,
   roleRank,
 } from "./rbac"
 
@@ -182,59 +180,6 @@ describe("permission checks", () => {
     })
   })
 
-  describe("isViewer", () => {
-    it("viewer is viewer", () => {
-      expect(isViewer("viewer")).toBe(true)
-    })
-
-    it("admin is not viewer", () => {
-      expect(isViewer("admin")).toBe(false)
-    })
-  })
-
-  describe("canSubmitShotRequest", () => {
-    it("admin can submit shot requests", () => {
-      expect(canSubmitShotRequest("admin")).toBe(true)
-    })
-
-    it("producer can submit shot requests", () => {
-      expect(canSubmitShotRequest("producer")).toBe(true)
-    })
-
-    it("crew cannot submit shot requests", () => {
-      expect(canSubmitShotRequest("crew")).toBe(false)
-    })
-
-    it("warehouse cannot submit shot requests", () => {
-      expect(canSubmitShotRequest("warehouse")).toBe(false)
-    })
-
-    it("viewer cannot submit shot requests", () => {
-      expect(canSubmitShotRequest("viewer")).toBe(false)
-    })
-  })
-
-  describe("canTriageShotRequests", () => {
-    it("admin can triage shot requests", () => {
-      expect(canTriageShotRequests("admin")).toBe(true)
-    })
-
-    it("producer can triage shot requests", () => {
-      expect(canTriageShotRequests("producer")).toBe(true)
-    })
-
-    it("crew cannot triage shot requests", () => {
-      expect(canTriageShotRequests("crew")).toBe(false)
-    })
-
-    it("warehouse cannot triage shot requests", () => {
-      expect(canTriageShotRequests("warehouse")).toBe(false)
-    })
-
-    it("viewer cannot triage shot requests", () => {
-      expect(canTriageShotRequests("viewer")).toBe(false)
-    })
-  })
 })
 
 describe("canEditScene", () => {
@@ -259,6 +204,31 @@ describe("canEditScene", () => {
 
   it("viewer cannot edit scenes", () => {
     expect(canEditScene("viewer")).toBe(false)
+  })
+})
+
+describe("canRestoreVersions", () => {
+  // Consolidates the 5a version-history twins (shot + product History
+  // sections). Intentionally narrower than the shot rules' ['producer','crew']
+  // arms — crew stays excluded until a 5e/5f decision widens it.
+  it("admin can restore versions", () => {
+    expect(canRestoreVersions("admin")).toBe(true)
+  })
+
+  it("producer can restore versions", () => {
+    expect(canRestoreVersions("producer")).toBe(true)
+  })
+
+  it("crew cannot restore versions (UI narrower than the shot rules on purpose)", () => {
+    expect(canRestoreVersions("crew")).toBe(false)
+  })
+
+  it("warehouse cannot restore versions", () => {
+    expect(canRestoreVersions("warehouse")).toBe(false)
+  })
+
+  it("viewer cannot restore versions", () => {
+    expect(canRestoreVersions("viewer")).toBe(false)
   })
 })
 

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -82,20 +82,8 @@ export function canManageLocations(role: Role): boolean {
   return role === ROLE.ADMIN || role === ROLE.PRODUCER
 }
 
-export function isViewer(role: Role): boolean {
-  return role === ROLE.VIEWER
-}
-
 export function isAdmin(role: Role): boolean {
   return role === ROLE.ADMIN
-}
-
-export function canSubmitShotRequest(role: Role): boolean {
-  return role === ROLE.ADMIN || role === ROLE.PRODUCER
-}
-
-export function canTriageShotRequests(role: Role): boolean {
-  return role === ROLE.ADMIN || role === ROLE.PRODUCER
 }
 
 export function canManageCasting(role: Role): boolean {
@@ -112,6 +100,19 @@ export function canManageCasting(role: Role): boolean {
 // 'warehouse' from this helper AND from the lanes rule role lists.
 export function canEditScene(role: Role): boolean {
   return role === ROLE.ADMIN || role === ROLE.PRODUCER || role === ROLE.WAREHOUSE
+}
+
+// Version-history restore (shot + product detail History sections). Backing
+// rules differ per surface: shot restore = shot update (firestore.rules:457-472)
+// + version create (:511-516), both project-scoped via shotProjectRole
+// (['producer','crew'] arms); product restore = productFamilies update (:568)
+// + version create (:614-616), GLOBAL isAdmin || isProducer. The shot section
+// feeds this the EFFECTIVE role; the product section stays PINNED to the
+// global claim (org-backend rule). UI is intentionally narrower than the shot
+// rules (crew excluded) — behavior-preserving consolidation of the 5a twins;
+// widening to crew is a 5e/5f decision, not a cleanup.
+export function canRestoreVersions(role: Role): boolean {
+  return role === ROLE.ADMIN || role === ROLE.PRODUCER
 }
 
 // Total order over roles for "is this a downgrade" comparisons (the 5b


### PR DESCRIPTION
## Summary

Phase 5b-II of the redesign: the consumer-wiring tranche deferred from 5b-I (per the 5b build spec's per-gate source table). Project-scoped capability gates outside the shots surface now consume `useEffectiveRole() { role, resolving }` — the same source the hardened rules read — instead of the global claim. Built via a 36-agent scout→build→adversarial-verify workflow; every rewired gate was traced against `firestore.rules` + `storage.rules` for all five roles, member AND non-member. `firestore.rules` / `storage.rules` are NOT touched by this PR.

### Wired to the effective role (resolving-gated: write affordances render NOTHING while the first member read resolves)
- **Pulls**: `PullListPage` showCreate, `PullDetailPage` canEdit/canFulfill (backing rule: project-scoped `/pulls` write arm, firestore.rules:757-766)
- **Schedules**: `ScheduleListPage`, `CreateScheduleDialog`, `CallSheetBuilderPage` (builder-vs-preview fork skeletons while resolving; `/schedules` :794-801 + subcollections)
- **Casting board edit**: Add Talent / status / votes / remove (project wildcard write arm). The **Share button is split out** and stays on the global claim — `/castingShares` create is global-producer (:227-231); the backend cannot see a project promotion
- **Project assets**: effective AND global (the actual writes are arrayUnion/arrayRemove on org-scoped talent/locations/crew docs whose rules read the GLOBAL claim — the AND is the rules-honest shape; both rule sets cited in code)
- **Tag management**: rename/merge/delete batch-write shot docs → hardened `/shots` update arm
- **Shot version restore**: restore writes the shot doc → hardened `/shots` update arm

### Rules-honesty fix surfaced by the adversarial trace
- **Schedules Delete is now admin-only in the UI** (`canDelete` split from `canManage` in `ScheduleListPage`/`ScheduleCard`): the `/schedules` delete arm is admin-only (firestore.rules:801) while the affordance was admin||producer-gated — a producer got permission-denied. Pre-existing gap, fixed here because this PR rewires that gate; test-pinned.

### Casting Book batch split
`bookCastingTalent` gains `includeTalentBacklink`: the talent-doc `projectIds` arrayUnion only rides the atomic batch when the caller's global claim passes the talent rules (org-scoped, global admin/producer). A talent booked by a project-PROMOTED member skips the backlink (drift tracked in the 5b spec deferred register, owner 5f) instead of failing the whole batch.

### Pinned gates (zero behavior change, annotated with backing rule lines)
Shares (`canShare`), casting shares / shared links, image uploads (`canUploadShotImages`, storage is global-claim-only), products/library/org dashboards, `RequireRole`, nav-config, CommandPalette admin, request centre, `ShotLooksSection` canManageCatalog, ShootReadinessWidget, project dialogs — 28 pins, each with a code comment citing its rule.

### Cleanup (deferred-register items)
- Dead rbac helpers deleted: `isViewer`, `canSubmitShotRequest`, `canTriageShotRequests` (repo-wide grep: zero consumers)
- Version-history twins consolidated into `canRestoreVersions` in rbac.ts (shot section = effective role; product section stays global per the productFamilies rules — behavior-preserving)
- `ProjectAccessTab`: surfaces each member's effective access (admin diagnostic, normalizeRole/roleRank parity with the hook)
- `ShotDetailPageUnified` :191-192 comment handed off to 5e
- `ShotCommentsSection` double-gate residue annotated + tracked for 5f (Q4 viewer commenting) — no behavior change
- ProjectScopeProvider hoist **assessed and SKIPPED** (medium risk: a `projects/:id` layout route would swallow OnSetViewerPage, which must stay outside the provider) — deferred to Phase 6

### Intentional dispositions (for review)
- **UI-only downgrades are accepted by design** (locked 2026-06-10): a project-downgraded global producer keeps a rules lane via `producerCanAccessProject`. Not a finding.
- **UI-hidden / rules-allow combos are fail-toward-fewer** and acceptable.
- `canFulfillPulls` stays admin||warehouse (UI-stricter than the rule's producer arm) — deliberate.

## Test plan
- 114 targeted tests across 13 files green locally (`CI=1 npm test -- --run <file>`): new consumer tests per wired gate asserting (a) resolving hides write affordances, (b) member-doc role wins over the global claim, (c) downgrade shows the role chip; rbac tests updated for deleted helpers + `canRestoreVersions`; schedules admin-only-delete pins
- lint 0/0, production build clean
- CI `ui-checks` (job `test`, incl. the emulator rules lane) is the final arbiter