### PR TITLE
feat(shots): Phase 5e-I — resolver affordances/chrome outputs + device-authority subsumption

### DIFF
--- a/src-vnext/features/shots/components/ProductColorwayStrip.tsx
+++ b/src-vnext/features/shots/components/ProductColorwayStrip.tsx
@@ -1,0 +1,90 @@
+// Product colorway strip — pure-text typographic centerpiece (read-only; writes stay in the right rail).
+// Extracted from ShotDetailPageUnified (Phase 5e-I): the Shoot shell (5e-II)
+// and the Review surface (5f) reuse it — this extraction is the 5e/5f
+// presentational seam. Behavior-preserving: markup, classes, and testids are
+// identical to the private original.
+import { SectionLabel } from "@/features/shots/components/ShotDetailShared"
+import type { ShotLook } from "@/shared/types"
+
+export function ProductColorwayStrip({
+  looks,
+  activeLookId,
+}: {
+  readonly looks: ReadonlyArray<ShotLook>
+  readonly activeLookId: string | null | undefined
+}) {
+  const sorted = [...looks].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const productCount = sorted.reduce((acc, l) => acc + (l.products?.length ?? 0), 0)
+  const resolvedActiveId =
+    activeLookId && sorted.some((l) => l.id === activeLookId)
+      ? activeLookId
+      : sorted.length > 0
+        ? sorted[0]!.id
+        : null
+
+  return (
+    <section
+      className="border-t border-[var(--color-border)] pt-4"
+      data-testid="product-colorway-strip"
+    >
+      <div className="flex items-baseline gap-2">
+        <SectionLabel>Products</SectionLabel>
+        {sorted.length > 0 && (
+          <span className="text-2xs text-[var(--color-text-subtle)]">
+            {productCount} {productCount === 1 ? "item" : "items"} &middot; {sorted.length}{" "}
+            {sorted.length === 1 ? "look" : "looks"}
+          </span>
+        )}
+      </div>
+
+      {sorted.length === 0 ? (
+        <p className="mt-1.5 text-sm text-[var(--color-text-muted)]">
+          No products yet. Add a look in the rail.
+        </p>
+      ) : (
+        sorted.map((look) => (
+          <div key={look.id} className="mt-3 first-of-type:mt-2">
+            <p className="label-meta">
+              {look.label || "Look"}
+              {look.id === resolvedActiveId ? <> &middot; Active</> : null}
+            </p>
+            {(look.products ?? []).length === 0 ? (
+              <p className="py-1 text-sm text-[var(--color-text-muted)]">
+                No products in this look.
+              </p>
+            ) : (
+              (look.products ?? []).map((p, i) => (
+                <div
+                  key={`${p.familyId}-${p.colourId ?? p.skuId ?? ""}-${i}`}
+                  className="flex flex-wrap items-baseline gap-x-2.5 py-1"
+                >
+                  <span className="text-base font-semibold text-[var(--color-text)]">
+                    {p.familyName ?? p.familyId}
+                  </span>
+                  {(p.colourName || p.size) && (
+                    <span className="text-sm text-[var(--color-text-secondary)]">
+                      {p.colourName && (
+                        <>
+                          &middot;{" "}
+                          <span className="font-semibold text-[var(--color-text)]">
+                            {p.colourName}
+                          </span>
+                        </>
+                      )}
+                      {p.size && <> &middot; {p.size}</>}
+                    </span>
+                  )}
+                  {p.skuName && (
+                    <span className="ml-auto text-2xs tabular-nums text-[var(--color-text-subtle)]">
+                      {p.skuName}
+                    </span>
+                  )}
+                </div>
+              ))
+            )}
+          </div>
+        ))
+      )}
+    </section>
+  )
+}

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -29,6 +29,7 @@ import { ShotReferenceLinksSection } from "@/features/shots/components/ShotRefer
 import { SceneContextBanner } from "@/features/shots/components/SceneContextBanner"
 import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { ShotDetailSidebar } from "@/features/shots/components/ShotDetailSidebar"
+import { ProductColorwayStrip } from "@/features/shots/components/ProductColorwayStrip"
 import { ShotDetailQuickAdd } from "@/features/shots/components/ShotDetailQuickAdd"
 import { readShotListNavOrder } from "@/features/shots/lib/shotListNavOrder"
 import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
@@ -39,7 +40,8 @@ import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 import { canEditScene as canEditSceneForRole, canManageShots } from "@/shared/lib/rbac"
 import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
