### PR TITLE
refactor(talent): useTalentDialogs reducer — Talent redesign Phase 0b

### DIFF
--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -18,6 +18,7 @@ import { LoadingState } from "@/shared/components/LoadingState"
 import { ListPageSkeleton } from "@/shared/components/Skeleton"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
+import { useTalentDialogs } from "@/features/library/hooks/useTalentDialogs"
 import { Button } from "@/ui/button"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
@@ -92,19 +93,31 @@ export default function LibraryTalentPage() {
   ])
 
   const [busy, setBusy] = useState(false)
-  const [headshotRemoveOpen, setHeadshotRemoveOpen] = useState(false)
-  const [galleryRemoveOpen, setGalleryRemoveOpen] = useState(false)
-  const [galleryRemoveTarget, setGalleryRemoveTarget] = useState<TalentImage | null>(null)
-  const [sessionRemoveOpen, setSessionRemoveOpen] = useState(false)
-  const [sessionRemoveTarget, setSessionRemoveTarget] = useState<CastingSession | null>(null)
   const [sessionExpanded, setSessionExpanded] = useState<Record<string, boolean>>({})
-  const [deleteOpen, setDeleteOpen] = useState(false)
-  const [createSessionOpen, setCreateSessionOpen] = useState(false)
-  const [printSessionId, setPrintSessionId] = useState<string | null>(null)
-  const [createSessionDate, setCreateSessionDate] = useState(() =>
-    new Date().toISOString().slice(0, 10),
-  )
-  const [createSessionTitle, setCreateSessionTitle] = useState("")
+  // Phase 0b: the six removal / create-session / print dialogs are consolidated
+  // into one reducer-backed hook (was ten loose useState cells). Drop-in setters.
+  const {
+    headshotRemoveOpen,
+    setHeadshotRemoveOpen,
+    galleryRemoveOpen,
+    setGalleryRemoveOpen,
+    galleryRemoveTarget,
+    setGalleryRemoveTarget,
+    sessionRemoveOpen,
+    setSessionRemoveOpen,
+    sessionRemoveTarget,
+    setSessionRemoveTarget,
+    deleteOpen,
+    setDeleteOpen,
+    createSessionOpen,
+    setCreateSessionOpen,
+    createSessionDate,
+    setCreateSessionDate,
+    createSessionTitle,
+    setCreateSessionTitle,
+    printSessionId,
+    setPrintSessionId,
+  } = useTalentDialogs()
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -94,8 +94,6 @@ export default function LibraryTalentPage() {
 
   const [busy, setBusy] = useState(false)
   const [sessionExpanded, setSessionExpanded] = useState<Record<string, boolean>>({})
-  // Phase 0b: the six removal / create-session / print dialogs are consolidated
-  // into one reducer-backed hook (was ten loose useState cells). Drop-in setters.
   const {
     headshotRemoveOpen,
     setHeadshotRemoveOpen,

--- a/src-vnext/features/library/hooks/useTalentDialogs.test.ts
+++ b/src-vnext/features/library/hooks/useTalentDialogs.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from "vitest"
+import { act, renderHook } from "@testing-library/react"
+import type { CastingSession, TalentImage } from "@/features/library/components/talentUtils"
+import {
+  createTalentDialogsState,
+  talentDialogsReducer,
+  useTalentDialogs,
+  type TalentDialogsState,
+} from "@/features/library/hooks/useTalentDialogs"
+
+// The reducer stores these as opaque references (it never reads their fields),
+// so minimal literals are sufficient for transition tests.
+const IMG = { id: "img-1" } as TalentImage
+const SESSION = { id: "sess-1" } as CastingSession
+
+describe("createTalentDialogsState", () => {
+  it("returns all dialogs closed with empty targets", () => {
+    const s = createTalentDialogsState()
+    expect(s).toMatchObject({
+      headshotRemoveOpen: false,
+      galleryRemoveOpen: false,
+      galleryRemoveTarget: null,
+      sessionRemoveOpen: false,
+      sessionRemoveTarget: null,
+      deleteOpen: false,
+      createSessionOpen: false,
+      createSessionTitle: "",
+      printSessionId: null,
+    })
+  })
+
+  it("defaults the create-session date to today (YYYY-MM-DD)", () => {
+    expect(createTalentDialogsState().createSessionDate).toMatch(/^\d{4}-\d{2}-\d{2}$/)
+  })
+})
+
+describe("talentDialogsReducer", () => {
+  const base: TalentDialogsState = createTalentDialogsState()
+
+  it("sets a boolean field without touching others", () => {
+    const next = talentDialogsReducer(base, { field: "deleteOpen", value: true })
+    expect(next.deleteOpen).toBe(true)
+    expect(next.headshotRemoveOpen).toBe(false)
+    expect(next.createSessionOpen).toBe(false)
+  })
+
+  it("sets and clears object targets", () => {
+    const withTarget = talentDialogsReducer(base, { field: "galleryRemoveTarget", value: IMG })
+    expect(withTarget.galleryRemoveTarget).toBe(IMG)
+    const cleared = talentDialogsReducer(withTarget, { field: "galleryRemoveTarget", value: null })
+    expect(cleared.galleryRemoveTarget).toBeNull()
+  })
+
+  it("stores a session target and a print id", () => {
+    const a = talentDialogsReducer(base, { field: "sessionRemoveTarget", value: SESSION })
+    expect(a.sessionRemoveTarget).toBe(SESSION)
+    const b = talentDialogsReducer(base, { field: "printSessionId", value: "s1" })
+    expect(b.printSessionId).toBe("s1")
+  })
+
+  it("supports the functional-updater form of SetStateAction", () => {
+    const next = talentDialogsReducer(base, {
+      field: "deleteOpen",
+      value: (prev) => !prev,
+    })
+    expect(next.deleteOpen).toBe(true)
+  })
+
+  it("returns the SAME state reference when the value is unchanged (no needless re-render)", () => {
+    const next = talentDialogsReducer(base, { field: "headshotRemoveOpen", value: false })
+    expect(next).toBe(base)
+  })
+
+  it("does not mutate the previous state", () => {
+    const before = { ...base }
+    talentDialogsReducer(base, { field: "createSessionTitle", value: "Jan 30" })
+    expect(base).toEqual(before)
+  })
+})
+
+describe("useTalentDialogs", () => {
+  it("exposes the initial state and all setters", () => {
+    const { result } = renderHook(() => useTalentDialogs())
+    expect(result.current.headshotRemoveOpen).toBe(false)
+    expect(result.current.createSessionTitle).toBe("")
+    expect(typeof result.current.setDeleteOpen).toBe("function")
+    expect(typeof result.current.setPrintSessionId).toBe("function")
+  })
+
+  it("updates state through a setter", () => {
+    const { result } = renderHook(() => useTalentDialogs())
+    act(() => result.current.setCreateSessionOpen(true))
+    expect(result.current.createSessionOpen).toBe(true)
+    act(() => result.current.setCreateSessionTitle("Jan 30 casting"))
+    expect(result.current.createSessionTitle).toBe("Jan 30 casting")
+  })
+
+  it("supports functional updaters through a setter", () => {
+    const { result } = renderHook(() => useTalentDialogs())
+    act(() => result.current.setDeleteOpen((prev) => !prev))
+    expect(result.current.deleteOpen).toBe(true)
+  })
+
+  it("keeps setter identities stable across renders", () => {
+    const { result, rerender } = renderHook(() => useTalentDialogs())
+    const first = result.current.setDeleteOpen
+    act(() => result.current.setHeadshotRemoveOpen(true))
+    rerender()
+    expect(result.current.setDeleteOpen).toBe(first)
+  })
+})

--- a/src-vnext/features/library/hooks/useTalentDialogs.ts
+++ b/src-vnext/features/library/hooks/useTalentDialogs.ts
@@ -1,16 +1,7 @@
 import { useMemo, useReducer, type Dispatch, type SetStateAction } from "react"
 import type { CastingSession, TalentImage } from "@/features/library/components/talentUtils"
 
-/**
- * Consolidated state for the six removal / create-session / print dialogs that
- * LibraryTalentPage drives. Phase 0b of the Talent redesign replaces ten loose
- * `useState` cells in the orchestrator with this single reducer-backed hook.
- *
- * Pure refactor: the returned setters are faithful `Dispatch<SetStateAction<T>>`
- * drop-ins for the prior `useState` setters, so consumer behaviour is identical.
- * (`busy`, `sessionExpanded`, and `createOpen` are intentionally NOT here — they
- * are not removal/create-session dialog state and move in later phases.)
- */
+/** Reducer-backed state + setters for the talent removal / create-session / print dialogs. */
 export interface TalentDialogsState {
   readonly headshotRemoveOpen: boolean
   readonly galleryRemoveOpen: boolean
@@ -57,8 +48,7 @@ export function talentDialogsReducer(
   action: TalentDialogsAction,
 ): TalentDialogsState {
   const prev = state[action.field]
-  // The per-field action union guarantees `value` matches the field's type, but
-  // TypeScript can't correlate the two across the union, so we re-narrow here.
+  // Re-narrow: TS can't correlate the union's field+value after the lookup above.
   const next = applySetStateAction(action.value as SetStateAction<typeof prev>, prev)
   if (Object.is(prev, next)) return state
   return { ...state, [action.field]: next }

--- a/src-vnext/features/library/hooks/useTalentDialogs.ts
+++ b/src-vnext/features/library/hooks/useTalentDialogs.ts
@@ -1,0 +1,110 @@
+import { useMemo, useReducer, type Dispatch, type SetStateAction } from "react"
+import type { CastingSession, TalentImage } from "@/features/library/components/talentUtils"
+
+/**
+ * Consolidated state for the six removal / create-session / print dialogs that
+ * LibraryTalentPage drives. Phase 0b of the Talent redesign replaces ten loose
+ * `useState` cells in the orchestrator with this single reducer-backed hook.
+ *
+ * Pure refactor: the returned setters are faithful `Dispatch<SetStateAction<T>>`
+ * drop-ins for the prior `useState` setters, so consumer behaviour is identical.
+ * (`busy`, `sessionExpanded`, and `createOpen` are intentionally NOT here — they
+ * are not removal/create-session dialog state and move in later phases.)
+ */
+export interface TalentDialogsState {
+  readonly headshotRemoveOpen: boolean
+  readonly galleryRemoveOpen: boolean
+  readonly galleryRemoveTarget: TalentImage | null
+  readonly sessionRemoveOpen: boolean
+  readonly sessionRemoveTarget: CastingSession | null
+  readonly deleteOpen: boolean
+  readonly createSessionOpen: boolean
+  readonly createSessionDate: string
+  readonly createSessionTitle: string
+  readonly printSessionId: string | null
+}
+
+/** One action per field; `value` mirrors React's `SetStateAction` (value or updater fn). */
+type TalentDialogsAction = {
+  readonly [K in keyof TalentDialogsState]: {
+    readonly field: K
+    readonly value: SetStateAction<TalentDialogsState[K]>
+  }
+}[keyof TalentDialogsState]
+
+/** Resolves a `SetStateAction` against the previous value, exactly as React does internally. */
+function applySetStateAction<T>(value: SetStateAction<T>, prev: T): T {
+  return typeof value === "function" ? (value as (prevState: T) => T)(prev) : value
+}
+
+export function createTalentDialogsState(): TalentDialogsState {
+  return {
+    headshotRemoveOpen: false,
+    galleryRemoveOpen: false,
+    galleryRemoveTarget: null,
+    sessionRemoveOpen: false,
+    sessionRemoveTarget: null,
+    deleteOpen: false,
+    createSessionOpen: false,
+    createSessionDate: new Date().toISOString().slice(0, 10),
+    createSessionTitle: "",
+    printSessionId: null,
+  }
+}
+
+export function talentDialogsReducer(
+  state: TalentDialogsState,
+  action: TalentDialogsAction,
+): TalentDialogsState {
+  const prev = state[action.field]
+  // The per-field action union guarantees `value` matches the field's type, but
+  // TypeScript can't correlate the two across the union, so we re-narrow here.
+  const next = applySetStateAction(action.value as SetStateAction<typeof prev>, prev)
+  if (Object.is(prev, next)) return state
+  return { ...state, [action.field]: next }
+}
+
+export interface TalentDialogsApi extends TalentDialogsState {
+  readonly setHeadshotRemoveOpen: Dispatch<SetStateAction<boolean>>
+  readonly setGalleryRemoveOpen: Dispatch<SetStateAction<boolean>>
+  readonly setGalleryRemoveTarget: Dispatch<SetStateAction<TalentImage | null>>
+  readonly setSessionRemoveOpen: Dispatch<SetStateAction<boolean>>
+  readonly setSessionRemoveTarget: Dispatch<SetStateAction<CastingSession | null>>
+  readonly setDeleteOpen: Dispatch<SetStateAction<boolean>>
+  readonly setCreateSessionOpen: Dispatch<SetStateAction<boolean>>
+  readonly setCreateSessionDate: Dispatch<SetStateAction<string>>
+  readonly setCreateSessionTitle: Dispatch<SetStateAction<string>>
+  readonly setPrintSessionId: Dispatch<SetStateAction<string | null>>
+}
+
+export function useTalentDialogs(): TalentDialogsApi {
+  const [state, dispatch] = useReducer(talentDialogsReducer, undefined, createTalentDialogsState)
+
+  // Stable setter identities (dispatch is stable) — drop-in for useState setters.
+  const setters = useMemo(
+    () => ({
+      setHeadshotRemoveOpen: (value: SetStateAction<boolean>) =>
+        dispatch({ field: "headshotRemoveOpen", value }),
+      setGalleryRemoveOpen: (value: SetStateAction<boolean>) =>
+        dispatch({ field: "galleryRemoveOpen", value }),
+      setGalleryRemoveTarget: (value: SetStateAction<TalentImage | null>) =>
+        dispatch({ field: "galleryRemoveTarget", value }),
+      setSessionRemoveOpen: (value: SetStateAction<boolean>) =>
+        dispatch({ field: "sessionRemoveOpen", value }),
+      setSessionRemoveTarget: (value: SetStateAction<CastingSession | null>) =>
+        dispatch({ field: "sessionRemoveTarget", value }),
+      setDeleteOpen: (value: SetStateAction<boolean>) => dispatch({ field: "deleteOpen", value }),
+      setCreateSessionOpen: (value: SetStateAction<boolean>) =>
+        dispatch({ field: "createSessionOpen", value }),
+      setCreateSessionDate: (value: SetStateAction<string>) =>
+        dispatch({ field: "createSessionDate", value }),
+      setCreateSessionTitle: (value: SetStateAction<string>) =>
+        dispatch({ field: "createSessionTitle", value }),
+      setPrintSessionId: (value: SetStateAction<string | null>) =>
+        dispatch({ field: "printSessionId", value }),
+    }),
+    [],
+  )
+
+  return { ...state, ...setters }
+}


### PR DESCRIPTION
## Phase 0b — `useTalentDialogs` reducer (pure refactor)

Second slice of the **Library → Talent redesign** (rest-of-app #2), per [`outputs/2026-06-13-talent-redesign-build-spec.md`](.) §5 phase 0b / §4 P1. Decisions all locked (Session 25); Phase 0a (test fix) merged in #456.

### What
Consolidate the **ten loose dialog `useState` cells** in `LibraryTalentPage.tsx` — the six removal / create-session / print dialogs — into a single `useReducer`-backed `useTalentDialogs` hook. The orchestrator drops from 21 state cells toward fewer; dialog transition logic becomes cohesive and unit-testable.

### Why it's a faithful drop-in (no behavior change)
- The hook returns **`Dispatch<SetStateAction<T>>`** setters (a superset of the consumers' `(value)=>void` prop types), so `TalentDialogCluster` and `TalentDetailPanel` are **untouched**.
- `createSessionDate`'s lazy `new Date()` initializer is preserved exactly via `useReducer`'s 3-arg lazy init (runs once at mount).
- The reducer's `Object.is(prev,next) → return state` bail-out replicates `useState`'s same-value re-render skip; spreading preserves sibling fields by reference, so consolidating ten cells into one object never changes any field's bail-out or identity.
- Setter identities are stable (`useMemo([])` over stable `dispatch`).
- `busy`, `sessionExpanded` (Phase 4), and `createOpen` (create-talent dialog, tied to the keyboard shortcut + header) are **deliberately left as `useState`** — out of 0b scope.

### Verification
- Independent 3-lens adversarial review (behavior-equivalence · completeness/scope · code-quality/types) + arbiter → **unanimous "faithful-drop-in", zero must-fix.**
- eslint `--max-warnings=0` clean on all 3 files.
- New `useTalentDialogs.test.ts`: **12/12** (reducer transitions, `Object.is` no-op short-circuit, both `SetStateAction` forms, no-mutation, hook wiring, setter-identity stability).
- Existing behavioral guard `LibraryTalentPage.test.tsx`: **6/6** (drives create-casting / export-print / inline-edit / delete flows through the refactored setters end-to-end).
- `tsc` delta **exactly 0** (160 baseline = 160 after; none touch the changed files). `tsc` is not a CI gate here.

### Dispositioned review nits (non-blocking)
- **`useReducer` is the only one in `src-vnext`** — kept: it is the spec's explicit "reducer" ask and makes the consolidation testable as a pure function.
- **Functional-updater path is unused in production** — kept intentionally: faithful `Dispatch<SetStateAction<T>>` contract, unit-tested, zero cost.
- **Two `as` casts** — the canonical correlated-union / `SetStateAction` workarounds, already code-commented.
- **Test co-located (not in `__tests__/`)** — matches the dominant repo-wide hook-test convention; vitest picks it up.

### Test plan
- [x] `CI=1 npm test -- --run src-vnext/features/library/hooks/useTalentDialogs.test.ts`
- [x] `CI=1 npm test -- --run src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx`
- [x] `eslint --max-warnings=0`
- [ ] CI `ui-checks` (`test` job incl. emulator lanes) — the arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)