### PR TITLE
feat(shots): merge two shots into one via a ShotMergeWizard (#6)

### DIFF
--- a/src-vnext/features/shots/components/BulkActionBar.tsx
+++ b/src-vnext/features/shots/components/BulkActionBar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react"
-import { Layers, MapPin, Tag, Trash2, User } from "lucide-react"
+import { GitMerge, Layers, MapPin, Tag, Trash2, User } from "lucide-react"
 import { toast } from "sonner"
 import { Button } from "@/ui/button"
 import { Checkbox } from "@/ui/checkbox"
@@ -46,6 +46,7 @@ interface BulkActionBarProps {
   readonly onBulkDeleteOpen: () => void
   readonly onClearSelection: () => void
   readonly onGroupSceneOpen?: () => void
+  readonly onMergeOpen?: () => void
   // Flags
   readonly canShare: boolean
   readonly canExport: boolean
@@ -68,6 +69,7 @@ export function BulkActionBar({
   onBulkDeleteOpen,
   onClearSelection,
   onGroupSceneOpen,
+  onMergeOpen,
   canShare,
   canExport,
   locations,
@@ -305,6 +307,17 @@ export function BulkActionBar({
           >
             <Layers className="mr-1.5 h-3.5 w-3.5" />
             Set Scene
+          </Button>
+        )}
+        {onMergeOpen && canManageShots(role) && (
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={selectedIds.size !== 2}
+            onClick={onMergeOpen}
+          >
+            <GitMerge className="mr-1.5 h-3.5 w-3.5" />
+            Merge
           </Button>
         )}
         {canManageShots(role) && (

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -47,6 +47,7 @@ import { useLanes } from "@/features/shots/hooks/useLanes"
 import { SceneHeader } from "@/features/shots/components/SceneHeader"
 import { SceneDetailSheet } from "@/features/shots/components/SceneDetailSheet"
 import { GroupIntoSceneDialog } from "@/features/shots/components/GroupIntoSceneDialog"
+import { ShotMergeWizard } from "@/features/shots/components/ShotMergeWizard"
 import { createLane, assignShotsToLane, ungroupAllShotsFromLane, deleteLane } from "@/features/shots/lib/laneActions"
 import { writeShotListNavOrder } from "@/features/shots/lib/shotListNavOrder"
 import { Skeleton } from "@/ui/skeleton"
@@ -91,6 +92,7 @@ export default function ShotListPage() {
   const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false)
   const [renumberOpen, setRenumberOpen] = useState(false)
   const [groupSceneOpen, setGroupSceneOpen] = useState(false)
+  const [mergeOpen, setMergeOpen] = useState(false)
   const [deleteSceneTarget, setDeleteSceneTarget] = useState<{ id: string; name: string } | null>(null)
   const [editSceneId, setEditSceneId] = useState<string | null>(null)
   const [collapsedScenes, setCollapsedScenes] = useState<ReadonlySet<string>>(new Set())
@@ -469,6 +471,7 @@ export default function ShotListPage() {
           role={role}
           onShareOpen={() => setShareOpen(true)}
           onGroupSceneOpen={() => setGroupSceneOpen(true)}
+          onMergeOpen={() => setMergeOpen(true)}
           onExportClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}
           onCreatePullOpen={() => setCreatePullOpen(true)}
           onBulkDeleteOpen={() => setBulkDeleteOpen(true)}
@@ -977,6 +980,19 @@ export default function ShotListPage() {
         user={user}
         onDeleted={clearSelection}
       />
+
+      {selectedShots[0] && selectedShots[1] && selectedShots.length === 2 && (
+        <ShotMergeWizard
+          open={mergeOpen}
+          onOpenChange={setMergeOpen}
+          clientId={clientId}
+          user={user}
+          shotA={selectedShots[0]}
+          shotB={selectedShots[1]}
+          projectId={projectId}
+          onMerged={clearSelection}
+        />
+      )}
 
       <RenumberShotsDialog
         open={renumberOpen}

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -93,6 +93,12 @@ export default function ShotListPage() {
   const [renumberOpen, setRenumberOpen] = useState(false)
   const [groupSceneOpen, setGroupSceneOpen] = useState(false)
   const [mergeOpen, setMergeOpen] = useState(false)
+  // Snapshot the two merge candidates at open time. Hosting the wizard on the
+  // live `selectedShots` would unmount it mid-flow: a successful merge soft-
+  // deletes the loser, which drops it out of `displayShots` → `selectedShots`
+  // falls to 1 → the dialog unmounts before the Result step can render (and
+  // leaves `mergeOpen` true, re-popping next time two shots are selected).
+  const [mergeShots, setMergeShots] = useState<readonly [Shot, Shot] | null>(null)
   const [deleteSceneTarget, setDeleteSceneTarget] = useState<{ id: string; name: string } | null>(null)
   const [editSceneId, setEditSceneId] = useState<string | null>(null)
   const [collapsedScenes, setCollapsedScenes] = useState<ReadonlySet<string>>(new Set())
@@ -355,6 +361,15 @@ export default function ShotListPage() {
     return displayShots.filter((s) => selectedIds.has(s.id))
   }, [displayShots, selectedIds, selectionEnabled])
 
+  // Open the merge wizard on a snapshot of the current pair (see mergeShots).
+  const openMerge = () => {
+    const [a, b] = selectedShots
+    if (a && b && selectedShots.length === 2) {
+      setMergeShots([a, b])
+      setMergeOpen(true)
+    }
+  }
+
   // -- Loading / error states --
   const stuck = useStuckLoading(loading)
 
@@ -471,7 +486,7 @@ export default function ShotListPage() {
           role={role}
           onShareOpen={() => setShareOpen(true)}
           onGroupSceneOpen={() => setGroupSceneOpen(true)}
-          onMergeOpen={() => setMergeOpen(true)}
+          onMergeOpen={openMerge}
           onExportClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}
           onCreatePullOpen={() => setCreatePullOpen(true)}
           onBulkDeleteOpen={() => setBulkDeleteOpen(true)}
@@ -981,14 +996,17 @@ export default function ShotListPage() {
         onDeleted={clearSelection}
       />
 
-      {selectedShots[0] && selectedShots[1] && selectedShots.length === 2 && (
+      {mergeShots && (
         <ShotMergeWizard
           open={mergeOpen}
-          onOpenChange={setMergeOpen}
+          onOpenChange={(o) => {
+            setMergeOpen(o)
+            if (!o) setMergeShots(null)
+          }}
           clientId={clientId}
           user={user}
-          shotA={selectedShots[0]}
-          shotB={selectedShots[1]}
+          shotA={mergeShots[0]}
+          shotB={mergeShots[1]}
           projectId={projectId}
           onMerged={clearSelection}
         />

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -363,8 +363,10 @@ export default function ShotListPage() {
 
   // Open the merge wizard on a snapshot of the current pair (see mergeShots).
   const openMerge = () => {
+    if (selectedShots.length !== 2) return
     const [a, b] = selectedShots
-    if (a && b && selectedShots.length === 2) {
+    if (a && b) {
+      // a && b is the type-narrowing guard (TS can't narrow a tuple from .length).
       setMergeShots([a, b])
       setMergeOpen(true)
     }

--- a/src-vnext/features/shots/components/ShotMergeWizard.tsx
+++ b/src-vnext/features/shots/components/ShotMergeWizard.tsx
@@ -13,7 +13,8 @@ import { Checkbox } from "@/ui/checkbox"
 import { toast } from "sonner"
 import { cn } from "@/shared/lib/utils"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
-import type { AuthUser, Shot, ShotFirestoreStatus } from "@/shared/types"
+import { getShotStatusLabel } from "@/shared/lib/statusMappings"
+import type { AuthUser, Shot } from "@/shared/types"
 import {
   buildShotMergePlan,
   executeShotMerge,
@@ -42,13 +43,6 @@ const STEPS: ReadonlyArray<{ readonly key: WizardStep; readonly label: string }>
   { key: "preview", label: "Preview" },
   { key: "result", label: "Result" },
 ]
-
-const STATUS_LABELS: Record<ShotFirestoreStatus, string> = {
-  todo: "To do",
-  in_progress: "In progress",
-  complete: "Complete",
-  on_hold: "On hold",
-}
 
 const MODE_OPTIONS: ReadonlyArray<{
   readonly key: ShotMergeMode
@@ -196,7 +190,7 @@ function ShotCompareCard({
         </div>
         <div className="flex justify-between">
           <dt>Status</dt>
-          <dd className="font-medium text-[var(--color-text)]">{STATUS_LABELS[shot.status]}</dd>
+          <dd className="font-medium text-[var(--color-text)]">{getShotStatusLabel(shot.status)}</dd>
         </div>
         {shot.locationName && (
           <div className="flex items-center gap-1">

--- a/src-vnext/features/shots/components/ShotMergeWizard.tsx
+++ b/src-vnext/features/shots/components/ShotMergeWizard.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/ui/dialog"
 import { Button } from "@/ui/button"
 import { Checkbox } from "@/ui/checkbox"
+import { RadioGroup, RadioGroupItem } from "@/ui/radio-group"
 import { toast } from "sonner"
 import { cn } from "@/shared/lib/utils"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
@@ -343,33 +344,38 @@ export function ShotMergeWizard({
                 <legend className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--color-text-subtle)]">
                   Merge mode
                 </legend>
-                <div role="radiogroup" aria-label="Merge mode" className="grid gap-2 sm:grid-cols-2">
+                <RadioGroup
+                  value={mode}
+                  onValueChange={(v) => setMode(v as ShotMergeMode)}
+                  aria-label="Merge mode"
+                  className="grid gap-2 sm:grid-cols-2"
+                >
                   {MODE_OPTIONS.map((opt) => {
                     const selected = mode === opt.key
+                    const id = `merge-mode-${opt.key}`
                     return (
-                      <button
-                        key={opt.key}
-                        type="button"
-                        role="radio"
-                        aria-checked={selected}
-                        onClick={() => setMode(opt.key)}
-                        className={cn(
-                          "rounded-md border p-3 text-left transition-colors",
-                          selected
-                            ? "border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
-                            : "border-[var(--color-border)] hover:border-[var(--color-text-subtle)]",
-                        )}
-                      >
-                        <div className="text-sm font-medium text-[var(--color-text)]">
-                          {opt.label}
-                        </div>
-                        <div className="mt-0.5 text-xs text-[var(--color-text-muted)]">
-                          {opt.helper}
-                        </div>
-                      </button>
+                      <div key={opt.key}>
+                        <RadioGroupItem value={opt.key} id={id} className="sr-only" />
+                        <label
+                          htmlFor={id}
+                          className={cn(
+                            "block cursor-pointer rounded-md border p-3 text-left transition-colors",
+                            selected
+                              ? "border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
+                              : "border-[var(--color-border)] hover:border-[var(--color-text-subtle)]",
+                          )}
+                        >
+                          <div className="text-sm font-medium text-[var(--color-text)]">
+                            {opt.label}
+                          </div>
+                          <div className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+                            {opt.helper}
+                          </div>
+                        </label>
+                      </div>
                     )
                   })}
-                </div>
+                </RadioGroup>
               </fieldset>
 
               <div className="flex justify-end gap-2">

--- a/src-vnext/features/shots/components/ShotMergeWizard.tsx
+++ b/src-vnext/features/shots/components/ShotMergeWizard.tsx
@@ -1,0 +1,511 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { GitMerge, Image as ImageIcon, MapPin, Calendar } from "lucide-react"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/ui/dialog"
+import { Button } from "@/ui/button"
+import { Checkbox } from "@/ui/checkbox"
+import { toast } from "sonner"
+import { cn } from "@/shared/lib/utils"
+import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
+import type { AuthUser, Shot, ShotFirestoreStatus } from "@/shared/types"
+import {
+  buildShotMergePlan,
+  executeShotMerge,
+  type ShotMergeMode,
+  type ShotMergeResult,
+} from "../lib/shotMergeWrites"
+
+interface ShotMergeWizardProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly clientId: string | null
+  readonly user: AuthUser | null
+  /** The exactly-2 selected shots. */
+  readonly shotA: Shot
+  readonly shotB: Shot
+  /** For the "View shot" nav. */
+  readonly projectId: string
+  /** Clear selection on success. */
+  readonly onMerged?: () => void
+}
+
+type WizardStep = "compare" | "preview" | "result"
+
+const STEPS: ReadonlyArray<{ readonly key: WizardStep; readonly label: string }> = [
+  { key: "compare", label: "Compare" },
+  { key: "preview", label: "Preview" },
+  { key: "result", label: "Result" },
+]
+
+const STATUS_LABELS: Record<ShotFirestoreStatus, string> = {
+  todo: "To do",
+  in_progress: "In progress",
+  complete: "Complete",
+  on_hold: "On hold",
+}
+
+const MODE_OPTIONS: ReadonlyArray<{
+  readonly key: ShotMergeMode
+  readonly label: string
+  readonly helper: string
+}> = [
+  {
+    key: "combine",
+    label: "Combine into one outfit look",
+    helper: "Products from both shots merge into a single look (deduped).",
+  },
+  {
+    key: "separate",
+    label: "Keep as separate looks",
+    helper: "Each shot's looks are preserved side by side as alternatives.",
+  },
+]
+
+function StepIndicator({
+  steps,
+  current,
+}: {
+  readonly steps: ReadonlyArray<{ readonly key: WizardStep; readonly label: string }>
+  readonly current: WizardStep
+}) {
+  const currentIndex = steps.findIndex((s) => s.key === current)
+
+  return (
+    <div className="flex items-center gap-1">
+      {steps.map((s, i) => {
+        const isActive = s.key === current
+        const isPast = i < currentIndex
+        return (
+          <div key={s.key} className="flex items-center gap-1">
+            {i > 0 && (
+              <div
+                className={cn(
+                  "h-px w-4",
+                  isPast ? "bg-[var(--color-status-green-text)]" : "bg-[var(--color-border)]",
+                )}
+              />
+            )}
+            <div
+              className={cn(
+                "flex items-center gap-1.5 rounded-full px-2.5 py-1 text-2xs font-medium transition-colors",
+                isActive
+                  ? "bg-[var(--color-primary)] text-[var(--color-primary-fg)]"
+                  : isPast
+                    ? "bg-[var(--color-status-green-bg)] text-[var(--color-status-green-text)]"
+                    : "bg-[var(--color-surface-subtle)] text-[var(--color-text-subtle)]",
+              )}
+            >
+              <span>{i + 1}</span>
+              <span className="hidden sm:inline">{s.label}</span>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+/** Distinct product count across a shot's looks (or root products fallback). */
+function shotProductCount(shot: Shot): number {
+  if (shot.looks?.length) {
+    const seen = new Set<string>()
+    for (const look of shot.looks) {
+      for (const p of look.products ?? []) {
+        seen.add(`${p.familyId}::${p.skuId ?? ""}::${p.colourId ?? ""}`)
+      }
+    }
+    return seen.size
+  }
+  return shot.products?.length ?? 0
+}
+
+/** Number of looks (legacy root-products shot counts as one synthetic look). */
+function shotLookCount(shot: Shot): number {
+  if (shot.looks?.length) return shot.looks.length
+  return shot.products?.length ? 1 : 0
+}
+
+function formatDate(shot: Shot): string | null {
+  if (!shot.date) return null
+  try {
+    return shot.date.toDate().toLocaleDateString()
+  } catch {
+    return null
+  }
+}
+
+function ShotCompareCard({
+  shot,
+  isPrimary,
+}: {
+  readonly shot: Shot
+  readonly isPrimary: boolean
+}) {
+  const heroUrl = useStorageUrl(shot.heroImage?.path)
+  const resolved = heroUrl ?? shot.heroImage?.downloadURL
+  const date = formatDate(shot)
+
+  return (
+    <div
+      className={cn(
+        "flex-1 rounded-lg border p-3",
+        isPrimary
+          ? "border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
+          : "border-[var(--color-border)]",
+      )}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        <span className="text-2xs font-medium uppercase tracking-wide text-[var(--color-text-subtle)]">
+          {isPrimary ? "Primary (kept)" : "Secondary (merged in)"}
+        </span>
+      </div>
+      <div className="mb-3 aspect-video w-full overflow-hidden rounded-md bg-[var(--color-surface-subtle)]">
+        {resolved ? (
+          <img
+            src={resolved}
+            alt={shot.title}
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-[var(--color-text-subtle)]">
+            <ImageIcon className="h-6 w-6" />
+          </div>
+        )}
+      </div>
+      <h3 className="mb-2 truncate text-sm font-semibold text-[var(--color-text)]" title={shot.title}>
+        {shot.title}
+      </h3>
+      <dl className="space-y-1 text-xs text-[var(--color-text-muted)]">
+        <div className="flex justify-between">
+          <dt>Products</dt>
+          <dd className="font-medium text-[var(--color-text)]">{shotProductCount(shot)}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt>Looks</dt>
+          <dd className="font-medium text-[var(--color-text)]">{shotLookCount(shot)}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt>Talent</dt>
+          <dd className="font-medium text-[var(--color-text)]">{shot.talent?.length ?? 0}</dd>
+        </div>
+        <div className="flex justify-between">
+          <dt>Status</dt>
+          <dd className="font-medium text-[var(--color-text)]">{STATUS_LABELS[shot.status]}</dd>
+        </div>
+        {shot.locationName && (
+          <div className="flex items-center gap-1">
+            <MapPin className="h-3 w-3 shrink-0" />
+            <span className="truncate">{shot.locationName}</span>
+          </div>
+        )}
+        {date && (
+          <div className="flex items-center gap-1">
+            <Calendar className="h-3 w-3 shrink-0" />
+            <span>{date}</span>
+          </div>
+        )}
+      </dl>
+    </div>
+  )
+}
+
+export function ShotMergeWizard({
+  open,
+  onOpenChange,
+  clientId,
+  user,
+  shotA,
+  shotB,
+  projectId,
+  onMerged,
+}: ShotMergeWizardProps) {
+  const navigate = useNavigate()
+
+  const [step, setStep] = useState<WizardStep>("compare")
+  // true → shotA is primary; false → shotB is primary.
+  const [aIsPrimary, setAIsPrimary] = useState(true)
+  const [mode, setMode] = useState<ShotMergeMode>("combine")
+  const [confirmed, setConfirmed] = useState(false)
+  const [merging, setMerging] = useState(false)
+  const [mergeResult, setMergeResult] = useState<ShotMergeResult | null>(null)
+
+  // Reset state when dialog closes.
+  useEffect(() => {
+    if (!open) {
+      setStep("compare")
+      setAIsPrimary(true)
+      setMode("combine")
+      setConfirmed(false)
+      setMerging(false)
+      setMergeResult(null)
+    }
+  }, [open])
+
+  const primary = aIsPrimary ? shotA : shotB
+  const secondary = aIsPrimary ? shotB : shotA
+
+  const preview = useMemo(() => {
+    if (step !== "preview") return null
+    return buildShotMergePlan({ primary, secondary, mode })
+  }, [step, primary, secondary, mode])
+
+  const handleSwap = useCallback(() => {
+    setAIsPrimary((prev) => !prev)
+  }, [])
+
+  const handleToPreview = useCallback(() => {
+    setConfirmed(false)
+    setStep("preview")
+  }, [])
+
+  const handleBackToCompare = useCallback(() => {
+    setStep("compare")
+  }, [])
+
+  const handleMerge = useCallback(async () => {
+    if (!clientId) {
+      toast.error("Merge failed", { description: "Missing client context." })
+      return
+    }
+    setMerging(true)
+    try {
+      const result = await executeShotMerge({
+        clientId,
+        primary,
+        secondary,
+        mode,
+        user,
+      })
+      setMergeResult(result)
+      setStep("result")
+    } catch (err) {
+      toast.error("Merge failed", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
+    } finally {
+      setMerging(false)
+    }
+  }, [clientId, primary, secondary, mode, user])
+
+  const handleViewShot = useCallback(() => {
+    if (!mergeResult) return
+    onOpenChange(false)
+    onMerged?.()
+    navigate(`/projects/${projectId}/shots/${mergeResult.mergedShotId}`)
+  }, [mergeResult, projectId, navigate, onOpenChange, onMerged])
+
+  const handleClose = useCallback(() => {
+    onOpenChange(false)
+    onMerged?.()
+  }, [onOpenChange, onMerged])
+
+  // Prevent closing during merge.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (merging) return
+      onOpenChange(next)
+    },
+    [merging, onOpenChange],
+  )
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle className="heading-section">Merge shots</DialogTitle>
+          <DialogDescription className="text-sm text-[var(--color-text-muted)]">
+            Combine two shots into one. The secondary shot is soft-deleted (recoverable).
+          </DialogDescription>
+        </DialogHeader>
+
+        <StepIndicator steps={STEPS} current={step} />
+
+        <div className="max-h-[calc(100vh-16rem)] overflow-y-auto">
+          {step === "compare" && (
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row">
+                <ShotCompareCard shot={shotA} isPrimary={aIsPrimary} />
+                <ShotCompareCard shot={shotB} isPrimary={!aIsPrimary} />
+              </div>
+
+              <div className="flex items-center justify-between rounded-md border border-[var(--color-border)] p-3">
+                <div className="text-xs text-[var(--color-text-muted)]">
+                  <span className="font-medium text-[var(--color-text)]">{primary.title}</span> is
+                  kept as the primary; its title, date, location and status stay unchanged.
+                </div>
+                <Button variant="outline" size="sm" onClick={handleSwap}>
+                  Swap
+                </Button>
+              </div>
+
+              <fieldset className="space-y-2">
+                <legend className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--color-text-subtle)]">
+                  Merge mode
+                </legend>
+                <div className="grid gap-2 sm:grid-cols-2">
+                  {MODE_OPTIONS.map((opt) => {
+                    const selected = mode === opt.key
+                    return (
+                      <button
+                        key={opt.key}
+                        type="button"
+                        onClick={() => setMode(opt.key)}
+                        aria-pressed={selected}
+                        className={cn(
+                          "rounded-md border p-3 text-left transition-colors",
+                          selected
+                            ? "border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
+                            : "border-[var(--color-border)] hover:border-[var(--color-text-subtle)]",
+                        )}
+                      >
+                        <div className="text-sm font-medium text-[var(--color-text)]">
+                          {opt.label}
+                        </div>
+                        <div className="mt-0.5 text-xs text-[var(--color-text-muted)]">
+                          {opt.helper}
+                        </div>
+                      </button>
+                    )
+                  })}
+                </div>
+              </fieldset>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" size="sm" onClick={() => onOpenChange(false)}>
+                  Cancel
+                </Button>
+                <Button size="sm" onClick={handleToPreview}>
+                  Next
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === "preview" && preview && (
+            <div className="space-y-4">
+              <div className="rounded-md border border-[var(--color-border)] p-3">
+                <div className="mb-2 text-sm font-semibold text-[var(--color-text)]">
+                  {primary.title}
+                </div>
+                <dl className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-3">
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Products combined</dt>
+                    <dd className="text-lg font-semibold text-[var(--color-text)]">
+                      {preview.result.productsCombined}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Talent added</dt>
+                    <dd className="text-lg font-semibold text-[var(--color-text)]">
+                      {preview.result.talentAdded}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">References kept</dt>
+                    <dd className="text-lg font-semibold text-[var(--color-text)]">
+                      {preview.result.referencesKept}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Looks</dt>
+                    <dd className="text-lg font-semibold text-[var(--color-text)]">
+                      {preview.result.looksKept}
+                    </dd>
+                  </div>
+                </dl>
+                <p className="mt-2 text-xs text-[var(--color-text-muted)]">
+                  Primary meta kept (title, date, location, status).
+                </p>
+              </div>
+
+              <div className="rounded-md border border-[var(--color-status-amber-border,var(--color-border))] bg-[var(--color-surface-subtle)] p-3 text-xs text-[var(--color-text-muted)]">
+                &ldquo;{secondary.title}&rdquo; will be soft-deleted (recoverable).
+              </div>
+
+              <label className="flex cursor-pointer items-start gap-2 text-xs text-[var(--color-text)]">
+                <Checkbox
+                  checked={confirmed}
+                  onCheckedChange={(v) => setConfirmed(v === true)}
+                  className="mt-0.5"
+                />
+                <span>
+                  I understand the secondary shot will be merged in and soft-deleted.
+                </span>
+              </label>
+
+              <div className="flex justify-end gap-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleBackToCompare}
+                  disabled={merging}
+                >
+                  Back
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleMerge}
+                  disabled={!confirmed || merging}
+                >
+                  <GitMerge className="mr-1.5 h-3.5 w-3.5" />
+                  {merging ? "Merging…" : "Merge"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {step === "result" && mergeResult && (
+            <div className="space-y-4">
+              <div className="rounded-md border border-[var(--color-status-green-border,var(--color-border))] bg-[var(--color-status-green-bg)] p-3">
+                <div className="text-sm font-semibold text-[var(--color-status-green-text)]">
+                  Shots merged
+                </div>
+                <dl className="mt-2 grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Products</dt>
+                    <dd className="font-semibold text-[var(--color-text)]">
+                      {mergeResult.productsCombined}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Talent added</dt>
+                    <dd className="font-semibold text-[var(--color-text)]">
+                      {mergeResult.talentAdded}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">References</dt>
+                    <dd className="font-semibold text-[var(--color-text)]">
+                      {mergeResult.referencesKept}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-[var(--color-text-subtle)]">Looks</dt>
+                    <dd className="font-semibold text-[var(--color-text)]">
+                      {mergeResult.looksKept}
+                    </dd>
+                  </div>
+                </dl>
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" size="sm" onClick={handleViewShot}>
+                  View shot
+                </Button>
+                <Button size="sm" onClick={handleClose}>
+                  Close
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src-vnext/features/shots/components/ShotMergeWizard.tsx
+++ b/src-vnext/features/shots/components/ShotMergeWizard.tsx
@@ -164,6 +164,7 @@ function ShotCompareCard({
           <img
             src={resolved}
             alt={shot.title}
+            loading="lazy"
             className="h-full w-full object-cover"
           />
         ) : (
@@ -172,7 +173,7 @@ function ShotCompareCard({
           </div>
         )}
       </div>
-      <h3 className="mb-2 truncate text-sm font-semibold text-[var(--color-text)]" title={shot.title}>
+      <h3 className="heading-subsection mb-2 truncate" title={shot.title}>
         {shot.title}
       </h3>
       <dl className="space-y-1 text-xs text-[var(--color-text-muted)]">
@@ -342,15 +343,16 @@ export function ShotMergeWizard({
                 <legend className="mb-1 text-xs font-medium uppercase tracking-wide text-[var(--color-text-subtle)]">
                   Merge mode
                 </legend>
-                <div className="grid gap-2 sm:grid-cols-2">
+                <div role="radiogroup" aria-label="Merge mode" className="grid gap-2 sm:grid-cols-2">
                   {MODE_OPTIONS.map((opt) => {
                     const selected = mode === opt.key
                     return (
                       <button
                         key={opt.key}
                         type="button"
+                        role="radio"
+                        aria-checked={selected}
                         onClick={() => setMode(opt.key)}
-                        aria-pressed={selected}
                         className={cn(
                           "rounded-md border p-3 text-left transition-colors",
                           selected

--- a/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, cleanup } from "@testing-library/react"
+import { BulkActionBar } from "@/features/shots/components/BulkActionBar"
+import type { Role, Shot } from "@/shared/types"
+
+// useAvailableTags reads Firestore via useShots — stub it so the bar renders standalone.
+vi.mock("@/features/shots/hooks/useAvailableTags", () => ({
+  useAvailableTags: () => ({ tags: [], loading: false, error: null }),
+}))
+
+function makeShot(id: string): Shot {
+  return {
+    id,
+    title: `Shot ${id}`,
+    status: "todo",
+    talent: [],
+    products: [],
+    sortOrder: 0,
+  } as unknown as Shot
+}
+
+const DISPLAY_SHOTS: ReadonlyArray<Shot> = [
+  makeShot("a"),
+  makeShot("b"),
+  makeShot("c"),
+]
+
+function renderBar(opts: {
+  selectedIds: ReadonlySet<string>
+  role: Role
+  onMergeOpen?: () => void
+}) {
+  const onMergeOpen = opts.onMergeOpen
+  render(
+    <BulkActionBar
+      displayShots={DISPLAY_SHOTS}
+      selectedIds={opts.selectedIds}
+      onSelectAll={() => {}}
+      onDeselectAll={() => {}}
+      clientId="client-1"
+      user={null}
+      role={opts.role}
+      onShareOpen={() => {}}
+      onExportClick={() => {}}
+      onCreatePullOpen={() => {}}
+      onBulkDeleteOpen={() => {}}
+      onClearSelection={() => {}}
+      onGroupSceneOpen={() => {}}
+      onMergeOpen={onMergeOpen}
+      canShare
+      canExport
+      locations={[]}
+      talent={[]}
+    />,
+  )
+}
+
+function mergeButton(): HTMLButtonElement | null {
+  return screen
+    .queryAllByRole("button")
+    .find((b) => b.textContent?.trim() === "Merge") as HTMLButtonElement | null ?? null
+}
+
+describe("BulkActionBar — Merge action", () => {
+  beforeEach(() => cleanup())
+
+  it("renders the Merge button for canManageShots roles", () => {
+    renderBar({ selectedIds: new Set(["a", "b"]), role: "producer", onMergeOpen: () => {} })
+    expect(mergeButton()).not.toBeNull()
+  })
+
+  it("does NOT render Merge for a viewer (no canManageShots)", () => {
+    renderBar({ selectedIds: new Set(["a", "b"]), role: "viewer", onMergeOpen: () => {} })
+    expect(mergeButton()).toBeNull()
+  })
+
+  it("does NOT render Merge when no onMergeOpen handler is supplied", () => {
+    renderBar({ selectedIds: new Set(["a", "b"]), role: "producer" })
+    expect(mergeButton()).toBeNull()
+  })
+
+  it("enables Merge only at exactly 2 selected", () => {
+    // 1 selected -> disabled
+    renderBar({ selectedIds: new Set(["a"]), role: "admin", onMergeOpen: () => {} })
+    expect(mergeButton()?.disabled).toBe(true)
+    cleanup()
+
+    // 2 selected -> enabled
+    renderBar({ selectedIds: new Set(["a", "b"]), role: "admin", onMergeOpen: () => {} })
+    expect(mergeButton()?.disabled).toBe(false)
+    cleanup()
+
+    // 3 selected -> disabled
+    renderBar({ selectedIds: new Set(["a", "b", "c"]), role: "admin", onMergeOpen: () => {} })
+    expect(mergeButton()?.disabled).toBe(true)
+  })
+
+  it("disables Merge at 0 selected", () => {
+    renderBar({ selectedIds: new Set(), role: "crew", onMergeOpen: () => {} })
+    expect(mergeButton()?.disabled).toBe(true)
+  })
+
+  it("fires onMergeOpen when clicked at exactly 2 selected", () => {
+    const onMergeOpen = vi.fn()
+    renderBar({ selectedIds: new Set(["a", "b"]), role: "crew", onMergeOpen })
+    fireEvent.click(mergeButton()!)
+    expect(onMergeOpen).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src-vnext/features/shots/components/__tests__/ShotMergeWizard.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotMergeWizard.test.tsx
@@ -213,6 +213,21 @@ describe("ShotMergeWizard", () => {
     })
   })
 
+  it("surfaces a toast and stays on preview when the merge fails", async () => {
+    executeShotMergeMock.mockRejectedValueOnce(new Error("batch failed"))
+    renderWizard()
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge/i }))
+
+    await waitFor(() => expect(toastError).toHaveBeenCalled())
+    // Did NOT advance to the result step…
+    expect(screen.queryByText("Shots merged")).toBeNull()
+    // …and the Merge button is re-enabled (merging reset in the finally block).
+    expect(screen.getByRole("button", { name: /Merge/i })).not.toBeDisabled()
+  })
+
   it("View shot navigates to the project-scoped shot-detail route", async () => {
     const onMerged = vi.fn()
     renderWizard({ projectId: "p9", onMerged })

--- a/src-vnext/features/shots/components/__tests__/ShotMergeWizard.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotMergeWizard.test.tsx
@@ -1,0 +1,229 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import { Timestamp } from "firebase/firestore"
+import type { Shot } from "@/shared/types"
+import type {
+  ShotMergeMode,
+  ShotMergeResult,
+} from "@/features/shots/lib/shotMergeWrites"
+
+// --- Mocks (hoisted handles) ---
+const mockNavigate = vi.fn()
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  )
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+vi.mock("@/shared/hooks/useStorageUrl", () => ({
+  useStorageUrl: () => undefined,
+}))
+
+const buildShotMergePlanMock = vi.fn()
+const executeShotMergeMock = vi.fn()
+vi.mock("@/features/shots/lib/shotMergeWrites", () => ({
+  buildShotMergePlan: (args: unknown) => buildShotMergePlanMock(args),
+  executeShotMerge: (args: unknown) => executeShotMergeMock(args),
+}))
+
+const toastError = vi.fn()
+vi.mock("sonner", () => ({
+  toast: { error: (...a: unknown[]) => toastError(...a) },
+}))
+
+import { ShotMergeWizard } from "@/features/shots/components/ShotMergeWizard"
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    referenceLinks: overrides.referenceLinks,
+    looks: overrides.looks,
+    activeLookId: overrides.activeLookId,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+const user = { uid: "u1", email: null, displayName: null, photoURL: null }
+
+/** Read the `<dd>` value rendered next to a `<dt>` label. */
+function valueFor(label: string): string {
+  const dt = screen.getByText(label)
+  const dd = dt.parentElement?.querySelector("dd")
+  return dd?.textContent ?? ""
+}
+
+function planWith(
+  result: Partial<ShotMergeResult> = {},
+): { patch: Record<string, unknown>; result: Omit<ShotMergeResult, "mergedShotId"> } {
+  return {
+    patch: {},
+    result: {
+      productsCombined: result.productsCombined ?? 3,
+      talentAdded: result.talentAdded ?? 1,
+      looksKept: result.looksKept ?? 1,
+      referencesKept: result.referencesKept ?? 2,
+    },
+  }
+}
+
+function renderWizard(props: Partial<Parameters<typeof ShotMergeWizard>[0]> = {}) {
+  const shotA = props.shotA ?? makeShot({ id: "a", title: "Shot A" })
+  const shotB = props.shotB ?? makeShot({ id: "b", title: "Shot B" })
+  return render(
+    <ShotMergeWizard
+      open={props.open ?? true}
+      onOpenChange={props.onOpenChange ?? vi.fn()}
+      clientId={props.clientId ?? "c1"}
+      user={props.user ?? user}
+      shotA={shotA}
+      shotB={shotB}
+      projectId={props.projectId ?? "p1"}
+      onMerged={props.onMerged}
+    />,
+  )
+}
+
+describe("ShotMergeWizard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    buildShotMergePlanMock.mockReturnValue(planWith())
+    executeShotMergeMock.mockResolvedValue({
+      mergedShotId: "a",
+      productsCombined: 3,
+      talentAdded: 1,
+      looksKept: 1,
+      referencesKept: 2,
+    } satisfies ShotMergeResult)
+  })
+
+  it("walks compare → preview → result", async () => {
+    renderWizard()
+    // Compare step renders both titles (as card headings).
+    expect(screen.getByRole("heading", { name: "Shot A" })).toBeInTheDocument()
+    expect(screen.getByRole("heading", { name: "Shot B" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    // Preview computed.
+    expect(buildShotMergePlanMock).toHaveBeenCalled()
+    expect(screen.getByText("Products combined")).toBeInTheDocument()
+
+    // Confirm gate then merge.
+    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge/i }))
+
+    await waitFor(() =>
+      expect(screen.getByText("Shots merged")).toBeInTheDocument(),
+    )
+  })
+
+  it("Swap flips which shot is primary (passed to executeShotMerge)", async () => {
+    const shotA = makeShot({ id: "a", title: "Shot A" })
+    const shotB = makeShot({ id: "b", title: "Shot B" })
+    renderWizard({ shotA, shotB })
+
+    // Default: A primary.
+    fireEvent.click(screen.getByRole("button", { name: "Swap" }))
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge/i }))
+
+    await waitFor(() => expect(executeShotMergeMock).toHaveBeenCalled())
+    const arg = executeShotMergeMock.mock.calls[0]?.[0] as {
+      primary: Shot
+      secondary: Shot
+    }
+    expect(arg.primary.id).toBe("b")
+    expect(arg.secondary.id).toBe("a")
+  })
+
+  it("mode toggle changes the preview counts", () => {
+    buildShotMergePlanMock.mockImplementation(
+      (args: { mode: ShotMergeMode }) =>
+        args.mode === "combine"
+          ? planWith({ productsCombined: 3, looksKept: 1 })
+          : planWith({ productsCombined: 5, looksKept: 2 }),
+    )
+    renderWizard()
+
+    // Default combine.
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    expect(valueFor("Products combined")).toBe("3")
+
+    // Back, choose separate.
+    fireEvent.click(screen.getByRole("button", { name: "Back" }))
+    fireEvent.click(screen.getByText("Keep as separate looks"))
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    const calls = buildShotMergePlanMock.mock.calls
+    const lastArg = calls[calls.length - 1]?.[0] as { mode: ShotMergeMode }
+    expect(lastArg.mode).toBe("separate")
+    expect(valueFor("Products combined")).toBe("5")
+  })
+
+  it("confirm checkbox gates the Merge button", () => {
+    renderWizard()
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    const mergeBtn = screen.getByRole("button", { name: /Merge/i })
+    expect(mergeBtn).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("checkbox"))
+    expect(mergeBtn).not.toBeDisabled()
+  })
+
+  it("Merge calls executeShotMerge with primary/secondary/mode/clientId/user", async () => {
+    const shotA = makeShot({ id: "a", title: "Shot A" })
+    const shotB = makeShot({ id: "b", title: "Shot B" })
+    renderWizard({ shotA, shotB, clientId: "c1", user })
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge/i }))
+
+    await waitFor(() => expect(executeShotMergeMock).toHaveBeenCalledTimes(1))
+    expect(executeShotMergeMock).toHaveBeenCalledWith({
+      clientId: "c1",
+      primary: shotA,
+      secondary: shotB,
+      mode: "combine",
+      user,
+    })
+  })
+
+  it("View shot navigates to the project-scoped shot-detail route", async () => {
+    const onMerged = vi.fn()
+    renderWizard({ projectId: "p9", onMerged })
+
+    fireEvent.click(screen.getByRole("button", { name: "Next" }))
+    fireEvent.click(screen.getByRole("checkbox"))
+    fireEvent.click(screen.getByRole("button", { name: /Merge/i }))
+    await waitFor(() => screen.getByText("Shots merged"))
+
+    fireEvent.click(screen.getByRole("button", { name: "View shot" }))
+    expect(mockNavigate).toHaveBeenCalledWith("/projects/p9/shots/a")
+    expect(onMerged).toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/shots/lib/shotMergeWrites.test.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.test.ts
@@ -1,7 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 
+// Hoisted batch spies so the firebase/firestore mock factory can close over them.
+const { batchUpdate, batchCommit, makeBatch } = vi.hoisted(() => {
+  const batchUpdate = vi.fn()
+  const batchCommit = vi.fn().mockResolvedValue(undefined)
+  const makeBatch = vi.fn(() => ({ update: batchUpdate, commit: batchCommit }))
+  return { batchUpdate, batchCommit, makeBatch }
+})
+
 vi.mock("firebase/firestore", () => ({
   serverTimestamp: vi.fn(() => ({ _methodName: "serverTimestamp" })),
+  doc: vi.fn((_db: unknown, ...segments: string[]) => ({ path: segments.join("/") })),
+  writeBatch: makeBatch,
 }))
 
 vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
@@ -15,13 +25,11 @@ vi.mock("@/shared/lib/paths", () => ({
   ],
 }))
 
-// Mock the writer so executeShotMerge tests assert orchestration only.
-vi.mock("./updateShotWithVersion", () => ({
-  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
-}))
+// Best-effort audit write — stubbed so orchestration tests stay focused.
+const createShotVersionSnapshot = vi.hoisted(() => vi.fn().mockResolvedValue("v1"))
+vi.mock("./shotVersioning", () => ({ createShotVersionSnapshot }))
 
 import { buildShotMergePlan, executeShotMerge } from "./shotMergeWrites"
-import { updateShotWithVersion } from "./updateShotWithVersion"
 import type {
   AuthUser,
   ProductAssignment,
@@ -403,7 +411,7 @@ describe("executeShotMerge — orchestration", () => {
     vi.clearAllMocks()
   })
 
-  it("writes primary FIRST then soft-deletes secondary; returns counts", async () => {
+  it("merges primary + soft-deletes secondary in ONE atomic batch; returns counts", async () => {
     const primary = makeShot({
       id: "A",
       title: "Shot A",
@@ -429,27 +437,44 @@ describe("executeShotMerge — orchestration", () => {
     expect(out.mergedShotId).toBe("A")
     expect(out.talentAdded).toBe(1)
 
-    const calls = vi.mocked(updateShotWithVersion).mock.calls
-    expect(calls).toHaveLength(2)
-    // primary first
-    expect(calls[0]![0].shotId).toBe("A")
-    expect(calls[0]![0].source).toBe("shot-merge")
-    // secondary soft-deleted (deleted:true), NOT hard-deleted
-    expect(calls[1]![0].shotId).toBe("B")
-    expect(calls[1]![0].source).toBe("shot-merge-loser")
-    expect(calls[1]![0].patch).toMatchObject({ deleted: true })
-    expect(calls[1]![0].patch).toHaveProperty("deletedAt")
+    // ONE batch, committed exactly once (atomic) — both writes land together.
+    expect(makeBatch).toHaveBeenCalledTimes(1)
+    expect(batchCommit).toHaveBeenCalledTimes(1)
+
+    const updates = batchUpdate.mock.calls
+    expect(updates).toHaveLength(2)
+    // primary update FIRST, carries the merged looks (not a delete).
+    expect((updates[0]![0] as { path: string }).path).toBe("clients/unbound-merino/shots/A")
+    expect(updates[0]![1]).toHaveProperty("looks")
+    expect(updates[0]![1]).not.toHaveProperty("deleted")
+    // secondary soft-deleted (deleted:true + deletedAt), NOT hard-deleted.
+    expect((updates[1]![0] as { path: string }).path).toBe("clients/unbound-merino/shots/B")
+    expect(updates[1]![1]).toMatchObject({ deleted: true })
+    expect(updates[1]![1]).toHaveProperty("deletedAt")
+
+    // Best-effort version snapshots for both shots (audit, fired after commit).
+    expect(createShotVersionSnapshot).toHaveBeenCalledTimes(2)
   })
 
-  it("does not delete secondary if primary write throws (no orphan)", async () => {
-    vi.mocked(updateShotWithVersion).mockRejectedValueOnce(new Error("primary failed"))
+  it("commits nothing if the batch fails — no half-merged pair (atomic)", async () => {
+    batchCommit.mockRejectedValueOnce(new Error("batch failed"))
     const primary = makeShot({ id: "A", title: "Shot A" })
     const secondary = makeShot({ id: "B", title: "Shot B" })
 
     await expect(
       executeShotMerge({ clientId: "c1", primary, secondary, mode: "combine", user }),
-    ).rejects.toThrow("primary failed")
+    ).rejects.toThrow("batch failed")
 
-    expect(vi.mocked(updateShotWithVersion).mock.calls).toHaveLength(1)
+    // Firestore guarantees an all-or-nothing batch: neither shot is mutated.
+    expect(batchCommit).toHaveBeenCalledTimes(1)
+  })
+
+  it("throws on a missing clientId before touching Firestore", async () => {
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    await expect(
+      executeShotMerge({ clientId: "", primary, secondary, mode: "combine", user }),
+    ).rejects.toThrow("Missing clientId")
+    expect(makeBatch).not.toHaveBeenCalled()
   })
 })

--- a/src-vnext/features/shots/lib/shotMergeWrites.test.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.test.ts
@@ -271,6 +271,27 @@ describe("buildShotMergePlan — talent / links / tags / meta", () => {
     expect((patch.tags as Array<{ id: string }>).map((t) => t.id)).toEqual(["tag1", "tag2"])
   })
 
+  it("omits union fields entirely when both shots lack them (no [] written to absent fields)", () => {
+    // Neither shot has talent / talentIds / referenceLinks / tags.
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    for (const k of ["talent", "talentIds", "referenceLinks", "tags"]) {
+      expect(patch).not.toHaveProperty(k)
+    }
+  })
+
+  it("includes a union field when at least one shot has it", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", talent: ["Alice"], talentIds: ["t1"] })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.talent).toEqual(["Alice"])
+    expect(patch.talentIds).toEqual(["t1"])
+    // The fields the merge doesn't touch stay absent.
+    expect(patch).not.toHaveProperty("tags")
+    expect(patch).not.toHaveProperty("referenceLinks")
+  })
+
   it("leaves primary meta out of the patch (title/date/location/status/shotNumber/laneId/sortOrder)", () => {
     const primary = makeShot({
       id: "A",

--- a/src-vnext/features/shots/lib/shotMergeWrites.test.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.test.ts
@@ -1,0 +1,434 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+vi.mock("firebase/firestore", () => ({
+  serverTimestamp: vi.fn(() => ({ _methodName: "serverTimestamp" })),
+}))
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
+vi.mock("@/shared/lib/paths", () => ({
+  shotPath: (shotId: string, clientId: string) => [
+    "clients",
+    clientId,
+    "shots",
+    shotId,
+  ],
+}))
+
+// Mock the writer so executeShotMerge tests assert orchestration only.
+vi.mock("./updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
+}))
+
+import { buildShotMergePlan, executeShotMerge } from "./shotMergeWrites"
+import { updateShotWithVersion } from "./updateShotWithVersion"
+import type {
+  AuthUser,
+  ProductAssignment,
+  Shot,
+  ShotLook,
+  ShotReferenceImage,
+} from "@/shared/types"
+
+const TS = { _methodName: "serverTimestamp" } as unknown
+
+function makeShot(overrides: Partial<Shot> & { id: string; title: string }): Shot {
+  return {
+    projectId: "p1",
+    clientId: "unbound-merino",
+    status: "todo",
+    talent: [],
+    talentIds: [],
+    products: [],
+    sortOrder: 0,
+    createdAt: TS as Shot["createdAt"],
+    updatedAt: TS as Shot["updatedAt"],
+    createdBy: "u1",
+    ...overrides,
+  } as Shot
+}
+
+function product(overrides: Partial<ProductAssignment> & { familyId: string }): ProductAssignment {
+  return { ...overrides }
+}
+
+function look(overrides: Partial<ShotLook> & { id: string }): ShotLook {
+  return { products: [], ...overrides }
+}
+
+function ref(id: string, extra?: Partial<ShotReferenceImage>): ShotReferenceImage {
+  return { id, path: `refs/${id}.jpg`, ...extra }
+}
+
+/** DEEP recursive scan for any `undefined` value (objects + arrays). */
+function deepUndefinedPaths(value: unknown, path = ""): string[] {
+  if (value === undefined) return [path || "<root>"]
+  if (value === null || typeof value !== "object") return []
+  if (Array.isArray(value)) {
+    return value.flatMap((v, i) => deepUndefinedPaths(v, `${path}[${i}]`))
+  }
+  // serverTimestamp sentinel / Date / Timestamp pass-through
+  if ("_methodName" in (value as Record<string, unknown>)) return []
+  return Object.entries(value as Record<string, unknown>).flatMap(([k, v]) =>
+    deepUndefinedPaths(v, path ? `${path}.${k}` : k),
+  )
+}
+
+describe("buildShotMergePlan — combine mode", () => {
+  it("unions products into ONE look, deduped by family/sku/colour", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "look-a",
+      looks: [
+        look({
+          id: "look-a",
+          products: [
+            product({ familyId: "f1", skuId: "s1", colourId: "navy" }),
+            product({ familyId: "f1", skuId: "s1", colourId: "red" }),
+          ],
+        }),
+      ],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      activeLookId: "look-b",
+      looks: [
+        look({
+          id: "look-b",
+          products: [
+            product({ familyId: "f1", skuId: "s1", colourId: "navy" }), // dup
+            product({ familyId: "f2", skuId: "s2", colourId: "navy" }), // new
+          ],
+        }),
+      ],
+    })
+
+    const { patch, result } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks).toHaveLength(1)
+    expect(looks[0]!.products).toHaveLength(3)
+    expect(patch.activeLookId).toBe("look-a")
+    // root products mirror the active look
+    expect(patch.products).toEqual(looks[0]!.products)
+    expect(result.productsCombined).toBe(3)
+    expect(result.looksKept).toBe(1)
+  })
+
+  it("unions references by id across both shots' looks", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [look({ id: "la", references: [ref("r1"), ref("r2")] })],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      looks: [look({ id: "lb", references: [ref("r2"), ref("r3")] })],
+    })
+    const { patch, result } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks[0]!.references!.map((r) => r.id)).toEqual(["r1", "r2", "r3"])
+    expect(result.referencesKept).toBe(3)
+  })
+
+  it("drops heroProductId/displayImageId when no longer valid", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [
+        look({
+          id: "la",
+          products: [product({ familyId: "f1" })],
+          heroProductId: "f1",
+          displayImageId: "r1",
+          references: [ref("r1")],
+        }),
+      ],
+    })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks[0]!.heroProductId).toBe("f1")
+    expect(looks[0]!.displayImageId).toBe("r1")
+  })
+})
+
+describe("buildShotMergePlan — separate mode", () => {
+  it("keeps both shots' looks and remaps colliding ids + reassigns order", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "shared",
+      looks: [look({ id: "shared", products: [product({ familyId: "f1" })] })],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      looks: [look({ id: "shared", products: [product({ familyId: "f2" })] })],
+    })
+    const { patch, result } = buildShotMergePlan({ primary, secondary, mode: "separate" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks).toHaveLength(2)
+    expect(looks[0]!.id).toBe("shared")
+    expect(looks[1]!.id).toBe("shared-b")
+    expect(looks.map((l) => l.order)).toEqual([0, 1])
+    expect(patch.activeLookId).toBe("shared")
+    // separate counts all products across all looks
+    expect(result.productsCombined).toBe(2)
+    expect(result.looksKept).toBe(2)
+  })
+
+  it("active look mirror points at active look products", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [look({ id: "la", products: [product({ familyId: "f1" })] })],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      looks: [look({ id: "lb", products: [product({ familyId: "f2" })] })],
+    })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "separate" })
+    expect((patch.products as ProductAssignment[]).map((p) => p.familyId)).toEqual(["f1"])
+  })
+})
+
+describe("buildShotMergePlan — legacy root products (no looks)", () => {
+  it("normalizes root products into a synthesized look in combine mode", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      products: [product({ familyId: "f1" })],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      products: [product({ familyId: "f2" })],
+    })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks).toHaveLength(1)
+    expect(looks[0]!.id).toBe("A-root")
+    expect((looks[0]!.products).map((p) => p.familyId)).toEqual(["f1", "f2"])
+  })
+
+  it("normalizes root products into synthesized looks in separate mode", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", products: [product({ familyId: "f1" })] })
+    const secondary = makeShot({ id: "B", title: "Shot B", products: [product({ familyId: "f2" })] })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "separate" })
+    const looks = patch.looks as ShotLook[]
+    expect(looks.map((l) => l.id)).toEqual(["A-root", "B-root"])
+  })
+})
+
+describe("buildShotMergePlan — talent / links / tags / meta", () => {
+  it("unions talent and talentIds in lockstep and counts talentAdded", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      talent: ["Alice"],
+      talentIds: ["t1"],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      talent: ["Alice", "Bob"],
+      talentIds: ["t1", "t2"],
+    })
+    const { patch, result } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.talent).toEqual(["Alice", "Bob"])
+    expect(patch.talentIds).toEqual(["t1", "t2"])
+    expect(result.talentAdded).toBe(1)
+  })
+
+  it("unions referenceLinks by url and tags by id", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      referenceLinks: [{ id: "l1", title: "P", url: "http://x", type: "web" }],
+      tags: [{ id: "tag1", label: "Hero", color: "#f00" }],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      referenceLinks: [
+        { id: "l2", title: "Q", url: "http://x", type: "web" }, // dup url
+        { id: "l3", title: "R", url: "http://y", type: "web" },
+      ],
+      tags: [{ id: "tag1", label: "Hero", color: "#f00" }, { id: "tag2", label: "B", color: "#0f0" }],
+    })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect((patch.referenceLinks as Array<{ url: string }>).map((l) => l.url)).toEqual([
+      "http://x",
+      "http://y",
+    ])
+    expect((patch.tags as Array<{ id: string }>).map((t) => t.id)).toEqual(["tag1", "tag2"])
+  })
+
+  it("leaves primary meta out of the patch (title/date/location/status/shotNumber/laneId/sortOrder)", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      status: "complete",
+      locationId: "loc1",
+      shotNumber: "001",
+      laneId: "lane1",
+      sortOrder: 5,
+    })
+    const secondary = makeShot({ id: "B", title: "Shot B", status: "todo" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    for (const k of ["title", "date", "locationId", "locationName", "status", "shotNumber", "laneId", "sortOrder", "description"]) {
+      expect(patch).not.toHaveProperty(k)
+    }
+  })
+})
+
+describe("buildShotMergePlan — notesAddendum (notes BLOCKED)", () => {
+  it("concatenates with the divider and NEVER includes notes", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", notes: "<b>html</b>", notesAddendum: "alpha" })
+    const secondary = makeShot({ id: "B", title: "Shot B", notes: "ignored", notesAddendum: "beta" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.notesAddendum).toBe('alpha\n\n— merged from "Shot B" —\n\nbeta')
+    expect(patch).not.toHaveProperty("notes")
+  })
+
+  it("omits notesAddendum when neither shot has addendum prose (nothing to add)", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", notes: "<b>html</b>" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch).not.toHaveProperty("notesAddendum")
+  })
+
+  it("appends a divider when only the primary has addendum prose", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", notesAddendum: "alpha" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.notesAddendum).toBe('alpha\n\n— merged from "Shot B" —')
+  })
+})
+
+describe("buildShotMergePlan — heroImage", () => {
+  it("primary wins", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      heroImage: { path: "a.jpg", downloadURL: "http://a" },
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      heroImage: { path: "b.jpg", downloadURL: "http://b" },
+    })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.heroImage).toEqual({ path: "a.jpg", downloadURL: "http://a" })
+  })
+
+  it("falls back to secondary", () => {
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      heroImage: { path: "b.jpg", downloadURL: "http://b" },
+    })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.heroImage).toEqual({ path: "b.jpg", downloadURL: "http://b" })
+  })
+
+  it("omits heroImage when both absent (never null over existing)", () => {
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch).not.toHaveProperty("heroImage")
+  })
+})
+
+describe("buildShotMergePlan — sanitize (no undefined anywhere, deep)", () => {
+  it("strips nested undefined from looks[].products", () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [
+        look({
+          id: "la",
+          products: [
+            product({
+              familyId: "f1",
+              skuId: undefined,
+              colourId: undefined,
+              quantity: undefined,
+            }),
+          ],
+          references: [ref("r1", { downloadURL: undefined, uploadedBy: undefined })],
+        }),
+      ],
+    })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(deepUndefinedPaths(patch)).toEqual([])
+  })
+})
+
+describe("executeShotMerge — orchestration", () => {
+  const user: AuthUser = { uid: "u1", email: "ted@x.com" } as AuthUser
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("writes primary FIRST then soft-deletes secondary; returns counts", async () => {
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [look({ id: "la", products: [product({ familyId: "f1" })] })],
+      talentIds: ["t1"],
+    })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      looks: [look({ id: "lb", products: [product({ familyId: "f2" })] })],
+      talentIds: ["t1", "t2"],
+    })
+
+    const out = await executeShotMerge({
+      clientId: "unbound-merino",
+      primary,
+      secondary,
+      mode: "combine",
+      user,
+    })
+
+    expect(out.mergedShotId).toBe("A")
+    expect(out.talentAdded).toBe(1)
+
+    const calls = vi.mocked(updateShotWithVersion).mock.calls
+    expect(calls).toHaveLength(2)
+    // primary first
+    expect(calls[0]![0].shotId).toBe("A")
+    expect(calls[0]![0].source).toBe("shot-merge")
+    // secondary soft-deleted (deleted:true), NOT hard-deleted
+    expect(calls[1]![0].shotId).toBe("B")
+    expect(calls[1]![0].source).toBe("shot-merge-loser")
+    expect(calls[1]![0].patch).toMatchObject({ deleted: true })
+    expect(calls[1]![0].patch).toHaveProperty("deletedAt")
+  })
+
+  it("does not delete secondary if primary write throws (no orphan)", async () => {
+    vi.mocked(updateShotWithVersion).mockRejectedValueOnce(new Error("primary failed"))
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+
+    await expect(
+      executeShotMerge({ clientId: "c1", primary, secondary, mode: "combine", user }),
+    ).rejects.toThrow("primary failed")
+
+    expect(vi.mocked(updateShotWithVersion).mock.calls).toHaveLength(1)
+  })
+})