-import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { useIsMobile, useIsDesktop } from "@/shared/hooks/useMediaQuery"
+import { useResolvedSurface } from "@/features/shots/hooks/useResolvedSurface"
 import { textPreview } from "@/shared/lib/textPreview"
 import {
   SectionLabel,
@@ -55,7 +57,6 @@ import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
 import { ActiveEditorsBar } from "@/features/shots/components/ActiveEditorsBar"
 import { SHOT_STATUS_CYCLE } from "@/shared/lib/statusMappings"
-import type { ShotLook } from "@/shared/types"
 
 // ---------------------------------------------------------------------------
 // Meta line segment (one editorial line replacing the three MetaEditorCards)
@@ -89,93 +90,6 @@ function MetaDot() {
 }
 
 // ---------------------------------------------------------------------------
-// Product colorway strip — pure-text typographic centerpiece (read-only; writes stay in the right rail).
-// ---------------------------------------------------------------------------
-
-function ProductColorwayStrip({
-  looks,
-  activeLookId,
-}: {
-  readonly looks: ReadonlyArray<ShotLook>
-  readonly activeLookId: string | null | undefined
-}) {
-  const sorted = [...looks].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-  const productCount = sorted.reduce((acc, l) => acc + (l.products?.length ?? 0), 0)
-  const resolvedActiveId =
-    activeLookId && sorted.some((l) => l.id === activeLookId)
-      ? activeLookId
-      : sorted.length > 0
-        ? sorted[0]!.id
-        : null
-
-  return (
-    <section
-      className="border-t border-[var(--color-border)] pt-4"
-      data-testid="product-colorway-strip"
-    >
-      <div className="flex items-baseline gap-2">
-        <SectionLabel>Products</SectionLabel>
-        {sorted.length > 0 && (
-          <span className="text-2xs text-[var(--color-text-subtle)]">
-            {productCount} {productCount === 1 ? "item" : "items"} &middot; {sorted.length}{" "}
-            {sorted.length === 1 ? "look" : "looks"}
-          </span>
-        )}
-      </div>
-
-      {sorted.length === 0 ? (
-        <p className="mt-1.5 text-sm text-[var(--color-text-muted)]">
-          No products yet. Add a look in the rail.
-        </p>
-      ) : (
-        sorted.map((look) => (
-          <div key={look.id} className="mt-3 first-of-type:mt-2">
-            <p className="label-meta">
-              {look.label || "Look"}
-              {look.id === resolvedActiveId ? <> &middot; Active</> : null}
-            </p>
-            {(look.products ?? []).length === 0 ? (
-              <p className="py-1 text-sm text-[var(--color-text-muted)]">
-                No products in this look.
-              </p>
-            ) : (
-              (look.products ?? []).map((p, i) => (
-                <div
-                  key={`${p.familyId}-${p.colourId ?? p.skuId ?? ""}-${i}`}
-                  className="flex flex-wrap items-baseline gap-x-2.5 py-1"
-                >
-                  <span className="text-base font-semibold text-[var(--color-text)]">
-                    {p.familyName ?? p.familyId}
-                  </span>
-                  {(p.colourName || p.size) && (
-                    <span className="text-sm text-[var(--color-text-secondary)]">
-                      {p.colourName && (
-                        <>
-                          &middot;{" "}
-                          <span className="font-semibold text-[var(--color-text)]">
-                            {p.colourName}
-                          </span>
-                        </>
-                      )}
-                      {p.size && <> &middot; {p.size}</>}
-                    </span>
-                  )}
-                  {p.skuName && (
-                    <span className="ml-auto text-2xs tabular-nums text-[var(--color-text-subtle)]">
-                      {p.skuName}
-                    </span>
-                  )}
-                </div>
-              ))
-            )}
-          </div>
-        ))
-      )}
-    </section>
-  )
-}
-
-// ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 
@@ -191,26 +105,45 @@ export function ShotDetailPageUnified() {
   const { role, resolving: roleResolving } = useEffectiveRole()
   const { projectName } = useProjectScope()
 
-  // ONE device-authority read feeding named capability booleans. The rules
-  // backstop shipped at 5b-I — mobile edit enablement is now Phase 5e's job
-  // (mobile-crew edit / Shoot surface). Do NOT remove !isMobile here; 5e
-  // removes it deliberately behind its own surface gating.
+  // ONE device-authority read feeding named capability booleans — the device
+  // terms flow through resolveSurface's affordances since 5e-I, reproducing
+  // today's `!isMobile` values exactly. The VALUE flips (mobile-crew edit /
+  // Shoot surface) happen at 5e-II behind featureShootSurface. The resolver
+  // output stays presentation-only: each affordance replaces ONLY the device
+  // term of its gate — the role/global-claim terms stay HERE.
   // Backing rule for the shot writes below: hardened /shots
   // (firestore.rules:435-472, ['producer','crew'] arms).
+  //
+  // affordances are null while resolving (first uncached member read / auth
+  // settling) — every gate must keep TODAY'S value through that gap: the
+  // role-gated flags already collapse via !roleResolving, but the role-free/
+  // global-pinned ones (export, share, upload, status control) stay live, so
+  // their device terms fall back to the raw device reads.
   const isMobile = useIsMobile()
-  const canEdit = !roleResolving && canManageShots(role) && !isMobile
+  const isDesktop = useIsDesktop()
+  const { affordances, chrome } = useResolvedSurface()
+  const canEdit =
+    !roleResolving && canManageShots(role) && (affordances?.fieldEditing ?? !isMobile)
   const canDoOperational = !roleResolving && canManageShots(role)
-  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  const canManageLifecycle =
+    !roleResolving &&
+    (role === "admin" || role === "producer") &&
+    (affordances?.lifecycle ?? !isMobile)
   // PINNED to the GLOBAL claim: storage.rules sees only the auth token
   // (isProducerOrWardrobe, storage.rules:15-25 — no cross-service
   // firestore.get()), so a project-promoted crew still cannot upload and the
   // UI must not advertise it from the effective role.
-  const canUploadShotImages = (globalRole === "admin" || globalRole === "producer") && !isMobile
+  const canUploadShotImages =
+    (globalRole === "admin" || globalRole === "producer") &&
+    (affordances?.imageUpload ?? !isMobile)
   // NO role gate, by locked decision: export is device-only. The export
   // backend rules (exportTemplates firestore.rules:641-651, exportReports
   // :868-877) don't gate this affordance; the per-share export toggle is 5f.
   // Do not add an effective-role (or any role) source here.
-  const canExport = !isMobile
+  // 5e-I named sub-delta: affordances.export keys to device === 'desktop' —
+  // the export route's RequireDesktop needs ≥1024px, so today's 768-1023
+  // tablet button dead-ended in a toast+redirect. Fallback matches.
+  const canExport = affordances?.export ?? isDesktop
   // PINNED to the GLOBAL claim: /shotShares create requires a global producer
   // claim (firestore.rules:193-204) — backend can't see a project promotion.
   const canShare = globalRole === "admin" || globalRole === "producer"
@@ -219,6 +152,9 @@ export function ShotDetailPageUnified() {
   // /lanes rule (firestore.rules:880-882, :901-904 — already project-aware;
   // warehouse keeps lane-write until 5f per locked Q3).
   const canEditScene = !roleResolving && canEditSceneForRole(role)
+  // Status-control fork keyed off chrome (5e-I): 'tap-row' iff mobile —
+  // zero delta vs the old isMobile ternary; 5e-II reshapes it per surface.
+  const statusControl = chrome?.statusControl ?? (isMobile ? "tap-row" : "badge-select")
 
   const [shareOpen, setShareOpen] = useState(false)
   const [sceneSheetOpen, setSceneSheetOpen] = useState(false)
@@ -441,7 +377,7 @@ export function ShotDetailPageUnified() {
                 Export
               </Button>
             )}
-            {canShare && !isMobile && (
+            {canShare && (affordances?.share ?? !isMobile) && (
               <Button variant="outline" onClick={() => setShareOpen(true)}>
                 Share
               </Button>
@@ -466,7 +402,7 @@ export function ShotDetailPageUnified() {
                 shot.shotNumber && <span>#{shot.shotNumber}</span>
               )}
             </span>
-            {!isMobile && (
+            {statusControl === "badge-select" && (
               <ShotStatusSelect
                 shotId={shot.id}
                 currentStatus={shot.status}
@@ -498,7 +434,7 @@ export function ShotDetailPageUnified() {
           </div>
 
           {/* Mobile: full-width status tap row (today's behavior, unchanged) */}
-          {isMobile && canDoOperational && <ShotStatusTapRow shot={shot} />}
+          {statusControl === "tap-row" && canDoOperational && <ShotStatusTapRow shot={shot} />}
         </header>
 
         {/* ── Scene context banner ── */}

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -123,8 +123,8 @@ export default function ShotListPage() {
   // hardened /shots (firestore.rules:435-472, ['producer','crew'] arms).
   const showCreate = !roleResolving && canManageShots(role)
   const canReorder = !roleResolving && canManageShots(role)
-  const canBulkPull = !roleResolving && canGeneratePulls(role) && (affordances?.bulkPull ?? false)
-  const canRepair = !roleResolving && (role === "admin" || role === "producer") && (affordances?.repair ?? false)
+  const canBulkPull = !roleResolving && canGeneratePulls(role) && (affordances?.bulkPull ?? !isMobile)
+  const canRepair = !roleResolving && (role === "admin" || role === "producer") && (affordances?.repair ?? !isMobile)
   // PINNED to the GLOBAL claim: /shotShares create requires a global producer
   // claim (firestore.rules:193-204) — the backend cannot see a project
   // promotion, so the UI must not advertise Share from the effective role.
@@ -140,7 +140,7 @@ export default function ShotListPage() {
   // Export rendered immediately on desktop (no flash-of-missing) and hidden
   // on tablet/mobile throughout — same device keying, pinned in tests.
   const canExport = affordances?.export ?? isDesktop
-  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && (affordances?.lifecycle ?? false)
+  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && (affordances?.lifecycle ?? !isMobile)
   // Scene/lane writes (edit, delete, ungroup) consolidate on canEditScene
   // (rbac.ts), which mirrors the /lanes rule (firestore.rules:880-882,
   // :901-904 — already project-aware). Crew users see the scene grouping UI

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -15,6 +15,7 @@ import { ShotQuickAdd } from "@/features/shots/components/ShotQuickAdd"
 import { ShotsTable, REORDER_SHOT_LIMIT } from "@/features/shots/components/ShotsTable"
 import { resolveReorderDisabledReason } from "@/features/shots/components/DisabledDragHandle"
 import { useShotListState } from "@/features/shots/hooks/useShotListState"
+import { useResolvedSurface } from "@/features/shots/hooks/useResolvedSurface"
 import type { SurfaceDevice } from "@/features/shots/lib/resolveSurface"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
@@ -60,6 +61,10 @@ export default function ShotListPage() {
   const navigate = useNavigate()
   const isMobile = useIsMobile()
   const isDesktop = useIsDesktop()
+  // 5e-I: resolved-surface affordances replace ONLY the device terms of the
+  // flags below (resolveSurface output is presentation-only by law) — every
+  // role/rbac term stays here. null while auth/role resolve.
+  const { affordances } = useResolvedSurface()
   const { data: talentRecords } = useTalent()
   const { data: locationRecords } = useLocations()
   const { data: productFamilies } = useProductFamilies()
@@ -118,8 +123,8 @@ export default function ShotListPage() {
   // hardened /shots (firestore.rules:435-472, ['producer','crew'] arms).
   const showCreate = !roleResolving && canManageShots(role)
   const canReorder = !roleResolving && canManageShots(role)
-  const canBulkPull = !roleResolving && canGeneratePulls(role) && !isMobile
-  const canRepair = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  const canBulkPull = !roleResolving && canGeneratePulls(role) && (affordances?.bulkPull ?? false)
+  const canRepair = !roleResolving && (role === "admin" || role === "producer") && (affordances?.repair ?? false)
   // PINNED to the GLOBAL claim: /shotShares create requires a global producer
   // claim (firestore.rules:193-204) — the backend cannot see a project
   // promotion, so the UI must not advertise Share from the effective role.
@@ -128,8 +133,14 @@ export default function ShotListPage() {
   // backend rules (exportTemplates firestore.rules:641-651, exportReports
   // :868-877) don't gate this affordance; the per-share export toggle is 5f.
   // Do not add an effective-role (or any role) source here.
-  const canExport = !isMobile
-  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && !isMobile
+  // 5e-I: now DESKTOP-keyed (affordances.export), matching the export route's
+  // RequireDesktop (≥1024px) — the named tablet fix: today's 768-1023px Export
+  // button dead-ends in RequireDesktop's toast+redirect. With no role term to
+  // wait on, falling back to `isDesktop` while affordances resolve keeps
+  // Export rendered immediately on desktop (no flash-of-missing) and hidden
+  // on tablet/mobile throughout — same device keying, pinned in tests.
+  const canExport = affordances?.export ?? isDesktop
+  const canManageLifecycle = !roleResolving && (role === "admin" || role === "producer") && (affordances?.lifecycle ?? false)
   // Scene/lane writes (edit, delete, ungroup) consolidate on canEditScene
   // (rbac.ts), which mirrors the /lanes rule (firestore.rules:880-882,
   // :901-904 — already project-aware). Crew users see the scene grouping UI

--- a/src-vnext/features/shots/components/ShotVersionHistorySection.tsx
+++ b/src-vnext/features/shots/components/ShotVersionHistorySection.tsx
@@ -6,7 +6,7 @@ import { InlineEmpty } from "@/shared/components/InlineEmpty"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
 import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
-import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { useResolvedSurface } from "@/features/shots/hooks/useResolvedSurface"
 import { canRestoreVersions } from "@/shared/lib/rbac"
 import { useShotVersions } from "@/features/shots/hooks/useShotVersions"
 import { restoreShotVersion } from "@/features/shots/lib/shotVersioning"
@@ -41,17 +41,21 @@ export function ShotVersionHistorySection({ shot }: { readonly shot: Shot }) {
   // shotProjectRole arms, so the member doc WINS over the global claim
   // (locked Q5/Q6). The Restore affordance renders NOTHING while the first
   // uncached member read is in flight (roleResolving) — never the global-role
-  // guess. !isMobile is a device concern, not RBAC — it stays here.
+  // guess. The device concern lives in resolveSurface's affordances since
+  // 5e-I (versionRestore — same value as the old isMobile kill-switch); the
+  // ROLE term stays here: canRestoreVersions deliberately excludes crew (UI
+  // narrower than the rules; crew-widening is a 5f decision).
   const { role, resolving: roleResolving } = useEffectiveRole()
-  const isMobile = useIsMobile()
+  const { affordances } = useResolvedSurface()
   const [open, setOpen] = useState(false)
   const [restoreTarget, setRestoreTarget] = useState<ShotVersion | null>(null)
   const [restoring, setRestoring] = useState(false)
 
   const canRestore = useMemo(() => {
-    if (isMobile) return false
+    // null affordances == resolving — same false as the roleResolving term.
+    if (!affordances?.versionRestore) return false
     return !roleResolving && canRestoreVersions(role)
-  }, [isMobile, roleResolving, role])
+  }, [affordances, roleResolving, role])
 
   const {
     data: versions,

--- a/src-vnext/features/shots/components/__tests__/ProductColorwayStrip.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ProductColorwayStrip.test.tsx
@@ -1,0 +1,95 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 5e-I extraction pin (build spec, PR partition 5e-I).
+//
+// ProductColorwayStrip moved out of ShotDetailPageUnified into its own file
+// so the Shoot shell (5e-II) and the Review surface (5f) can reuse it. These
+// tests pin the extracted component's rendering contract — same testids, same
+// markup as the private original — so the extraction stays behavior-free.
+import { describe, it, expect } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ProductColorwayStrip } from "@/features/shots/components/ProductColorwayStrip"
+import type { ShotLook } from "@/shared/types"
+
+const looks: ShotLook[] = [
+  {
+    id: "look-2",
+    label: "Look B",
+    order: 2,
+    products: [
+      {
+        familyId: "fam-2",
+        familyName: "Merino Hoodie",
+        colourId: "col-2",
+        colourName: "Charcoal",
+        size: "L",
+        skuId: "sku-2",
+        skuName: "MH-CHAR-L",
+      },
+    ],
+  },
+  {
+    id: "look-1",
+    label: "Look A",
+    order: 1,
+    products: [
+      { familyId: "fam-1", familyName: "Merino Tee" },
+      { familyId: "fam-3" },
+    ],
+  },
+]
+
+describe("ProductColorwayStrip", () => {
+  it("renders looks sorted by order with item/look counts and marks the active look", () => {
+    render(<ProductColorwayStrip looks={looks} activeLookId="look-2" />)
+
+    expect(screen.getByTestId("product-colorway-strip")).toBeInTheDocument()
+    expect(screen.getByText("3 items · 2 looks")).toBeInTheDocument()
+
+    // Sorted by `order`: Look A (order 1) before Look B (order 2).
+    const labels = screen
+      .getAllByText(/^Look [AB]/)
+      .map((el) => el.textContent)
+    expect(labels).toEqual(["Look A", "Look B · Active"])
+  })
+
+  it("falls back to the first sorted look when activeLookId does not match any look", () => {
+    render(<ProductColorwayStrip looks={looks} activeLookId="look-gone" />)
+
+    // Look A is first after sorting, so it inherits the Active marker.
+    expect(screen.getByText("Look A · Active")).toBeInTheDocument()
+    expect(screen.getByText("Look B")).toBeInTheDocument()
+  })
+
+  it("renders the empty state when there are no looks", () => {
+    render(<ProductColorwayStrip looks={[]} activeLookId={null} />)
+
+    expect(screen.getByTestId("product-colorway-strip")).toBeInTheDocument()
+    expect(
+      screen.getByText("No products yet. Add a look in the rail."),
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/items ·/)).not.toBeInTheDocument()
+  })
+
+  it("renders product line fields: family, colour, size, and sku", () => {
+    render(<ProductColorwayStrip looks={looks} activeLookId="look-2" />)
+
+    // Full product line (Look B).
+    expect(screen.getByText("Merino Hoodie")).toBeInTheDocument()
+    expect(screen.getByText("Charcoal")).toBeInTheDocument()
+    expect(screen.getByText(/· L/)).toBeInTheDocument()
+    expect(screen.getByText("MH-CHAR-L")).toBeInTheDocument()
+
+    // Sparse lines (Look A): name-only product, and familyId fallback when
+    // familyName is missing.
+    expect(screen.getByText("Merino Tee")).toBeInTheDocument()
+    expect(screen.getByText("fam-3")).toBeInTheDocument()
+  })
+
+  it("renders the per-look empty message when a look has no products", () => {
+    const emptyLook: ShotLook[] = [{ id: "look-empty", label: "Bare", products: [] }]
+    render(<ProductColorwayStrip looks={emptyLook} activeLookId={null} />)
+
+    expect(screen.getByText("0 items · 1 look")).toBeInTheDocument()
+    expect(screen.getByText("No products in this look.")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotDetailPageUnified.test.tsx
@@ -81,12 +81,16 @@ vi.mock("@/shared/hooks/useEffectiveRole", () => ({
   }),
 }))
 
-// Desktop mode.
+// Desktop by default; per-test override for the 5e-I tablet export pin.
+const deviceState = vi.hoisted(() => ({
+  device: "desktop" as "mobile" | "tablet" | "desktop",
+}))
+
 vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useMediaQuery: () => false,
-  useIsMobile: () => false,
-  useIsTablet: () => false,
-  useIsDesktop: () => true,
+  useIsMobile: () => deviceState.device === "mobile",
+  useIsTablet: () => deviceState.device === "tablet",
+  useIsDesktop: () => deviceState.device === "desktop",
 }))
 
 vi.mock("@/features/shots/hooks/usePickerData", () => ({
@@ -251,6 +255,7 @@ describe("ShotDetailPageUnified", () => {
     effectiveState.resolving = false
     laneState.lanes = []
     laneState.laneById = new Map()
+    deviceState.device = "desktop"
   })
 
   it("renders the scan-path order: description, hero, products, meta, notes, links, tags, comments, history, rail", () => {
@@ -479,6 +484,40 @@ describe("ShotDetailPageUnified", () => {
     renderPage()
 
     expectAllWriteAffordances()
+  })
+
+  // ── 5e-I named sub-delta: export keys to device === 'desktop' ─────────────
+
+  it("tablet (768-1023): Export hidden — the route's RequireDesktop needs ≥1024px; every other gate keeps its non-mobile value", () => {
+    deviceState.device = "tablet"
+    mockShot()
+
+    renderPage()
+
+    // The one intentional 5e-I behavior change: the tablet Export button
+    // dead-ended in RequireDesktop's toast+redirect — affordances.export
+    // now keys to desktop, so it no longer mounts.
+    expect(screen.queryByRole("button", { name: "Export" })).not.toBeInTheDocument()
+    // Everything else on tablet is byte-identical to today's !isMobile gates.
+    expect(screen.getByTestId("shot-title-edit")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+    expect(screen.getByTestId("lifecycle-actions-stub")).toBeInTheDocument()
+    expect(screen.getByTestId("hero-stub")).toHaveAttribute("data-can-upload", "true")
+    // statusControl stays 'badge-select' off-mobile: select renders, no tap row.
+    expect(screen.getByTestId("shot-status-select-trigger")).toBeInTheDocument()
+    expect(screen.queryByTestId("status-tap-row")).not.toBeInTheDocument()
+  })
+
+  it("mobile: the chrome statusControl fork renders the tap row, not the badge select (zero-delta)", () => {
+    deviceState.device = "mobile"
+    mockShot()
+
+    renderPage()
+
+    expect(screen.getByTestId("status-tap-row")).toBeInTheDocument()
+    expect(screen.queryByTestId("shot-status-select-trigger")).not.toBeInTheDocument()
+    // Export keys to desktop — hidden on mobile, same as today's !isMobile.
+    expect(screen.queryByRole("button", { name: "Export" })).not.toBeInTheDocument()
   })
 
   it("warehouse mounts zero enabled write affordances and the 1-4 keys no-op", () => {

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
@@ -43,10 +43,32 @@ vi.mock("@/app/providers/ProjectScopeProvider", () => ({
   useOptionalProjectScope: () => ({ projectId: "p1", projectName: "Project 1" }),
 }))
 
-vi.mock("@/shared/hooks/useMediaQuery", () => ({
-  useIsMobile: () => false,
-  useIsDesktop: () => false,
+// Device state. Default (both false) is TABLET (768-1023px) — the historical
+// shape of this file. Flip isDesktop for the desktop-keyed export pins below.
+const mediaState = vi.hoisted(() => ({
+  isMobile: false,
+  isDesktop: false,
 }))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => mediaState.isMobile,
+  useIsDesktop: () => mediaState.isDesktop,
+}))
+
+// 5e-I flag-flip audit: this file pins the LEGACY (flag-off) card-grid
+// default rendering and silently relied on featureSurfaceResolver defaulting
+// false. The default flipped to true at 5e-I (never-customized producers
+// resolve the table surface default), so the flag is pinned OFF explicitly
+// here — the flag-ON resolution path is owned by
+// useShotListState.resolver.test.tsx.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureSurfaceResolver" ? false : actual.isFeatureEnabled(flag),
+  }
+})
 
 vi.mock("@/features/shots/components/ShotStatusSelect", () => ({
   ShotStatusSelect: ({ currentStatus }: { readonly currentStatus: string }) => (
@@ -112,6 +134,8 @@ describe("ShotListPage", () => {
     window.localStorage.clear()
     effectiveState.role = null
     effectiveState.resolving = false
+    mediaState.isMobile = false
+    mediaState.isDesktop = false
     ;(useTalent as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [],
       loading: false,
@@ -658,6 +682,40 @@ describe("ShotListPage", () => {
     expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
       "Viewer on this project",
     )
+  })
+
+  // ── 5e-I export device keying (the one named sub-delta) ──────────────────
+
+  it("hides Export on tablet (768-1023px) — affordances.export keys to desktop, matching the route's RequireDesktop", () => {
+    // Default mediaState is tablet. Before 5e-I this button rendered (canExport
+    // was !isMobile) and dead-ended in RequireDesktop's toast+redirect.
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.queryByRole("button", { name: "Export" })).not.toBeInTheDocument()
+    // Control: the actions row itself rendered (Share is device-free).
+    expect(screen.getByRole("button", { name: "Share" })).toBeInTheDocument()
+  })
+
+  it("shows Export on desktop immediately, even while the effective role resolves (no flash-of-missing)", () => {
+    // canExport has NO role term (locked) — while affordances are null during
+    // the first member read it falls back to the same desktop keying.
+    mediaState.isDesktop = true
+    effectiveState.resolving = true
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.getByRole("button", { name: "Export" })).toBeInTheDocument()
   })
 
   it("renders note URLs as clickable links", () => {

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
@@ -47,6 +47,20 @@ vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsDesktop: () => true,
 }))
 
+// 5e-I flag-flip audit: these tests click into the card grid (the legacy
+// producer default) and silently relied on featureSurfaceResolver defaulting
+// false — flag-on, a never-customized desktop producer resolves the TABLE
+// surface default. Pin the flag OFF explicitly; the flag-ON path is owned by
+// useShotListState.resolver.test.tsx.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureSurfaceResolver" ? false : actual.isFeatureEnabled(flag),
+  }
+})
+
 vi.mock("@/features/shots/components/ShotStatusSelect", () => ({
   ShotStatusSelect: ({ currentStatus }: { readonly currentStatus: string }) => (
     <span>status:{currentStatus}</span>

--- a/src-vnext/features/shots/components/__tests__/ShotVersionHistorySection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotVersionHistorySection.test.tsx
@@ -9,8 +9,12 @@ vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+// Desktop. useResolvedSurface (5e-I) reads useIsMobile + useIsDesktop — the
+// section's device term flows through affordances.versionRestore now.
 vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsMobile: () => false,
+  useIsTablet: () => false,
+  useIsDesktop: () => true,
 }))
 
 vi.mock("@/app/providers/AuthProvider", () => ({

--- a/src-vnext/features/shots/hooks/__tests__/useResolvedSurface.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useResolvedSurface.test.tsx
@@ -1,0 +1,185 @@
+/// <reference types="@testing-library/jest-dom" />
+// 5e-I — unit pins for the shared surface hook. useAuth / useEffectiveRole /
+// useMediaQuery are mocked (the hook calls them INTERNALLY so suite-level
+// module mocks flow through); resolveSurface is the REAL pure function, so
+// the affordances pass-through pins the actual 5e-I device derivations,
+// including the one named sub-delta (export keys to desktop, not !mobile).
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { renderHook } from "@testing-library/react"
+import type { Role } from "@/shared/types"
+
+const authState = vi.hoisted(() => ({
+  loading: false,
+}))
+
+const roleState = vi.hoisted(() => ({
+  role: "producer" as Role,
+  resolving: false,
+}))
+
+const deviceState = vi.hoisted(() => ({
+  isMobile: false,
+  isDesktop: true,
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    role: "viewer",
+    user: { uid: "u1" },
+    clientId: "c1",
+    loading: authState.loading,
+  }),
+}))
+
+vi.mock("@/shared/hooks/useEffectiveRole", () => ({
+  useEffectiveRole: () => ({ role: roleState.role, resolving: roleState.resolving }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => deviceState.isMobile,
+  useIsDesktop: () => deviceState.isDesktop,
+}))
+
+import { useResolvedSurface } from "../useResolvedSurface"
+
+function setDevice(device: "mobile" | "tablet" | "desktop") {
+  deviceState.isMobile = device === "mobile"
+  deviceState.isDesktop = device === "desktop"
+}
+
+beforeEach(() => {
+  authState.loading = false
+  roleState.role = "producer"
+  roleState.resolving = false
+  setDevice("desktop")
+})
+
+describe("useResolvedSurface — resolving gate", () => {
+  it("returns resolving:true with no resolved values while the effective role is resolving", () => {
+    roleState.resolving = true
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current).toEqual({
+      surface: null,
+      affordances: null,
+      chrome: null,
+      resolving: true,
+    })
+  })
+
+  it("returns resolving:true with no resolved values while auth is loading", () => {
+    authState.loading = true
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current).toEqual({
+      surface: null,
+      affordances: null,
+      chrome: null,
+      resolving: true,
+    })
+  })
+
+  it("resolves once the gate clears on rerender", () => {
+    roleState.resolving = true
+    const { result, rerender } = renderHook(() => useResolvedSurface())
+    expect(result.current.resolving).toBe(true)
+
+    roleState.resolving = false
+    rerender()
+    expect(result.current.resolving).toBe(false)
+    expect(result.current.surface).toBe("plan-build")
+    expect(result.current.affordances).not.toBeNull()
+    expect(result.current.chrome).not.toBeNull()
+  })
+})
+
+describe("useResolvedSurface — device mapping", () => {
+  it.each([
+    ["mobile", "tap-row"],
+    ["tablet", "badge-select"],
+    ["desktop", "badge-select"],
+  ] as const)("maps %s to the 3-valued device like ShotListPage's surfaceDevice", (device, statusControl) => {
+    setDevice(device)
+    const { result } = renderHook(() => useResolvedSurface())
+    // statusControl forks on mobile; export forks tablet vs desktop — together
+    // they pin all three device values through the real resolver.
+    expect(result.current.chrome?.statusControl).toBe(statusControl)
+    expect(result.current.affordances?.export).toBe(device === "desktop")
+  })
+})
+
+describe("useResolvedSurface — affordances/chrome pass-through", () => {
+  it("passes through the desktop affordances (all on, export desktop-keyed true)", () => {
+    setDevice("desktop")
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.affordances).toEqual({
+      fieldEditing: true,
+      lifecycle: true,
+      imageUpload: true,
+      share: true,
+      export: true,
+      bulkPull: true,
+      repair: true,
+      versionRestore: true,
+    })
+    expect(result.current.chrome).toEqual({
+      toolbar: "full",
+      viewSwitcher: true,
+      quickAdd: true,
+      statusControl: "badge-select",
+    })
+  })
+
+  it("passes through the tablet affordances (export false — the named 5e-I sub-delta)", () => {
+    setDevice("tablet")
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.affordances).toEqual({
+      fieldEditing: true,
+      lifecycle: true,
+      imageUpload: true,
+      share: true,
+      export: false,
+      bulkPull: true,
+      repair: true,
+      versionRestore: true,
+    })
+  })
+
+  it("passes through the mobile affordances (all off)", () => {
+    setDevice("mobile")
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.affordances).toEqual({
+      fieldEditing: false,
+      lifecycle: false,
+      imageUpload: false,
+      share: false,
+      export: false,
+      bulkPull: false,
+      repair: false,
+      versionRestore: false,
+    })
+    expect(result.current.chrome?.statusControl).toBe("tap-row")
+  })
+
+  it("resolves the surface from the effective role", () => {
+    roleState.role = "crew"
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.surface).toBe("shoot")
+  })
+})
+
+describe("useResolvedSurface — memoization", () => {
+  it("returns a referentially stable result across rerenders with unchanged inputs", () => {
+    const { result, rerender } = renderHook(() => useResolvedSurface())
+    const first = result.current
+    rerender()
+    expect(result.current).toBe(first)
+  })
+
+  it("returns a new result when the device changes", () => {
+    const { result, rerender } = renderHook(() => useResolvedSurface())
+    const first = result.current
+    setDevice("tablet")
+    rerender()
+    expect(result.current).not.toBe(first)
+    expect(result.current.affordances?.export).toBe(false)
+  })
+})

--- a/src-vnext/features/shots/hooks/useResolvedSurface.ts
+++ b/src-vnext/features/shots/hooks/useResolvedSurface.ts
@@ -1,0 +1,70 @@
+import { useMemo } from "react"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
+import { useIsMobile, useIsDesktop } from "@/shared/hooks/useMediaQuery"
+import { resolveSurface } from "@/features/shots/lib/resolveSurface"
+import type {
+  Affordances,
+  Chrome,
+  SurfaceDevice,
+  SurfaceKind,
+} from "@/features/shots/lib/resolveSurface"
+
+// 5e-I shared surface hook — the capability-consumer call site for
+// resolveSurface (the detail page does no surface resolution of its own; the
+// list page keeps its url/stored view path through useShotListState).
+//
+// NOT flag-gated, by design: resolveSurface is pure and the 5e-I affordances
+// values are pure device derivations identical to today's `!isMobile` gates,
+// so always-on is zero-delta. featureShootSurface changes the VALUES at
+// 5e-II; featureSurfaceResolver gates only the list's viewMode/groupKey
+// substitution (inside useShotListState) — untouched here.
+//
+// Output stays presentation-only (resolveSurface header law): consumers
+// replace ONLY the device term of an existing gate — the rbac/global-claim
+// term stays at the consumer.
+
+export interface UseResolvedSurfaceResult {
+  readonly surface: SurfaceKind | null
+  readonly affordances: Affordances | null
+  readonly chrome: Chrome | null
+  /** Mirrors the surfaceContext null-while-(authLoading || roleResolving) gate. */
+  readonly resolving: boolean
+}
+
+const RESOLVING_RESULT: UseResolvedSurfaceResult = {
+  surface: null,
+  affordances: null,
+  chrome: null,
+  resolving: true,
+}
+
+export function useResolvedSurface(): UseResolvedSurfaceResult {
+  const { loading: authLoading } = useAuth()
+  const { role, resolving: roleResolving } = useEffectiveRole()
+  const isMobile = useIsMobile()
+  const isDesktop = useIsDesktop()
+
+  // Same 3-valued derivation as ShotListPage's surfaceDevice.
+  const device: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
+
+  // Never resolve from the global-role guess: while the first member-doc read
+  // is in flight (or auth is settling) return no affordances, mirroring the
+  // existing render-nothing-while-resolving discipline.
+  const resolving = authLoading || roleResolving
+
+  return useMemo(() => {
+    if (resolving) return RESOLVING_RESULT
+    // 5e-III View-as seam: the preview role interposes on effectiveRole HERE.
+    const { surface, affordances, chrome } = resolveSurface({
+      effectiveRole: role,
+      device,
+      // Capability consumers need no view resolution — the list page keeps
+      // its own url/stored path through useShotListState.
+      urlView: null,
+      urlGroup: null,
+      storedView: null,
+    })
+    return { surface, affordances, chrome, resolving: false }
+  }, [resolving, role, device])
+}

--- a/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/resolveSurface.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest"
 import {
   resolveSurface,
+  type Affordances,
+  type Chrome,
   type ResolveSurfaceInput,
   type SurfaceDevice,
   type SurfaceKind,
@@ -200,6 +202,75 @@ describe("resolveSurface — provenance (viewSource)", () => {
     expect(out.viewMode).toBe("table")
     expect(out.groupKey).toBe("status")
     expect(out.viewSource).toBe("url")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Affordances / chrome — 5e-I characterization table (build spec §The API).
+// Every value reproduces TODAY'S device gate at the consumer; the ONE named
+// sub-delta is `export` keying to desktop (the 768-1023 tablet Export button
+// dead-ends in RequireDesktop's toast+redirect today). Values are deliberately
+// surface-INDEPENDENT at 5e-I — asserted across every role per device.
+// ---------------------------------------------------------------------------
+
+const EXPECTED_AFFORDANCES: Record<SurfaceDevice, Affordances> = {
+  mobile: {
+    fieldEditing: false,
+    lifecycle: false,
+    imageUpload: false,
+    share: false,
+    export: false,
+    bulkPull: false,
+    repair: false,
+    versionRestore: false,
+  },
+  tablet: {
+    fieldEditing: true,
+    lifecycle: true,
+    imageUpload: true,
+    share: true,
+    export: false, // the named sub-delta: tablet loses the dead-end Export button
+    bulkPull: true,
+    repair: true,
+    versionRestore: true,
+  },
+  desktop: {
+    fieldEditing: true,
+    lifecycle: true,
+    imageUpload: true,
+    share: true,
+    export: true,
+    bulkPull: true,
+    repair: true,
+    versionRestore: true,
+  },
+}
+
+const EXPECTED_CHROME: Record<SurfaceDevice, Chrome> = {
+  mobile: { toolbar: "full", viewSwitcher: false, quickAdd: true, statusControl: "tap-row" },
+  tablet: { toolbar: "full", viewSwitcher: true, quickAdd: true, statusControl: "badge-select" },
+  desktop: { toolbar: "full", viewSwitcher: true, quickAdd: true, statusControl: "badge-select" },
+}
+
+describe("resolveSurface — affordances/chrome role × device matrix (5e-I characterization)", () => {
+  for (const role of ROLES) {
+    for (const device of DEVICES) {
+      it(`role=${role} device=${device} → today's device gates (export desktop-keyed)`, () => {
+        const out = resolveSurface(input({ effectiveRole: role, device }))
+        expect(out.affordances).toEqual(EXPECTED_AFFORDANCES[device])
+        expect(out.chrome).toEqual(EXPECTED_CHROME[device])
+      })
+    }
+  }
+
+  it("derives from surface + device only: url/stored/group inputs never alter affordances or chrome", () => {
+    for (const device of DEVICES) {
+      const noisy = resolveSurface(
+        input({ effectiveRole: "producer", device, urlView: "table", urlGroup: "status", storedView: "card" }),
+      )
+      expect(noisy.affordances).toEqual(EXPECTED_AFFORDANCES[device])
+      expect(noisy.chrome).toEqual(EXPECTED_CHROME[device])
+    }
   })
 })
 

--- a/src-vnext/features/shots/lib/resolveSurface.ts
+++ b/src-vnext/features/shots/lib/resolveSurface.ts
@@ -13,8 +13,44 @@ export type SurfaceKind = "plan-build" | "shoot" | "review-client" | "review-war
 /** Provenance of the resolved viewMode/groupKey. */
 export type ViewSource = "url" | "stored" | "surface-default" | "device-forced"
 
-// affordances / chrome / columns deliberately absent: nothing consumes them in Phase 4
-// (CLAUDE.md no-stubs rule); 5e/5f/6 add each slot when its first consumer lands.
+// columns deliberately absent: nothing consumes it before Phase 6 (CLAUDE.md no-stubs rule).
+
+/**
+ * Presentation-only by construction (header law carries verbatim): each field
+ * replaces ONLY the device term of an existing consumer gate — the rbac/
+ * global-claim term stays at the consumer. No can-* or write handler may
+ * consume these as a role source.
+ */
+export interface Affordances {
+  /** → ShotDetailPageUnified canEdit's !isMobile term. */
+  readonly fieldEditing: boolean
+  /** → ShotDetailPageUnified + ShotListPage canManageLifecycle device terms. */
+  readonly lifecycle: boolean
+  /** → ShotDetailPageUnified canUploadShotImages device term ONLY — role term stays GLOBAL-pinned. */
+  readonly imageUpload: boolean
+  /** → ShotDetailPageUnified's inline share !isMobile — role term stays global-pinned. */
+  readonly share: boolean
+  /** → ShotDetailPageUnified canExport + ShotListPage canExport — stays ROLE-FREE (locked). */
+  readonly export: boolean
+  /** → ShotListPage canBulkPull device term. */
+  readonly bulkPull: boolean
+  /** → ShotListPage canRepair device term. */
+  readonly repair: boolean
+  /** → ShotVersionHistorySection's INTERNAL isMobile kill-switch (own hook, outside the page capability block). */
+  readonly versionRestore: boolean
+}
+
+/** Shell chrome decisions — same presentation-only law as Affordances. */
+export interface Chrome {
+  /** → ShotListToolbar mount in ShotListPage. */
+  readonly toolbar: "full" | "minimal" | "none"
+  /** → ShotListToolbar card/table toggle. */
+  readonly viewSwitcher: boolean
+  /** → showCreate button + the FAB ?create=1 consume path in ShotListPage. */
+  readonly quickAdd: boolean
+  /** → the desktop-select-vs-mobile-tap-row fork in ShotDetailPageUnified. */
+  readonly statusControl: "tap-row" | "badge-select"
+}
 
 export interface ResolveSurfaceInput {
   /** Already-resolved role. Opaque — see header comment (5b upgrades source). */
@@ -34,6 +70,8 @@ export interface ResolvedSurface {
   readonly viewMode: ViewMode
   readonly groupKey: GroupKey
   readonly viewSource: ViewSource
+  readonly affordances: Affordances
+  readonly chrome: Chrome
 }
 
 // ---------------------------------------------------------------------------
@@ -115,5 +153,30 @@ export function resolveSurface(input: ResolveSurfaceInput): ResolvedSurface {
   const groupKey: GroupKey = isMobile ? "none" : preForcingGroup
   const viewSource: ViewSource = forcingChangedOutcome ? "device-forced" : preForcingSource
 
-  return { surface, viewMode, groupKey, viewSource }
+  // Affordances/chrome — derived from surface + device ONLY. At 5e-I every
+  // value reproduces TODAY'S device gate, deliberately surface-INDEPENDENT so
+  // rewired consumers are zero-delta; 5e-II reshapes these for
+  // surface === 'shoot' behind featureShootSurface. The one named sub-delta:
+  // `export` keys to desktop, not !mobile — the export route's RequireDesktop
+  // needs ≥1024px, so today's 768-1023 tablet Export button dead-ends in a
+  // toast+redirect.
+  const offMobile = device !== "mobile"
+  const affordances: Affordances = {
+    fieldEditing: offMobile,
+    lifecycle: offMobile,
+    imageUpload: offMobile,
+    share: offMobile,
+    export: device === "desktop",
+    bulkPull: offMobile,
+    repair: offMobile,
+    versionRestore: offMobile,
+  }
+  const chrome: Chrome = {
+    toolbar: "full",
+    viewSwitcher: offMobile,
+    quickAdd: true,
+    statusControl: device === "mobile" ? "tap-row" : "badge-select",
+  }
+
+  return { surface, viewMode, groupKey, viewSource, affordances, chrome }
 }

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -14,26 +14,40 @@ describe("feature flags", () => {
     expect(isFeatureEnabled("featurePublishing")).toBe(false)
   })
 
-  it("defaults featureSurfaceResolver to false (Phase 4 is dark on main; CI build env never defines VITE_SURFACE_RESOLVER)", () => {
-    expect(getFeatureFlags().featureSurfaceResolver).toBe(false)
-    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
+  it("defaults featureSurfaceResolver to TRUE (5e-I default flip — never-customized producers on tablet/desktop get the table surface default)", () => {
+    expect(getFeatureFlags().featureSurfaceResolver).toBe(true)
+    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
   })
 
-  it("VITE_SURFACE_RESOLVER='1' or 'true' enables featureSurfaceResolver (LoginPage env-parse precedent)", () => {
+  it("VITE_SURFACE_RESOLVER stays an enable-only override hook: no env value can turn the default-ON resolver off", () => {
+    for (const value of ["0", "false", "", "off"]) {
+      vi.stubEnv("VITE_SURFACE_RESOLVER", value)
+      expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
+    }
     vi.stubEnv("VITE_SURFACE_RESOLVER", "1")
     expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
-
-    vi.stubEnv("VITE_SURFACE_RESOLVER", "true")
-    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
-
-    vi.stubEnv("VITE_SURFACE_RESOLVER", "TRUE")
-    expect(isFeatureEnabled("featureSurfaceResolver")).toBe(true)
   })
 
-  it("any other VITE_SURFACE_RESOLVER value stays off (no URL/localStorage override layer)", () => {
+  it("defaults featureShootSurface to false (Phase 5e is dark on main; CI build env never defines VITE_SHOOT_SURFACE)", () => {
+    expect(getFeatureFlags().featureShootSurface).toBe(false)
+    expect(isFeatureEnabled("featureShootSurface")).toBe(false)
+  })
+
+  it("VITE_SHOOT_SURFACE='1' or 'true' enables featureShootSurface (VITE_SURFACE_RESOLVER env-parse precedent)", () => {
+    vi.stubEnv("VITE_SHOOT_SURFACE", "1")
+    expect(isFeatureEnabled("featureShootSurface")).toBe(true)
+
+    vi.stubEnv("VITE_SHOOT_SURFACE", "true")
+    expect(isFeatureEnabled("featureShootSurface")).toBe(true)
+
+    vi.stubEnv("VITE_SHOOT_SURFACE", "TRUE")
+    expect(isFeatureEnabled("featureShootSurface")).toBe(true)
+  })
+
+  it("any other VITE_SHOOT_SURFACE value stays off (no URL/localStorage override layer)", () => {
     for (const value of ["0", "false", "", "yes", "on"]) {
-      vi.stubEnv("VITE_SURFACE_RESOLVER", value)
-      expect(isFeatureEnabled("featureSurfaceResolver")).toBe(false)
+      vi.stubEnv("VITE_SHOOT_SURFACE", value)
+      expect(isFeatureEnabled("featureShootSurface")).toBe(false)
     }
   })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -16,18 +16,34 @@ export interface FeatureFlags {
   readonly featurePublishing: boolean
   /**
    * Phase 4 — resolveSurface job-default resolution in useShotListState.
-   * Default OFF (flag-off path is byte-identical to pre-Phase-4 trunk).
-   * Enabled ONLY via `VITE_SURFACE_RESOLVER=1` (or `true`) at build/dev time
-   * (LoginPage VITE_USE_FIREBASE_EMULATORS precedent) — e.g. the :5174
-   * eyeball runs `VITE_SURFACE_RESOLVER=1 npm run dev -- --port 5174`.
-   * CI build env must never define it. No URL/localStorage override layer.
+   * Default flipped to ON at 5e-I (was OFF since Phase 4). The ONE named,
+   * accepted behavior change of the flip: never-customized producers on
+   * tablet/desktop land on the plan-build 'table' surface default instead of
+   * 'card'. Everyone else is byte-identical (URL/stored choices still win;
+   * crew/warehouse/viewer resolution is inert vs legacy).
+   * `VITE_SURFACE_RESOLVER` is kept as the enable-only override hook
+   * (LoginPage VITE_USE_FIREBASE_EMULATORS precedent) — inert while the
+   * default is true; retire it at flag removal. No URL/localStorage
+   * override layer.
    */
   readonly featureSurfaceResolver: boolean
+  /**
+   * Phase 5e — the Shoot surface. Gates ALL Phase 5e behavior: the Shoot
+   * shell render, the `!isMobile` capability removals, and the View-as menu.
+   * Structurally requires resolver output — the shell mounts only off a
+   * resolved `surface === 'shoot'`, never off this flag alone.
+   * Default OFF (flag-off path is byte-identical to 5e-I trunk). Enabled
+   * ONLY via `VITE_SHOOT_SURFACE=1` (or `true`) at build/dev time
+   * (featureSurfaceResolver env-parse precedent). CI build env must never
+   * define it. No URL/localStorage override layer.
+   */
+  readonly featureShootSurface: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
   featurePublishing: false,
-  featureSurfaceResolver: false,
+  featureSurfaceResolver: true,
+  featureShootSurface: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -50,6 +66,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureSurfaceResolver:
       DEFAULT_FLAGS.featureSurfaceResolver ||
       parseEnvFlag(import.meta.env.VITE_SURFACE_RESOLVER),
+    featureShootSurface:
+      DEFAULT_FLAGS.featureShootSurface ||
+      parseEnvFlag(import.meta.env.VITE_SHOOT_SURFACE),
   }
 }
 

--- a/tests/role-matrix.spec.ts
+++ b/tests/role-matrix.spec.ts
@@ -80,26 +80,32 @@ test.describe('Shot detail — non-member (global crew, no project membership)',
 });
 
 /**
- * Phase 4 — flag-off NO-CHANGE assertions (build spec §Test plan item 4).
+ * Phase 4 → 5e-I — resolver-default pins (build spec §Test plan item 4,
+ * updated at 5e-I).
  *
- * `featureSurfaceResolver` is enabled ONLY via `VITE_SURFACE_RESOLVER=1` at
- * build/dev time, and the CI build env never defines it — so this suite runs
- * against the FLAG-OFF path and pins the pre-Phase-4 trunk behavior that the
- * resolver must not change while the flag is off:
+ * As of 5e-I `featureSurfaceResolver` DEFAULTS ON (flags.ts;
+ * VITE_SURFACE_RESOLVER survives only as an enable-only override hook) — so
+ * this suite now runs against the FLAG-ON resolution path. Resolution is
+ * byte-identical to the legacy path except the ONE named, accepted change in
+ * (a); every other pin carries over verbatim:
  *
- *   (a) producer default view stays CARD for never-customized users (the
- *       flag-on resolver defaults producers to table — that flip is a named,
- *       accepted behavior change AT FLAG REMOVAL, not before);
- *   (b) mount performs ZERO URL writes (no view/group params materialize);
+ *   (a) NEVER-CUSTOMIZED producer default view is now TABLE on desktop (the
+ *       plan-build surface default) — the named, accepted behavior change of
+ *       the 5e-I default flip. Stored and URL choices still outrank it;
+ *   (b) mount performs ZERO URL writes (resolution is a pure derivation —
+ *       no view/group params materialize);
  *   (c) mobile forcing is override-without-erase: a 390px viewport forces the
  *       card list and hides the view toggle WITHOUT erasing latent
  *       `?view=table&group=status`, and resizing across 768px (live
- *       matchMedia) restores them;
+ *       matchMedia) restores them — reproduced by the resolver's
+ *       device-forced rung (last + non-destructive);
  *   (d) read-only roles keep their read-only list chrome (no "New Shot"),
  *       and crew KEEPS its existing "New Shot" affordance
- *       (canManageShots(crew)=true today — flag-off must not revoke it);
+ *       (canManageShots(crew)=true today). Crew/warehouse/viewer resolution
+ *       is INERT under flag-on (their surface defaults are card, same as
+ *       legacy);
  *   (e) a deep-linked `?view=table&group=status` survives a RELOAD unchanged
- *       (URL is the source of truth; resolution adds/removes nothing) — pinned
+ *       (URL is the source of truth; it outranks every resolver rung) — pinned
  *       for producer, crew, and viewer.
  *
  * The mobile case uses a PER-TEST viewport override — the auth fixtures pin
@@ -113,7 +119,7 @@ test.describe('Shot detail — non-member (global crew, no project membership)',
 const DEEP_LINK_SEARCH = '?view=table&group=status';
 
 /**
- * Shared flag-off pin (assertion (e)): deep-linked `?view=table&group=status`
+ * Shared pin (assertion (e)): deep-linked `?view=table&group=status`
  * renders the table on a desktop viewport, the load mutates NOTHING in the
  * URL (assert page.url() exactly), and a reload comes back byte-identical.
  */
@@ -136,8 +142,8 @@ async function expectDeepLinkSurvivesReload(
   expect(new URL(page.url()).search).toBe(DEEP_LINK_SEARCH);
 }
 
-test.describe('Shots list — Phase 4 flag-off no-change', () => {
-  test('producer (desktop, never customized): default view stays card; mount writes no URL params', async ({
+test.describe('Shots list — resolver default-ON pins (5e-I)', () => {
+  test('producer (desktop, never customized): default view is TABLE (5e-I named change); mount writes no URL params', async ({
     producerPage,
   }) => {
     await producerPage.goto(SHOTS_URL);
@@ -148,11 +154,14 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
       producerPage.getByText(SEED_SHOT_AURORA.title).first(),
     ).toBeVisible();
 
-    // (a) Default is the CARD view: no table is mounted. The fixture context
-    // is rebuilt from the global-setup storage state every test, so this
-    // producer has no stored `:view:v1` choice — the "never customized" case
-    // the flag-on resolver would flip to table. Flag-off must stay card.
-    await expect(producerPage.locator('main table')).toHaveCount(0);
+    // (a) Default is the TABLE view — the named, accepted behavior change of
+    // the 5e-I featureSurfaceResolver default flip: a never-customized
+    // producer on desktop resolves the plan-build 'table' surface default.
+    // The fixture context is rebuilt from the global-setup storage state
+    // every test, so this producer has no stored `:view:v1` choice — exactly
+    // the "never customized" case the flip targets. (Stored/URL choices
+    // still win — see the deep-link pins below.)
+    await expect(producerPage.locator('main table').first()).toBeVisible();
 
     // Desktop toolbar still offers the view toggle (gated on !isMobile only).
     await expect(
@@ -173,7 +182,7 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
   });
 
   /**
-   * CREW — flag-off pin for the third write-capable role. Crew has a global
+   * CREW — resolver-inert pin for the third write-capable role. Crew has a global
    * claim role='crew' but NO project members doc (intentionally — the
    * lanes-carve-out repro at the top of this file is load-bearing on crew
    * staying a non-member; do NOT seed one). On the LIST page the denied lanes
@@ -204,7 +213,9 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
       crewPage.getByRole('button', { name: /new shot/i }).first(),
     ).toBeVisible();
 
-    // (a)+(b) Card default + zero URL writes on an absent-override load.
+    // (d)+(b) Crew default stays CARD (flag-on is INERT for crew: the shoot
+    // surface default is card, same as legacy) + zero URL writes on an
+    // absent-override load.
     await expect(crewPage.locator('main table')).toHaveCount(0);
     const url = new URL(crewPage.url());
     expect(url.searchParams.get('view')).toBeNull();
@@ -262,7 +273,9 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
       viewerPage.getByRole('button', { name: /new shot/i }),
     ).toHaveCount(0);
 
-    // Card default + zero URL writes — same flag-off pins as the producer case.
+    // Card default + zero URL writes — viewer resolves the review-client
+    // surface whose default is card (flag-on inert; the table flip is
+    // plan-build only).
     await expect(viewerPage.locator('main table')).toHaveCount(0);
     const url = new URL(viewerPage.url());
     expect(url.searchParams.get('view')).toBeNull();
@@ -278,7 +291,8 @@ test.describe('Shots list — Phase 4 flag-off no-change', () => {
    * WARDROBE — annotated VIEWER DUPLICATE (build spec §Test plan item 4).
    *
    * This test deliberately duplicates the viewer assertions above, because for
-   * the shots LIST under flag-off the two roles are behaviorally identical:
+   * the shots LIST the two roles are behaviorally identical (under the
+   * default-ON resolver both land on card-default review-* surfaces):
    *
    * - The wardrobe user carries a legacy global claim role='wardrobe'. As of
    *   Phase 4 (spec security invariant 5) the client's normalizeRole maps


### PR DESCRIPTION
## Summary

Phase 5e-I of the redesign (spec: `2026-06-11-phase5e-build-spec.md`, Ted-approved with decisions A–G locked). First of the 3-PR 5e partition — **zero behavior delta except two named changes**:

1. **`featureSurfaceResolver` default flips ON** — never-customized producers/admins on tablet/desktop get the **table** default instead of card (the accepted change named since the Phase-4 flag-removal checklist). URL params and stored explicit choices still win; crew/warehouse/viewer resolution is byte-identical (pinned).
2. **Export keys to desktop** — the 768–1023px tablet Export button no longer mounts. It was a dead-end: `canExport` was true at ≥768px but the export route's `RequireDesktop` requires ≥1024px, so tablet taps got a toast+redirect.

## What changed

- **`resolveSurface` gains `affordances` + `chrome` outputs** (cut from Phase 4 per no-stubs; landing now WITH their first consumers). Every field has a named consumer; 5e-I values are pure device derivations reproducing today's gates. 5e-II reshapes them for `surface==='shoot'` behind `featureShootSurface`.
- **New `useResolvedSurface()` hook** — the shared resolution call site for list + detail. Always-on by design (the resolver flag gates only the list's viewMode/groupKey substitution). The opaque `effectiveRole` input is the 5e-III View-as interposition seam (comment-marked, not built).
- **Every `!isMobile` capability term rewired through `affordances`**: ShotDetailPageUnified (canEdit / canManageLifecycle / canUploadShotImages / canExport / inline Share / the status-control render fork), ShotListPage (canBulkPull / canRepair / canExport / canManageLifecycle), ShotVersionHistorySection (the internal isMobile kill-switch). **The rbac/global-claim terms stay byte-identical at the consumers** — resolver output never acts as a role source (the Phase-4 security law).
- **`featureShootSurface` added** (default OFF, `VITE_SHOOT_SURFACE` enable-only) — gates all 5e behavior; the Shoot shell (5e-II) mounts only off resolved `surface==='shoot'`.
- **`ProductColorwayStrip` extracted** to its own file (behavior-preserving) — the 5e-II Shoot shell + 5f Review presentational seam. First tests added.
- Resolving-gap behavior preserved exactly (raw device fallbacks while affordances resolve — pinned; no flash-of-missing-Export on desktop, no flash-of-appearing write affordances).

## Hard no-touch (verified byte-identical)

`firestore.rules` · `storage.rules` · `rbac.ts` · `PublicShotSharePage` · `useShotListState`'s resolution path · the ShotListPage `:596` JSX fork (5e-II's) · toolbar props.

## Test plan

- Built by a 12-agent writer→adversarial-verifier workflow (every partition PASS; zero-delta traced per gate × role × device × resolving-gap).
- **788/788 tests green across 10 files** (run locally): flags, resolveSurface (legacy-oracle matrix untouched + new role×device affordances/chrome characterization matrix), useResolvedSurface (12 new), ShotDetailPageUnified 26 (incl. tablet-export-hidden + mobile tap-row pins), ShotListPage 28 (incl. desktop-export-no-flash pin), ShotVersionHistorySection, ProductColorwayStrip, resolver inertness pins (unmodified, green).
- `tests/role-matrix.spec.ts` assertion (a) re-pinned to the table default — CI ui-checks is the arbiter for the E2E lane.
- Lint clean on all changed files; production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)