### PR TITLE
feat(shots): quiet View-as (preview-as-crew) menu — Phase 5e-III

### DIFF
--- a/src-vnext/app/App.tsx
+++ b/src-vnext/app/App.tsx
@@ -3,6 +3,8 @@ import { Toaster } from "sonner"
 import { AuthProvider } from "@/app/providers/AuthProvider"
 import { ThemeProvider } from "@/app/providers/ThemeProvider"
 import { SearchCommandProvider } from "@/app/providers/SearchCommandProvider"
+// 5e-III: in-memory "View as" preview provider (no persistence)
+import { ViewAsPreviewProvider } from "@/app/providers/ViewAsPreviewProvider"
 import { TooltipProvider } from "@/ui/tooltip"
 import { AppRoutes } from "@/app/routes"
 
@@ -12,10 +14,13 @@ export function App() {
       <ThemeProvider>
         <AuthProvider>
           <SearchCommandProvider>
-            <TooltipProvider delayDuration={200}>
-              <AppRoutes />
-              <Toaster position="bottom-right" richColors closeButton />
-            </TooltipProvider>
+            {/* 5e-III: View-as preview state — in-memory only, consumers under it need auth too */}
+            <ViewAsPreviewProvider>
+              <TooltipProvider delayDuration={200}>
+                <AppRoutes />
+                <Toaster position="bottom-right" richColors closeButton />
+              </TooltipProvider>
+            </ViewAsPreviewProvider>
           </SearchCommandProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/src-vnext/app/App.tsx
+++ b/src-vnext/app/App.tsx
@@ -3,7 +3,6 @@ import { Toaster } from "sonner"
 import { AuthProvider } from "@/app/providers/AuthProvider"
 import { ThemeProvider } from "@/app/providers/ThemeProvider"
 import { SearchCommandProvider } from "@/app/providers/SearchCommandProvider"
-// 5e-III: in-memory "View as" preview provider (no persistence)
 import { ViewAsPreviewProvider } from "@/app/providers/ViewAsPreviewProvider"
 import { TooltipProvider } from "@/ui/tooltip"
 import { AppRoutes } from "@/app/routes"
@@ -14,7 +13,6 @@ export function App() {
       <ThemeProvider>
         <AuthProvider>
           <SearchCommandProvider>
-            {/* 5e-III: View-as preview state — in-memory only, consumers under it need auth too */}
             <ViewAsPreviewProvider>
               <TooltipProvider delayDuration={200}>
                 <AppRoutes />

--- a/src-vnext/app/providers/ViewAsPreviewProvider.tsx
+++ b/src-vnext/app/providers/ViewAsPreviewProvider.tsx
@@ -2,11 +2,13 @@ import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
   type ReactNode,
 } from "react"
 import { Role } from "@/shared/types"
+import { useAuth } from "@/app/providers/AuthProvider"
 
 // 5e-III: In-memory "View as" preview. A GLOBAL admin/producer can preview the
 // Crew (Shoot) surface without persisting anything. NO localStorage, NO URL,
@@ -29,10 +31,20 @@ export function ViewAsPreviewProvider({
 }: {
   readonly children: ReactNode
 }) {
+  const { user, role } = useAuth()
   const [previewRole, setPreviewRole] = useState<Role | null>(null)
 
   // 5e-III: clearing the preview returns the user to their real view.
   const clearPreview = useCallback(() => setPreviewRole(null), [])
+
+  // 5e-III: reset the in-memory preview when the signed-in identity or global
+  // role changes (an in-place sign-out/sign-in, or a mid-session claim change).
+  // Otherwise a stale 'crew' preview strands the next, lower-privilege user in
+  // the narrowed shell with no visible control to exit. Reset only — not a
+  // persistence write.
+  useEffect(() => {
+    setPreviewRole(null)
+  }, [user?.uid, role])
 
   const value = useMemo<ViewAsPreviewContextValue>(
     () => ({ previewRole, setPreviewRole, clearPreview }),

--- a/src-vnext/app/providers/ViewAsPreviewProvider.tsx
+++ b/src-vnext/app/providers/ViewAsPreviewProvider.tsx
@@ -1,0 +1,51 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react"
+import { Role } from "@/shared/types"
+
+// 5e-III: In-memory "View as" preview. A GLOBAL admin/producer can preview the
+// Crew (Shoot) surface without persisting anything. NO localStorage, NO URL,
+// NO resolvedRoleCache commit, NO toast — React state ONLY. The preview only
+// NARROWS the presentation surface; real write-gates keep using the real role.
+interface ViewAsPreviewContextValue {
+  readonly previewRole: Role | null // null = not previewing; at 5e only ever "crew" or null
+  readonly setPreviewRole: (role: Role | null) => void
+  readonly clearPreview: () => void
+}
+
+const ViewAsPreviewContext = createContext<ViewAsPreviewContextValue>({
+  previewRole: null,
+  setPreviewRole: () => {},
+  clearPreview: () => {},
+})
+
+export function ViewAsPreviewProvider({
+  children,
+}: {
+  readonly children: ReactNode
+}) {
+  const [previewRole, setPreviewRole] = useState<Role | null>(null)
+
+  // 5e-III: clearing the preview returns the user to their real view.
+  const clearPreview = useCallback(() => setPreviewRole(null), [])
+
+  const value = useMemo<ViewAsPreviewContextValue>(
+    () => ({ previewRole, setPreviewRole, clearPreview }),
+    [previewRole, clearPreview],
+  )
+
+  return (
+    <ViewAsPreviewContext.Provider value={value}>
+      {children}
+    </ViewAsPreviewContext.Provider>
+  )
+}
+
+export function useViewAsPreview(): ViewAsPreviewContextValue {
+  return useContext(ViewAsPreviewContext)
+}

--- a/src-vnext/app/providers/ViewAsPreviewProvider.tsx
+++ b/src-vnext/app/providers/ViewAsPreviewProvider.tsx
@@ -48,7 +48,7 @@ export function ViewAsPreviewProvider({
 
   const value = useMemo<ViewAsPreviewContextValue>(
     () => ({ previewRole, setPreviewRole, clearPreview }),
-    [previewRole, clearPreview],
+    [previewRole, setPreviewRole, clearPreview],
   )
 
   return (

--- a/src-vnext/app/providers/__tests__/ViewAsPreviewProvider.test.tsx
+++ b/src-vnext/app/providers/__tests__/ViewAsPreviewProvider.test.tsx
@@ -4,6 +4,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import { renderHook, act } from "@testing-library/react"
 import type { ReactNode } from "react"
+
+// The provider reads useAuth to reset the preview when the signed-in identity
+// or global role changes — mock it so tests can simulate a user swap.
+const authState = vi.hoisted(() => ({ uid: "u1", role: "admin" }))
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({
+    user: authState.uid ? { uid: authState.uid } : null,
+    role: authState.role,
+  }),
+}))
+
 import {
   ViewAsPreviewProvider,
   useViewAsPreview,
@@ -17,6 +28,8 @@ describe("ViewAsPreviewProvider", () => {
   let setItemSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
+    authState.uid = "u1"
+    authState.role = "admin"
     setItemSpy = vi.spyOn(window.localStorage.__proto__, "setItem")
   })
 
@@ -48,5 +61,28 @@ describe("ViewAsPreviewProvider", () => {
     act(() => result.current.setPreviewRole("crew"))
     act(() => result.current.clearPreview())
     expect(setItemSpy).not.toHaveBeenCalled()
+  })
+
+  it("resets the preview when the signed-in user changes (no stale preview across an in-place sign-in)", () => {
+    const { result, rerender } = renderHook(() => useViewAsPreview(), { wrapper })
+    act(() => result.current.setPreviewRole("crew"))
+    expect(result.current.previewRole).toBe("crew")
+    // Simulate an in-place user swap (sign-out → sign-in as a different user).
+    act(() => {
+      authState.uid = "u2"
+      rerender()
+    })
+    expect(result.current.previewRole).toBeNull()
+  })
+
+  it("resets the preview when the global role changes (mid-session claim change)", () => {
+    const { result, rerender } = renderHook(() => useViewAsPreview(), { wrapper })
+    act(() => result.current.setPreviewRole("crew"))
+    expect(result.current.previewRole).toBe("crew")
+    act(() => {
+      authState.role = "viewer"
+      rerender()
+    })
+    expect(result.current.previewRole).toBeNull()
   })
 })

--- a/src-vnext/app/providers/__tests__/ViewAsPreviewProvider.test.tsx
+++ b/src-vnext/app/providers/__tests__/ViewAsPreviewProvider.test.tsx
@@ -1,0 +1,52 @@
+/// <reference types="@testing-library/jest-dom" />
+// 5e-III — in-memory View-as preview provider. ZERO PERSISTENCE invariant:
+// entering/clearing the preview must NOT write localStorage, URL, or fire a toast.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import type { ReactNode } from "react"
+import {
+  ViewAsPreviewProvider,
+  useViewAsPreview,
+} from "@/app/providers/ViewAsPreviewProvider"
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ViewAsPreviewProvider>{children}</ViewAsPreviewProvider>
+}
+
+describe("ViewAsPreviewProvider", () => {
+  let setItemSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    setItemSpy = vi.spyOn(window.localStorage.__proto__, "setItem")
+  })
+
+  afterEach(() => {
+    setItemSpy.mockRestore()
+  })
+
+  it("defaults previewRole to null (not previewing)", () => {
+    const { result } = renderHook(() => useViewAsPreview(), { wrapper })
+    expect(result.current.previewRole).toBeNull()
+  })
+
+  it("setPreviewRole('crew') updates the preview role", () => {
+    const { result } = renderHook(() => useViewAsPreview(), { wrapper })
+    act(() => result.current.setPreviewRole("crew"))
+    expect(result.current.previewRole).toBe("crew")
+  })
+
+  it("clearPreview resets the preview role to null", () => {
+    const { result } = renderHook(() => useViewAsPreview(), { wrapper })
+    act(() => result.current.setPreviewRole("crew"))
+    expect(result.current.previewRole).toBe("crew")
+    act(() => result.current.clearPreview())
+    expect(result.current.previewRole).toBeNull()
+  })
+
+  it("writes NOTHING to localStorage on enter or clear (zero persistence)", () => {
+    const { result } = renderHook(() => useViewAsPreview(), { wrapper })
+    act(() => result.current.setPreviewRole("crew"))
+    act(() => result.current.clearPreview())
+    expect(setItemSpy).not.toHaveBeenCalled()
+  })
+})

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -22,6 +22,8 @@ import { useAuth } from "@/app/providers/AuthProvider"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
+import { ViewAsMenu } from "@/shared/components/ViewAsMenu"
+import { useViewAsPreview } from "@/app/providers/ViewAsPreviewProvider"
 import { canEditScene, canGeneratePulls, canManageShots } from "@/shared/lib/rbac"
 import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { isFeatureEnabled } from "@/shared/lib/flags"