--- a/src-vnext/features/shots/lib/shotMergeWrites.test.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.test.ts
@@ -142,7 +142,7 @@ describe("buildShotMergePlan — combine mode", () => {
     expect(result.referencesKept).toBe(3)
   })
 
-  it("drops heroProductId/displayImageId when no longer valid", () => {
+  it("keeps heroProductId/displayImageId when still valid in the merged look", () => {
     const primary = makeShot({
       id: "A",
       title: "Shot A",
@@ -162,6 +162,30 @@ describe("buildShotMergePlan — combine mode", () => {
     const looks = patch.looks as ShotLook[]
     expect(looks[0]!.heroProductId).toBe("f1")
     expect(looks[0]!.displayImageId).toBe("r1")
+  })
+
+  it("omits heroProductId/displayImageId (not null) when the id is no longer valid", () => {
+    // hero/display point at ids that aren't among the merged products/refs.
+    const primary = makeShot({
+      id: "A",
+      title: "Shot A",
+      activeLookId: "la",
+      looks: [
+        look({
+          id: "la",
+          products: [product({ familyId: "f1" })],
+          heroProductId: "gone",
+          displayImageId: "missing",
+        }),
+      ],
+    })
+    const secondary = makeShot({ id: "B", title: "Shot B" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    const looks = patch.looks as ShotLook[]
+    // sanitizeForFirestore strips the undefined fallback — the keys are ABSENT,
+    // never written as an explicit null to a field that may not have existed.
+    expect(looks[0]).not.toHaveProperty("heroProductId")
+    expect(looks[0]).not.toHaveProperty("displayImageId")
   })
 })
 
@@ -255,6 +279,33 @@ describe("buildShotMergePlan — talent / links / tags / meta", () => {
     expect(result.talentAdded).toBe(1)
   })
 
+  it("keeps talent/talentIds in lockstep when the same id has divergent names", () => {
+    // Same person (t1) carries a different denormalized name in each shot.
+    // Unioning names + ids independently would yield talent=2, talentIds=1.
+    const primary = makeShot({ id: "A", title: "Shot A", talent: ["Alice"], talentIds: ["t1"] })
+    const secondary = makeShot({
+      id: "B",
+      title: "Shot B",
+      talent: ["Alice Smith", "Bob"],
+      talentIds: ["t1", "t2"],
+    })
+    const { patch, result } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    // One entry per id, primary's name wins on the conflict; arrays stay aligned.
+    expect(patch.talentIds).toEqual(["t1", "t2"])
+    expect(patch.talent).toEqual(["Alice", "Bob"])
+    expect((patch.talent as string[]).length).toBe((patch.talentIds as string[]).length)
+    expect(result.talentAdded).toBe(1)
+  })
+
+  it("carries legacy name-only talent (no talentId) through the union", () => {
+    const primary = makeShot({ id: "A", title: "Shot A", talent: ["Legacy Person"], talentIds: [] })
+    const secondary = makeShot({ id: "B", title: "Shot B", talent: ["Bob"], talentIds: ["t2"] })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.talentIds).toEqual(["t2"])
+    // id-bearing names first, then name-only legacy entries.
+    expect(patch.talent).toEqual(["Bob", "Legacy Person"])
+  })
+
   it("unions referenceLinks by url and tags by id", () => {
     const primary = makeShot({
       id: "A",
@@ -334,11 +385,20 @@ describe("buildShotMergePlan — notesAddendum (notes BLOCKED)", () => {
     expect(patch).not.toHaveProperty("notesAddendum")
   })
 
-  it("appends a divider when only the primary has addendum prose", () => {
+  it("leaves notesAddendum untouched (no dangling divider) when only the primary has prose", () => {
+    // Secondary contributes nothing → there's nothing to merge in; the primary's
+    // existing addendum stays as-is rather than gaining a trailing em-dash divider.
     const primary = makeShot({ id: "A", title: "Shot A", notesAddendum: "alpha" })
     const secondary = makeShot({ id: "B", title: "Shot B" })
     const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
-    expect(patch.notesAddendum).toBe('alpha\n\n— merged from "Shot B" —')
+    expect(patch).not.toHaveProperty("notesAddendum")
+  })
+
+  it("prepends the divider before secondary prose when only the secondary has addendum", () => {
+    const primary = makeShot({ id: "A", title: "Shot A" })
+    const secondary = makeShot({ id: "B", title: "Shot B", notesAddendum: "beta" })
+    const { patch } = buildShotMergePlan({ primary, secondary, mode: "combine" })
+    expect(patch.notesAddendum).toBe('— merged from "Shot B" —\n\nbeta')
   })
 })
 

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -1,6 +1,9 @@
-import { serverTimestamp } from "firebase/firestore"
+import { doc, serverTimestamp, writeBatch } from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { shotPath } from "@/shared/lib/paths"
 import { sanitizeForFirestore } from "@/shared/lib/firestoreSanitize"
-import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import { buildShotWritePayload } from "@/features/shots/lib/updateShot"
+import { createShotVersionSnapshot } from "@/features/shots/lib/shotVersioning"
 import type {
   AuthUser,
   ProductAssignment,
@@ -293,14 +296,18 @@ function unionTags(
   return out
 }
 
+/** Build a Firestore doc ref from a path-helper string array. */
+function shotDocRef(shotId: string, clientId: string) {
+  const path = shotPath(shotId, clientId)
+  return doc(db, path[0]!, ...path.slice(1))
+}
+
 /**
- * Thin orchestrator — does the two writes.
- * Primary write FIRST; if it throws, the secondary is never soft-deleted (no orphan).
- *
- * NOTE: the two writes are sequential, not atomic. A successful primary write
- * followed by a failed secondary soft-delete leaves both shots visible with
- * duplicated products. Acceptable for v1 pairwise merge (the user can re-run);
- * TODO(v2): wrap both in a single WriteBatch once version snapshots support it.
+ * Orchestrator — applies the merge as a SINGLE atomic WriteBatch: the primary's
+ * merged patch and the secondary's soft-delete commit together or not at all, so
+ * a partial failure can never leave a half-merged pair (both shots visible with
+ * duplicated products). Version snapshots are best-effort audit writes fired
+ * after the atomic merge lands (mirroring updateShotWithVersion's posture).
  */
 export async function executeShotMerge(args: {
   clientId: string
@@ -310,25 +317,56 @@ export async function executeShotMerge(args: {
   user: AuthUser | null
 }): Promise<ShotMergeResult> {
   const { clientId, primary, secondary, mode, user } = args
+  if (!clientId) throw new Error("Missing clientId.")
+
   const { patch, result } = buildShotMergePlan({ primary, secondary, mode })
 
-  await updateShotWithVersion({
-    clientId,
-    shotId: primary.id,
-    patch,
-    shot: primary,
-    user,
-    source: "shot-merge",
-  })
+  // buildShotWritePayload strips the BLOCKED `notes` field + top-level undefined
+  // (the patch is already deep-sanitized); same guard updateShotWithVersion uses.
+  const primaryPayload = buildShotWritePayload(patch)
+  const secondaryPayload: Record<string, unknown> = {
+    deleted: true,
+    deletedAt: serverTimestamp(),
+  }
+  const auditFields = user?.uid ? { updatedBy: user.uid } : {}
 
-  await updateShotWithVersion({
-    clientId,
-    shotId: secondary.id,
-    patch: { deleted: true, deletedAt: serverTimestamp() },
-    shot: secondary,
-    user,
-    source: "shot-merge-loser",
+  const batch = writeBatch(db)
+  batch.update(shotDocRef(primary.id, clientId), {
+    ...primaryPayload,
+    updatedAt: serverTimestamp(),
+    ...auditFields,
   })
+  batch.update(shotDocRef(secondary.id, clientId), {
+    ...secondaryPayload,
+    updatedAt: serverTimestamp(),
+    ...auditFields,
+  })
+  await batch.commit()
+
+  // Best-effort version snapshots (audit, not core state) — never block or fail
+  // the merge if they error.
+  if (user?.uid) {
+    void createShotVersionSnapshot({
+      clientId,
+      shotId: primary.id,
+      previousShot: primary,
+      patch: primaryPayload,
+      user,
+      changeType: "update",
+    }).catch((err) => {
+      console.error("[executeShotMerge] primary version snapshot failed", err)
+    })
+    void createShotVersionSnapshot({
+      clientId,
+      shotId: secondary.id,
+      previousShot: secondary,
+      patch: secondaryPayload,
+      user,
+      changeType: "update",
+    }).catch((err) => {
+      console.error("[executeShotMerge] loser version snapshot failed", err)
+    })
+  }
 
   return { mergedShotId: primary.id, ...result }
 }

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -98,16 +98,50 @@ function countLooksRefs(looks: ReadonlyArray<ShotLook>): number {
   return n
 }
 
-/** Union+dedup two string arrays, preserving first-seen order. */
-function unionStrings(a: ReadonlyArray<string>, b: ReadonlyArray<string>): string[] {
-  const seen = new Set<string>()
-  const out: string[] = []
-  for (const s of [...a, ...b]) {
-    if (seen.has(s)) continue
-    seen.add(s)
-    out.push(s)
+/**
+ * Union talent across two shots, keyed by `talentId` so the `talent` (display
+ * names) and `talentIds` arrays stay in LOCKSTEP. Unioning the two arrays
+ * independently desyncs them when the same id carries a different denormalized
+ * name in each shot (e.g. "Alice" vs "Alice Smith") — names would dedup to 2,
+ * ids to 1. Here each id appears once with the PRIMARY's name (first-seen wins),
+ * and legacy name-only talent (no id) is carried through, name-deduped.
+ */
+function unionTalent(
+  primary: Shot,
+  secondary: Shot,
+): { talent: string[]; talentIds: string[]; talentAdded: number } {
+  const nameById = new Map<string, string>()
+  const orderedIds: string[] = []
+  const nameOnly: string[] = []
+  const seenNameOnly = new Set<string>()
+
+  const add = (names: ReadonlyArray<string>, ids: ReadonlyArray<string>) => {
+    for (let i = 0; i < Math.max(names.length, ids.length); i++) {
+      const id = ids[i]
+      const name = names[i]
+      if (id) {
+        if (!nameById.has(id)) {
+          nameById.set(id, name ?? id)
+          orderedIds.push(id)
+        }
+        // else: id already seen — primary's name wins, don't overwrite.
+      } else if (name && !seenNameOnly.has(name)) {
+        seenNameOnly.add(name)
+        nameOnly.push(name)
+      }
+    }
   }
-  return out
+
+  add(primary.talent ?? [], primary.talentIds ?? [])
+  const primaryIds = new Set(orderedIds)
+  add(secondary.talent ?? [], secondary.talentIds ?? [])
+
+  const talentIds = orderedIds
+  const talent = [...orderedIds.map((id) => nameById.get(id)!), ...nameOnly]
+  const talentAdded = (secondary.talentIds ?? []).filter(
+    (id) => !primaryIds.has(id),
+  ).length
+  return { talent, talentIds, talentAdded }
 }
 
 /**
@@ -145,14 +179,17 @@ export function buildShotMergePlan(args: {
 
     const productIds = new Set(products.map((p) => p.familyId))
     const refIds = new Set(references.map((r) => r.id))
+    // Fall back to `undefined` (not null) when the original id is no longer
+    // valid, so sanitizeForFirestore strips the key rather than writing an
+    // explicit null to a field that may never have existed on the look.
     const heroProductId =
       targetLook.heroProductId && productIds.has(targetLook.heroProductId)
         ? targetLook.heroProductId
-        : null
+        : undefined
     const displayImageId =
       targetLook.displayImageId && refIds.has(targetLook.displayImageId)
         ? targetLook.displayImageId
-        : null
+        : undefined
 
     mergedLooks = [
       {
@@ -194,13 +231,7 @@ export function buildShotMergePlan(args: {
   const rootProductsMirror =
     mergedLooks.find((l) => l.id === activeLookId)?.products ?? []
 
-  const talent = unionStrings(primary.talent ?? [], secondary.talent ?? [])
-  const talentIds = unionStrings(primary.talentIds ?? [], secondary.talentIds ?? [])
-
-  const primaryTalentIdSet = new Set(primary.talentIds ?? [])
-  const talentAdded = (secondary.talentIds ?? []).filter(
-    (id) => !primaryTalentIdSet.has(id),
-  ).length
+  const { talent, talentIds, talentAdded } = unionTalent(primary, secondary)
 
   const referenceLinks = unionReferenceLinks(
     primary.referenceLinks ?? [],
@@ -230,8 +261,10 @@ export function buildShotMergePlan(args: {
   if (heroImage) patch.heroImage = heroImage
 
   // notesAddendum concatenation — NEVER `notes`.
-  // Only build a divider when there is real prose on either side; a divider with
-  // no surrounding content is "nothing to add" → omit the key.
+  // Only touch the field when the SECONDARY contributes prose: otherwise there is
+  // nothing to merge in and the primary's existing addendum should stay as-is (a
+  // divider with nothing after it would be a dangling em-dash). When secondary
+  // has prose, prepend the primary's (if any) + a provenance divider.
   const primaryAddendum =
     typeof primary.notesAddendum === "string" && primary.notesAddendum.trim()
       ? primary.notesAddendum
@@ -240,15 +273,11 @@ export function buildShotMergePlan(args: {
     typeof secondary.notesAddendum === "string" && secondary.notesAddendum.trim()
       ? secondary.notesAddendum
       : ""
-  if (primaryAddendum || secondaryAddendum) {
+  if (secondaryAddendum) {
     const divider = `— merged from "${secondary.title}" —`
-    const notesAddendum = [primaryAddendum, divider, secondaryAddendum]
+    patch.notesAddendum = [primaryAddendum, divider, secondaryAddendum]
       .filter((s) => s.length > 0)
       .join("\n\n")
-    // Omit if the result equals primary's existing addendum (nothing to add).
-    if (notesAddendum && notesAddendum !== primaryAddendum) {
-      patch.notesAddendum = notesAddendum
-    }
   }
 
   const sanitized = sanitizeForFirestore(patch) as Record<string, unknown>

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -209,11 +209,17 @@ export function buildShotMergePlan(args: {
     looks: mergedLooks,
     activeLookId,
     products: rootProductsMirror,
-    talent,
-    talentIds,
-    referenceLinks,
-    tags,
   }
+
+  // Only include the union fields when non-empty so the merge never writes `[]`
+  // to a field both shots lacked (which would change the document shape). The
+  // union is always a superset of the primary's, so omitting an empty result
+  // never drops existing data — the in-place primary update leaves its (also
+  // empty/absent) field untouched.
+  if (talent.length > 0) patch.talent = talent
+  if (talentIds.length > 0) patch.talentIds = talentIds
+  if (referenceLinks.length > 0) patch.referenceLinks = referenceLinks
+  if (tags.length > 0) patch.tags = tags
 
   // heroImage: primary ?? secondary. Omit the key entirely if both absent —
   // never write null over an existing image.
@@ -290,6 +296,11 @@ function unionTags(
 /**
  * Thin orchestrator — does the two writes.
  * Primary write FIRST; if it throws, the secondary is never soft-deleted (no orphan).
+ *
+ * NOTE: the two writes are sequential, not atomic. A successful primary write
+ * followed by a failed secondary soft-delete leaves both shots visible with
+ * duplicated products. Acceptable for v1 pairwise merge (the user can re-run);
+ * TODO(v2): wrap both in a single WriteBatch once version snapshots support it.
  */
 export async function executeShotMerge(args: {
   clientId: string

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -99,12 +99,17 @@ function countLooksRefs(looks: ReadonlyArray<ShotLook>): number {
 }
 
 /**
- * Union talent across two shots, keyed by `talentId` so the `talent` (display
- * names) and `talentIds` arrays stay in LOCKSTEP. Unioning the two arrays
- * independently desyncs them when the same id carries a different denormalized
- * name in each shot (e.g. "Alice" vs "Alice Smith") — names would dedup to 2,
- * ids to 1. Here each id appears once with the PRIMARY's name (first-seen wins),
- * and legacy name-only talent (no id) is carried through, name-deduped.
+ * Union talent across two shots, keyed by `talentId`. For id-bearing entries the
+ * `talent` (display names) and `talentIds` arrays stay INDEX-ALIGNED — each id
+ * appears once with the PRIMARY's name (first-seen wins). Unioning the two arrays
+ * independently would desync them when the same id carries a different
+ * denormalized name in each shot ("Alice" vs "Alice Smith"): names dedup to 2,
+ * ids to 1.
+ *
+ * ASYMMETRY: legacy name-only talent (a name in `talent[]` with no corresponding
+ * `talentIds[]` entry) is appended to `talent` AFTER the id-bearing names, so for
+ * such shots `talent.length > talentIds.length`. Index alignment holds only for
+ * the id-bearing prefix — do not assume `talent[i]` ↔ `talentIds[i]` past it.
  */
 function unionTalent(
   primary: Shot,

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -1,0 +1,323 @@
+import { serverTimestamp } from "firebase/firestore"
+import { sanitizeForFirestore } from "@/shared/lib/firestoreSanitize"
+import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersion"
+import type {
+  AuthUser,
+  ProductAssignment,
+  Shot,
+  ShotLook,
+  ShotReferenceImage,
+  ShotReferenceLink,
+  ShotTag,
+} from "@/shared/types"
+
+export type ShotMergeMode = "combine" | "separate" // A = combine, B = separate looks
+
+export interface ShotMergeResult {
+  readonly mergedShotId: string
+  /** products in the merged active look (combine) or total across looks (separate) */
+  readonly productsCombined: number
+  /** distinct talentIds added from the secondary */
+  readonly talentAdded: number
+  /** # looks in the merged shot */
+  readonly looksKept: number
+  /** # reference images carried into the merged shot's looks */
+  readonly referencesKept: number
+}
+
+/** Dedup key for a product assignment — British `colourId`, never `colorId`. */
+function productKey(p: ProductAssignment): string {
+  return `${p.familyId}::${p.skuId ?? ""}::${p.colourId ?? ""}`
+}
+
+/** Union products preserving first-seen order, deduped by family/sku/colour. */
+function unionProducts(
+  lists: ReadonlyArray<ReadonlyArray<ProductAssignment>>,
+): ProductAssignment[] {
+  const seen = new Set<string>()
+  const out: ProductAssignment[] = []
+  for (const list of lists) {
+    for (const p of list) {
+      const key = productKey(p)
+      if (seen.has(key)) continue
+      seen.add(key)
+      out.push(p)
+    }
+  }
+  return out
+}
+
+/** Union reference images preserving first-seen order, deduped by id. */
+function unionRefs(
+  lists: ReadonlyArray<ReadonlyArray<ShotReferenceImage>>,
+): ShotReferenceImage[] {
+  const seen = new Set<string>()
+  const out: ShotReferenceImage[] = []
+  for (const list of lists) {
+    for (const r of list) {
+      if (seen.has(r.id)) continue
+      seen.add(r.id)
+      out.push(r)
+    }
+  }
+  return out
+}
+
+/**
+ * Normalize a shot to a list of looks.
+ * - If `looks[]` exists, use them verbatim (preserve ids/labels/order/refs/hero/display).
+ * - Else if root `products[]` exists, synthesize one look.
+ * - Else [].
+ */
+function normalizeToLooks(shot: Shot): ShotLook[] {
+  if (shot.looks?.length) return [...shot.looks]
+  if (shot.products?.length) {
+    return [
+      {
+        id: `${shot.id}-root`,
+        label: "Primary",
+        order: 0,
+        products: shot.products,
+        references: [],
+      },
+    ]
+  }
+  return []
+}
+
+function looksRefs(looks: ReadonlyArray<ShotLook>): ShotReferenceImage[][] {
+  return looks.map((l) => [...(l.references ?? [])])
+}
+
+function countLooksRefs(looks: ReadonlyArray<ShotLook>): number {
+  let n = 0
+  for (const l of looks) n += l.references?.length ?? 0
+  return n
+}
+
+/** Union+dedup two string arrays, preserving first-seen order. */
+function unionStrings(a: ReadonlyArray<string>, b: ReadonlyArray<string>): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const s of [...a, ...b]) {
+    if (seen.has(s)) continue
+    seen.add(s)
+    out.push(s)
+  }
+  return out
+}
+
+/**
+ * PURE — no Firestore. Returns the deep-SANITIZED patch for the primary plus
+ * the result counts. The planner keeps `looks[]` as the source of truth and
+ * MIRRORS root `products` = the active look's products. `notes` is NEVER touched
+ * (BLOCKED_FIELD); concatenation targets `notesAddendum`.
+ */
+export function buildShotMergePlan(args: {
+  primary: Shot
+  secondary: Shot
+  mode: ShotMergeMode
+}): { patch: Record<string, unknown>; result: Omit<ShotMergeResult, "mergedShotId"> } {
+  const { primary, secondary, mode } = args
+
+  const primaryLooks = normalizeToLooks(primary)
+  const secondaryLooks = normalizeToLooks(secondary)
+
+  let mergedLooks: ShotLook[]
+  let activeLookId: string | null
+
+  if (mode === "combine") {
+    const targetLook: ShotLook =
+      primaryLooks.find((l) => l.id === primary.activeLookId) ??
+      primaryLooks[0] ?? {
+        id: `${primary.id}-merged`,
+        label: "Primary",
+        order: 0,
+        products: [],
+      }
+
+    const allLooks = [...primaryLooks, ...secondaryLooks]
+    const products = unionProducts(allLooks.map((l) => l.products ?? []))
+    const references = unionRefs(looksRefs(allLooks))
+
+    const productIds = new Set(products.map((p) => p.familyId))
+    const refIds = new Set(references.map((r) => r.id))
+    const heroProductId =
+      targetLook.heroProductId && productIds.has(targetLook.heroProductId)
+        ? targetLook.heroProductId
+        : null
+    const displayImageId =
+      targetLook.displayImageId && refIds.has(targetLook.displayImageId)
+        ? targetLook.displayImageId
+        : null
+
+    mergedLooks = [
+      {
+        ...targetLook,
+        order: 0,
+        products,
+        references,
+        heroProductId,
+        displayImageId,
+      },
+    ]
+    activeLookId = mergedLooks[0]!.id
+  } else {
+    const primaryIds = new Set(primaryLooks.map((l) => l.id))
+    const usedIds = new Set(primaryIds)
+    const remappedSecondary = secondaryLooks.map((l) => {
+      if (!usedIds.has(l.id)) {
+        usedIds.add(l.id)
+        return l
+      }
+      let candidate = `${l.id}-b`
+      while (usedIds.has(candidate)) candidate = `${candidate}-b`
+      usedIds.add(candidate)
+      return { ...l, id: candidate }
+    })
+
+    mergedLooks = [...primaryLooks, ...remappedSecondary].map((l, i) => ({
+      ...l,
+      order: i,
+    }))
+
+    const primaryActiveInMerged =
+      primary.activeLookId != null && primaryIds.has(primary.activeLookId)
+    activeLookId = primaryActiveInMerged
+      ? primary.activeLookId!
+      : (mergedLooks[0]?.id ?? null)
+  }
+
+  const rootProductsMirror =
+    mergedLooks.find((l) => l.id === activeLookId)?.products ?? []
+
+  const talent = unionStrings(primary.talent ?? [], secondary.talent ?? [])
+  const talentIds = unionStrings(primary.talentIds ?? [], secondary.talentIds ?? [])
+
+  const primaryTalentIdSet = new Set(primary.talentIds ?? [])
+  const talentAdded = (secondary.talentIds ?? []).filter(
+    (id) => !primaryTalentIdSet.has(id),
+  ).length
+
+  const referenceLinks = unionReferenceLinks(
+    primary.referenceLinks ?? [],
+    secondary.referenceLinks ?? [],
+  )
+  const tags = unionTags(primary.tags ?? [], secondary.tags ?? [])
+
+  const patch: Record<string, unknown> = {
+    looks: mergedLooks,
+    activeLookId,
+    products: rootProductsMirror,
+    talent,
+    talentIds,
+    referenceLinks,
+    tags,
+  }
+
+  // heroImage: primary ?? secondary. Omit the key entirely if both absent —
+  // never write null over an existing image.
+  const heroImage = primary.heroImage ?? secondary.heroImage
+  if (heroImage) patch.heroImage = heroImage
+
+  // notesAddendum concatenation — NEVER `notes`.
+  // Only build a divider when there is real prose on either side; a divider with
+  // no surrounding content is "nothing to add" → omit the key.
+  const primaryAddendum =
+    typeof primary.notesAddendum === "string" && primary.notesAddendum.trim()
+      ? primary.notesAddendum
+      : ""
+  const secondaryAddendum =
+    typeof secondary.notesAddendum === "string" && secondary.notesAddendum.trim()
+      ? secondary.notesAddendum
+      : ""
+  if (primaryAddendum || secondaryAddendum) {
+    const divider = `— merged from "${secondary.title}" —`
+    const notesAddendum = [primaryAddendum, divider, secondaryAddendum]
+      .filter((s) => s.length > 0)
+      .join("\n\n")
+    // Omit if the result equals primary's existing addendum (nothing to add).
+    if (notesAddendum && notesAddendum !== primaryAddendum) {
+      patch.notesAddendum = notesAddendum
+    }
+  }
+
+  const sanitized = sanitizeForFirestore(patch) as Record<string, unknown>
+
+  const result: Omit<ShotMergeResult, "mergedShotId"> = {
+    productsCombined:
+      mode === "combine"
+        ? rootProductsMirror.length
+        : mergedLooks.reduce((n, l) => n + (l.products?.length ?? 0), 0),
+    talentAdded,
+    looksKept: mergedLooks.length,
+    referencesKept: countLooksRefs(mergedLooks),
+  }
+
+  return { patch: sanitized, result }
+}
+
+/** Union+dedup reference links by `url`, preserving first-seen order. */
+function unionReferenceLinks(
+  a: ReadonlyArray<ShotReferenceLink>,
+  b: ReadonlyArray<ShotReferenceLink>,
+): ShotReferenceLink[] {
+  const seen = new Set<string>()
+  const out: ShotReferenceLink[] = []
+  for (const link of [...a, ...b]) {
+    if (seen.has(link.url)) continue
+    seen.add(link.url)
+    out.push(link)
+  }
+  return out
+}
+
+/** Union+dedup tags by `id`, preserving first-seen order. */
+function unionTags(
+  a: ReadonlyArray<ShotTag>,
+  b: ReadonlyArray<ShotTag>,
+): ShotTag[] {
+  const seen = new Set<string>()
+  const out: ShotTag[] = []
+  for (const tag of [...a, ...b]) {
+    if (seen.has(tag.id)) continue
+    seen.add(tag.id)
+    out.push(tag)
+  }
+  return out
+}
+
+/**
+ * Thin orchestrator — does the two writes.
+ * Primary write FIRST; if it throws, the secondary is never soft-deleted (no orphan).
+ */
+export async function executeShotMerge(args: {
+  clientId: string
+  primary: Shot
+  secondary: Shot
+  mode: ShotMergeMode
+  user: AuthUser | null
+}): Promise<ShotMergeResult> {
+  const { clientId, primary, secondary, mode, user } = args
+  const { patch, result } = buildShotMergePlan({ primary, secondary, mode })
+
+  await updateShotWithVersion({
+    clientId,
+    shotId: primary.id,
+    patch,
+    shot: primary,
+    user,
+    source: "shot-merge",
+  })
+
+  await updateShotWithVersion({
+    clientId,
+    shotId: secondary.id,
+    patch: { deleted: true, deletedAt: serverTimestamp() },
+    shot: secondary,
+    user,
+    source: "shot-merge-loser",
+  })
+
+  return { mergedShotId: primary.id, ...result }
+}


### PR DESCRIPTION
## What & why
Lets a user combine two shots into one on the Shots list — Ted's example: merge "Men's Linen Beach Shorts (Denim)" + "Men's Tropical Linen Shirt (White)" into a single styled shot. Mirrors the existing **Product Merge Wizard** so it feels native. (Issue #6 from the 2026-06-12 batch; built to the approved `outputs/2026-06-12-shot-merge-spec.md` + engineering contract.)

## UX
- Select **exactly 2** shots → a **Merge** action in `BulkActionBar` (gated `canManageShots`, enabled only at 2 selected) → a 3-step **`ShotMergeWizard`**: **Compare** (pick primary, swap, choose mode) → **Preview** (counts + soft-delete warning + confirm checkbox) → **Result** (summary + View shot).

## Merge semantics
- **Mode A — Combine into one outfit look** (default): all products from both shots union into the primary's active look (dedup by `familyId::skuId::colourId`), producing one look. **Mode B — Keep as separate looks**: both shots' looks are kept (id-collision remap + re-ordered).
- Union **talent/talentIds** (lockstep), **referenceLinks** (by url), **tags** (by id). Primary's **title/date/location/status/shotNumber/laneId/sortOrder** win. `heroImage` = primary ?? secondary. Notes concatenate into **`notesAddendum`** with a `— merged from "<title>" —` divider.
- Loser is **soft-deleted** (`deleted:true, deletedAt`), recoverable.

## Key engineering decisions (confirmed in code)
- **`looks[]` is the source of truth**; root `products[]` is a legacy fallback → the merge keeps looks canonical and **mirrors root `products` to the active look**. Legacy root-products-only shots are normalized into a synthesized look first.
- **Deep-sanitize the patch** (`sanitizeForFirestore`): `buildShotWritePayload` only strips *top-level* undefined, but `looks[]` carry nested undefined that Firestore would reject (same class as the prior version-snapshot bug).
- **Never write `notes`** — it's a `BLOCKED_FIELD`; concatenation targets `notesAddendum`.
- `executeShotMerge` writes the **primary first** (with a version snapshot), then soft-deletes the loser (own snapshot) — a failed primary write never orphans a deleted secondary.
- The planner (`buildShotMergePlan`) is **pure** (no Firestore) → fully unit-tested.

## How it was built
Scout → build → adversarial-verify dynamic workflow (9 agents): 2 scouts, 3 build slices (planner+writer · wizard · bar+host), 4 adversarial verifiers (planner / wizard+host / rules-trace / full-diff). All 4 PASS; only low cosmetic notes (one of which — a "Talent unioned" label that rendered the *added* count — is fixed in this PR).

## Tests / gates (verified locally)
- `shotMergeWrites` (19), `ShotMergeWizard` (6), `BulkActionBar` (6); CI-adjacent `ShotListPage.test.tsx` + `ShotListPage.unifiedEditorFork.test.tsx` (33) — **64 green** total · `npm run build` clean · eslint exit 0 · no new tsc errors.
- **Rules-traced**: no `firestore.rules` change — the shots update arm already governs both writes for admin/producer/crew; UI gate (`canManageShots`) matches.

## Notes
- v1 is **pairwise** (exactly 2); N-way deferred. Immutability preserved (planner builds new objects). Behavior-free `data-testid` only.
- ⚠️ Node 24 on Actions runners since 2026-06-16 — if CI breaks, suspect checkout@v4/setup-node@v4/auth@v2 first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)