### PR TITLE
feat(a11y): Phase 7 PR-A — contrast token fix + un-quarantine a11y.spec

### DIFF
--- a/docs/DESIGN_SYSTEM.md
+++ b/docs/DESIGN_SYSTEM.md
@@ -46,8 +46,9 @@ This file is referenced from `CLAUDE.md` Hard Rule #3 and must be consulted befo
 
 | Instead of | Use |
 |------------|-----|
-| `text-gray-400` | `text-[var(--color-text-subtle)]` |
-| `text-gray-500` | `text-[var(--color-text-muted)]` |
+| `text-gray-500`/`-600` (secondary text) | `text-[var(--color-text-secondary)]` (post-Phase-7 `--color-text-muted` is an alias of this — same `#52525b`, AA-safe) |
+| `text-gray-400` (tertiary text) | `text-[var(--color-text-subtle)]` (`#5b5b60`, AA-safe on light surfaces) |
+| `text-gray-400` (decorative `--` placeholder, non-text only) | `text-[var(--color-text-disabled)]` |
 | `text-white` | `text-[var(--color-text)]` |
 | `bg-zinc-800` | `bg-[var(--color-surface-subtle)]` |
 | `bg-zinc-900` | `bg-[var(--color-surface)]` |
@@ -176,7 +177,7 @@ Our tables must match Saturation's level of interactivity. Reference: `app.satur
 
 ### Cell Content
 - Text values: `text-[var(--color-text-muted)]` for secondary data
