### PR TITLE
feat(shots): warehouse Review surface (review-warehouse) + canEditScene A1 — Phase 5f-III

### DIFF
--- a/src-vnext/features/shots/components/ReviewShotDetail.tsx
+++ b/src-vnext/features/shots/components/ReviewShotDetail.tsx
@@ -19,10 +19,18 @@
 //   → minimal read-only meta (talent / location) → products read-only LAST
 //   (ProductColorwayStrip readOnly=true).
 //
-// Deliberately ABSENT (scoping boundaries): no version-history section
-// (edit-diff audit is a producer/crew tool, not a client approval affordance),
-// no field editors, no lifecycle menu, no status tap-row (clients can't write
-// shots — status is shown read-only), no upload, no share.
+// review-warehouse composition (the warehouse's job is to PULL): product-FORWARD
+//   — ProductColorwayStrip readOnly FIRST (every look's garments, because the
+//   warehouse pulls everything, not just the cover) → shot # / title /
+//   read-only status context → read-only talent / location meta → comment
+//   composer OPEN (same writeAuthoritative escape hatch as the client variant;
+//   warehouse can leave notes). NO hero-led layout, NO prep status (no such
+//   field exists in the model).
+//
+// Deliberately ABSENT (scoping boundaries, BOTH variants): no version-history
+// section (edit-diff audit is a producer/crew tool, not a review affordance),
+// no field editors, no lifecycle menu, no status tap-row (review surfaces don't
+// write shots — status is shown read-only), no upload, no share.
 import { useMemo } from "react"
 import { useParams } from "react-router-dom"
 import { LoadingState } from "@/shared/components/LoadingState"
