### PR TITLE
chore(ci): enable featureReviewSurface in prod — 5f go-live (DO NOT MERGE until rules deployed)

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -43,6 +43,7 @@ jobs:
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
           VITE_FLAG_CALLSHEET_BUILDER:       1
+          VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -71,6 +72,7 @@ jobs:
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
           VITE_FLAG_CALLSHEET_BUILDER:       1
+          VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
## 5f go-live — flip the Review surfaces ON in production

Sets `VITE_REVIEW_SURFACE=1` in `deploy-live.yml`'s two build env blocks (Build + Hosting predeploy), mirroring the existing `VITE_FLAG_CALLSHEET_BUILDER=1`. **Merging this triggers a prod hosting deploy with the client/warehouse Review surfaces ON** for viewer/warehouse users.

### Why this mechanism (prod env var, not a default flip)
- The flag default stays `false` in `flags.ts`, so **dev, CI unit tests, the ui-checks E2E lane, and preview deploys are all unchanged** (flag off) — no flag-flip test audit, no E2E churn.
- Only the live hosting build flips it on. Same pattern the call-sheet builder already uses.

### ⚠️ Merge coordination (read before merging)
1. **Deploy the rules FIRST** (Ted, manual): `firebase deploy --only firestore:rules` — this enforces the warehouse lane-write revoke (Q3) backend-side. The `canEditScene` A1 UI removal already shipped, so ordering is technically safe either way, but rules-first closes the defense-in-depth gap before the read-only surface goes live.
2. **Then merge this PR** → the deploy-live run flips the flag in the prod build.
3. Optional pre-flight: confirm the prod roster's warehouse users (the revoke removes their lane-write by design — make sure it's expected, not a surprise).

**Held for Ted's go — do not auto-merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)