-- Empty values: `<span className="text-[var(--color-text-subtle)]">--</span>`
+- Empty values: `<span className="text-[var(--color-text-disabled)]">--</span>` (decorative `--` placeholder; `--color-text-disabled` is reserved for this, never for readable text)
 - Never display `[object Object]` — always extract primitive values from nested objects
 - Measurement objects: extract `.value` property when type is object
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,6 @@ export default defineConfig({
   // smoke suite (storageState auth), which guards against the white-screen
   // regression. DO NOT add specs here without a tracking entry in QUARANTINE.md.
   testIgnore: [
-    '**/a11y.spec.ts',            // real WCAG AA contrast violations in the app
     // auth.spec.ts un-quarantined 2026-06-06: interactive-login helper fixed
     // (authed-signal wait + domcontentloaded + real sign-out + emulator-only
     // submit selector). See QUARANTINE.md "Interactive-login helper fix".

--- a/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
+++ b/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
@@ -17,7 +17,9 @@ import AdminPage from "./AdminPage"
  * typography class (design-tokens.js). It is used on every table header of
  * the AdminPage team roster, and previously pointed at --color-text-subtle
  * (#a1a1aa / zinc-400), which gives only 2.56:1 on white — failing AA. H-2
- * moved it to --color-text-muted (#71717a / zinc-500), 4.83:1 on white.
+ * moved it to --color-text-secondary (#52525b / zinc-600), 7.73:1 on white
+ * (design-tokens.js:120). This guard reads that token name from the plugin
+ * source at runtime, so it stays correct as token values evolve.
  *
  * If this fails, either the token was reverted or a new axe-relevant text
  * element on the Admin page is rendering with insufficient contrast.
@@ -111,8 +113,8 @@ function contrastRatio(fg: string, bg: string): number {
 const TOKENS = {
   "color-text": "#18181b",            // zinc-900
   "color-text-secondary": "#52525b",  // zinc-600
-  "color-text-muted": "#71717a",      // zinc-500
-  "color-text-subtle": "#a1a1aa",     // zinc-400
+  "color-text-muted": "#52525b",      // re-pointed to zinc-600 for AA (Phase 7; was #71717a)
+  "color-text-subtle": "#5b5b60",     // darkened for AA on all light surfaces (Phase 7; was #a1a1aa)
   "color-surface": "#f5f5f5",         // Immediate White (top of ramp; no pure #fff)
   "color-surface-subtle": "#ebebeb",
   "color-bg": "#eaeaea",              // App background — light grey
@@ -125,13 +127,14 @@ const AA_LARGE = 3.0
 
 describe("WCAG contrast math sanity", () => {
   it("matches known zinc-on-white reference ratios within rounding", () => {
-    // Cross-checked against the WebAIM calculator. These reference ratios are
-    // for zinc text on pure WHITE (#ffffff), so they pin the contrastRatio math
-    // to a fixed reference — independent of the app's actual surface token
-    // (which is the off-white Immediate #f5f5f5, exercised by the H-2 tests).
+    // These reference ratios pin the contrastRatio math to fixed values for the
+    // post-Phase-7 token hexes on pure WHITE (#ffffff), independent of the app's
+    // actual surface token (the off-white Immediate #f5f5f5, exercised by the
+    // H-2 tests). Subtle/muted were re-pointed in Phase 7 for AA, so the prior
+    // zinc-400 (2.56:1) / zinc-500 (4.83:1) references no longer apply.
     const WHITE = "#ffffff"
-    expect(contrastRatio(TOKENS["color-text-subtle"], WHITE)).toBeCloseTo(2.56, 1)
-    expect(contrastRatio(TOKENS["color-text-muted"], WHITE)).toBeCloseTo(4.83, 1)
+    expect(contrastRatio(TOKENS["color-text-subtle"], WHITE)).toBeCloseTo(6.75, 1)  // #5b5b60
+    expect(contrastRatio(TOKENS["color-text-muted"], WHITE)).toBeCloseTo(7.73, 1)   // #52525b (== secondary)
     expect(contrastRatio(TOKENS["color-text-secondary"], WHITE)).toBeCloseTo(7.73, 1)
   })
 })
@@ -179,16 +182,18 @@ describe("Admin page color-contrast (H-2 regression)", () => {
     }
   })
 
-  it("refuses any .label-meta rendering on a white-ish surface that fails AA", () => {
-    // Defensive: assert directly that --color-text-subtle is NOT a valid
-    // choice for .label-meta, since that was the H-2 offender.
-    const badRatio = contrastRatio(
+  it("--color-text-subtle now clears AA on the surface (Phase 7 re-point)", () => {
+    // Pre-Phase-7 this test asserted the OPPOSITE: --color-text-subtle (#a1a1aa,
+    // zinc-400) was the H-2 offender and FAILED AA on white-ish surfaces. Phase 7
+    // darkened subtle to #5b5b60, which now clears AA on every light surface incl.
+    // the worst case #e0e0e0. The original "this token fails AA" guard is therefore
+    // retired (the bad contrast no longer exists). We keep the check, inverted, so
+    // a future revert of subtle back toward zinc-400 trips it.
+    const ratio = contrastRatio(
       TOKENS["color-text-subtle"],
       TOKENS["color-surface"],
     )
-    expect(badRatio).toBeLessThan(AA_NORMAL)
-    // If this assertion flips (i.e. zinc-400 ever clears AA on white) the
-    // H-2 guard becomes redundant, which is a fine problem to have.
+    expect(ratio).toBeGreaterThanOrEqual(AA_NORMAL)
   })
 
   it("renders the admin page with every table header using the fixed token", () => {

--- a/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
+++ b/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
@@ -113,9 +113,7 @@ function contrastRatio(fg: string, bg: string): number {
 const TOKENS = {
   "color-text": "#18181b",            // zinc-900
   "color-text-secondary": "#52525b",  // zinc-600
-  // muted is INTENTIONALLY aliased to secondary (#52525b) post-Phase-7: the old
-  // lighter muted tier (#71717a) failed AA so it was retired; hierarchy now comes
-  // from type weight/size, not color (DESIGN.md). The collision is deliberate.
+  // muted intentionally aliased to secondary post-Phase-7 (old #71717a failed AA; tiering via type, not color)
   "color-text-muted": "#52525b",      // re-pointed to zinc-600 for AA (Phase 7; was #71717a)
   "color-text-subtle": "#5b5b60",     // darkened for AA on all light surfaces (Phase 7; was #a1a1aa)
   "color-surface": "#f5f5f5",         // Immediate White (top of ramp; no pure #fff)

--- a/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
+++ b/src-vnext/features/admin/components/AdminPage.a11y.test.tsx
@@ -113,6 +113,9 @@ function contrastRatio(fg: string, bg: string): number {
 const TOKENS = {
   "color-text": "#18181b",            // zinc-900
   "color-text-secondary": "#52525b",  // zinc-600
+  // muted is INTENTIONALLY aliased to secondary (#52525b) post-Phase-7: the old
+  // lighter muted tier (#71717a) failed AA so it was retired; hierarchy now comes
+  // from type weight/size, not color (DESIGN.md). The collision is deliberate.
   "color-text-muted": "#52525b",      // re-pointed to zinc-600 for AA (Phase 7; was #71717a)
   "color-text-subtle": "#5b5b60",     // darkened for AA on all light surfaces (Phase 7; was #a1a1aa)
   "color-surface": "#f5f5f5",         // Immediate White (top of ramp; no pure #fff)

--- a/src-vnext/features/library/components/TalentCastingPrintPortal.tsx
+++ b/src-vnext/features/library/components/TalentCastingPrintPortal.tsx
@@ -54,7 +54,7 @@ function PrintDoc({
 
   // bg-white is intentional: print portal always renders on white paper
   return (
-    <div data-talent-casting-print-root className="min-h-screen bg-white">
+    <div data-talent-casting-print-root data-callsheet-doc-light className="min-h-screen bg-white">
       <div className="mx-auto w-full max-w-5xl p-8">
         <div className="flex items-start justify-between gap-6">
           <div className="min-w-0">

--- a/src-vnext/index.css
+++ b/src-vnext/index.css
@@ -29,8 +29,9 @@
   /* Text */
   --color-text: #18181b;
   --color-text-secondary: #52525b;
-  --color-text-muted: #71717a;
-  --color-text-subtle: #a1a1aa;
+  --color-text-muted: #52525b;
+  --color-text-subtle: #5b5b60;
+  --color-text-disabled: #a1a1aa; /* DECORATIVE ONLY ("--" placeholder); mirrors :root for print-doc parity */
 
   /* Borders */
   --color-border: #e4e4e7;
@@ -185,7 +186,7 @@
   .callsheet-key-time-label {
     font-size: var(--text-3xs);
     font-weight: 400;
-    color: var(--color-text-muted, #71717a);
+    color: var(--color-text-muted, #52525b);
     text-transform: uppercase;
     letter-spacing: 0.04em;
     display: block;
@@ -247,7 +248,7 @@
 
   .callsheet-header-schedule {
     font-size: var(--text-2xs);
-    color: var(--color-text-muted, #71717a);
+    color: var(--color-text-muted, #52525b);
   }
 
   .callsheet-header-crew-call {
@@ -263,7 +264,7 @@
     font-weight: 600;
     letter-spacing: 0.06em;
     text-transform: uppercase;
-    color: var(--color-text-subtle, #a1a1aa);
+    color: var(--color-text-subtle, #5b5b60);
   }
 
   .callsheet-header-day {
@@ -294,7 +295,7 @@
   .callsheet-header-weather-summary {
     font-size: var(--text-3xs);
     font-weight: 400;
-    color: var(--color-text-muted, #71717a);
+    color: var(--color-text-muted, #52525b);
   }
 
   .callsheet-location-strip {
@@ -308,7 +309,7 @@
 
   .callsheet-location-label {
     font-weight: 600;
-    color: var(--color-text-muted, #71717a);
+    color: var(--color-text-muted, #52525b);
     font-size: var(--text-3xs);
     letter-spacing: 0.04em;
     text-transform: uppercase;
@@ -325,7 +326,7 @@
     display: none;
     font-size: var(--text-3xs);
     font-weight: 500;
-    color: var(--color-text-muted, #71717a);
+    color: var(--color-text-muted, #52525b);
     letter-spacing: 0.04em;
     text-transform: uppercase;
     justify-content: space-between;
@@ -342,7 +343,7 @@
     bottom: var(--space-2-5);
     left: var(--space-5);
     font-size: var(--text-3xs);
-    color: var(--color-text-subtle, #a1a1aa);
+    color: var(--color-text-subtle, #5b5b60);
     letter-spacing: 0.02em;
   }
 

--- a/tests/QUARANTINE.md
+++ b/tests/QUARANTINE.md
@@ -268,12 +268,28 @@ quarantine, and it runs on **every PR**:
 
 | Spec | Category | Failure | Fix needed |
 |---|---|---|---|
-| `a11y.spec.ts` | App a11y | 93+ genuine WCAG AA contrast violations (e.g. muted `#71717a` on `#f4f4f5` = 4.39 vs 4.5) | Fix app contrast tokens (touches brand palette — product/design decision) or adjust the assertion threshold |
 | `visual.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines on the CI runner image |
 | `e2e/richtext-bubble.spec.ts` | Snapshots | Baselines missing/mismatched | Regenerate baselines |
 
 (`diagnose-sticky.spec.js` was a scratch ad-hoc diagnostic with no assertions —
 **deleted 2026-06-06** rather than quarantined; nothing of value lost.)
+
+### Un-quarantined (resolved)
+
+- ~~`a11y.spec.ts` — App a11y contrast (was: 93+ WCAG AA contrast violations,
+  root cause muted `#71717a` failing 4.5:1 on light surfaces).~~ **Resolved
+  2026-06-13 (Phase 7 PR-A).** The contrast token fix re-pointed
+  `--color-text-muted` `#71717a`→`#52525b` and `--color-text-subtle`
+  `#a1a1aa`→`#5b5b60` (both clear AA on every live light surface incl. the
+  worst case `#e0e0e0`), and the `testIgnore` line was removed so the spec runs
+  in CI. **Scoped to the `color-contrast` rule only** (Phase 7 Decision 4): the
+  phase owns the contrast fix; pre-existing non-contrast violations are NOT
+  Phase 7 blockers.
+  - **Phase 8 follow-up — owner: Phase 8, condition: after Phases 1–7 freeze.**
+    Inventory + fix the pre-existing NON-contrast wcag2a/aa violations
+    (link-name, region, form labels, aria, etc.) on the four tested pages
+    (`/`, `/products`, `/shots`, `/admin`), then broaden `a11y.spec.ts` back to
+    `.withTags(['wcag2a','wcag2aa'])`. Until then the suite guards contrast only.
 
 ### Single-test quarantine
 
@@ -299,12 +315,15 @@ quarantine, and it runs on **every PR**:
 
 ## Sign-off (CLAUDE.md Rule 6b)
 
-The a11y quarantine covers genuine WCAG AA violations (HIGH). Per Rule 6b these
-require explicit user approval to defer rather than fix in-sprint. **Approved by
+The a11y quarantine covered genuine WCAG AA violations (HIGH). Per Rule 6b these
+required explicit user approval to defer rather than fix in-sprint. **Approved by
 Ted on 2026-06-04** as the "stabilize the gate now, fix the dormant backlog
 incrementally" path — the white-screen root cause (the months-long blocker) was
-fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
-(below), not a merge blocker.
+fixed; the unmasked a11y/CRUD/visual backlog was accepted as tracked follow-up
+(below), not a merge blocker. **The a11y contrast quarantine is now RESOLVED
+(2026-06-13, Phase 7 PR-A)** — see "Un-quarantined (resolved)" above; the suite
+runs in CI scoped to `color-contrast` (Decision 4), with the full-ruleset
+broadening tracked as a Phase 8 row.
 
 ## Follow-up backlog (separate work)
 
@@ -335,7 +354,11 @@ fixed; the unmasked a11y/CRUD/visual backlog is accepted as tracked follow-up
    seed (read-only summary on `SEED_SHOT_AURORA`; status mutation + reload
    persistence + Notes autosave on `SEED_SHOT_EDITABLE`). Un-quarantined. See
    "Sidebar-summary rewrite" above.
-6. **App a11y contrast** — product/design pass on muted-text tokens (review with Ted).
+6. ~~**App a11y contrast** — product/design pass on muted-text tokens (review with Ted).~~
+   **Done 2026-06-13 (Phase 7 PR-A).** 4-step text ramp landed (`--color-text-muted`
+   → `#52525b`, `--color-text-subtle` → `#5b5b60`, new fenced `--color-text-disabled`);
+   `a11y.spec.ts` un-quarantined, scoped to `color-contrast`. Phase 8 broadens to the
+   full wcag2a/aa ruleset (see "Un-quarantined (resolved)").
 7. **Visual baselines** — regenerate on the CI runner image; un-quarantines
    `visual` + `richtext-bubble`.
 8. **Cross-browser job** — re-add firefox/webkit as a separate, non-blocking job

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -3,7 +3,17 @@ import AxeBuilder from '@axe-core/playwright';
 
 /**
  * Accessibility tests using axe-core.
- * Tests WCAG 2.0 Level A and AA compliance.
+ *
+ * Phase 7 scope (Decision 4): this suite is un-quarantined as the guard for the
+ * contrast token fix and is therefore SCOPED TO THE `color-contrast` RULE ONLY.
+ * The phase owns the muted/subtle text-token contrast fix; pre-existing
+ * NON-contrast violations (link-name, region, form labels, aria, etc.) are
+ * tracked as Phase 8 rows, not Phase 7 blockers — so the gate tests exactly
+ * what this phase fixes and cannot red on unrelated debt.
+ *
+ * Phase 8 follow-up (owner: Phase 8): broaden back to the full
+ * `.withTags(['wcag2a','wcag2aa'])` ruleset once the pre-existing non-contrast
+ * violations are inventoried + fixed. See tests/QUARANTINE.md.
  */
 
 test.describe('Accessibility Tests', () => {
@@ -13,7 +23,7 @@ test.describe('Accessibility Tests', () => {
     await producerPage.locator('nav, [role="navigation"]').first().waitFor({ state: 'visible', timeout: 10000 });
 
     const results = await new AxeBuilder({ page: producerPage })
-      .withTags(['wcag2a', 'wcag2aa'])
+      .withRules(['color-contrast'])
       .analyze();
 
     // Log violations for debugging
@@ -35,7 +45,7 @@ test.describe('Accessibility Tests', () => {
     await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
 
     const results = await new AxeBuilder({ page: producerPage })
-      .withTags(['wcag2a', 'wcag2aa'])
+      .withRules(['color-contrast'])
       .analyze();
 
     if (results.violations.length > 0) {
@@ -59,10 +69,15 @@ test.describe('Accessibility Tests', () => {
 
     const currentUrl = producerPage.url();
 
+    // Hardening (Phase 7 Decision 7): fail loudly if /shots navigation did not
+    // land — without this the conditional below silently no-ops and the axe
+    // gate passes without ever running, defeating the un-quarantine.
+    expect(currentUrl).toContain('/shots');
+
     // Only run a11y test if we successfully loaded shots page
     if (currentUrl.includes('/shots')) {
       const results = await new AxeBuilder({ page: producerPage })
-        .withTags(['wcag2a', 'wcag2aa'])
+        .withRules(['color-contrast'])
         .analyze();
 
       if (results.violations.length > 0) {
@@ -82,7 +97,7 @@ test.describe('Accessibility Tests', () => {
     await adminPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
 
     const results = await new AxeBuilder({ page: adminPage })
-      .withTags(['wcag2a', 'wcag2aa'])
+      .withRules(['color-contrast'])
       .analyze();
 
     if (results.violations.length > 0) {

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from './fixtures/auth';
 import AxeBuilder from '@axe-core/playwright';
+import { SEED_PROJECT_ID } from './helpers/seedConstants';
 
 /**
  * Accessibility tests using axe-core.
@@ -59,36 +60,30 @@ test.describe('Accessibility Tests', () => {
   });
 
   test('shots page has no critical a11y violations', async ({ producerPage }) => {
-    // First need to have an active project
-    await producerPage.goto('/');
-    await producerPage.locator('nav, [role="navigation"]').first().waitFor({ state: 'visible', timeout: 10000 });
-
-    // Try to navigate to shots
-    await producerPage.goto('/shots');
+    // Shots are project-scoped (/projects/:id/shots) — go straight to the seeded
+    // project's shot list, mirroring shots-toolbar.spec / shots-crud.spec. The
+    // legacy top-level /shots route no longer renders the list (the redesign
+    // moved it under the project), so the old goto('/shots') timed out waiting
+    // for <main> and the axe gate never ran.
+    await producerPage.goto(`/projects/${SEED_PROJECT_ID}/shots`);
     await producerPage.locator('main, [role="main"]').first().waitFor({ state: 'visible', timeout: 10000 });
 
-    const currentUrl = producerPage.url();
+    // Hardening (Phase 7 Decision 7): fail loudly if the shot list did not land,
+    // so the axe gate below can never silently no-op.
+    expect(producerPage.url()).toContain(`/projects/${SEED_PROJECT_ID}/shots`);
 
-    // Hardening (Phase 7 Decision 7): fail loudly if /shots navigation did not
-    // land — without this the conditional below silently no-ops and the axe
-    // gate passes without ever running, defeating the un-quarantine.
-    expect(currentUrl).toContain('/shots');
+    const results = await new AxeBuilder({ page: producerPage })
+      .withRules(['color-contrast'])
+      .analyze();
 
-    // Only run a11y test if we successfully loaded shots page
-    if (currentUrl.includes('/shots')) {
-      const results = await new AxeBuilder({ page: producerPage })
-        .withRules(['color-contrast'])
-        .analyze();
-
-      if (results.violations.length > 0) {
-        console.log('Accessibility violations found on Shots page:');
-        results.violations.forEach(violation => {
-          console.log(`- ${violation.id}: ${violation.description}`);
-        });
-      }
-
-      expect(results.violations).toEqual([]);
+    if (results.violations.length > 0) {
+      console.log('Accessibility violations found on Shots page:');
+      results.violations.forEach(violation => {
+        console.log(`- ${violation.id}: ${violation.description}`);
+      });
     }
+
+    expect(results.violations).toEqual([]);
   });
 
   test('admin page has no critical a11y violations', async ({ adminPage }) => {

--- a/tokens.css
+++ b/tokens.css
@@ -95,7 +95,7 @@
   /* --- Text --- */
   --color-text: #18181b;              /* Primary text (zinc-900) */
   --color-text-secondary: #52525b;    /* Secondary (zinc-600) */
-  --color-text-muted: #52525b;        /* Muted floor — re-pointed to zinc-600 for AA (was #71717a, failed 4.5:1 on every light surface) */
+  --color-text-muted: #52525b;        /* Re-pointed to zinc-600 for AA (was #71717a, failed 4.5:1 on every light surface). INTENTIONALLY == --color-text-secondary now: the old lighter muted tier is retired for AA; primary/secondary/tertiary hierarchy comes from type weight+size, not color (DESIGN.md). Per-tier color is re-established only if Phase 7b type-tiering needs it. */
   --color-text-subtle: #5b5b60;       /* Tertiary text — darkened for AA on all light surfaces incl. worst-case #e0e0e0 5.11:1 (was #a1a1aa) */
   --color-text-disabled: #a1a1aa;     /* NEW — DECORATIVE ONLY: the literal "--" placeholder glyph / non-text decoration. Fails 4.5:1 AND 3:1 on light surfaces — must NEVER style readable text. */
   --color-text-inverted: #f5f5f5;     /* Immediate White — on dark backgrounds */

--- a/tokens.css
+++ b/tokens.css
@@ -95,7 +95,7 @@
   /* --- Text --- */
   --color-text: #18181b;              /* Primary text (zinc-900) */
   --color-text-secondary: #52525b;    /* Secondary (zinc-600) */
-  --color-text-muted: #52525b;        /* Re-pointed to zinc-600 for AA (was #71717a, failed 4.5:1 on every light surface). INTENTIONALLY == --color-text-secondary now: the old lighter muted tier is retired for AA; primary/secondary/tertiary hierarchy comes from type weight+size, not color (DESIGN.md). Per-tier color is re-established only if Phase 7b type-tiering needs it. */
+  --color-text-muted: #52525b;        /* AA fix: re-pointed to zinc-600, now == secondary; muted tier retired, hierarchy via type weight/size (DESIGN.md) */
   --color-text-subtle: #5b5b60;       /* Tertiary text — darkened for AA on all light surfaces incl. worst-case #e0e0e0 5.11:1 (was #a1a1aa) */
   --color-text-disabled: #a1a1aa;     /* NEW — DECORATIVE ONLY: the literal "--" placeholder glyph / non-text decoration. Fails 4.5:1 AND 3:1 on light surfaces — must NEVER style readable text. */
   --color-text-inverted: #f5f5f5;     /* Immediate White — on dark backgrounds */

--- a/tokens.css
+++ b/tokens.css
@@ -95,8 +95,9 @@
   /* --- Text --- */
   --color-text: #18181b;              /* Primary text (zinc-900) */
   --color-text-secondary: #52525b;    /* Secondary (zinc-600) */
-  --color-text-muted: #71717a;        /* Muted (zinc-500) */
-  --color-text-subtle: #a1a1aa;       /* Subtle (zinc-400) */
+  --color-text-muted: #52525b;        /* Muted floor — re-pointed to zinc-600 for AA (was #71717a, failed 4.5:1 on every light surface) */
+  --color-text-subtle: #5b5b60;       /* Tertiary text — darkened for AA on all light surfaces incl. worst-case #e0e0e0 5.11:1 (was #a1a1aa) */
+  --color-text-disabled: #a1a1aa;     /* NEW — DECORATIVE ONLY: the literal "--" placeholder glyph / non-text decoration. Fails 4.5:1 AND 3:1 on light surfaces — must NEVER style readable text. */
   --color-text-inverted: #f5f5f5;     /* Immediate White — on dark backgrounds */
 
   /* --- Print / Document --- */
@@ -380,6 +381,7 @@
   --color-text-secondary: #d4d4d8;    /* zinc-300 */
   --color-text-muted: #a1a1aa;        /* zinc-400 */
   --color-text-subtle: #71717a;       /* zinc-500 */
+  --color-text-disabled: #71717a;     /* Symmetry with :root — DECORATIVE ONLY ("--" placeholder); dark subtle value, AA-safe on dark surfaces */
   --color-text-inverted: #18181b;     /* zinc-900 — for use on light backgrounds */
 
   /* --- Borders --- */


### PR DESCRIPTION
## Phase 7 PR-A — Contrast token fix + a11y.spec un-quarantine

First of two Phase 7 capstone PRs. **PR-A is the atomic, CI-gated token contrast fix** (zero design subjectivity). PR-B (the optional type-tiering brand pass) comes after Ted eyeballs PR-A screenshots.

Audit + spec: `Projects/Shot Builder/outputs/2026-06-13-phase7-build-spec.md` (GO_WITH_CHANGES). Built scout→build→adversarial-verify; both verifiers cleared the diff; lint + `AdminPage.a11y.test.tsx` (4/4) + production build green locally.

### What changed
- **`tokens.css` `:root`** — `--color-text-muted` `#71717a`→`#52525b` (the AA-failing token: 3.66–4.43:1 across the live light surfaces, all <4.5); `--color-text-subtle` `#a1a1aa`→`#5b5b60`; new **`--color-text-disabled` `#a1a1aa`** fenced by comment to the non-text `--` placeholder only. `.dark` block untouched (already passes AA) + disabled token added for symmetry.
- **`src-vnext/index.css`** — mirrored the re-point in the `[data-callsheet-doc-light]` print scope (so the call-sheet PDF stays in sync with the app) + updated the 7 hardcoded `var(…, #hex)` fallbacks.
- **`playwright.config.ts`** — removed the `a11y.spec.ts` `testIgnore` entry. `visual.spec.ts` + `richtext-bubble.spec.ts` stay quarantined (Phase 8).
- **`tests/a11y.spec.ts`** — **scoped axe to the `color-contrast` rule** (Decision 4) + hardened the `/shots` navigation so the gate can't silently no-op (Decision 7).
- **`TalentCastingPrintPortal.tsx`** — added `data-callsheet-doc-light` (pre-existing dark-prints-white-text bug, Decision 1).
- **`AdminPage.a11y.test.tsx` + `QUARANTINE.md`** — synced token assertions/comments + tracked the Phase 8 broadening.

### Why `#5b5b60` (not the spec's `#646469`)
The build found a real consumer — `AddShotToScheduleDialog.tsx:174` renders `text-subtle` directly on `bg-surface-muted` (`#e0e0e0`). The spec's default `#646469` is only **4.458:1** there (fails AA). `#5b5b60` clears **5.115:1** on `#e0e0e0` (and AA on every other light surface) while staying visibly lighter than secondary `#52525b`, preserving the tier distinction.

### The CI gate (Decision 4)
The un-quarantined `a11y.spec` is **scoped to `color-contrast`** and asserts zero violations on 4 pages (`/`, `/products`, `/shots`, `/admin`). This is the real arbiter — the emulator suite can't run locally (Java-blocked). **Pre-existing NON-contrast violations are intentionally out of scope** (tracked as a Phase 8 row in `QUARANTINE.md`), so this gate tests exactly what Phase 7 fixes.

### Notes for review
- The `--color-text-disabled` fence is a comment, not lint-enforced (no consumer renders it as text today; the axe run is the backstop).
- Decisions **D2 (type-tiering)** and **D3 (red-period semantics)** are deliberately NOT in this PR (PR-B / deferred).

🚫 **Do not merge without Ted's go.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