@@ -71,6 +73,10 @@ export default function ShotListPage() {
   // RESOLVED surface (same fork idiom as ShotDetailPageUnified), and chrome
   // drives the toolbar/quick-add decisions below.
   const { surface, affordances, chrome } = useResolvedSurface()
+  // 5e-III: in-memory "View as" preview. previewRole (null = not previewing)
+  // interposes ONLY on surfaceContext.role below — every real write-gate keeps
+  // using the REAL effective role, so preview can only NARROW the surface.
+  const { previewRole } = useViewAsPreview()
   const { data: talentRecords } = useTalent()
   const { data: locationRecords } = useLocations()
   const { data: productFamilies } = useProductFamilies()
@@ -204,9 +210,17 @@ export default function ShotListPage() {
   // EFFECTIVE role — resolveSurface's input contract is byte-unchanged (the
   // opaque effectiveRole param is 5e's View-as interposition seam).
   const surfaceDevice: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
+  // 5e-III: previewRole substitutes for the EFFECTIVE role at surface
+  // resolution ONLY (the real `role` above still drives every write-gate).
+  // previewActive flags the suppression of url/stored view rungs inside
+  // useShotListState so the previewer's own stored choice can't mask the
+  // previewed surface default. Still null while auth/role resolve (no flash).
   const surfaceContext = useMemo(
-    () => (authLoading || roleResolving ? null : { role, device: surfaceDevice }),
-    [authLoading, roleResolving, role, surfaceDevice],
+    () =>
+      authLoading || roleResolving
+        ? null
+        : { role: previewRole ?? role, device: surfaceDevice, previewActive: previewRole != null },
+    [authLoading, roleResolving, role, previewRole, surfaceDevice],
   )
 
   // -- All filter / sort / view state --
@@ -442,6 +456,10 @@ export default function ShotListPage() {
         actions={
           <div className="flex items-center gap-2">
             <EffectiveRoleChip />
+            {/* 5e-III View-as: quiet preview menu, self-gated on the GLOBAL
+                admin/producer claim + featureShootSurface (renders null
+                otherwise). Adjacent to the chip so preview state reads together. */}
+            <ViewAsMenu />
             {canExport && (
               <Button variant="outline" onClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}>
                 Export

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -456,9 +456,7 @@ export default function ShotListPage() {
         actions={
           <div className="flex items-center gap-2">
             <EffectiveRoleChip />
-            {/* 5e-III View-as: quiet preview menu, self-gated on the GLOBAL
-                admin/producer claim + featureShootSurface (renders null
-                otherwise). Adjacent to the chip so preview state reads together. */}
+            {/* 5e-III View-as: self-gated on the global claim + featureShootSurface. */}
             <ViewAsMenu />
             {canExport && (
               <Button variant="outline" onClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}>

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -210,11 +210,8 @@ export default function ShotListPage() {
   // EFFECTIVE role — resolveSurface's input contract is byte-unchanged (the
   // opaque effectiveRole param is 5e's View-as interposition seam).
   const surfaceDevice: SurfaceDevice = isMobile ? "mobile" : isDesktop ? "desktop" : "tablet"
-  // 5e-III: previewRole substitutes for the EFFECTIVE role at surface
-  // resolution ONLY (the real `role` above still drives every write-gate).
-  // previewActive flags the suppression of url/stored view rungs inside
-  // useShotListState so the previewer's own stored choice can't mask the
-  // previewed surface default. Still null while auth/role resolve (no flash).
+  // 5e-III: previewRole feeds surface resolution ONLY — the real `role` above
+  // still drives every write-gate, so preview can never escalate.
   const surfaceContext = useMemo(
     () =>
       authLoading || roleResolving

--- a/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx
@@ -61,12 +61,20 @@ vi.mock("@/shared/hooks/useMediaQuery", () => ({
 // resolve the table surface default), so the flag is pinned OFF explicitly
 // here — the flag-ON resolution path is owned by
 // useShotListState.resolver.test.tsx.
+// 5e-III: featureShootSurface gates the View-as menu mount; default OFF here
+// (matches the rest of this legacy-pinned file). Flip per-test for the mount pin.
+const flagState = vi.hoisted(() => ({ shootSurface: false }))
+
 vi.mock("@/shared/lib/flags", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
   return {
     ...actual,
     isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
-      flag === "featureSurfaceResolver" ? false : actual.isFeatureEnabled(flag),
+      flag === "featureSurfaceResolver"
+        ? false
+        : flag === "featureShootSurface"
+          ? flagState.shootSurface
+          : actual.isFeatureEnabled(flag),
   }
 })
 
@@ -139,6 +147,7 @@ describe("ShotListPage", () => {
     effectiveState.resolving = false
     mediaState.isMobile = false
     mediaState.isDesktop = false
+    flagState.shootSurface = false
     ;(useTalent as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [],
       loading: false,
@@ -842,6 +851,35 @@ describe("ShotListPage", () => {
     expect(screen.queryByTestId("create-shot-dialog-open")).not.toBeInTheDocument()
     expect(capturedSearch).toBeDefined()
     expect(new URLSearchParams(capturedSearch!).get("create")).toBe("1")
+  })
+
+  // ── 5e-III View-as menu mount (Writer 4 slice) ───────────────────────────
+
+  it("mounts the View-as menu in the header actions when featureShootSurface is on (global producer)", () => {
+    flagState.shootSurface = true
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    // The quiet trigger renders (useAuth mock = global producer). Its own
+    // dropdown behavior is owned by ViewAsMenu's component test.
+    expect(screen.getByTestId("view-as-trigger")).toBeInTheDocument()
+  })
+
+  it("does NOT mount the View-as menu when featureShootSurface is off (default)", () => {
+    ;(useShots as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [makeShot({ id: "a", title: "Alpha" })],
+      loading: false,
+      error: null,
+    })
+
+    renderPage("/projects/p1/shots")
+
+    expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
   })
 
   it("renders note URLs as clickable links", () => {

--- a/src-vnext/features/shots/hooks/__tests__/useResolvedSurface.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useResolvedSurface.test.tsx
@@ -28,6 +28,12 @@ const flagState = vi.hoisted(() => ({
   shootSurface: false,
 }))
 
+// 5e-III: in-memory View-as preview. Default previewRole null = not previewing,
+// so every pre-5e-III pin below stays byte-identical.
+const previewState = vi.hoisted(() => ({
+  previewRole: null as Role | null,
+}))
+
 vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({
     role: "viewer",
@@ -44,6 +50,14 @@ vi.mock("@/shared/hooks/useEffectiveRole", () => ({
 vi.mock("@/shared/hooks/useMediaQuery", () => ({
   useIsMobile: () => deviceState.isMobile,
   useIsDesktop: () => deviceState.isDesktop,
+}))
+
+vi.mock("@/app/providers/ViewAsPreviewProvider", () => ({
+  useViewAsPreview: () => ({
+    previewRole: previewState.previewRole,
+    setPreviewRole: () => {},
+    clearPreview: () => {},
+  }),
 }))
 
 vi.mock("@/shared/lib/flags", async (importOriginal) => {
@@ -67,6 +81,7 @@ beforeEach(() => {
   roleState.role = "producer"
   roleState.resolving = false
   flagState.shootSurface = false
+  previewState.previewRole = null
   setDevice("desktop")
 })
 
@@ -297,5 +312,62 @@ describe("useResolvedSurface — featureShootSurface flag ON", () => {
     expect(result.current).not.toBe(off)
     expect(result.current.affordances?.fieldEditing).toBe(true)
     expect(result.current.chrome?.toolbar).toBe("minimal")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// 5e-III View-as preview — previewRole interposes at the resolveSurface call
+// only. previewRole "crew" => the shoot surface regardless of the real role;
+// previewRole null => byte-identical to pre-5e-III behavior.
+// ---------------------------------------------------------------------------
+
+describe("useResolvedSurface — 5e-III View-as preview", () => {
+  beforeEach(() => {
+    // The flag gates the whole 5e initiative; preview is exercised flag-ON.
+    flagState.shootSurface = true
+  })
+
+  it("resolves the shoot surface when previewing as crew even though the real role is producer", () => {
+    roleState.role = "producer"
+    previewState.previewRole = "crew"
+    setDevice("desktop")
+    const { result } = renderHook(() => useResolvedSurface())
+    // Real role is producer (plan-build); the preview narrows to the shoot shell.
+    expect(result.current.surface).toBe("shoot")
+    expect(result.current.chrome?.toolbar).toBe("minimal")
+    expect(result.current.chrome?.viewSwitcher).toBe(false)
+    expect(result.current.chrome?.statusControl).toBe("tap-row")
+  })
+
+  it("preview wins regardless of the real role passed (admin → crew shoot surface)", () => {
+    roleState.role = "admin"
+    previewState.previewRole = "crew"
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.surface).toBe("shoot")
+  })
+
+  it("previewRole null is byte-identical to before — the real role drives the surface", () => {
+    roleState.role = "producer"
+    previewState.previewRole = null
+    const { result } = renderHook(() => useResolvedSurface())
+    expect(result.current.surface).toBe("plan-build")
+  })
+
+  it("recomputes when the preview is entered then cleared (previewRole is a memo dependency)", () => {
+    roleState.role = "producer"
+    setDevice("desktop")
+    previewState.previewRole = null
+    const { result, rerender } = renderHook(() => useResolvedSurface())
+    const real = result.current
+    expect(real.surface).toBe("plan-build")
+
+    previewState.previewRole = "crew"
+    rerender()
+    expect(result.current).not.toBe(real)
+    expect(result.current.surface).toBe("shoot")
+
+    previewState.previewRole = null
+    rerender()
+    expect(result.current.surface).toBe("plan-build")
   })
 })

--- a/src-vnext/features/shots/hooks/__tests__/useShotListState.resolver.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useShotListState.resolver.test.tsx
@@ -186,6 +186,32 @@ describe("useShotListState — featureSurfaceResolver flag-ON integration", () =
     expect(view.result.current.viewMode).toBe("card") // inert: card, same as legacy
   })
 
+  // ── 5e-III View-as preview: previewActive suppresses url/stored rungs ──────
+
+  it("previewActive suppresses a stored 'table' choice: crew preview resolves the shoot surface (card), not the previewer's table", () => {
+    // The previewing producer has explicitly chosen 'table' for their own
+    // plan-build view. Under preview (previewActive) that stored choice must NOT
+    // outrank the previewed shoot surface default — otherwise the shell is
+    // masked by the previewer's own 'table'.
+    window.localStorage.setItem(VIEW_STORAGE_KEY, "table")
+    const { view, getSearch } = setup("", {
+      role: "crew",
+      device: "desktop",
+      previewActive: true,
+    })
+
+    expect(view.result.current.surface).toBe("shoot")
+    expect(view.result.current.viewMode).toBe("card") // stored 'table' suppressed
+    expect(view.result.current.groupKey).toBe("none")
+
+    // Still a pure derivation under preview — zero URL writes, zero localStorage
+    // writes (the stored key is untouched, NOT cleared).
+    view.rerender()
+    expect(mocks.setSearchParamsCalls).toHaveLength(0)
+    expect(getSearch()).toBe("")
+    expect(window.localStorage.getItem(VIEW_STORAGE_KEY)).toBe("table")
+  })
+
   it("setViewMode still writes URL + localStorage identically under flag-on (setters untouched)", () => {
     const { view, getSearch } = setup("", { role: "producer", device: "desktop" })
 

--- a/src-vnext/features/shots/hooks/useResolvedSurface.ts
+++ b/src-vnext/features/shots/hooks/useResolvedSurface.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { useViewAsPreview } from "@/app/providers/ViewAsPreviewProvider"
 import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { useIsMobile, useIsDesktop } from "@/shared/hooks/useMediaQuery"
 import { isFeatureEnabled } from "@/shared/lib/flags"
@@ -45,6 +46,11 @@ const RESOLVING_RESULT: UseResolvedSurfaceResult = {
 export function useResolvedSurface(): UseResolvedSurfaceResult {
   const { loading: authLoading } = useAuth()
   const { role, resolving: roleResolving } = useEffectiveRole()
+  // 5e-III View-as: the in-memory preview role (null = not previewing). It
+  // interposes ONLY at surface resolution below — it never flows through
+  // useEffectiveRole, so the real role above (and every rbac write-gate keyed
+  // off it) is unchanged. Preview can only NARROW the presentation surface.
+  const { previewRole } = useViewAsPreview()
   const isMobile = useIsMobile()
   const isDesktop = useIsDesktop()
 
@@ -63,9 +69,13 @@ export function useResolvedSurface(): UseResolvedSurfaceResult {
 
   return useMemo(() => {
     if (resolving) return RESOLVING_RESULT
-    // 5e-III View-as seam: the preview role interposes on effectiveRole HERE.
+    // 5e-III View-as seam (LIVE): when previewing, substitute the preview role
+    // for the real effective role at THIS resolveSurface call only. The
+    // url/stored view rungs stay null so the previewed shoot-surface default
+    // is never masked by the previewer's own stored view choice. This narrows
+    // presentation only — the real role term used by write-gates is untouched.
     const { surface, affordances, chrome } = resolveSurface({
-      effectiveRole: role,
+      effectiveRole: previewRole ?? role,
       device,
       // Capability consumers need no view resolution — the list page keeps
       // its own url/stored path through useShotListState.
@@ -75,5 +85,5 @@ export function useResolvedSurface(): UseResolvedSurfaceResult {
       shootSurfaceEnabled,
     })
     return { surface, affordances, chrome, resolving: false }
-  }, [resolving, role, device, shootSurfaceEnabled])
+  }, [resolving, previewRole, role, device, shootSurfaceEnabled])
 }

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -127,9 +127,7 @@ export type ShotListSurfaceContext = {
   readonly role: Role
   readonly device: SurfaceDevice
   /** 5e-III — when true, the View-as preview suppresses url/stored view rungs
-   *  so the previewed surface's default isn't masked by the previewer's own
-   *  stored choice (e.g. a stored 'table' would otherwise outrank the previewed
-   *  shoot surface default and hide the shell). Additive; defaults undefined. */
+   *  so the previewer's own stored choice can't mask the previewed surface. */
   readonly previewActive?: boolean
 }
 

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -126,6 +126,11 @@ export type ShotListState = {
 export type ShotListSurfaceContext = {
   readonly role: Role
   readonly device: SurfaceDevice
+  /** 5e-III — when true, the View-as preview suppresses url/stored view rungs
+   *  so the previewed surface's default isn't masked by the previewer's own
+   *  stored choice (e.g. a stored 'table' would otherwise outrank the previewed
+   *  shoot surface default and hide the shell). Additive; defaults undefined. */
+  readonly previewActive?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -316,12 +321,17 @@ export function useShotListState(params: {
   // writes. Gated on surfaceContext (null while auth loads — no viewer-flash).
   const resolved = useMemo(() => {
     if (!surfaceResolverEnabled || !surfaceContext) return null
+    // 5e-III View-as seam: under an active preview, suppress the url/stored
+    // view rungs (pass null) so the previewer's own stored 'table' choice can't
+    // outrank — and thus mask — the previewed surface's default. Pure
+    // derivation either way: still zero setSearchParams / localStorage writes.
+    const previewActive = surfaceContext.previewActive === true
     return resolveSurface({
       effectiveRole: surfaceContext.role,
       device: surfaceContext.device,
-      urlView: viewParam,
-      urlGroup: groupParam,
-      storedView: storedExplicitView,
+      urlView: previewActive ? null : viewParam,
+      urlGroup: previewActive ? null : groupParam,
+      storedView: previewActive ? null : storedExplicitView,
       shootSurfaceEnabled,
     })
   }, [surfaceResolverEnabled, surfaceContext, viewParam, groupParam, storedExplicitView, shootSurfaceEnabled])

--- a/src-vnext/shared/components/CommandPalette.tsx
+++ b/src-vnext/shared/components/CommandPalette.tsx
@@ -11,6 +11,7 @@ import {
   Film,
   Package2,
   Clapperboard,
+  Eye,
 } from "lucide-react"
 import {
   Command,
@@ -25,7 +26,9 @@ import { Dialog, DialogContent, DialogTitle } from "@/ui/dialog"
 import { useSearchCommand } from "@/app/providers/SearchCommandProvider"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useOptionalProjectScope } from "@/app/providers/ProjectScopeProvider"
+import { useViewAsPreview } from "@/app/providers/ViewAsPreviewProvider"
 import { ROLE } from "@/shared/lib/rbac"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useProjects } from "@/features/projects/hooks/useProjects"
 import { useProductFamilies } from "@/features/products/hooks/useProducts"
 import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
@@ -74,6 +77,9 @@ function CommandPaletteInner({
 }) {
   const navigate = useNavigate()
   const { role } = useAuth()
+  // 5e-III: in-memory "View as" preview (NO persistence). The preview only
+  // swaps the presentation surface — real write-gates keep using the real role.
+  const { previewRole, setPreviewRole, clearPreview } = useViewAsPreview()
   const [query, setQuery] = useState("")
 
   const { data: projects } = useProjects()
@@ -123,6 +129,15 @@ function CommandPaletteInner({
   // (firestore.rules:539-543) and /pendingInvitations (firestore.rules:547-549)
   // require the global admin claim — never a project-level role.
   const isAdmin = role === ROLE.ADMIN
+
+  // 5e-III: "View as" quick actions are gated behind the Shoot-surface flag AND
+  // the GLOBAL admin/producer claim (same global-role pin as `isAdmin` above —
+  // this is the org-scope claim from useAuth(), NOT useEffectiveRole). The
+  // actions interpose ONLY at surface resolution; they never persist anything
+  // (no URL, no localStorage, no resolvedRoleCache commit, no toast).
+  const canViewAs =
+    isFeatureEnabled("featureShootSurface") &&
+    (role === ROLE.ADMIN || role === ROLE.PRODUCER)
 
   return (
     <>
@@ -329,6 +344,32 @@ function CommandPaletteInner({
                 >
                   <Settings className="text-muted-foreground" />
                   <span>Go to Admin</span>
+                </CommandItem>
+              )}
+              {/* 5e-III: View-as preview toggle. Does NOT navigate — it flips
+                  the in-memory preview surface and closes the palette. */}
+              {canViewAs && !previewRole && (
+                <CommandItem
+                  value="action-view-as-crew"
+                  onSelect={() => {
+                    setPreviewRole(ROLE.CREW)
+                    onClose()
+                  }}
+                >
+                  <Eye className="text-muted-foreground" />
+                  <span>View as Crew (Shoot)</span>
+                </CommandItem>
+              )}
+              {canViewAs && previewRole && (
+                <CommandItem
+                  value="action-view-as-return"
+                  onSelect={() => {
+                    clearPreview()
+                    onClose()
+                  }}
+                >
+                  <Eye className="text-muted-foreground" />
+                  <span>Return to your view</span>
                 </CommandItem>
               )}
             </CommandGroup>

--- a/src-vnext/shared/components/EffectiveRoleChip.tsx
+++ b/src-vnext/shared/components/EffectiveRoleChip.tsx
@@ -1,4 +1,6 @@
+import { Eye } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { useViewAsPreview } from "@/app/providers/ViewAsPreviewProvider"
 import { useEffectiveRole } from "@/shared/hooks/useEffectiveRole"
 import { roleLabel, roleRank } from "@/shared/lib/rbac"
 
@@ -10,6 +12,26 @@ import { roleLabel, roleRank } from "@/shared/lib/rbac"
 export function EffectiveRoleChip() {
   const { role: globalRole, loading: authLoading } = useAuth()
   const { role, resolving } = useEffectiveRole()
+  // 5e-III View-as: the in-memory preview role (null = not previewing).
+  const { previewRole } = useViewAsPreview()
+
+  // 5e-III: the "Previewing as X" state is DISTINCT from and takes precedence
+  // over the downgrade pill. Branch on previewRole explicitly — do NOT lean on
+  // the downgrade guard below (a producer previewing as crew is the canonical
+  // case, and while roleRank(crew) < roleRank(producer) happens to hold, the
+  // preview chip must render on its own terms). Visually distinct: Eye prefix +
+  // strong border so the previewer always knows they're in a narrowed view.
+  if (previewRole !== null) {
+    return (
+      <span
+        data-testid="view-as-previewing-chip"
+        className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-[var(--color-border-strong)] bg-[var(--color-surface-subtle)] px-2 py-0.5 text-2xs font-medium text-[var(--color-text-muted)]"
+      >
+        <Eye className="h-3 w-3" aria-hidden="true" />
+        Previewing as {roleLabel(previewRole)}
+      </span>
+    )
+  }
 
   if (authLoading || resolving) return null
   if (roleRank(role) >= roleRank(globalRole)) return null

--- a/src-vnext/shared/components/EffectiveRoleChip.tsx
+++ b/src-vnext/shared/components/EffectiveRoleChip.tsx
@@ -15,12 +15,11 @@ export function EffectiveRoleChip() {
   // 5e-III View-as: the in-memory preview role (null = not previewing).
   const { previewRole } = useViewAsPreview()
 
-  // 5e-III: the "Previewing as X" state is DISTINCT from and takes precedence
-  // over the downgrade pill. Branch on previewRole explicitly — do NOT lean on
-  // the downgrade guard below (a producer previewing as crew is the canonical
-  // case, and while roleRank(crew) < roleRank(producer) happens to hold, the
-  // preview chip must render on its own terms). Visually distinct: Eye prefix +
-  // strong border so the previewer always knows they're in a narrowed view.
+  // 5e-III: an active preview always renders its own "Previewing as X" chip,
+  // ahead of BOTH the auth/role loading guards and the downgrade pill below: a
+  // preview is only ever set by deliberate action, so if a claim refresh briefly
+  // re-enters `resolving` the previewer must still see they're in a narrowed
+  // view, not a blank. (The downgrade-rank guard below would also miss it.)
   if (previewRole !== null) {
     return (
       <span

--- a/src-vnext/shared/components/ViewAsMenu.tsx
+++ b/src-vnext/shared/components/ViewAsMenu.tsx
@@ -66,7 +66,9 @@ export function ViewAsMenu() {
         <DropdownMenuItem
           data-testid="view-as-return"
           disabled={!isPreviewing}
-          onSelect={() => clearPreview()}
+          onSelect={() => {
+            if (isPreviewing) clearPreview()
+          }}
         >
           Return to your view
         </DropdownMenuItem>

--- a/src-vnext/shared/components/ViewAsMenu.tsx
+++ b/src-vnext/shared/components/ViewAsMenu.tsx
@@ -56,10 +56,7 @@ export function ViewAsMenu() {
             on the provider — no persistence side-effects. */}
         <DropdownMenuItem
           data-testid="view-as-crew"
-          onSelect={(event) => {
-            event.preventDefault()
-            setPreviewRole(ROLE.CREW)
-          }}
+          onSelect={() => setPreviewRole(ROLE.CREW)}
         >
           Crew (Shoot)
         </DropdownMenuItem>
@@ -69,10 +66,7 @@ export function ViewAsMenu() {
         <DropdownMenuItem
           data-testid="view-as-return"
           disabled={!isPreviewing}
-          onSelect={(event) => {
-            event.preventDefault()
-            clearPreview()
-          }}
+          onSelect={() => clearPreview()}
         >
           Return to your view
         </DropdownMenuItem>

--- a/src-vnext/shared/components/ViewAsMenu.tsx
+++ b/src-vnext/shared/components/ViewAsMenu.tsx
@@ -1,0 +1,82 @@
+import { Eye } from "lucide-react"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useViewAsPreview } from "@/app/providers/ViewAsPreviewProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
+import { ROLE } from "@/shared/lib/rbac"
+import { Button } from "@/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu"
+
+// 5e-III: the QUIET "View as" menu. A passive, GLOBAL-claim-only affordance that
+// lets an admin/producer PREVIEW the Crew (Shoot) surface without persisting
+// anything. Consumes the in-memory ViewAsPreviewProvider ONLY — no localStorage,
+// no URL, no navigation, no resolvedRoleCache, no toast. The preview NARROWS the
+// presentation surface; every real write-gate keeps using the real role.
+export function ViewAsMenu() {
+  // 5e-III gate: the WHOLE 5e initiative lives behind featureShootSurface
+  // (default OFF in prod). Render nothing unless the flag is on.
+  const shootSurfaceEnabled = isFeatureEnabled("featureShootSurface")
+
+  // 5e-III: gate on the GLOBAL claim from useAuth (admin/producer), NOT the
+  // effective role — this affordance is the global-claim privilege to preview,
+  // distinct from useEffectiveRole. Never route preview through that hook.
+  const { role } = useAuth()
+  const isGlobalAdminOrProducer =
+    role === ROLE.ADMIN || role === ROLE.PRODUCER
+
+  const { previewRole, setPreviewRole, clearPreview } = useViewAsPreview()
+
+  // Quiet: passive admin/producer-only affordance, only when the flag is on.
+  if (!shootSurfaceEnabled || !isGlobalAdminOrProducer) return null
+
+  const isPreviewing = previewRole !== null
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className="gap-1.5"
+          data-testid="view-as-trigger"
+        >
+          <Eye className="h-4 w-4" />
+          {isPreviewing ? "Previewing as Crew" : "View as"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-52">
+        <DropdownMenuLabel>View as</DropdownMenuLabel>
+        {/* 5e-III scope: ONLY "Crew (Shoot)". setPreviewRole is in-memory state
+            on the provider — no persistence side-effects. */}
+        <DropdownMenuItem
+          data-testid="view-as-crew"
+          onSelect={(event) => {
+            event.preventDefault()
+            setPreviewRole(ROLE.CREW)
+          }}
+        >
+          Crew (Shoot)
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {/* 5e-III: "Return to your view" clears the in-memory preview. Enabled
+            only while previewing — clearPreview is a no-op otherwise. */}
+        <DropdownMenuItem
+          data-testid="view-as-return"
+          disabled={!isPreviewing}
+          onSelect={(event) => {
+            event.preventDefault()
+            clearPreview()
+          }}
+        >
+          Return to your view
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src-vnext/shared/components/__tests__/CommandPalette.test.tsx
+++ b/src-vnext/shared/components/__tests__/CommandPalette.test.tsx
@@ -20,6 +20,26 @@ vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: "admin", clientId: "c1" }),
 }))
 
+// 5e-III: View-as preview provider — hoisted swappable state so tests can
+// toggle previewing on/off and assert the setter / clear calls.
+const mockViewAsPreview = vi.hoisted(() => ({
+  previewRole: null as "crew" | null,
+  setPreviewRole: vi.fn(),
+  clearPreview: vi.fn(),
+}))
+
+vi.mock("@/app/providers/ViewAsPreviewProvider", () => ({
+  useViewAsPreview: () => mockViewAsPreview,
+}))
+
+// 5e-III: feature flags — hoisted so each test can flip featureShootSurface.
+const mockFlagEnabled = vi.hoisted(() => ({ current: true }))
+
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) =>
+    flag === "featureShootSurface" ? mockFlagEnabled.current : false,
+}))
+
 // Project scope — hoisted ref so tests can swap between null and a value
 const mockProjectScope: { current: { projectId: string; projectName: string } | null } = {
   current: { projectId: "p1", projectName: "Alpha Project" },
@@ -281,6 +301,9 @@ describe("CommandPalette", () => {
     // Default: scoped to project p1, lazy fetch returns nothing
     mockProjectScope.current = { projectId: "p1", projectName: "Alpha Project" }
     primeLazyFetch({})
+    // 5e-III defaults: flag ON, not previewing
+    mockFlagEnabled.current = true
+    mockViewAsPreview.previewRole = null
   })
 
   it("renders the palette when open", () => {
@@ -374,6 +397,40 @@ describe("CommandPalette", () => {
     expect(mockNavigate).toHaveBeenCalledWith("/admin")
   })
 
+  // -------------------------------------------------------------------------
+  // 5e-III — "View as" quick actions
+  // -------------------------------------------------------------------------
+
+  it("shows 'View as Crew (Shoot)' for flag-on admin when not previewing", () => {
+    renderOpen()
+    expect(screen.getByText("View as Crew (Shoot)")).toBeInTheDocument()
+  })
+
+  it("calls setPreviewRole('crew') when 'View as Crew (Shoot)' is selected", () => {
+    renderOpen()
+    fireEvent.click(screen.getByText("View as Crew (Shoot)"))
+    expect(mockViewAsPreview.setPreviewRole).toHaveBeenCalledWith("crew")
+    // View-as does NOT navigate.
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
+  it("does NOT show the View-as action when the Shoot-surface flag is off", () => {
+    mockFlagEnabled.current = false
+    renderOpen()
+    expect(screen.queryByText("View as Crew (Shoot)")).not.toBeInTheDocument()
+    expect(screen.queryByText("Return to your view")).not.toBeInTheDocument()
+  })
+
+  it("shows 'Return to your view' while previewing and calls clearPreview", () => {
+    mockViewAsPreview.previewRole = "crew"
+    renderOpen()
+    // The enter action is replaced by the return action while previewing.
+    expect(screen.queryByText("View as Crew (Shoot)")).not.toBeInTheDocument()
+    fireEvent.click(screen.getByText("Return to your view"))
+    expect(mockViewAsPreview.clearPreview).toHaveBeenCalledTimes(1)
+    expect(mockNavigate).not.toHaveBeenCalled()
+  })
+
   it("stores navigated item in localStorage recent items", async () => {
     renderOpen()
     const input = screen.getByPlaceholderText("Search projects, products, talent, crew...")
@@ -439,6 +496,9 @@ describe("CommandPalette — lazy project-scoped indexing", () => {
     localStorage.clear()
     mockProjectScope.current = { projectId: "p1", projectName: "Alpha Project" }
     primeLazyFetch({})
+    // 5e-III defaults: flag ON, not previewing
+    mockFlagEnabled.current = true
+    mockViewAsPreview.previewRole = null
   })
 
   it("fetches shots, pulls, and lanes exactly once when palette opens inside a project", async () => {

--- a/src-vnext/shared/components/__tests__/EffectiveRoleChip.test.tsx
+++ b/src-vnext/shared/components/__tests__/EffectiveRoleChip.test.tsx
@@ -5,6 +5,9 @@ import { render, screen } from "@testing-library/react"
 
 const authState = vi.hoisted(() => ({ role: "producer", loading: false }))
 const effectiveState = vi.hoisted(() => ({ role: "producer", resolving: false }))
+// 5e-III: View-as preview. Default previewRole null = not previewing, so the
+// existing downgrade/no-render pins below stay unchanged.
+const previewState = vi.hoisted(() => ({ previewRole: null as string | null }))
 
 vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: authState.role, loading: authState.loading }),
@@ -17,6 +20,14 @@ vi.mock("@/shared/hooks/useEffectiveRole", () => ({
   }),
 }))
 
+vi.mock("@/app/providers/ViewAsPreviewProvider", () => ({
+  useViewAsPreview: () => ({
+    previewRole: previewState.previewRole,
+    setPreviewRole: () => {},
+    clearPreview: () => {},
+  }),
+}))
+
 import { EffectiveRoleChip } from "@/shared/components/EffectiveRoleChip"
 
 describe("EffectiveRoleChip", () => {
@@ -25,6 +36,7 @@ describe("EffectiveRoleChip", () => {
     authState.loading = false
     effectiveState.role = "producer"
     effectiveState.resolving = false
+    previewState.previewRole = null
   })
 
   it("is hidden when the effective role equals the global role", () => {
@@ -64,5 +76,62 @@ describe("EffectiveRoleChip", () => {
     authState.loading = true
     rerender(<EffectiveRoleChip />)
     expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+  })
+
+  // 5e-III View-as preview — a DISTINCT chip that takes precedence over and is
+  // independent of the downgrade condition.
+  describe("5e-III View-as preview", () => {
+    it("renders the distinct 'Previewing as Crew' chip when previewRole is crew", () => {
+      previewState.previewRole = "crew"
+      render(<EffectiveRoleChip />)
+      const chip = screen.getByTestId("view-as-previewing-chip")
+      expect(chip).toHaveTextContent("Previewing as Crew")
+      // The downgrade pill must NOT also render.
+      expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+    })
+
+    it("renders the preview chip even when there is NO real downgrade (effective === global)", () => {
+      // Producer global AND producer effective => no downgrade pill would show,
+      // but the preview chip still renders because it branches on previewRole.
+      authState.role = "producer"
+      effectiveState.role = "producer"
+      previewState.previewRole = "crew"
+      render(<EffectiveRoleChip />)
+      expect(screen.getByTestId("view-as-previewing-chip")).toHaveTextContent(
+        "Previewing as Crew",
+      )
+    })
+
+    it("preview chip takes precedence even while the effective role is resolving", () => {
+      // previewRole branches BEFORE the resolving/loading guards.
+      effectiveState.resolving = true
+      previewState.previewRole = "crew"
+      render(<EffectiveRoleChip />)
+      expect(
+        screen.getByTestId("view-as-previewing-chip"),
+      ).toBeInTheDocument()
+    })
+
+    it("previewRole null keeps the existing downgrade behavior (no preview chip)", () => {
+      previewState.previewRole = null
+      effectiveState.role = "viewer"
+      render(<EffectiveRoleChip />)
+      expect(
+        screen.queryByTestId("view-as-previewing-chip"),
+      ).not.toBeInTheDocument()
+      expect(screen.getByTestId("effective-role-chip")).toHaveTextContent(
+        "Viewer on this project",
+      )
+    })
+
+    it("previewRole null with no downgrade renders nothing at all", () => {
+      previewState.previewRole = null
+      effectiveState.role = "producer"
+      render(<EffectiveRoleChip />)
+      expect(
+        screen.queryByTestId("view-as-previewing-chip"),
+      ).not.toBeInTheDocument()
+      expect(screen.queryByTestId("effective-role-chip")).not.toBeInTheDocument()
+    })
   })
 })

--- a/src-vnext/shared/components/__tests__/ViewAsMenu.test.tsx
+++ b/src-vnext/shared/components/__tests__/ViewAsMenu.test.tsx
@@ -1,0 +1,107 @@
+/// <reference types="@testing-library/jest-dom" />
+// 5e-III — the QUIET "View as" trigger menu. Gated on featureShootSurface AND
+// the GLOBAL admin/producer claim. Drives the in-memory ViewAsPreviewProvider
+// ONLY — these tests assert it calls setPreviewRole("crew") / clearPreview and
+// renders nothing for a viewer or when the flag is off.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+
+const authState = vi.hoisted(() => ({ role: "admin" }))
+const flagState = vi.hoisted(() => ({ featureShootSurface: true }))
+const previewState = vi.hoisted(() => ({
+  previewRole: null as string | null,
+  setPreviewRole: vi.fn(),
+  clearPreview: vi.fn(),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ role: authState.role }),
+}))
+
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) =>
+    flag === "featureShootSurface" ? flagState.featureShootSurface : false,
+}))
+
+vi.mock("@/app/providers/ViewAsPreviewProvider", () => ({
+  useViewAsPreview: () => ({
+    previewRole: previewState.previewRole,
+    setPreviewRole: previewState.setPreviewRole,
+    clearPreview: previewState.clearPreview,
+  }),
+}))
+
+import { ViewAsMenu } from "@/shared/components/ViewAsMenu"
+
+describe("ViewAsMenu", () => {
+  beforeEach(() => {
+    authState.role = "admin"
+    flagState.featureShootSurface = true
+    previewState.previewRole = null
+    previewState.setPreviewRole.mockReset()
+    previewState.clearPreview.mockReset()
+  })
+
+  it("renders nothing for a viewer (non-global claim)", () => {
+    authState.role = "viewer"
+    render(<ViewAsMenu />)
+    expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing for crew (non-global claim)", () => {
+    authState.role = "crew"
+    render(<ViewAsMenu />)
+    expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
+  })
+
+  it("renders nothing when the featureShootSurface flag is off", () => {
+    flagState.featureShootSurface = false
+    render(<ViewAsMenu />)
+    expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
+  })
+
+  it("renders the trigger for a global admin with the flag on", () => {
+    render(<ViewAsMenu />)
+    expect(screen.getByTestId("view-as-trigger")).toBeInTheDocument()
+    expect(screen.getByTestId("view-as-trigger")).toHaveTextContent("View as")
+  })
+
+  it("renders the trigger for a global producer with the flag on", () => {
+    authState.role = "producer"
+    render(<ViewAsMenu />)
+    expect(screen.getByTestId("view-as-trigger")).toBeInTheDocument()
+  })
+
+  it("calls setPreviewRole('crew') when the Crew (Shoot) item is chosen", async () => {
+    const user = userEvent.setup()
+    render(<ViewAsMenu />)
+    await user.click(screen.getByTestId("view-as-trigger"))
+    await user.click(await screen.findByTestId("view-as-crew"))
+    expect(previewState.setPreviewRole).toHaveBeenCalledTimes(1)
+    expect(previewState.setPreviewRole).toHaveBeenCalledWith("crew")
+    expect(previewState.clearPreview).not.toHaveBeenCalled()
+  })
+
+  it("shows 'Previewing as Crew' and an enabled return item while previewing, and clears on select", async () => {
+    previewState.previewRole = "crew"
+    const user = userEvent.setup()
+    render(<ViewAsMenu />)
+    const trigger = screen.getByTestId("view-as-trigger")
+    expect(trigger).toHaveTextContent("Previewing as Crew")
+    await user.click(trigger)
+    const returnItem = await screen.findByTestId("view-as-return")
+    expect(returnItem).not.toHaveAttribute("aria-disabled", "true")
+    await user.click(returnItem)
+    expect(previewState.clearPreview).toHaveBeenCalledTimes(1)
+    expect(previewState.setPreviewRole).not.toHaveBeenCalled()
+  })
+
+  it("disables the return item when NOT previewing", async () => {
+    const user = userEvent.setup()
+    render(<ViewAsMenu />)
+    await user.click(screen.getByTestId("view-as-trigger"))
+    const returnItem = await screen.findByTestId("view-as-return")
+    expect(returnItem).toHaveAttribute("aria-disabled", "true")
+  })
+})

--- a/src-vnext/shared/components/__tests__/ViewAsMenu.test.tsx
+++ b/src-vnext/shared/components/__tests__/ViewAsMenu.test.tsx
@@ -55,6 +55,12 @@ describe("ViewAsMenu", () => {
     expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
   })
 
+  it("renders nothing for warehouse (non-global claim)", () => {
+    authState.role = "warehouse"
+    render(<ViewAsMenu />)
+    expect(screen.queryByTestId("view-as-trigger")).not.toBeInTheDocument()
+  })
+
   it("renders nothing when the featureShootSurface flag is off", () => {
     flagState.featureShootSurface = false
     render(<ViewAsMenu />)


### PR DESCRIPTION
## Phase 5e-III — the quiet View-as menu

The final slice of the Shoot-surface redesign. A **global admin/producer** can **preview the Crew (Shoot) surface** without persisting anything, and return to their real view. Everything is gated behind `featureShootSurface` (the whole 5e initiative; **default OFF in prod** → this PR is a no-op until the flag flips).

### The hard invariants (pinned by tests)
1. **Never through `useEffectiveRole`.** That hook's module-level `resolvedRoleCache`, its commit, and the downgrade `toast(...)` would persist/announce a preview as a real role change. The file is **byte-untouched** (`git diff` empty). The preview interposes ONLY at surface resolution.
2. **Zero persistence** on enter/exit: no `:view:v1` write, no `setSearchParams`, no cache commit, no toast. The provider is in-memory `useState` only.
3. **Suppresses the url/stored rungs** (passes `urlView`/`urlGroup`/`storedView` as null) so the previewer's own stored `table` choice can't outrank — and mask — the previewed shoot-surface default.
4. **Narrows, never escalates.** Every real write-gate keeps using the real effective role; preview only swaps the presentation surface/affordances.

### What changed
- **`ViewAsPreviewProvider`** (new) — in-memory `useState` preview role, modeled on `SearchCommandProvider`; mounted in `App.tsx` so it survives list→detail nav.
- **`useResolvedSurface`** — at the existing `// 5e-III View-as seam`, `effectiveRole: previewRole ?? role` (url/stored already null). Drives the shell mount + `affordances`/`chrome`.
- **`useShotListState`** — `ShotListSurfaceContext.previewActive` (additive) nulls the view rungs in the pure `resolveSurface` derivation. `ShotListPage` surfaceContext sets `role: previewRole ?? role` (the page's real write-gates keep the real `role`).
- **`ViewAsMenu`** (new) — chip-adjacent dropdown in the shots `PageHeader`; self-gated on `featureShootSurface` + the GLOBAL admin/producer claim. "Crew (Shoot)" / "Return to your view".
- **`CommandPalette`** — "View as Crew (Shoot)" / "Return to your view" quick actions, same gate, no navigation.
- **`EffectiveRoleChip`** — distinct "Previewing as X" state (Eye + strong border), independent of the downgrade pill.

### Build approach
Scout → build → adversarial-verify dynamic workflow: 1 foundation writer + 4 parallel consumer writers + 3 adversarial verifiers (all PASS — `useEffectiveRole` untouched, narrow-not-escalate, gates+inertness). Gates re-verified on the main loop.

### Gates (verified on the main loop, independent of the workflow)
- **181 tests green** across the 12 touched/adjacent files (incl. the component-adjacent `FloatingActionBar.test.tsx`, the resolver inertness pins, and the Shoot shell tests).
- New coverage: provider zero-persistence spy; `useResolvedSurface` preview→`shoot` regardless of real role; chip preview state; `useShotListState.resolver` stored-`table` suppression under preview (`setSearchParams` count 0); palette quick actions.
- Lint clean · production build clean. `featureShootSurface` OFF → flag-off path byte-identical to 5e-II trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)