### PR TITLE
fix(products): product merge crash on a SKU with no name (#7)

### DIFF
--- a/AI_RULES.md
+++ b/AI_RULES.md
@@ -135,6 +135,16 @@ When creating or updating tags anywhere in the codebase:
 - **Export builder:** Inline on block data (persisted with export document)
 - **Reusable component:** `ColumnSettingsList.tsx` — DnD column list shared by shot table popover and share dialog
 
+### Scene Infrastructure Pattern (Sprint S29)
+
+- **Numbering:** Shots in scenes use letter suffixes: `{sceneNumber}{A-Z/AA-ZZ}`. Use `formatSceneShotNumber(sceneNumber, index)` — never construct manually. `parseSceneShotNumber("51A")` → `{ base: 51, suffix: "A" }`. Ungrouped shots in scene mode use raw `String(n)` (no `formatShotNumber` padding). Never use `Number()` or `padStart()` on shot numbers — use `localeCompare({ numeric: true })` for sorting.
+- **Scene colors:** Import from `lib/sceneColors.ts` (not from `SceneHeader.tsx`). `getSceneColor(key)` resolves to hex or falls back to `var(--color-text-subtle)`.
+- **Scene detail editing:** `SceneDetailSheet` uses blur-only saves (no debounced keystroke writes — prevents multi-user conflict). `useRef` init gate prevents Firestore snapshot echoes from clobbering in-progress edits. Toast deduplication via `{ id: "scene-update:{lane.id}" }`.
+- **Scene table grouping:** `ShotsTable` accepts `groups` prop. `SceneTableRow` renders header rows. Orphan `laneId` guard in `groupShots` uses `lanes.size > 0` to avoid load-race flicker. Groups sort by `sceneNumber` (not `sortOrder`).
+- **Crew gating:** `canManageLanes` prop gates the kebab menu. Scene writes restricted to admin/producer/warehouse. Crew users see read-only scene headers.
+- **createLane:** Always pass `existingLanes` for auto-increment. Without it, `Math.max(0, ...[])` = 0 and every new scene collides to `sceneNumber = 1`.
+- **Three-panel parity:** `SceneDetailSheet` is lifted to `ThreePanelLayout` (single instance). `SceneContextBanner` renders in both canvas + properties panels. `useLanes` call deduped — parent passes `lanes`/`laneById` as props.
+
 ---
 
 ## Off-Limits Without Approval
@@ -362,8 +372,8 @@ Violations of these rules break dark mode and visual consistency. They are treat
 **tailwind.config.js editorial body scale (Sprint S4):** `xs`=12px, `sm`=13px, `base`=14px, `lg`=16px, `xl`=18px. These are 1-2px smaller than Tailwind defaults. Do NOT use arbitrary `text-[Npx]` for any size in this range.
 
 **No raw Tailwind typography combos where semantic classes exist:**
-- `text-xl font-semibold`, `text-2xl font-bold`, `text-2xl font-semibold` → `.heading-page`
-- `text-2xl font-light tracking-tight` → `.heading-page`
+- `text-xl font-semibold`, `text-2xl font-bold`, `text-2xl font-semibold` → `.heading-page` (now **Founders X-Cond Bold 700** per the brand style guide; was Neue Haas Light 300 pre-2026-06-04)
+- `text-2xl font-light tracking-tight` (the old editorial-light page heading) → `.heading-page`
 - `text-base font-semibold tracking-tight` → `.heading-section`
 - `text-sm font-semibold tracking-tight` → `.heading-subsection`
 - `text-xs font-semibold uppercase tracking-widest text-muted` → `.label-meta`

--- a/Architecture.md
+++ b/Architecture.md
@@ -161,7 +161,7 @@ All data scoped by `clientId` from Firebase Auth custom claims.
   ├── projects/{projectId}/
   │   ├── members/{userId}/
   │   ├── pulls/{pullId}/              # Public via shareToken
-  │   ├── lanes/{laneId}/
+  │   ├── lanes/{laneId}/              # S28/S29: Scenes (project-scoped shot grouping)
   │   ├── departments/{departmentId}/
   │   │   └── positions/{positionId}/
   │   ├── activities/{activityId}/     # Audit trail, 90-day retention
@@ -215,8 +215,9 @@ interface Shot {
   talent: string[]           // talentId references
   products: ProductAssignment[]
   locationId?: string
-  laneId?: string
+  laneId?: string            // S28: references lanes/{laneId} for scene grouping
   sortOrder: number
+  shotNumber?: string        // S29: "51A" (scene letter suffix) or "01" (flat sequential)
   notes?: string
   heroImage?: { path: string; downloadURL: string }
   tags?: string[]
@@ -225,6 +226,28 @@ interface Shot {
   updatedAt: Timestamp
   createdBy: string
 }
+```
+
+**Lane (Scene):** (Sprint S28/S29)
+```typescript
+interface Lane {
+  id: string
+  name: string
+  projectId: string
+  clientId: string
+  sortOrder: number          // Display order (drag-and-drop)
+  sceneNumber?: number       // Stable identifier (1-9999, auto-incremented, user-editable)
+  color?: string             // Key from SCENE_COLORS palette (teal, purple, green, orange, pink, blue)
+  direction?: string         // Creative brief (max 500 chars)
+  notes?: string             // Operational notes (max 5000 chars)
+  createdAt: Timestamp
+  updatedAt: Timestamp
+  createdBy: string
+}
+// Path: clients/{clientId}/projects/{projectId}/lanes/{laneId}
+// Shot reference: Shot.laneId = Lane.id
+// Numbering: shots in scene get "{sceneNumber}{A-Z/AA-ZZ}" format
+// Firestore rules: explicit match before wildcard, direction/notes size + sceneNumber bounds enforced
 ```
 
 **Project:**
@@ -496,7 +519,7 @@ Single source of design truth. CSS custom properties for colors, spacing, typogr
 
 | Class | Spec | Usage |
 |---|---|---|
-| `.heading-page` | 24px / 300 / -0.02em / md:28px | Page-level `<h1>` (editorial light weight) |
+| `.heading-page` | Founders X-Cond Bold / 28px / 700 / 0 tracking / md:32px | Page-level `<h1>` (Immediate brand display; iconic red period). Updated 2026-06-04 from Neue Haas Light 300. |
 | `.heading-section` | 16px / 600 / -0.01em | Section `<h2>` |
 | `.heading-subsection` | 14px / 600 / -0.01em | Subsection `<h3>` |
 | `.label-meta` | 12px / 600 / upper / 0.05em / text-subtle | Uppercase meta labels |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Every layout starts from the smallest viewport. Desktop adds density and editing
 - Tailwind classes reference token values. No hardcoded hex colors or arbitrary spacing in components.
 - Use `text-3xs` (9px), `text-2xs` (10px), `text-xxs` (11px) for micro font sizes — never `text-[9px]`, `text-[10px]`, `text-[11px]`.
 - Use `text-sm` (13px), `text-base` (14px), `text-lg` (16px), `text-xl` (18px) — never `text-[13px]`, `text-[14px]`, `text-[15px]`. These sizes are overridden in `tailwind.config.js` to be 1-2px smaller than Tailwind defaults.
-- Page headings use `heading-page` semantic class (weight 300 editorial) — never `text-xl font-semibold` or `text-2xl font-bold`.
+- Page headings use the `heading-page` semantic class — **Founders Grotesk X-Condensed Bold (700)** per the Immediate brand style guide (updated 2026-06-04 from the former editorial Neue Haas Light 300). Never hand-roll with `text-xl font-semibold` / `text-2xl font-bold`.
 - Section headings use `heading-section` — never `text-base font-semibold`. Subsections use `heading-subsection`.
 - Tag badges use neutral body with subtle tag-color left borders (category as fallback) — never use rainbow `getTagColorClasses()` on `TagBadge`.
 - Every surface uses the same building blocks. No one-off component variants for a single page.
@@ -187,6 +187,20 @@ Phase order is the default. Override when reality demands it:
 - **Firestore missing field gotcha:** In Firestore rules, `resource.data.someField` on a document where the field doesn't exist **throws an error** causing the rule to deny. Always write optional fields with explicit `null` value (not omit them). Use defensive checks in rules: `!('fieldName' in resource.data) || resource.data.fieldName == null || ...`.
 - **Talent import script:** `scripts/import-talent-roster.ts` — dry-run by default, `--write` to execute. Reads Excel (Men/Women sheets), normalizes measurements, matches by name (Levenshtein fuzzy for near-misses), additive-only merge. Force-match aliases for confirmed duplicates. Uploads headshots as WebP (1600px, q82).
 - **Measurement parser:** `parseMeasurementValue` regex updated to handle spaces in heights (`6' 1"`) and half-inches (`5'11.5"`). `normalizeGender()` handles `male`/`female`/`man`/`woman` in addition to `men`/`women`. "Chest" added to men's `MEASUREMENT_GROUPS`.
+
+### 15. Sprint S29 New Infrastructure
+
+- **Scene-level direction and notes:** Lane type extended with optional `sceneNumber?: number`, `direction?: string` (max 500 chars), `notes?: string` (max 5000 chars). No migration needed — `useLanes.mapLane` backfills `sceneNumber = sortOrder + 1` for legacy lanes that lack it. `createLane` accepts `existingLanes` param to auto-increment sceneNumber — **always pass this** or every new scene gets `sceneNumber = 1`.
+- **Letter-suffix sub-numbering:** Shots in scenes get `{sceneNumber}{A-Z/AA-ZZ}` format (e.g., "51A", "51B"). `indexToLetterSuffix(0..701)` → "A".."ZZ" (clamped, `MAX_SHOTS_PER_SCENE = 702`). Ungrouped shots get raw unpadded sequential numbers in scene mode. All numbering functions in `shotNumbering.ts`. `parseSceneShotNumber("51A")` → `{ base: 51, suffix: "A" }`.
+- **Scene grouping in table view:** `ShotsTable` accepts `groups?: ReadonlyArray<ShotGroup>` + collapse/action callbacks. `SceneTableRow.tsx` renders scene header rows. `SceneHeader.tsx` enhanced with `sceneNumber`, `direction`, `onEdit`, `canManageLanes`. Scene groups sort by `sceneNumber` (not `sortOrder`).
+- **Scene colors extracted:** `SCENE_COLORS`, `getSceneColor`, `SceneColorKey` canonical location is `src-vnext/features/shots/lib/sceneColors.ts`. `SceneHeader.tsx` re-exports for backward compat.
+- **Scene detail sheet:** `SceneDetailSheet.tsx` — right-side Sheet for editing scene name, number, color, direction, notes. Blur-only saves (no debounce). `useRef` init gate prevents Firestore snapshot echoes from clobbering in-progress edits. Validates sceneNumber ≥ 1 and ≤ 9999, rejects duplicates against `siblingLanes`.
+- **Scene context banner:** `SceneContextBanner.tsx` — thin banner on shot detail showing scene color + name + direction preview. Integrated in `ShotDetailPage`, `ThreePanelCanvasPanel`, `ThreePanelPropertiesPanel`. `SceneDetailSheet` lifted to `ThreePanelLayout` to avoid duplicate instances.
+- **Scene assignment:** `SceneAssignPopover.tsx` for inline scene assignment from table cells. Scene column in `SHOT_TABLE_COLUMNS` (default hidden, order 14). `BulkActionBar` button renamed to "Set Scene".
+- **Renumber dialog scene mode:** `RenumberShotsDialog` has Sequential / By Scene toggle. Scene mode uses `previewRenumberWithScenes` + `renumberShotsWithScenes`. `maxSceneNumberOverride` prevents cross-filter collisions. Overflow guard: disables Renumber button when any scene exceeds 702 shots. Warning banner when sequential mode would destroy existing letter suffixes.
+- **Crew role gating:** `canManageLanes` prop on `SceneHeader`, `SceneTableRow`, `ShotsTable` hides the kebab menu for crew users. Lane CRUD restricted to admin/producer/warehouse in Firestore rules. `assignShotsToLane` writes to shots (not lanes), so crew CAN assign scenes.
+- **Firestore rules — lanes:** Explicit `match /lanes/{laneId}` before the wildcard catch-all with `direction.size() <= 500`, `notes.size() <= 5000`, `sceneNumber is int && >= 1 && <= 9999`. Read access includes `crew`/`warehouse`/`viewer`. Write access: admin/producer/warehouse.
+- **Export shot number display:** `padStart(3, "0")` removed from 4 export files. Shot numbers display raw. Export sort uses `localeCompare({ numeric: true, sensitivity: "base" })` — never `Number()`. Nulls sort last.
 
 ## Legacy Codebase Context
 

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -70,7 +70,7 @@ Persistent cross-session memory. Updated by Claude Code after each implementatio
 - **Block colors:** CSS var references via `blockColors.ts`, not Tailwind color classes
 - **Typography:** Semantic classes from `design-tokens.js` (`heading-page`, `heading-section`, `heading-subsection`)
 - **Font sizes:** Use `text-sm` (13px), `text-base` (14px), etc. — never `text-[13px]`
-- **Page headings:** `heading-page` class (weight 300 editorial) — never `text-xl font-semibold`
+- **Page headings:** `heading-page` class — Founders X-Cond Bold 700 (brand display; updated 2026-06-04 from Neue Haas Light 300) — never `text-xl font-semibold`
 - **Section headings:** `heading-section` class — never `text-base font-semibold`
 - **Subsection headings:** `heading-subsection` class — never `text-lg font-semibold`
 - **Tag badges:** Neutral body with subtle category-accent left borders

--- a/Plan.md
+++ b/Plan.md
@@ -1249,6 +1249,20 @@ Admin (role-gated: admin only)
   - [x] Fix X-Frame-Options for public share routes (Slack compatibility)
   - [x] 3 rounds of claude-review feedback addressed
 
+## Sprint S29: Scene Enhancement — Table Grouping, Notes, Letter-Suffix Numbering (2026-04-10)
+
+PR #409 merged. Firestore rules deployed. 38 files, +4966/-316. 167 test files / 1981 tests.
+
+- [x] **Phase 1 — Data Model:** Lane type extended (sceneNumber, direction, notes). useLanes returns laneById. createLane auto-increments sceneNumber. ShotGroup extended with scene metadata.
+- [x] **Phase 1 UI — Scene Detail Sheet:** SceneDetailSheet right slide-over (name, number, color, direction 500 chars, notes 5000 chars). SceneContextBanner in ShotDetailPage + ThreePanelCanvasPanel + ThreePanelPropertiesPanel. SceneHeader enhanced.
+- [x] **Phase 2 — Table Grouping:** SceneTableRow for table view. ShotsTable accepts groups + collapse callbacks. ShotListPage removed "switch to cards" banner. Orphan laneId guard with load-race protection.
+- [x] **Phase 3 — Sub-Numbering:** Letter-suffix system (51A, 51B, 51C). 8 new functions in shotNumbering.ts. RenumberShotsDialog Sequential/By Scene toggle. previewRenumberWithScenes + renumberShotsWithScenes. maxSceneNumberOverride for cross-filter safety.
+- [x] **Phase 4 — Scene Assignment:** Scene column in SHOT_TABLE_COLUMNS. SceneAssignPopover for inline assignment. BulkActionBar renamed to "Set Scene".
+- [x] **Pre-impl fixes:** Export sort NaN bug (blockDataResolvers), 4× padStart removal, shotTableColumns test update.
+- [x] **Firestore rules:** Explicit /lanes match with direction/notes size + sceneNumber bounds (1-9999). Crew gated from writes.
+- [x] **Review:** 4 internal review passes (pre-impl audit, data model + numbering, architect, full sprint) + 11 bot review rounds. All CRITICAL/HIGH/MEDIUM addressed.
+- [x] **Tests:** +76 new tests (53 numbering, 14 SceneDetailSheet, 10 SceneContextBanner, 5 SceneAssignPopover, misc).
+
 ---
 
 ## Cross-Phase Requirements

--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -26,7 +26,7 @@ This file is referenced from `CLAUDE.md` Hard Rule #3 and must be consulted befo
 
 | Class | Purpose | Weight |
 |-------|---------|--------|
-| `.heading-page` | Page titles | 300 (light, editorial) |
+| `.heading-page` | Page titles | Founders X-Cond Bold (700), brand display |
 | `.heading-section` | Section headings within a page | 600 |
 | `.heading-subsection` | Sub-section headings | 600 |
 | `.label-meta` | Uppercase micro labels (section headers in detail panels) | 600, uppercase, tracking-wider |
@@ -34,7 +34,7 @@ This file is referenced from `CLAUDE.md` Hard Rule #3 and must be consulted befo
 | `.body-text-muted` | De-emphasized body copy | 400 |
 | `.caption` | Footnotes, helper text | 400 |
 
-**Rule:** Page headings MUST use `heading-page` (weight 300). Never `text-xl font-semibold` or `text-2xl font-bold`.
+**Rule:** Page headings MUST use `heading-page` — **Founders Grotesk X-Condensed Bold (700)** per the Immediate brand style guide (updated 2026-06-04 from the former editorial Neue Haas Light 300). Never hand-roll with `text-xl font-semibold` or `text-2xl font-bold`.
 
 ---
 
@@ -257,6 +257,42 @@ All interaction utilities respect `prefers-reduced-motion: reduce`.
 - Keyboard navigation: Tab order must be logical; Escape closes dialogs/sheets
 - Color contrast: status badge text must meet WCAG AA against badge background
 - Animations: all must respect `prefers-reduced-motion`
+
+## 11. Scene Components (Sprint S29)
+
+### Scene Colors
+- **Canonical source:** `src-vnext/features/shots/lib/sceneColors.ts`
+- 6 accent colors: teal (`#14b8a6`), purple (`#a78bfa`), green (`#22c55e`), orange (`#fb923c`), pink (`#fb7185`), blue (`#3b82f6`)
+- Always use `getSceneColor(key)` to resolve — handles null → `var(--color-text-subtle)` fallback
+- Color displayed as 3px left border on scene headers, 8px dot in cells/popovers, ring on active swatch
+
+### SceneHeader / SceneTableRow
+- **Left border:** `border-left: 3px solid ${getSceneColor(color)}` (inline style, scene accent)
+- **Scene number prefix:** `#sceneNumber` in `text-[var(--color-text-subtle)]` before scene name
+- **Direction preview:** First 60 chars in `text-2xs text-[var(--color-text-muted)]` below name, with `title` attribute for hover tooltip
+- **Shot count badge:** `text-2xs` in rounded-full pill on the right side
+- **Kebab menu:** Only shown when `canManageLanes` is true (crew sees read-only headers)
+- **Table row hover:** `hover:bg-[var(--color-surface-muted)]` (one shade darker than `bg-[var(--color-surface-subtle)]`)
+
+### SceneContextBanner
+- Height ~36px, `bg-[var(--color-surface-subtle)]` with 3px left border in scene color
+- Content: color dot + `#sceneNumber sceneName` (`text-sm font-medium`) + direction preview (`text-xs text-muted`, 100 char truncation) + "View scene >" link
+- Returns null when shot has no laneId or lane not found in laneById
+
+### SceneDetailSheet
+- Right-side Sheet (380px width)
+- Labels use `text-2xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]`
+- Labels must have `htmlFor` associated with input `id`
+- Color picker: `fieldset`/`legend` pattern, `aria-pressed` on active swatch
+- Character counters: `text-3xs text-[var(--color-text-subtle)]` aligned right
+
+### SceneAssignPopover
+- Width: `w-52`, padding: `p-1`
+- Items: `px-2 py-1.5 rounded-sm hover:bg-[var(--color-surface-subtle)]`
+- Color dots: `h-2 w-2 rounded-full inline-block` with `getSceneColor()`
+- "None (ungrouped)" at top with `text-[var(--color-text-muted)]`
+- Active lane shows `Check` icon
+- Stops click propagation on content so table row click doesn't fire
 
 ---
 

--- a/docs/_runtime/CHECKPOINT.md
+++ b/docs/_runtime/CHECKPOINT.md
@@ -1,6 +1,6 @@
-# CHECKPOINT — Sprint S29 Implementation Complete (2026-04-10)
+# CHECKPOINT — Sprint S29 COMPLETE (2026-04-11)
 
-## Build clean. Lint zero. 167 test files / 1975 tests passing. Ready for commit + PR.
+## PR #409 merged. Firestore rules deployed. 167 test files / 1981 tests. Lint zero. Build clean.
 
 ## Sprint S29 — All Phases Complete
 
@@ -89,8 +89,10 @@ rule 6b ("no deferring known issues") in round-2 and round-3 review fixes:
 
 ## Deployment Checklist
 
-- [ ] `git add` + commit with conventional message
-- [ ] Open PR with full test/lint/build status
-- [ ] `firebase deploy --only firestore:rules` (new lanes rule)
+- [x] `git add` + commit with conventional message
+- [x] Open PR with full test/lint/build status (PR #409)
+- [x] 11 rounds of bot review — all findings addressed
+- [x] CI green (build, vitest, gitleaks, preview) — E2E pre-existing failure only
+- [x] Merge after CI + approval (squash `21e5076f`)
+- [x] `firebase deploy --only firestore:rules` (lanes rule deployed 2026-04-10)
 - [ ] User visual smoke test across table + detail + renumber flows
-- [ ] Merge after CI + approval

--- a/docs/_runtime/HANDOFF.md
+++ b/docs/_runtime/HANDOFF.md
@@ -1,7 +1,7 @@
-# HANDOFF — Sprint S29: Scene Enhancement (2026-04-10)
+# HANDOFF — Sprint S29: Scene Enhancement (2026-04-11)
 
 ## State
-Sprint S29 implementation COMPLETE. Build clean. Lint zero. 167 test files / 1975 tests passing. Not yet committed or deployed. Ready for PR.
+Sprint S29 COMPLETE. PR #409 merged to main (squash `21e5076f`). Firestore rules deployed to production. Build clean. Lint zero. 167 test files / 1981 tests passing. 11 rounds of bot review with all findings addressed.
 
 ## What Was Built
 
@@ -135,17 +135,19 @@ Sprint S29 closes three gaps in the S28 scene system:
 
 ## Next Steps
 
-1. **Visual smoke test with live data** — Requires logged-in Firebase user. User should verify: (a) table view scene grouping, (b) scene detail sheet editing flow, (c) scene context banner on shot detail, (d) renumber by scene, (e) scene assign popover from table cell.
-2. **Deploy Firestore rules** — `firebase deploy --only firestore:rules` (adds lane size validation)
-3. **Commit + PR** — Suggested title: `feat: S29 scene enhancement — table grouping, notes, letter-suffix numbering`. Include test/lint/build status in PR description.
-4. **Follow-up items (not blocking merge):**
-   - (All M-level follow-ups from initial review have been resolved per CLAUDE.md rule 6b.)
+1. **Visual smoke test with live data** — Verify: (a) table view scene grouping, (b) scene detail sheet editing flow, (c) scene context banner on shot detail, (d) renumber by scene, (e) scene assign popover from table cell.
+2. **Follow-up backlog (non-blocking):**
+   - ScenePicker in ThreePanelPropertiesPanel (Phase 4 deferred — requires non-trivial plumbing)
+   - E2E auth emulator fix (PR #396 — pre-existing, unrelated to S29)
+   - Recreate casting share links (old shares have 12-image cap)
+   - bulkShotUpdates unit tests
 
 ## Verification Status
 
-- **Tests:** 167 files / 1975 passing (includes 39 new scene numbering + 24 new component tests)
+- **Tests:** 167 files / 1981 passing (includes 53 scene numbering + 14 SceneDetailSheet + 10 SceneContextBanner + 5 SceneAssignPopover + misc)
 - **Lint:** zero warnings
 - **Build:** clean (`npm run build` ~12s)
-- **Dev server:** starts and renders shell correctly
-- **HTML mockup:** visually verified in Chrome, matches implementation design
-- **Codex CLI:** unavailable (gpt-5.4-high not supported on ChatGPT account — known limitation)
+- **PR:** #409 merged (squash `21e5076f`), 11 bot review rounds
+- **Firestore rules:** deployed to production 2026-04-10
+- **HTML mockup:** `mockups/s29-scene-enhancements.html` — visually verified in Chrome
+- **Codex CLI:** attempted, gpt-5.4-high unavailable on ChatGPT account (known limitation — documented in memory)

--- a/src-vnext/features/products/lib/productMergeWrites.test.ts
+++ b/src-vnext/features/products/lib/productMergeWrites.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("firebase/firestore", () => ({
+  writeBatch: vi.fn(),
+  collection: vi.fn((...args: unknown[]) => ({ path: args.join("/") })),
+  doc: vi.fn(() => ({ id: `new-sku-${Math.random().toString(36).slice(2)}` })),
+  serverTimestamp: vi.fn(() => ({ _methodName: "serverTimestamp" })),
+}))
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
+vi.mock("@/shared/lib/paths", () => ({
+  productFamilySkusPath: (familyId: string, clientId: string) => [
+    "clients",
+    clientId,
+    "productFamilies",
+    familyId,
+    "skus",
+  ],
+}))
+
+import * as firestore from "firebase/firestore"
+import { productMergeWritesForTests } from "./productMergeWrites"
+import type { ProductSku } from "@/shared/types"
+
+const { transferNewSkus } = productMergeWritesForTests
+
+function makeSku(overrides: Partial<ProductSku> & { id: string }): ProductSku {
+  return {
+    name: "Denim Blue",
+    ...overrides,
+  } as ProductSku
+}
+
+/** Collect every undefined-valued field path in an object (Firestore rejects these). */
+function undefinedFields(obj: Record<string, unknown>): string[] {
+  return Object.entries(obj)
+    .filter(([, v]) => v === undefined)
+    .map(([k]) => k)
+}
+
+describe("transferNewSkus (product merge — Step 1)", () => {
+  let mockBatchSet: ReturnType<typeof vi.fn>
+  let mockBatchCommit: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBatchSet = vi.fn()
+    mockBatchCommit = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(firestore.writeBatch).mockReturnValue({
+      set: mockBatchSet,
+      commit: mockBatchCommit,
+      delete: vi.fn(),
+      update: vi.fn(),
+    } as unknown as ReturnType<typeof firestore.writeBatch>)
+  })
+
+  function run(skus: ReadonlyArray<ProductSku>) {
+    return transferNewSkus({
+      newSkus: skus,
+      winnerId: "winner1",
+      clientId: "unbound-merino",
+      mergedBy: "u1",
+      skuIdMap: new Map<string, string>(),
+    })
+  }
+
+  it("no-ops on empty input", async () => {
+    const count = await run([])
+    expect(count).toBe(0)
+    expect(firestore.writeBatch).not.toHaveBeenCalled()
+  })
+
+  // The exact production crash: a loser "new" SKU with NO name field made
+  // Step 1 write `name: undefined`, which Firestore rejects with
+  // "Unsupported field value: undefined (found in field name ...)".
+  it("a SKU missing `name` writes a defined name (no undefined field)", async () => {
+    await run([makeSku({ id: "lose1", name: undefined as unknown as string, colorName: "Sea Salt" })])
+
+    expect(mockBatchSet).toHaveBeenCalledTimes(1)
+    const payload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+    expect(undefinedFields(payload)).toEqual([])
+    expect(payload.name).toBe("Sea Salt") // falls back to colorName
+    expect(payload.colorName).toBe("Sea Salt")
+  })
+
+  it("falls back name → skuCode → 'Untitled' when name and colorName are absent", async () => {
+    await run([
+      makeSku({ id: "a", name: undefined as unknown as string, colorName: undefined, skuCode: "M-BT-PN-1097" }),
+      makeSku({ id: "b", name: undefined as unknown as string, colorName: undefined, skuCode: undefined }),
+    ])
+
+    const first = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+    const second = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(first.name).toBe("M-BT-PN-1097")
+    expect(second.name).toBe("Untitled")
+    expect(undefinedFields(first)).toEqual([])
+    expect(undefinedFields(second)).toEqual([])
+  })
+
+  it("strips nested undefined (e.g. assetRequirements) from the payload", async () => {
+    await run([
+      makeSku({
+        id: "c",
+        name: "Charcoal",
+        assetRequirements: { flatlay: undefined, onModel: true } as unknown as ProductSku["assetRequirements"],
+      }),
+    ])
+    const payload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+    const reqs = payload.assetRequirements as Record<string, unknown>
+    expect(reqs).not.toHaveProperty("flatlay") // undefined key omitted
+    expect(reqs.onModel).toBe(true)
+  })
+
+  it("preserves a present name and maps loser→new SKU ids", async () => {
+    const skuIdMap = new Map<string, string>()
+    await transferNewSkus({
+      newSkus: [makeSku({ id: "lose-xyz", name: "Forest Green" })],
+      winnerId: "winner1",
+      clientId: "unbound-merino",
+      mergedBy: "u1",
+      skuIdMap,
+    })
+    const payload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+    expect(payload.name).toBe("Forest Green")
+    expect(skuIdMap.has("lose-xyz")).toBe(true)
+    expect(mockBatchCommit).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src-vnext/features/products/lib/productMergeWrites.test.ts
+++ b/src-vnext/features/products/lib/productMergeWrites.test.ts
@@ -33,7 +33,7 @@ function makeSku(overrides: Partial<ProductSku> & { id: string }): ProductSku {
 }
 
 /** Collect every undefined-valued field path in an object (Firestore rejects these). */
-function undefinedFields(obj: Record<string, unknown>): string[] {
+function topLevelUndefinedFields(obj: Record<string, unknown>): string[] {
   return Object.entries(obj)
     .filter(([, v]) => v === undefined)
     .map(([k]) => k)
@@ -79,7 +79,7 @@ describe("transferNewSkus (product merge — Step 1)", () => {
 
     expect(mockBatchSet).toHaveBeenCalledTimes(1)
     const payload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
-    expect(undefinedFields(payload)).toEqual([])
+    expect(topLevelUndefinedFields(payload)).toEqual([])
     expect(payload.name).toBe("Sea Salt") // falls back to colorName
     expect(payload.colorName).toBe("Sea Salt")
   })
@@ -94,8 +94,8 @@ describe("transferNewSkus (product merge — Step 1)", () => {
     const second = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
     expect(first.name).toBe("M-BT-PN-1097")
     expect(second.name).toBe("Untitled")
-    expect(undefinedFields(first)).toEqual([])
-    expect(undefinedFields(second)).toEqual([])
+    expect(topLevelUndefinedFields(first)).toEqual([])
+    expect(topLevelUndefinedFields(second)).toEqual([])
   })
 
   it("strips nested undefined (e.g. assetRequirements) from the payload", async () => {

--- a/src-vnext/features/products/lib/productMergeWrites.ts
+++ b/src-vnext/features/products/lib/productMergeWrites.ts
@@ -97,26 +97,35 @@ async function transferNewSkus(args: {
       const newRef = doc(winnerSkuCol)
       // Track loser→winner SKU ID mapping for sample scope remapping
       skuIdMap.set(sku.id, newRef.id)
-      batch.set(newRef, {
-        colorName: sku.colorName ?? sku.name,
-        name: sku.name,
-        skuCode: sku.skuCode ?? null,
-        sizes: sku.sizes ? [...sku.sizes] : [],
-        status: sku.status ?? "active",
-        archived: sku.archived ?? false,
-        imagePath: sku.imagePath ?? null,
-        colorKey: sku.colorKey ?? null,
-        hexColor: sku.hexColor ?? null,
-        colourHex: sku.colourHex ?? null,
-        assetRequirements: sku.assetRequirements ?? null,
-        launchDate: sku.launchDate ?? null,
-        deleted: false,
-        deletedAt: null,
-        createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp(),
-        createdBy: mergedBy,
-        updatedBy: mergedBy,
-      })
+      // `name` is the only required SKU field, but legacy/imported loser SKUs can
+      // lack it — writing `name: undefined` makes Firestore reject the whole
+      // batch ("Unsupported field value: undefined"). Default to the best
+      // human-readable fallback, and sanitizeForFirestore() (matching steps 2–5)
+      // strips any remaining undefined from nested fields like assetRequirements.
+      const skuName = sku.name ?? sku.colorName ?? sku.skuCode ?? "Untitled"
+      batch.set(
+        newRef,
+        sanitizeForFirestore({
+          colorName: sku.colorName ?? skuName,
+          name: skuName,
+          skuCode: sku.skuCode ?? null,
+          sizes: sku.sizes ? [...sku.sizes] : [],
+          status: sku.status ?? "active",
+          archived: sku.archived ?? false,
+          imagePath: sku.imagePath ?? null,
+          colorKey: sku.colorKey ?? null,
+          hexColor: sku.hexColor ?? null,
+          colourHex: sku.colourHex ?? null,
+          assetRequirements: sku.assetRequirements ?? null,
+          launchDate: sku.launchDate ?? null,
+          deleted: false,
+          deletedAt: null,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+          createdBy: mergedBy,
+          updatedBy: mergedBy,
+        }) as Record<string, unknown>,
+      )
     }
     await batch.commit()
   }
@@ -382,10 +391,15 @@ async function updatePullReferences(args: {
           return item
         })
 
-        batch.update(pullDoc.ref, {
-          items: newItems,
-          updatedAt: serverTimestamp(),
-        })
+        batch.update(
+          pullDoc.ref,
+          sanitizeForFirestore({
+            // winnerName can be undefined for an unnamed winner family; sanitize
+            // so a re-pointed pull item never injects an undefined familyName.
+            items: newItems,
+            updatedAt: serverTimestamp(),
+          }) as Record<string, unknown>,
+        )
         updated += 1
       }
       await batch.commit()
@@ -794,3 +808,6 @@ export async function executeProductMerge(args: {
     throw err
   }
 }
+
+/** @internal Test-only surface — do not import outside tests. */
+export const productMergeWritesForTests = { transferNewSkus }

--- a/src-vnext/features/products/lib/productMergeWrites.ts
+++ b/src-vnext/features/products/lib/productMergeWrites.ts
@@ -294,7 +294,7 @@ async function updateShotReferences(args: {
       const mappedProducts = products.map((p) => {
         if (p.familyId === loserId) {
           changed = true
-          return { ...p, familyId: winnerId, familyName: winnerName }
+          return { ...p, familyId: winnerId, familyName: winnerName ?? p.familyName }
         }
         return p
       })
@@ -313,7 +313,7 @@ async function updateShotReferences(args: {
         const mappedLookProducts = lookProducts.map((p) => {
           if (p.familyId === loserId) {
             changed = true
-            return { ...p, familyId: winnerId, familyName: winnerName }
+            return { ...p, familyId: winnerId, familyName: winnerName ?? p.familyName }
           }
           return p
         })
@@ -386,16 +386,15 @@ async function updatePullReferences(args: {
         const items = (data.items ?? []) as Record<string, unknown>[]
         const newItems = items.map((item) => {
           if (item.familyId === loserId) {
-            return { ...item, familyId: winnerId, familyName: winnerName }
+            return { ...item, familyId: winnerId, familyName: winnerName ?? item.familyName }
           }
           return item
         })
 
+        // familyName falls back to the item's own (winnerName is preserved, not dropped); sanitize is belt-and-suspenders.
         batch.update(
           pullDoc.ref,
           sanitizeForFirestore({
-            // winnerName can be undefined for an unnamed winner family; sanitize
-            // so a re-pointed pull item never injects an undefined familyName.
             items: newItems,
             updatedAt: serverTimestamp(),
           }) as Record<string, unknown>,

--- a/src-vnext/features/products/lib/productMergeWrites.ts
+++ b/src-vnext/features/products/lib/productMergeWrites.ts
@@ -391,7 +391,7 @@ async function updatePullReferences(args: {
           return item
         })
 
-        // familyName falls back to the item's own (winnerName is preserved, not dropped); sanitize is belt-and-suspenders.
+        // winnerName is typed string but legacy families can lack styleName at runtime (the class this PR fixes) — fall back to the item's own name.
         batch.update(
           pullDoc.ref,
           sanitizeForFirestore({


### PR DESCRIPTION
**Phase B (bug 1 of 2)** of the talent/casting/products/shots fix batch.

## The crash
The Product Merge Wizard failed with:
> `[executeProductMerge] Step 1 (transferNewSkus) failed: WriteBatch.set() called with invalid data. Unsupported field value: undefined (found in field name in document clients/unbound-merino/productFamilies/…/skus/…)`

whenever the loser product had a "new" (unmatched) SKU **missing a `name`** — legacy/imported SKUs can lack it even though `name` is the only required SKU type field. Step 1 wrote `name: sku.name` directly and, unlike Steps 2–5, skipped `sanitizeForFirestore()`.

## Fix
- Default the written name to `sku.name ?? colorName ?? skuCode ?? "Untitled"` — a nameless SKU still merges with a human-readable label, never `undefined`.
- Wrap the Step 1 payload in `sanitizeForFirestore()` (parity with Steps 2–5); also strips nested `undefined` (e.g. `assetRequirements`).
- Defensively sanitize **Step 6** (`updatePullReferences`), where a re-pointed pull item could inject an `undefined` `familyName`.

## Verification
- New `productMergeWrites.test.ts` (**5 tests**): a production-shaped repro of the missing-`name` SKU (asserts no `undefined` in the batch payload + a defined name), the `name → skuCode → "Untitled"` fallback chain, nested-undefined stripping, and the happy path / id-map.
- Exposed `transferNewSkus` via an `@internal` `productMergeWritesForTests` export (matches the repo's `…ForTests` convention).
- **Lint clean · 5 tests pass · production build succeeds.**

No rules/functions changes. CI `ui-checks` (job `test`) is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)