@@ -68,17 +76,6 @@ export function ReviewShotDetail({ variant }: { readonly variant: ReviewVariant 
   }
   if (shot.deleted === true) return null
 
-  // 5f-III fills warehouse; until then render a quiet placeholder, never crash.
-  if (variant === "review-warehouse") {
-    return (
-      <div className="p-8 text-center" data-testid="review-warehouse-placeholder">
-        <p className="text-sm text-[var(--color-text-muted)]">
-          Warehouse review surface coming soon.
-        </p>
-      </div>
-    )
-  }
-
   const talentIds = shot.talentIds ?? shot.talent ?? []
   const resolvedTalentNames = talentIds
     .map((id) => talentNameById.get(id))
@@ -90,6 +87,80 @@ export function ReviewShotDetail({ variant }: { readonly variant: ReviewVariant 
         ? resolvedTalentNames.join(" · ")
         : `${talentIds.length} assigned`
   const locationLine = shot.locationName?.trim() || "—"
+
+  // ── review-warehouse: PRODUCT-FORWARD read-only pull view. Products FIRST
+  //    (every look), then identity/status context, meta, comment composer. ──
+  if (variant === "review-warehouse") {
+    return (
+      <ErrorBoundary>
+        <div
+          className="mx-auto flex w-full max-w-2xl flex-col gap-5"
+          data-testid="review-warehouse-detail"
+        >
+          {projectName && (
+            <p className="truncate text-xs text-[var(--color-text-muted)]">
+              {projectName}
+            </p>
+          )}
+
+          {/* ── Products FIRST — the warehouse pulls every garment across all
+              looks (ProductColorwayStrip renders all looks, read-only). ── */}
+          <div data-testid="review-warehouse-products">
+            <ProductColorwayStrip
+              looks={shot.looks ?? []}
+              activeLookId={shot.activeLookId}
+              readOnly
+            />
+          </div>
+
+          {/* ── Shot identity + read-only status context (no tap-row write). ── */}
+          <header
+            className="flex flex-col gap-1.5"
+            data-testid="review-warehouse-identity"
+          >
+            <span className="text-2xs font-bold uppercase tracking-wider text-[var(--color-text-subtle)]">
+              Shot{shot.shotNumber ? ` #${shot.shotNumber}` : ""}
+            </span>
+            <div className="flex flex-wrap items-baseline text-3xl">
+              <h1 className="text-3xl font-semibold leading-tight tracking-tight text-[var(--color-text)] [font-family:var(--font-serif)]">
+                {shot.title || "Untitled Shot"}
+              </h1>
+              <span className="iconic-period" aria-hidden="true">
+                .
+              </span>
+            </div>
+            <div data-testid="review-warehouse-status-badge">
+              <StatusBadge
+                label={getShotStatusLabel(shot.status)}
+                color={getShotStatusColor(shot.status)}
+              />
+            </div>
+          </header>
+
+          {/* ── Read-only talent / location meta. ── */}
+          <section
+            data-testid="review-warehouse-meta"
+            className="flex flex-col gap-2"
+          >
+            <div>
+              <SectionLabel>Talent</SectionLabel>
+              <p className="mt-1 text-sm text-[var(--color-text)]">{talentLine}</p>
+            </div>
+            <div>
+              <SectionLabel>Location</SectionLabel>
+              <p className="mt-1 text-sm text-[var(--color-text)]">{locationLine}</p>
+            </div>
+          </section>
+
+          {/* ── Comments — composer OPEN (same writeAuthoritative escape hatch
+              as the client variant; warehouse can leave pull notes). ── */}
+          <div data-testid="review-warehouse-composer">
+            <ShotCommentsSection shotId={shot.id} canComment writeAuthoritative />
+          </div>
+        </div>
+      </ErrorBoundary>
+    )
+  }
 
   return (
     <ErrorBoundary>

--- a/src-vnext/features/shots/components/ReviewWarehouseList.tsx
+++ b/src-vnext/features/shots/components/ReviewWarehouseList.tsx
@@ -1,0 +1,111 @@
+// Warehouse review list — the product-led pull list (Phase 5f-III, spec §PR
+// partition 5f-III).
+//
+// Mounted by ShotListPage INSTEAD of the producer table/card forks when
+// `featureReviewSurface` is ON and the resolved surface === 'review-warehouse'
+// (surface-keyed, not device-keyed — the Shoot-shell / review-client
+// precedent). This is the LIST counterpart to ReviewShotDetail's warehouse
+// variant: the warehouse's job is to PULL, so the surface leads with WHAT to
+// pull, not with hero images. Each row is one aggregated product requirement
+// (buildWarehousePullList collapses the same garment/colour/size requested by
+// multiple shots into ONE row) carrying everything needed to FIND the item —
+// product label, colourway, size, style/SKU — plus the shots that need it.
+//
+// PRESENTATION, not a permission boundary (spec §Rules-vs-UI): strictly
+// read-only — no bulk actions, no quick-add, no FAB, no lifecycle menu, no
+// status writes. The firestore rules already gate every write; this surface
+// simply does not render the producer affordances.
+//
+// ⚠️ NO prep / pull-status column — there is no per-product fulfilment field in
+// the shot/product model (that state lives in the SEPARATE pulls feature). A
+// row shows what the warehouse needs to LOCATE the item, never a fabricated
+// prep state. Tapping a "needed-for" shot chip opens that shot (onOpenShot).
+import { useMemo } from "react"
+import { buildWarehousePullList } from "@/features/shots/lib/warehousePullList"
+import type { Shot, ProductFamily } from "@/shared/types"
+
+export interface ReviewWarehouseListProps {
+  /** Display-order shots whose products feed the aggregated pull list. */
+  readonly shots: ReadonlyArray<Shot>
+  /** Resolves product style numbers for each pull-list row. */
+  readonly familyById: ReadonlyMap<string, ProductFamily>
+  readonly onOpenShot: (shotId: string) => void
+}
+
+export function ReviewWarehouseList({
+  shots,
+  familyById,
+  onOpenShot,
+}: ReviewWarehouseListProps) {
+  // Aggregate once per shots/family change — pure + deterministic.
+  const rows = useMemo(
+    () => buildWarehousePullList(shots, familyById),
+    [shots, familyById],
+  )
+
+  return (
+    <div
+      className="flex flex-col gap-2.5"
+      data-testid="review-warehouse-pull-list"
+    >
+      {rows.map((row) => (
+        <PullListRowItem key={row.key} row={row} onOpenShot={onOpenShot} />
+      ))}
+    </div>
+  )
+}
+
+function PullListRowItem({
+  row,
+  onOpenShot,
+}: {
+  readonly row: ReturnType<typeof buildWarehousePullList>[number]
+  readonly onOpenShot: (shotId: string) => void
+}) {
+  return (
+    <div
+      className="flex flex-col gap-2 rounded-[var(--radius-lg)] border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-3"
+      data-testid="pull-list-row"
+      data-row-key={row.key}
+    >
+      {/* ── What to pull: colourway swatch + product label + style/SKU. The
+          swatch is name-driven (the model carries no hex), so it reads as a
+          quiet labelled chip, never a fabricated colour. ── */}
+      <div className="flex flex-wrap items-baseline gap-x-2.5 gap-y-1">
+        {row.colourName && (
+          <span className="inline-flex items-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-2 py-0.5 text-2xs font-medium uppercase tracking-wide text-[var(--color-text-secondary)]">
+            {row.colourName}
+          </span>
+        )}
+        <span className="text-base font-semibold leading-tight text-[var(--color-text)]">
+          {row.label}
+        </span>
+        {row.styleNumber && (
+          <span className="ml-auto text-2xs tabular-nums text-[var(--color-text-subtle)]">
+            {row.styleNumber}
+          </span>
+        )}
+      </div>
+
+      {/* ── Needed for: the shots requesting this item. Each chip is a button
+          that opens its shot (the only affordance on this read-only surface). ── */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        <span className="text-2xs uppercase tracking-wider text-[var(--color-text-subtle)]">
+          Needed for
+        </span>
+        {row.neededByShots.map((ref) => (
+          <button
+            key={ref.shotId}
+            type="button"
+            onClick={() => onOpenShot(ref.shotId)}
+            className="inline-flex items-center rounded-[var(--radius-sm)] border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-2 py-0.5 text-2xs font-medium text-[var(--color-text-secondary)] transition-colors hover:bg-[var(--color-surface)] hover:text-[var(--color-text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--color-accent)]"
+            data-testid="pull-list-shot-chip"
+            data-shot-id={ref.shotId}
+          >
+            {ref.shotLabel}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
+++ b/src-vnext/features/shots/components/ShotDetailPageUnified.tsx
@@ -109,17 +109,20 @@ export function ShotDetailPageUnified() {
   if (isFeatureEnabled("featureShootSurface") && surface === "shoot") {
     return <ShootShotDetail />
   }
-  // 5f-II Review-client mount fork — the read-only approval gallery shell
-  // replaces the editor body when `featureReviewSurface` is ON and the resolved
-  // surface is 'review-client' (client/viewer; surface-keyed, mirrors the shoot
-  // fork above). Like the shoot shell it sources its own data via hooks
-  // (useParams/useShotDetailBundle/useTalent/useProjectScope) — no props
-  // plumbed in. 'review-warehouse' (5f-III) deliberately falls through to the
-  // editor for now. Flag OFF (or any non-review-client surface, or while the
-  // surface resolves): the body renders byte-identically — the existing test
-  // suite is the contract.
+  // 5f-II/5f-III Review mount forks — the read-only review surface replaces the
+  // editor body when `featureReviewSurface` is ON and the resolved surface is a
+  // review variant (5f-II: 'review-client', client/viewer; 5f-III:
+  // 'review-warehouse', warehouse). Surface-keyed, mirrors the shoot fork above.
+  // ONE component (ReviewShotDetail), variant-keyed; like the shoot shell it
+  // sources its own data via hooks (useParams/useShotDetailBundle/useTalent/
+  // useProjectScope) — no props plumbed in. Flag OFF (or any non-review surface,
+  // or while the surface resolves): the body renders byte-identically — the
+  // existing test suite is the contract.
   if (isFeatureEnabled("featureReviewSurface") && surface === "review-client") {
     return <ReviewShotDetail variant="review-client" />
+  }
+  if (isFeatureEnabled("featureReviewSurface") && surface === "review-warehouse") {
+    return <ReviewShotDetail variant="review-warehouse" />
   }
   return <ShotDetailEditorBody />
 }

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -14,6 +14,7 @@ import { ShotListToolbar } from "@/features/shots/components/ShotListToolbar"
 import { ShotQuickAdd } from "@/features/shots/components/ShotQuickAdd"
 import { ShootShotList } from "@/features/shots/components/ShootShotList"
 import { ReviewClientGallery } from "@/features/shots/components/ReviewClientGallery"
+import { ReviewWarehouseList } from "@/features/shots/components/ReviewWarehouseList"
 import { ShotsTable, REORDER_SHOT_LIMIT } from "@/features/shots/components/ShotsTable"
 import { resolveReorderDisabledReason } from "@/features/shots/components/DisabledDragHandle"
 import { useShotListState } from "@/features/shots/hooks/useShotListState"
@@ -174,6 +175,22 @@ export default function ShotListPage() {
   // the warehouse surface separately).
   const isReviewClient =
     isFeatureEnabled("featureReviewSurface") && surface === "review-client"
+  // -- 5f-III Warehouse pull list (spec §PR partition 5f-III) --
+  // Same surface-keyed mount idiom: structurally keyed off the RESOLVED
+  // surface, never the flag alone. surface is null while auth/role resolve, so
+  // it never mounts off the global-role guess. Flag OFF: isReviewWarehouse is
+  // always false — every render below is byte-identical. The warehouse list is
+  // the read-only product-LED pull list (buildWarehousePullList rows); like the
+  // client gallery it replaces the producer table/card forks, not the Shoot
+  // shell, and suppresses the same producer affordances (toolbar, quick-add,
+  // FAB, banners) via isReviewSurface below.
+  const isReviewWarehouse =
+    isFeatureEnabled("featureReviewSurface") && surface === "review-warehouse"
+  // Both review surfaces are strictly read-only — they suppress the same
+  // producer affordance blocks (toolbar / quick-add / reorder + filter
+  // banners). Folding them into one alias keeps those gates DRY; flag OFF both
+  // are false so the alias is false (byte-identical).
+  const isReviewSurface = isReviewClient || isReviewWarehouse
   // chrome.toolbar consumer: 'minimal' (shoot shell) drops the full
   // search/sort/filter toolbar block; flag-off resolves 'full' on every
   // surface (byte-identical). Falls back to 'full' while chrome resolves —
@@ -527,7 +544,7 @@ export default function ShotListPage() {
       {/* Toolbar: search + sort + inline filters + view. chrome.toolbar
           drives the mount: 'minimal' (Shoot shell) drops the whole block —
           no ShotListToolbar, no view switcher, no filter/reorder banners. */}
-      {showFullToolbar && !isReviewClient && shots.length > 0 && (
+      {showFullToolbar && !isReviewSurface && shots.length > 0 && (
         <>
           <ShotListToolbar
             queryDraft={queryDraft}
@@ -649,7 +666,7 @@ export default function ShotListPage() {
       {/* Quick-add inline input — the shell's create affordance too
           (chrome.quickAdd, spec §FAB ownership): the Shoot shell keeps this
           one minimal showCreate-gated input instead of growing its own. */}
-      {showCreate && quickAdd && !isReviewClient && shots.length > 0 && (
+      {showCreate && quickAdd && !isReviewSurface && shots.length > 0 && (
         <ShotQuickAdd
           shots={shots}
           onCreated={(shotId, title) => {
@@ -684,7 +701,7 @@ export default function ShotListPage() {
 
       {/* Sort override banner — full-toolbar chrome only (the shell has no
           sort controls to restore from) */}
-      {showFullToolbar && !isReviewClient && !isCustomSort && shots.length > 0 && (
+      {showFullToolbar && !isReviewSurface && !isCustomSort && shots.length > 0 && (
         <div className="mb-4 flex items-center gap-2 rounded-md bg-[var(--color-surface-subtle)] px-3 py-2 text-xs text-[var(--color-text-subtle)]">
           <Info className="h-3.5 w-3.5 flex-shrink-0" />
           <span>
@@ -723,6 +740,19 @@ export default function ShotListPage() {
            affordances are simply not rendered on this surface. Reuses the same
            displayShots + handleShotClick contract as the producer list. */
         <ReviewClientGallery
+          shots={displayShots}
+          familyById={familyById}
+          onOpenShot={handleShotClick}
+        />
+      ) : isReviewWarehouse ? (
+        /* 5f-III Warehouse pull list — REPLACES the producer table/card forks
+           below (surface-keyed, not device-keyed). Product-LED read-only rows:
+           the warehouse's job is to PULL, so each row leads with WHAT to pull
+           (product + colourway + size + style/SKU) and the shots that need it.
+           No bulk actions, no quick-add, no FAB — those producer affordances
+           are simply not rendered. Reuses the same displayShots + familyById +
+           handleShotClick contract as the producer list. */
+        <ReviewWarehouseList
           shots={displayShots}
           familyById={familyById}
           onOpenShot={handleShotClick}

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -483,36 +483,44 @@ export default function ShotListPage() {
             <EffectiveRoleChip />
             {/* 5e-III View-as: self-gated on the global claim + featureShootSurface. */}
             <ViewAsMenu />
-            {canExport && (
-              <Button variant="outline" onClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}>
-                Export
-              </Button>
+            {/* 5f: the Review surfaces (review-client / review-warehouse) are
+                read-only — suppress the plan-build header affordances here so the
+                producer chrome can't leak onto the client/warehouse Review views
+                regardless of the viewer's effective capability flags. */}
+            {!isReviewSurface && (
+              <>
+                {canExport && (
+                  <Button variant="outline" onClick={() => navigate(`/projects/${projectId}/export?preset=shot-list`)}>
+                    Export
+                  </Button>
+                )}
+                {canShare && (
+                  <Button variant="outline" onClick={() => setShareOpen(true)}>
+                    Share
+                  </Button>
+                )}
+                {canBulkPull && (
+                  <Button
+                    variant={selectionEnabled ? "default" : "outline"}
+                    onClick={() => {
+                      if (selectionEnabled) {
+                        clearSelection()
+                      } else {
+                        setSelectionMode(true)
+                      }
+                    }}
+                  >
+                    {selectionEnabled ? "Done" : "Select"}
+                  </Button>
+                )}
+                {showCreate && quickAdd ? (
+                  <Button onClick={() => setCreateOpen(true)}>
+                    <Plus className="mr-2 h-4 w-4" />
+                    New Shot
+                  </Button>
+                ) : null}
+              </>
             )}
-            {canShare && (
-              <Button variant="outline" onClick={() => setShareOpen(true)}>
-                Share
-              </Button>
-            )}
-            {canBulkPull && (
-              <Button
-                variant={selectionEnabled ? "default" : "outline"}
-                onClick={() => {
-                  if (selectionEnabled) {
-                    clearSelection()
-                  } else {
-                    setSelectionMode(true)
-                  }
-                }}
-              >
-                {selectionEnabled ? "Done" : "Select"}
-              </Button>
-            )}
-            {showCreate && quickAdd ? (
-              <Button onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-2 h-4 w-4" />
-                New Shot
-              </Button>
-            ) : null}
           </div>
         }
       />
@@ -737,10 +745,12 @@ export default function ShotListPage() {
            below (surface-keyed, not device-keyed). Image-led read-only tiles:
            the client's job is to decide/approve, so hero + status + product
            context lead. No bulk actions, no quick-add, no FAB — those producer
-           affordances are simply not rendered on this surface. Reuses the same
-           displayShots + handleShotClick contract as the producer list. */
+           affordances are simply not rendered on this surface. Feeds from
+           unfilteredSortedShots (not displayShots): the filter/sort toolbar is
+           suppressed here, so a lingering deep-link filter must NOT silently
+           hide shots with no visible control to clear it (the Shoot-shell rule). */
         <ReviewClientGallery
-          shots={displayShots}
+          shots={unfilteredSortedShots}
           familyById={familyById}
           onOpenShot={handleShotClick}
         />
@@ -750,10 +760,12 @@ export default function ShotListPage() {
            the warehouse's job is to PULL, so each row leads with WHAT to pull
            (product + colourway + size + style/SKU) and the shots that need it.
            No bulk actions, no quick-add, no FAB — those producer affordances
-           are simply not rendered. Reuses the same displayShots + familyById +
-           handleShotClick contract as the producer list. */
+           are simply not rendered. Feeds from unfilteredSortedShots (not
+           displayShots): the pull list must aggregate ALL shots' products, and
+           with the filter toolbar suppressed a lingering deep-link filter would
+           otherwise silently omit required items (the Shoot-shell rule). */
         <ReviewWarehouseList
-          shots={displayShots}
+          shots={unfilteredSortedShots}
           familyById={familyById}
           onOpenShot={handleShotClick}
         />

--- a/src-vnext/features/shots/components/__tests__/ReviewShotDetail.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ReviewShotDetail.test.tsx
@@ -1,6 +1,9 @@
 /// <reference types="@testing-library/jest-dom" />
-// 5f-II — unit matrix for the Review-client shell (the read-only approval
-// gallery surface) and its mount fork in ShotDetailPageUnified.
+// 5f-II / 5f-III — unit matrix for the Review shells (the read-only approval
+// surfaces) and their mount fork in ShotDetailPageUnified. The first describe
+// pins the 5f-II review-CLIENT shell; the trailing 5f-III block pins the
+// product-forward review-WAREHOUSE variant (products FIRST, read-only status,
+// open composer, no version-history, no hero-led layout).
 //
 // Renders through the ShotDetailPage default export so the real fork is
 // exercised: isFeatureEnabled('featureReviewSurface') && resolved
@@ -21,8 +24,9 @@
 //   - NO version-history section (the explicit scoping boundary)
 //   - products render through ProductColorwayStrip readOnly=true
 //   - producer + flag ON: NO review shell (surface is plan-build)
-//   - the 'review-warehouse' variant renders a quiet placeholder (5f-III stub),
-//     never the client composition
+//   - the 'review-warehouse' variant (5f-III) renders the product-forward pull
+//     detail (products FIRST, read-only status, open composer), never the
+//     client composition and never the old 5f-II placeholder
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { MemoryRouter, Routes, Route } from "react-router-dom"
@@ -443,12 +447,11 @@ describe("ReviewShotDetail (the 5f-II Review-client shell)", () => {
     expect(meta.textContent).toContain("—")
   })
 
-  // ── Variant guard: warehouse (5f-III) renders a placeholder, never crashes ─
+  // ── 5f-III: the 'review-warehouse' variant (PRODUCT-FORWARD pull view) ──────
 
-  it("the 'review-warehouse' variant renders a quiet placeholder — never the client composition", () => {
-    mockShot()
-
-    render(
+  function renderWarehouse(overrides: Partial<Shot> = {}) {
+    mockShot(overrides)
+    return render(
       <MemoryRouter initialEntries={["/projects/p1/shots/s1"]}>
         <Routes>
           <Route
@@ -458,10 +461,109 @@ describe("ReviewShotDetail (the 5f-II Review-client shell)", () => {
         </Routes>
       </MemoryRouter>,
     )
+  }
 
-    expect(screen.getByTestId("review-warehouse-placeholder")).toBeInTheDocument()
-    // The client-only blocks do NOT render for the warehouse stub.
+  it("review-warehouse: renders the product-forward pull detail, not the placeholder or client composition", () => {
+    renderWarehouse()
+
+    expect(screen.getByTestId("review-warehouse-detail")).toBeInTheDocument()
+    // The 5f-II placeholder is GONE (replaced by the real composition).
+    expect(screen.queryByTestId("review-warehouse-placeholder")).not.toBeInTheDocument()
+    // No client-variant blocks leak into the warehouse surface.
     expect(screen.queryByTestId("review-shot-detail")).not.toBeInTheDocument()
     expect(screen.queryByTestId("review-client-composer")).not.toBeInTheDocument()
+  })
+
+  it("review-warehouse: blocks render PRODUCT-FORWARD — products FIRST, then identity, meta, composer", () => {
+    renderWarehouse({
+      talentIds: ["t1", "t2"],
+      locationName: "Studio C",
+      looks: [
+        {
+          id: "l1",
+          label: "Primary",
+          order: 0,
+          products: [
+            { familyId: "f1", familyName: "Merino T-Shirt", colourName: "Ivory" },
+          ],
+        },
+      ],
+      activeLookId: "l1",
+    })
+
+    // Products FIRST (the warehouse pulls every garment), then identity/status,
+    // read-only meta, comment composer LAST.
+    expectDocumentOrder([
+      screen.getByTestId("review-warehouse-products"),
+      screen.getByTestId("review-warehouse-identity"),
+      screen.getByTestId("review-warehouse-meta"),
+      screen.getByTestId("review-warehouse-composer"),
+    ])
+
+    // The product strip is the FIRST block (nested inside the products wrapper).
+    const products = screen.getByTestId("review-warehouse-products")
+    expect(products).toContainElement(screen.getByTestId("product-colorway-strip"))
+    expect(screen.getByText("Merino T-Shirt")).toBeInTheDocument()
+
+    // Identity: shot number eyebrow + serif title.
+    expect(screen.getByText(/Shot #11/)).toBeInTheDocument()
+    expect(screen.getByText("Linen overshirt — window light")).toBeInTheDocument()
+
+    // Read-only meta: resolved talent + location.
+    const meta = screen.getByTestId("review-warehouse-meta")
+    expect(meta).toHaveTextContent("Malik R. · Dana K.")
+    expect(meta).toHaveTextContent("Studio C")
+  })
+
+  it("review-warehouse: the product strip renders read-only (ProductColorwayStrip readOnly)", () => {
+    renderWarehouse({
+      looks: [
+        {
+          id: "l1",
+          label: "Primary",
+          order: 0,
+          products: [
+            { familyId: "f1", familyName: "Merino T-Shirt", colourName: "Ivory" },
+          ],
+        },
+      ],
+      activeLookId: "l1",
+    })
+
+    const strip = screen.getByTestId("product-colorway-strip")
+    expect(strip).toBeInTheDocument()
+    // Read-only: no assignment-affordance copy on the strip.
+    expect(strip).not.toHaveTextContent("Add a look in the rail")
+  })
+
+  it("review-warehouse: status is shown READ-ONLY — a badge, never a tap-row or status select", () => {
+    renderWarehouse({ status: "in_progress" })
+
+    expect(screen.getByTestId("review-warehouse-status-badge")).toBeInTheDocument()
+    expect(screen.getByText("In Progress")).toBeInTheDocument()
+    // No status WRITE controls (warehouse review surface doesn't write shots).
+    expect(screen.queryByTestId("status-tap-row")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("status-tap-todo")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("shot-status-select-trigger")).not.toBeInTheDocument()
+  })
+
+  it("review-warehouse: the comment composer is OPEN — writeAuthoritative + canComment passed through", () => {
+    renderWarehouse()
+
+    const comments = screen.getByTestId("comments-stub")
+    expect(comments).toHaveAttribute("data-can-comment", "true")
+    expect(comments).toHaveAttribute("data-write-authoritative", "true")
+  })
+
+  it("review-warehouse: NO version-history section, and no hero-led layout (product-forward, not image-forward)", () => {
+    renderWarehouse()
+
+    // Scoping boundary: the version-history audit tool never mounts on review.
+    expect(screen.queryByTestId("history-stub")).not.toBeInTheDocument()
+    // The warehouse variant is product-forward — no hero image section leads it.
+    expect(screen.queryByTestId("hero-stub")).not.toBeInTheDocument()
+    // No plan-build chrome leaks.
+    expect(screen.queryByTestId("notes-stub")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("lifecycle-actions-stub")).not.toBeInTheDocument()
   })
 })

--- a/src-vnext/features/shots/components/__tests__/ReviewSurface.flagOff.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ReviewSurface.flagOff.test.tsx
@@ -240,4 +240,22 @@ describe("Review surface — flag OFF (no-change contract for a viewer)", () => 
     // The unified editor body renders instead (notes section is body-only).
     expect(screen.getByTestId("notes-stub")).toBeInTheDocument()
   })
+
+  // 5f-III: the warehouse fork is ALSO flag-gated. With featureReviewSurface
+  // OFF, a warehouse effective-role must fall through to the editor body exactly
+  // as today — the review-warehouse detail (sentinel: review-shot-detail) never
+  // mounts. (The ReviewShotDetail stub is variant-agnostic, so its absence
+  // proves NEITHER review variant mounted.)
+  it("ShotDetailPage: a warehouse role falls through to the editor body — the review-warehouse shell never mounts", () => {
+    authState.role = "warehouse"
+    effectiveState.role = "warehouse"
+
+    renderDetail()
+
+    expect(screen.queryByTestId("review-shot-detail")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("review-warehouse-detail")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("shoot-shot-detail")).not.toBeInTheDocument()
+    // The unified editor body renders instead (notes section is body-only).
+    expect(screen.getByTestId("notes-stub")).toBeInTheDocument()
+  })
 })

--- a/src-vnext/features/shots/lib/warehousePullList.test.ts
+++ b/src-vnext/features/shots/lib/warehousePullList.test.ts
@@ -60,6 +60,23 @@ describe("buildWarehousePullList", () => {
     expect(buildWarehousePullList([makeShot()])).toEqual([])
   })
 
+  it("includes legacy top-level shot.products for shots with no look rows", () => {
+    // legacy/imported shots carry assignments in shot.products with no looks
+    const shot = makeShot({ products: [shorts], looks: [] })
+    const rows = buildWarehousePullList([shot])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.label).toContain("Merino Flex Shorts")
+    expect(rows[0]!.neededByShots.map((r) => r.shotId)).toEqual(["shot-1"])
+  })
+
+  it("prefers look products over legacy shot.products when both exist (no double-count)", () => {
+    // a shot with looks should NOT also pull from the legacy fallback
+    const shot = makeShot({ products: [tee], looks: [makeLook("l", [shorts])] })
+    const rows = buildWarehousePullList([shot])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.label).toContain("Merino Flex Shorts")
+  })
+
   it("aggregates products across ALL looks of a shot, not just the primary", () => {
     const shot = makeShot({
       shotNumber: "1",

--- a/src-vnext/features/shots/lib/warehousePullList.test.ts
+++ b/src-vnext/features/shots/lib/warehousePullList.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest"
+import { buildWarehousePullList } from "./warehousePullList"
+import type { ProductAssignment, ProductFamily, Shot, ShotLook } from "@/shared/types"
+
+function makeShot(overrides: Partial<Shot> = {}): Shot {
+  return {
+    id: "shot-1",
+    title: "Test",
+    description: null,
+    projectId: "proj-1",
+    clientId: "client-1",
+    status: "todo",
+    talent: [],
+    products: [],
+    sortOrder: 1,
+    shotNumber: null,
+    date: null,
+    deleted: false,
+    notes: null,
+    referenceLinks: [],
+    createdAt: null,
+    updatedAt: null,
+    createdBy: "user-1",
+    ...overrides,
+  } as Shot
+}
+
+function makeLook(
+  id: string,
+  products: ProductAssignment[],
+  order = 0,
+): ShotLook {
+  return { id, order, products }
+}
+
+const shorts: ProductAssignment = {
+  familyId: "fam-shorts",
+  familyName: "Merino Flex Shorts",
+  colourName: "Maroon",
+  size: "M",
+  sizeScope: "single",
+  quantity: 2,
+}
+
+const tee: ProductAssignment = {
+  familyId: "fam-tee",
+  familyName: "Base Tee",
+  colourName: "Black",
+  size: "L",
+  sizeScope: "single",
+  quantity: 1,
+}
+
+describe("buildWarehousePullList", () => {
+  it("returns an empty list for no shots", () => {
+    expect(buildWarehousePullList([])).toEqual([])
+  })
+
+  it("returns an empty list when shots have no looks/products", () => {
+    expect(buildWarehousePullList([makeShot()])).toEqual([])
+  })
+
+  it("aggregates products across ALL looks of a shot, not just the primary", () => {
+    const shot = makeShot({
+      shotNumber: "1",
+      looks: [makeLook("look-a", [shorts], 0), makeLook("look-b", [tee], 1)],
+    })
+    const rows = buildWarehousePullList([shot])
+    expect(rows.map((r) => r.label)).toEqual([
+      "Base Tee (Black • L)",
+      "Merino Flex Shorts (Maroon • M • x2)",
+    ])
+  })
+
+  it("collapses the same garment/colour/size across shots into one row", () => {
+    const shotA = makeShot({
+      id: "shot-a",
+      shotNumber: "2",
+      looks: [makeLook("la", [shorts])],
+    })
+    const shotB = makeShot({
+      id: "shot-b",
+      shotNumber: "1",
+      looks: [makeLook("lb", [shorts])],
+    })
+    const rows = buildWarehousePullList([shotA, shotB])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.neededByShots).toEqual([
+      { shotId: "shot-b", shotLabel: "1" },
+      { shotId: "shot-a", shotLabel: "2" },
+    ])
+  })
+
+  it("de-duplicates a shot listed twice for the same product (two looks)", () => {
+    const shot = makeShot({
+      id: "shot-x",
+      shotNumber: "5",
+      looks: [makeLook("l1", [shorts], 0), makeLook("l2", [shorts], 1)],
+    })
+    const rows = buildWarehousePullList([shot])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.neededByShots).toEqual([{ shotId: "shot-x", shotLabel: "5" }])
+  })
+
+  it("treats different sizes of the same family as separate rows", () => {
+    const small: ProductAssignment = { ...shorts, size: "S" }
+    const shot = makeShot({ looks: [makeLook("l", [shorts, small])] })
+    const rows = buildWarehousePullList([shot])
+    expect(rows).toHaveLength(2)
+  })
+
+  it("treats different colourways of the same family/size as separate rows", () => {
+    const navy: ProductAssignment = { ...shorts, colourName: "Navy" }
+    const shot = makeShot({ looks: [makeLook("l", [shorts, navy])] })
+    const rows = buildWarehousePullList([shot])
+    expect(rows.map((r) => r.colourName).sort()).toEqual(["Maroon", "Navy"])
+  })
+
+  it("resolves styleNumber from the family map, falling back to styleNumbers[0]", () => {
+    const familyById = new Map<string, ProductFamily>([
+      ["fam-shorts", { id: "fam-shorts", styleName: "Shorts", styleNumber: "MS-100" }],
+      ["fam-tee", { id: "fam-tee", styleName: "Tee", styleNumbers: ["BT-200"] }],
+    ])
+    const shot = makeShot({ looks: [makeLook("l", [shorts, tee])] })
+    const rows = buildWarehousePullList([shot], familyById)
+    const byKey = new Map(rows.map((r) => [r.colourName, r.styleNumber]))
+    expect(byKey.get("Maroon")).toBe("MS-100")
+    expect(byKey.get("Black")).toBe("BT-200")
+  })
+
+  it("falls back to skuName when no family style number resolves", () => {
+    const p: ProductAssignment = { ...shorts, skuName: "SKU-XYZ" }
+    const shot = makeShot({ looks: [makeLook("l", [p])] })
+    expect(buildWarehousePullList([shot])[0]!.styleNumber).toBe("SKU-XYZ")
+  })
+
+  it("carries null styleNumber and colourName when unresolvable", () => {
+    const bare: ProductAssignment = { familyId: "fam-x", familyName: "Mystery" }
+    const shot = makeShot({ looks: [makeLook("l", [bare])] })
+    const row = buildWarehousePullList([shot])[0]!
+    expect(row.styleNumber).toBeNull()
+    expect(row.colourName).toBeNull()
+  })
+
+  it("skips deleted shots entirely", () => {
+    const live = makeShot({ id: "live", looks: [makeLook("l", [shorts])] })
+    const dead = makeShot({ id: "dead", deleted: true, looks: [makeLook("l", [tee])] })
+    const rows = buildWarehousePullList([live, dead])
+    expect(rows).toHaveLength(1)
+    expect(rows[0]!.label).toContain("Merino Flex Shorts")
+  })
+
+  it("falls back to title then id for the shot label", () => {
+    const titled = makeShot({ id: "t", shotNumber: null, title: "Opening Wide", looks: [makeLook("l", [shorts])] })
+    const idOnly = makeShot({ id: "id-only", shotNumber: null, title: "", looks: [makeLook("l2", [tee])] })
+    const rows = buildWarehousePullList([titled, idOnly])
+    expect(rows.find((r) => r.colourName === "Maroon")!.neededByShots[0]!.shotLabel).toBe("Opening Wide")
+    expect(rows.find((r) => r.colourName === "Black")!.neededByShots[0]!.shotLabel).toBe("id-only")
+  })
+
+  it("produces a deterministic, stable label sort", () => {
+    const shot = makeShot({ looks: [makeLook("l", [tee, shorts])] })
+    const rows = buildWarehousePullList([shot])
+    expect(rows.map((r) => r.label)).toEqual([
+      "Base Tee (Black • L)",
+      "Merino Flex Shorts (Maroon • M • x2)",
+    ])
+  })
+
+  // ⚠️ Anti-fabrication pin: there is NO per-product prep/pull-status field in
+  // the shot/product model (the only 'fulfilled'/'fulfillment' state lives in
+  // the SEPARATE pulls feature). The row shape is EXACTLY what the lib defines —
+  // a row must NOT invent a prep/status/fulfilled/pulled field. Asserting the
+  // full key-set (not just absence) catches any accidental extra column.
+  it("fabricates NO prep/status field — the row shape is exactly the lib contract", () => {
+    const shot = makeShot({ shotNumber: "9", looks: [makeLook("l", [shorts])] })
+    const row = buildWarehousePullList([shot])[0]!
+
+    expect(Object.keys(row).sort()).toEqual([
+      "colourName",
+      "key",
+      "label",
+      "neededByShots",
+      "styleNumber",
+    ])
+    // Explicit negatives for the prep-status fields a naive impl might invent.
+    expect(row).not.toHaveProperty("prep")
+    expect(row).not.toHaveProperty("prepStatus")
+    expect(row).not.toHaveProperty("status")
+    expect(row).not.toHaveProperty("fulfilled")
+    expect(row).not.toHaveProperty("fulfillment")
+    expect(row).not.toHaveProperty("pulled")
+    expect(row).not.toHaveProperty("quantity")
+    // The shot ref carries only id + label — no per-shot prep state either.
+    expect(Object.keys(row.neededByShots[0]!).sort()).toEqual(["shotId", "shotLabel"])
+  })
+})

--- a/src-vnext/features/shots/lib/warehousePullList.ts
+++ b/src-vnext/features/shots/lib/warehousePullList.ts
@@ -13,6 +13,7 @@
 // the warehouse needs to FIND the item (label, colourway, size, style/SKU) and
 // the shots that need it.
 import type { ProductAssignment, ProductFamily, Shot } from "@/shared/types"
+import { extractShotAssignedProducts } from "@/shared/lib/shotProducts"
 import { formatProductAssignmentLabel } from "./shotListSummaries"
 
 /** A shot that requires a given pull-list product. */
@@ -128,10 +129,19 @@ export function buildWarehousePullList(
       shotId: shot.id,
       shotLabel: shotLabelFor(shot),
     }
+    // Aggregate across ALL looks. For legacy/imported shots that carry no look
+    // rows but still hold top-level `shot.products` assignments (the app maps
+    // and renders these via extractShotAssignedProducts), fall back to the
+    // shared extractor so the pull list never silently omits required items.
+    // Dedup-by-compositeKey makes the fallback safe even if a shot had both.
+    const lookProducts: ProductAssignment[] = []
     for (const look of shot.looks ?? []) {
-      for (const product of look.products ?? []) {
-        collectAssignment(rows, product, shotRef, familyById)
-      }
+      for (const product of look.products ?? []) lookProducts.push(product)
+    }
+    const assignments =
+      lookProducts.length > 0 ? lookProducts : extractShotAssignedProducts(shot)
+    for (const product of assignments) {
+      collectAssignment(rows, product, shotRef, familyById)
     }
   }
 

--- a/src-vnext/features/shots/lib/warehousePullList.ts
+++ b/src-vnext/features/shots/lib/warehousePullList.ts
@@ -1,0 +1,147 @@
+// Warehouse pull-list aggregation (Phase 5f-III).
+//
+// PURE + deterministic. The warehouse pull surface must pull EVERY product
+// requirement across ALL looks of ALL shots (not just the primary look — the
+// shoot needs everything in the closet, not just the cover). We aggregate by a
+// stable composite key (familyId|familyName + colourName + size) so the same
+// garment/colour/size requested by multiple shots collapses into ONE row, with
+// the requesting shots listed under `neededByShots`.
+//
+// ⚠️ There is NO per-product prep/pull-status field in the shot/product model
+// (the only fulfillment state lives in the SEPARATE pulls feature, a different
+// entity). So a PullListRow carries NO fabricated prep status — it carries what
+// the warehouse needs to FIND the item (label, colourway, size, style/SKU) and
+// the shots that need it.
+import type { ProductAssignment, ProductFamily, Shot } from "@/shared/types"
+import { formatProductAssignmentLabel } from "./shotListSummaries"
+
+/** A shot that requires a given pull-list product. */
+export interface PullListShotRef {
+  readonly shotId: string
+  /** Shot number when present (e.g. "12"); falls back to the shot title. */
+  readonly shotLabel: string
+}
+
+/** One aggregated product requirement for the warehouse to pull. */
+export interface PullListRow {
+  /** Stable composite key: `${familyId|familyName}|${colourName}|${size}`. */
+  readonly key: string
+  /** Display label, reusing formatProductAssignmentLabel (no quantity dupes). */
+  readonly label: string
+  /** Resolved style number / SKU, or null when unresolvable. */
+  readonly styleNumber: string | null
+  /** Colourway name for a swatch, or null when none assigned. */
+  readonly colourName: string | null
+  /** Every shot that requires this product, de-duplicated, sorted. */
+  readonly neededByShots: ReadonlyArray<PullListShotRef>
+}
+
+function asNonEmptyString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function shotLabelFor(shot: Shot): string {
+  return (
+    asNonEmptyString(shot.shotNumber) ??
+    asNonEmptyString(shot.title) ??
+    shot.id
+  )
+}
+
+// Identity of a requirement = family + colourway + size. Quantity is NOT part
+// of the key (it's a per-line count, not an identity); colourName/size carry
+// the variant. familyName backstops a missing familyId so two unlinked
+// assignments of the same garment still collapse.
+function compositeKey(p: ProductAssignment): string {
+  const family =
+    asNonEmptyString(p.familyId) ?? asNonEmptyString(p.familyName) ?? "product"
+  const colour = asNonEmptyString(p.colourName) ?? ""
+  const size = asNonEmptyString(p.size) ?? p.sizeScope ?? ""
+  return `${family}|${colour}|${size}`
+}
+
+function resolveStyleNumber(
+  p: ProductAssignment,
+  familyById?: ReadonlyMap<string, ProductFamily>,
+): string | null {
+  const family = p.familyId && familyById ? familyById.get(p.familyId) : undefined
+  return family?.styleNumber ?? family?.styleNumbers?.[0] ?? asNonEmptyString(p.skuName)
+}
+
+interface MutableRow {
+  readonly key: string
+  readonly label: string
+  readonly styleNumber: string | null
+  readonly colourName: string | null
+  readonly shotRefs: Map<string, PullListShotRef>
+}
+
+function collectAssignment(
+  rows: Map<string, MutableRow>,
+  p: ProductAssignment,
+  shotRef: PullListShotRef,
+  familyById?: ReadonlyMap<string, ProductFamily>,
+): void {
+  const key = compositeKey(p)
+  const existing = rows.get(key)
+  if (existing) {
+    if (!existing.shotRefs.has(shotRef.shotId)) {
+      existing.shotRefs.set(shotRef.shotId, shotRef)
+    }
+    return
+  }
+  const shotRefs = new Map<string, PullListShotRef>()
+  shotRefs.set(shotRef.shotId, shotRef)
+  rows.set(key, {
+    key,
+    label: formatProductAssignmentLabel(p),
+    styleNumber: resolveStyleNumber(p, familyById),
+    colourName: asNonEmptyString(p.colourName),
+    shotRefs,
+  })
+}
+
+function sortShotRefs(
+  refs: Iterable<PullListShotRef>,
+): ReadonlyArray<PullListShotRef> {
+  return [...refs].sort((a, b) =>
+    a.shotLabel.localeCompare(b.shotLabel, undefined, { numeric: true }),
+  )
+}
+
+/**
+ * Aggregate every product requirement across ALL looks of ALL given shots into
+ * a deterministic, de-duplicated pull list. Deleted shots are skipped. Rows are
+ * stably sorted by label (then key) so renders and snapshots are reproducible.
+ */
+export function buildWarehousePullList(
+  shots: ReadonlyArray<Shot>,
+  familyById?: ReadonlyMap<string, ProductFamily>,
+): PullListRow[] {
+  const rows = new Map<string, MutableRow>()
+
+  for (const shot of shots) {
+    if (shot.deleted === true) continue
+    const shotRef: PullListShotRef = {
+      shotId: shot.id,
+      shotLabel: shotLabelFor(shot),
+    }
+    for (const look of shot.looks ?? []) {
+      for (const product of look.products ?? []) {
+        collectAssignment(rows, product, shotRef, familyById)
+      }
+    }
+  }
+
+  return [...rows.values()]
+    .map((row) => ({
+      key: row.key,
+      label: row.label,
+      styleNumber: row.styleNumber,
+      colourName: row.colourName,
+      neededByShots: sortShotRefs(row.shotRefs.values()),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label) || a.key.localeCompare(b.key))
+}

--- a/src-vnext/shared/lib/rbac.test.ts
+++ b/src-vnext/shared/lib/rbac.test.ts
@@ -182,10 +182,12 @@ describe("permission checks", () => {
 
 })
 
-describe("canEditScene", () => {
-  // Mirrors the /lanes rule role list (firestore.rules:880-882 create/update,
-  // :901-904 delete): admin || producer || warehouse. 5f's warehouse revoke
-  // edits this helper + the lanes rule lists together (two-line edit).
+describe("canEditScene (5f-III A1 — warehouse revoked)", () => {
+  // 5f-III revoke (A1): canEditScene is now admin || producer ONLY. Warehouse,
+  // which 5f-II kept for lane-write, no longer edits scenes/lanes — the surface
+  // is read-only for warehouse. This change is scene/lane-edit UI ONLY; it does
+  // NOT touch warehouse PULLS (canManagePulls, below) — guarded against
+  // over-reach by the "warehouse keeps pulls" pin in canManagePulls.
   it("admin can edit scenes", () => {
     expect(canEditScene("admin")).toBe(true)
   })
@@ -194,8 +196,8 @@ describe("canEditScene", () => {
     expect(canEditScene("producer")).toBe(true)
   })
 
-  it("warehouse keeps lane-write until the 5f revoke (locked Q3)", () => {
-    expect(canEditScene("warehouse")).toBe(true)
+  it("warehouse CANNOT edit scenes (5f-III A1 revoke — review surface is read-only)", () => {
+    expect(canEditScene("warehouse")).toBe(false)
   })
 
   it("crew cannot edit scenes (crew writes shots, not lanes)", () => {
@@ -204,6 +206,14 @@ describe("canEditScene", () => {
 
   it("viewer cannot edit scenes", () => {
     expect(canEditScene("viewer")).toBe(false)
+  })
+
+  // Over-reach guard: A1 removes scene-edit from warehouse but MUST NOT strip
+  // its pull capability (canManagePulls is a separate helper). If a future edit
+  // accidentally widened A1's revoke to pulls, this pin fails.
+  it("warehouse KEEPS pulls after the scene-edit revoke (A1 is cleanly scoped)", () => {
+    expect(canEditScene("warehouse")).toBe(false)
+    expect(canManagePulls("warehouse")).toBe(true)
   })
 })
 

--- a/src-vnext/shared/lib/rbac.ts
+++ b/src-vnext/shared/lib/rbac.ts
@@ -96,10 +96,13 @@ export function canManageCasting(role: Role): boolean {
 // producerCanAccessProject || hasProjectRole(projectId, ['producer',
 // 'warehouse']). Consumes the EFFECTIVE role (5b) — the two surviving
 // copies (ShotListPage canManageLanes, ShotDetailPageUnified canEditScene)
-// consolidate here. 5f's warehouse revoke is a two-line edit: remove
-// 'warehouse' from this helper AND from the lanes rule role lists.
+// consolidate here. 5f's warehouse revoke is two coordinated edits across two
+// PRs: this helper (5f-III, the UI half) AND the lanes rule role lists +
+// wildcard catch-all (5f-I / firestore.rules, the backend half). They align on
+// main once both merge; deploy the rules on go, coordinated with the
+// featureReviewSurface flip so warehouse never hits a UI/rules mismatch window.
 export function canEditScene(role: Role): boolean {
-  return role === ROLE.ADMIN || role === ROLE.PRODUCER || role === ROLE.WAREHOUSE
+  return role === ROLE.ADMIN || role === ROLE.PRODUCER
 }
 
 // Version-history restore (shot + product detail History sections). Backing


### PR DESCRIPTION
## Phase 5f-III — warehouse Review surface + the Q3 UI revoke

Re-opened continuation of #452 (auto-closed when its stacked base #451 merged + the branch was deleted). **Rebased onto main — identical content to the green #452**, now a clean 2-commit diff against main. App code behind `featureReviewSurface` (default OFF).

### What's built
- **`warehousePullList.ts`** (pure + tests) — aggregates every product across all looks of all shots into a pull list (label/style·SKU/colour/needed-for-shots), **no fabricated prep column** (no such field exists); falls back to `extractShotAssignedProducts` for legacy shots with no look rows.
- **`ReviewWarehouseList.tsx`** — read-only product-led pull list.
- **`ReviewShotDetail.tsx`** `review-warehouse` variant — `ProductColorwayStrip readOnly` first, read-only status, composer on, no version history.
- **Forks** extended to `review-warehouse`, flag-gated; flag-off byte-identical.
- **`rbac.ts` `canEditScene` A1** — warehouse removed (scene-edit UI only; warehouse keeps pulls). UI half of the Q3 revoke; backend half is #450, deploy-coordinated with the `featureReviewSurface` flip.

### Verified
- **Live `:5174` eyeball PASS** (client + warehouse, throwaway project deleted, Q2-26 No. 3 never opened): pull list aggregated a real product to a "needed for shot 01" row; warehouse detail product-forward; composer open.
- **Codex converged** — header-leak + stale-filter + legacy-products all fixed (commit on this branch); claude-review passed.
- Lint + 138 targeted tests + production build clean.

Spec: `outputs/2026-06-12-phase5f-build-spec.md` §2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)