### PR TITLE
test: auto-restore vi.stubGlobal/stubEnv between tests — Talent redesign Phase 0a

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,21 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
+    // Auto-restore every `vi.stubGlobal` / `vi.stubEnv` before each test.
+    // Without this, a test that stubs a global in a `beforeEach` and never
+    // unstubs (e.g. `vi.stubGlobal("localStorage", {...})` in useExportTemplates
+    // / documentPersistence) leaks the stub into later files that share a
+    // worker. The committed pool is `forks` (below) — one process per file — so
+    // CI never saw it. But the local dev wrapper (scripts/run-vitest.cjs) forces
+    // `--pool threads --singleThread`, where all files share ONE jsdom global:
+    // the leaked stub left `window.localStorage` a plain object whose prototype
+    // has no `setItem`, so ViewAsPreviewProvider's
+    // `vi.spyOn(localStorage.__proto__, "setItem")` threw "setItem does not
+    // exist" (6 false local-only failures). Restoring stubs before each test
+    // makes the suite correct under ANY pool and kills the whole class. (Both
+    // flags set for symmetry: every stubGlobal/stubEnv usage today is per-test.)
+    unstubGlobals: true,
+    unstubEnvs: true,
     // CI runners (GitHub free-tier) are significantly slower than local dev
     // machines. 60s prevents false negatives from integration-heavy component
     // tests (AdminPage, InviteUserDialog, LibraryTalentPage, etc.).

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,19 +11,9 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./vitest.setup.ts"],
     globals: true,
-    // Auto-restore every `vi.stubGlobal` / `vi.stubEnv` before each test.
-    // Without this, a test that stubs a global in a `beforeEach` and never
-    // unstubs (e.g. `vi.stubGlobal("localStorage", {...})` in useExportTemplates
-    // / documentPersistence) leaks the stub into later files that share a
-    // worker. The committed pool is `forks` (below) — one process per file — so
-    // CI never saw it. But the local dev wrapper (scripts/run-vitest.cjs) forces
-    // `--pool threads --singleThread`, where all files share ONE jsdom global:
-    // the leaked stub left `window.localStorage` a plain object whose prototype
-    // has no `setItem`, so ViewAsPreviewProvider's
-    // `vi.spyOn(localStorage.__proto__, "setItem")` threw "setItem does not
-    // exist" (6 false local-only failures). Restoring stubs before each test
-    // makes the suite correct under ANY pool and kills the whole class. (Both
-    // flags set for symmetry: every stubGlobal/stubEnv usage today is per-test.)
+    // Auto-restore vi.stubGlobal/vi.stubEnv before each test: a stub left set in
+    // one file (e.g. localStorage in documentPersistence/useExportTemplates) must
+    // not leak into later files under the local shared-jsdom-global pool.
     unstubGlobals: true,
     unstubEnvs: true,
     // CI runners (GitHub free-tier) are significantly slower than local dev


### PR DESCRIPTION
**Talent redesign — Phase 0a** (the smallest-safe-first slice from `outputs/2026-06-13-talent-redesign-build-spec.md`). Test config only — **no app code.**

## TL;DR
One line of vitest config (`unstubGlobals` + `unstubEnvs`) that turns the **full local test suite from red → green** by killing a cross-test global-pollution class. CI was already green (its `forks` pool isolates files), so this only affects local dev runs.

## Diagnosis (diagnose-then-fix — the premise was stale)
The task was "fix the LibraryTalentPage test hang." I reproduced faithfully before touching anything:
- `LibraryTalentPage.test.tsx` **passes and exits cleanly in both pool modes** (forks via `CI=1`, and the local `threads+singleThread`).
- The **full suite completes in ~29s** with output redirected to a file — **there is no hang.** The documented "hang" was a piping/SIGPIPE artifact (the team already knows: *redirect, never pipe*), and/or already resolved. `firebase.ts` already falls back to the memory cache when jsdom lacks IndexedDB, so the persistent-cache open-handle theory never manifests.

What the full local run **did** surface: **6 failing tests** in `ViewAsPreviewProvider.test.tsx` — `vi.spyOn(window.localStorage.__proto__, "setItem")` → *"setItem does not exist"*. They pass in isolation → cross-test pollution.

**Root cause:** `useExportTemplates.test.tsx` and `documentPersistence.test.ts` call `vi.stubGlobal("localStorage", {...})` in `beforeEach` and never unstub. Under the local `threads+singleThread` pool (one shared jsdom global), the stub leaks into later files, leaving `window.localStorage` a plain object whose prototype has no `setItem`. CI's `forks` pool runs each file in its own process, so it never saw it.

## The fix
`unstubGlobals: true` + `unstubEnvs: true` — vitest restores every `vi.stubGlobal`/`vi.stubEnv` before each test. Correct under any pool; kills the whole class. (Every `stubGlobal`/`stubEnv` usage in the tree is per-test in a `beforeEach`/`it`, so nothing relied on a stub persisting.)

## Verification
- **Full suite, `threads+singleThread` (the previously-red mode): 272 files passed | 1 skipped | 0 failed** (3671 tests), clean exit, ~29s. The 6 failures are gone.
- The affected/neighboring files (`useExportTemplates`, `documentPersistence`, `ViewAsPreviewProvider`, `flags` [stubEnv], `ErrorBoundary`, `LibraryTalentPage`) under `CI=1` **forks: 45/45 pass**.
- Independent code-reviewer pass: **APPROVE** (verified vitest hook-ordering from source so the per-test re-stub still wins; confirmed the setup-file polyfills are direct assignments, untouched by unstub). Both review nits addressed (comment pool accuracy + the `unstubEnvs` symmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)