### PR TITLE
feat(talent): Height/Waist roster toolbar filters + result count — Talent redesign Phase 1a

### DIFF
--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -42,6 +42,7 @@ import type { TalentSearchFilters } from "@/features/library/lib/talentFilters"
 import { EMPTY_TALENT_FILTERS, filterTalent } from "@/features/library/lib/talentFilters"
 import { TalentSearchFilterSheet, TalentFilterToolbar, TalentToolbarRangeFilters } from "@/features/library/components/TalentSearchFilters"
 import { isFeatureEnabled } from "@/shared/lib/flags"
+import { cn } from "@/shared/lib/utils"
 import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
 import {
   buildDisplayName,
@@ -584,7 +585,7 @@ export default function LibraryTalentPage() {
         />
       ) : (
         <div className="flex flex-col gap-4">
-          <div className={rosterIA ? "flex flex-wrap items-center gap-2" : "flex items-center gap-2"}>
+          <div className={cn("flex items-center gap-2", rosterIA && "flex-wrap")}>
             <SearchBar
               value={query}
               onChange={setQuery}

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -40,7 +40,8 @@ import {
 } from "@/features/library/lib/talentWrites"
 import type { TalentSearchFilters } from "@/features/library/lib/talentFilters"
 import { EMPTY_TALENT_FILTERS, filterTalent } from "@/features/library/lib/talentFilters"
-import { TalentSearchFilterSheet, TalentFilterToolbar } from "@/features/library/components/TalentSearchFilters"
+import { TalentSearchFilterSheet, TalentFilterToolbar, TalentToolbarRangeFilters } from "@/features/library/components/TalentSearchFilters"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useKeyboardShortcuts } from "@/shared/hooks/useKeyboardShortcuts"
 import {
   buildDisplayName,
@@ -75,6 +76,7 @@ export default function LibraryTalentPage() {
   // (firestore.rules:363-365) — a project promotion never unlocks these.
   const canCreate = canManageTalent(role)
   const canEdit = canCreate && !isMobile
+  const rosterIA = isFeatureEnabled("featureTalentRosterIA")
   const { data: talent, loading, error } = useTalentLibrary()
   const { data: projects } = useProjects()
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects])
@@ -582,13 +584,20 @@ export default function LibraryTalentPage() {
         />
       ) : (
         <div className="flex flex-col gap-4">
-          <div className="flex items-center gap-2">
+          <div className={rosterIA ? "flex flex-wrap items-center gap-2" : "flex items-center gap-2"}>
             <SearchBar
               value={query}
               onChange={setQuery}
               placeholder="Search talent…"
               className="max-w-sm flex-1"
             />
+            {rosterIA ? (
+              <TalentToolbarRangeFilters
+                filters={filters}
+                onFiltersChange={handleFiltersChange}
+                talent={talent}
+              />
+            ) : null}
             <TalentFilterToolbar
               filters={filters}
               onFiltersChange={handleFiltersChange}
@@ -616,6 +625,17 @@ export default function LibraryTalentPage() {
             matchCount={castingResults.length}
             results={castingResults}
           />
+
+          {rosterIA ? (
+            <div
+              className="text-xs text-[var(--color-text-muted)]"
+              data-testid="talent-result-count"
+            >
+              {filtered.length === talent.length
+                ? `${talent.length} talent`
+                : `Showing ${filtered.length} of ${talent.length} talent`}
+            </div>
+          ) : null}
 
           {filtered.length === 0 ? (
             <EmptyState

--- a/src-vnext/features/library/components/TalentSearchFilters.tsx
+++ b/src-vnext/features/library/components/TalentSearchFilters.tsx
@@ -423,7 +423,7 @@ export function TalentToolbarRangeFilters({
               <Button
                 variant="outline"
                 size="sm"
-                className={`gap-1.5 ${active ? "border-[var(--color-primary)]" : ""}`}
+                className={active ? "gap-1.5 border-[var(--color-primary)]" : "gap-1.5"}
                 aria-label={`${field.label} range filter`}
               >
                 <span className="font-medium">{field.label}</span>

--- a/src-vnext/features/library/components/TalentSearchFilters.tsx
+++ b/src-vnext/features/library/components/TalentSearchFilters.tsx
@@ -1,10 +1,13 @@
 import { useMemo, useState } from "react"
-import { Filter, X } from "lucide-react"
+import { ChevronDown, Filter, X } from "lucide-react"
 import type { TalentRecord } from "@/shared/types"
 import type { TalentSearchFilters as Filters, MeasurementRange } from "@/features/library/lib/talentFilters"
 import { EMPTY_TALENT_FILTERS, extractUniqueAgencies } from "@/features/library/lib/talentFilters"
-import { getMeasurementOptionsForGender } from "@/features/library/lib/measurementOptions"
+import { getMeasurementOptionsForGender, normalizeGender } from "@/features/library/lib/measurementOptions"
+import { useMeasurementBounds } from "@/features/library/hooks/useMeasurementBounds"
+import { MeasurementRangeSlider } from "@/features/library/components/MeasurementRangeSlider"
 import { Sheet, SheetClose, SheetContent, SheetHeader, SheetTitle } from "@/ui/sheet"
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { Button } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { Checkbox } from "@/ui/checkbox"
@@ -358,5 +361,90 @@ export function TalentFilterToolbar({
         </div>
       ) : null}
     </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Surfaced toolbar range filters (Talent redesign Phase 1a, flag-gated)
+// ---------------------------------------------------------------------------
+
+/** The fixed pair promoted onto the roster toolbar; both exist for all genders. */
+const TOOLBAR_RANGE_FIELDS: readonly { key: string; label: string }[] = [
+  { key: "height", label: "Height" },
+  { key: "waist", label: "Waist" },
+]
+
+/** Immutably set or clear one measurement range; clears the key when fully empty. */
+export function applyMeasurementRange(
+  filters: Filters,
+  key: string,
+  range: MeasurementRange,
+): Filters {
+  if (range.min === null && range.max === null) {
+    const { [key]: _removed, ...rest } = filters.measurementRanges
+    return { ...filters, measurementRanges: rest }
+  }
+  return {
+    ...filters,
+    measurementRanges: { ...filters.measurementRanges, [key]: range },
+  }
+}
+
+/** Compact trigger summary for a range; "any" when unset. */
+export function rangeSummary(range: MeasurementRange | undefined): string {
+  if (!range || (range.min === null && range.max === null)) return "any"
+  const fmt = (v: number | null) =>
+    v === null ? "any" : Number.isInteger(v) ? String(v) : v.toFixed(1)
+  return `${fmt(range.min)}–${fmt(range.max)}`
+}
+
+interface TalentToolbarRangeFiltersProps {
+  readonly filters: Filters
+  readonly onFiltersChange: (next: Filters) => void
+  readonly talent: readonly TalentRecord[]
+}
+
+export function TalentToolbarRangeFilters({
+  filters,
+  onFiltersChange,
+  talent,
+}: TalentToolbarRangeFiltersProps) {
+  const bounds = useMeasurementBounds(talent, normalizeGender(filters.gender))
+
+  return (
+    <>
+      {TOOLBAR_RANGE_FIELDS.map((field) => {
+        const range = filters.measurementRanges[field.key]
+        const active = !!range && (range.min !== null || range.max !== null)
+        const b = bounds[field.key] ?? { min: 0, max: 100, step: 0.5 }
+        return (
+          <Popover key={field.key}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                size="sm"
+                className={`gap-1.5 ${active ? "border-[var(--color-primary)]" : ""}`}
+                aria-label={`${field.label} range filter`}
+              >
+                <span className="font-medium">{field.label}</span>
+                <span className="text-[var(--color-text-muted)]">{rangeSummary(range)}</span>
+                <ChevronDown className="h-3.5 w-3.5 text-[var(--color-text-subtle)]" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent align="start" className="w-64">
+              <MeasurementRangeSlider
+                label={field.label}
+                fieldKey={field.key}
+                boundsMin={b.min}
+                boundsMax={b.max}
+                step={b.step}
+                value={range ?? { min: null, max: null }}
+                onChange={(next) => onFiltersChange(applyMeasurementRange(filters, field.key, next))}
+              />
+            </PopoverContent>
+          </Popover>
+        )
+      })}
+    </>
   )
 }

--- a/src-vnext/features/library/components/TalentSearchFilters.tsx
+++ b/src-vnext/features/library/components/TalentSearchFilters.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/ui/input"
 import { Checkbox } from "@/ui/checkbox"
 import { Separator } from "@/ui/separator"
 import { useIsMobile } from "@/shared/hooks/useMediaQuery"
+import { cn } from "@/shared/lib/utils"
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -374,6 +375,12 @@ const TOOLBAR_RANGE_FIELDS: readonly { key: string; label: string }[] = [
   { key: "waist", label: "Waist" },
 ]
 
+/** Domain-sensible fallback bounds (inches) — defensive; useMeasurementBounds already returns defaults for empty data. */
+const FALLBACK_BOUNDS: Readonly<Record<string, { min: number; max: number; step: number }>> = {
+  height: { min: 58, max: 82, step: 1 },
+  waist: { min: 22, max: 44, step: 0.5 },
+}
+
 /** Immutably set or clear one measurement range; clears the key when fully empty. */
 export function applyMeasurementRange(
   filters: Filters,
@@ -416,14 +423,14 @@ export function TalentToolbarRangeFilters({
       {TOOLBAR_RANGE_FIELDS.map((field) => {
         const range = filters.measurementRanges[field.key]
         const active = !!range && (range.min !== null || range.max !== null)
-        const b = bounds[field.key] ?? { min: 0, max: 100, step: 0.5 }
+        const b = bounds[field.key] ?? FALLBACK_BOUNDS[field.key] ?? { min: 0, max: 100, step: 0.5 }
         return (
           <Popover key={field.key}>
             <PopoverTrigger asChild>
               <Button
                 variant="outline"
                 size="sm"
-                className={active ? "gap-1.5 border-[var(--color-primary)]" : "gap-1.5"}
+                className={cn("gap-1.5", active && "border-[var(--color-primary)]")}
                 aria-label={`${field.label} range filter`}
               >
                 <span className="font-medium">{field.label}</span>

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.rosterIA.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.rosterIA.test.tsx
@@ -1,0 +1,118 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", role: "producer", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock("@/features/library/hooks/useTalentLibrary", () => ({
+  useTalentLibrary: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/resolveStoragePath", () => ({
+  isUrl: (value: string) => value.startsWith("https://") || value.startsWith("http://"),
+  resolveStoragePath: async (path: string) => path,
+  getCachedUrl: (path: string) =>
+    path.startsWith("https://") || path.startsWith("http://") ? path : undefined,
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/library/lib/talentWrites", () => ({
+  createTalent: vi.fn(),
+  updateTalent: vi.fn(),
+  setTalentHeadshot: vi.fn(),
+  removeTalentHeadshot: vi.fn(),
+  uploadTalentPortfolioImages: vi.fn(),
+  uploadTalentCastingImages: vi.fn(),
+  deleteTalentImagePaths: vi.fn(),
+}))
+
+// Flag ON for this file — exercises the Phase 1a roster IA surface.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) => flag === "featureTalentRosterIA",
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: true,
+    featureShootSurface: false,
+    featureReviewSurface: false,
+    featureTalentRosterIA: true,
+  }),
+}))
+
+import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
+import LibraryTalentPage from "@/features/library/components/LibraryTalentPage"
+
+function talent(id: string, name: string) {
+  return {
+    id,
+    name,
+    agency: "IMG",
+    email: null,
+    phone: null,
+    url: null,
+    gender: null,
+    notes: "",
+    measurements: null,
+    headshotPath: null,
+    headshotUrl: null,
+    galleryImages: [],
+    castingSessions: [],
+  }
+}
+
+function seed(rows: ReturnType<typeof talent>[]) {
+  ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: rows,
+    loading: false,
+    error: null,
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LibraryTalentPage />
+    </MemoryRouter>,
+  )
+}
+
+describe("LibraryTalentPage — roster IA (flag on)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("surfaces the Height and Waist toolbar controls", () => {
+    seed([talent("t1", "Alice Adams"), talent("t2", "Bob Brown")])
+    renderPage()
+    expect(screen.getByRole("button", { name: "Height range filter" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Waist range filter" })).toBeInTheDocument()
+  })
+
+  it("shows the total count when nothing is filtered", () => {
+    seed([talent("t1", "Alice Adams"), talent("t2", "Bob Brown")])
+    renderPage()
+    expect(screen.getByTestId("talent-result-count")).toHaveTextContent("2 talent")
+  })
+
+  it("updates the result count as the search narrows results", () => {
+    seed([talent("t1", "Alice Adams"), talent("t2", "Bob Brown")])
+    renderPage()
+    fireEvent.change(screen.getByPlaceholderText(/Search talent/i), {
+      target: { value: "Alice" },
+    })
+    expect(screen.getByTestId("talent-result-count")).toHaveTextContent("Showing 1 of 2 talent")
+  })
+})

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
@@ -75,6 +75,34 @@ describe("LibraryTalentPage", { timeout: 60_000 }, () => {
     expect(screen.getByRole("button", { name: "Create talent" })).toBeInTheDocument()
   })
 
+  it("does not surface the roster IA (Height/Waist controls, result count) when the flag is off", () => {
+    ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [
+        {
+          id: "t1",
+          name: "Alex Rivera",
+          agency: "IMG",
+          email: null,
+          phone: null,
+          url: null,
+          gender: null,
+          notes: "",
+          measurements: null,
+          headshotPath: null,
+          headshotUrl: null,
+          galleryImages: [],
+          castingSessions: [],
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderPage()
+    expect(screen.queryByTestId("talent-result-count")).toBeNull()
+    expect(screen.queryByRole("button", { name: /range filter/i })).toBeNull()
+  })
+
   it("creates a talent from the dialog", async () => {
     ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [],

--- a/src-vnext/features/library/components/__tests__/TalentSearchFilters.test.tsx
+++ b/src-vnext/features/library/components/__tests__/TalentSearchFilters.test.tsx
@@ -1,7 +1,13 @@
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
-import { TalentSearchFilterSheet, TalentFilterToolbar } from "@/features/library/components/TalentSearchFilters"
+import {
+  TalentSearchFilterSheet,
+  TalentFilterToolbar,
+  TalentToolbarRangeFilters,
+  applyMeasurementRange,
+  rangeSummary,
+} from "@/features/library/components/TalentSearchFilters"
 import { EMPTY_TALENT_FILTERS } from "@/features/library/lib/talentFilters"
 import type { TalentSearchFilters } from "@/features/library/lib/talentFilters"
 import type { TalentRecord } from "@/shared/types"
@@ -212,5 +218,80 @@ describe("TalentFilterToolbar", () => {
     expect(onFiltersChange).toHaveBeenCalledWith(
       expect.objectContaining({ gender: null }),
     )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Phase 1a — surfaced toolbar range filters
+// ---------------------------------------------------------------------------
+
+describe("applyMeasurementRange", () => {
+  it("sets a range under the given key", () => {
+    const next = applyMeasurementRange(EMPTY_TALENT_FILTERS, "height", { min: 64, max: 70 })
+    expect(next.measurementRanges).toEqual({ height: { min: 64, max: 70 } })
+  })
+
+  it("clears the key when the range is fully empty", () => {
+    const seeded = applyMeasurementRange(EMPTY_TALENT_FILTERS, "waist", { min: 26, max: null })
+    const cleared = applyMeasurementRange(seeded, "waist", { min: null, max: null })
+    expect(cleared.measurementRanges).toEqual({})
+  })
+
+  it("leaves other ranges untouched", () => {
+    const a = applyMeasurementRange(EMPTY_TALENT_FILTERS, "height", { min: 64, max: null })
+    const b = applyMeasurementRange(a, "waist", { min: null, max: 30 })
+    expect(b.measurementRanges).toEqual({
+      height: { min: 64, max: null },
+      waist: { min: null, max: 30 },
+    })
+  })
+
+  it("does not mutate the input filters", () => {
+    const before = JSON.stringify(EMPTY_TALENT_FILTERS)
+    applyMeasurementRange(EMPTY_TALENT_FILTERS, "height", { min: 64, max: 70 })
+    expect(JSON.stringify(EMPTY_TALENT_FILTERS)).toBe(before)
+  })
+})
+
+describe("rangeSummary", () => {
+  it("returns 'any' for undefined or empty ranges", () => {
+    expect(rangeSummary(undefined)).toBe("any")
+    expect(rangeSummary({ min: null, max: null })).toBe("any")
+  })
+
+  it("formats a full range with an en-dash", () => {
+    expect(rangeSummary({ min: 64, max: 70 })).toBe("64–70")
+  })
+
+  it("shows 'any' for an open bound", () => {
+    expect(rangeSummary({ min: null, max: 70 })).toBe("any–70")
+    expect(rangeSummary({ min: 64, max: null })).toBe("64–any")
+  })
+
+  it("renders one decimal place for fractional values", () => {
+    expect(rangeSummary({ min: 25.5, max: null })).toBe("25.5–any")
+  })
+})
+
+describe("TalentToolbarRangeFilters", () => {
+  it("renders Height and Waist triggers showing 'any' when unset", () => {
+    render(
+      <TalentToolbarRangeFilters
+        filters={EMPTY_TALENT_FILTERS}
+        onFiltersChange={() => {}}
+        talent={TALENT}
+      />,
+    )
+    expect(screen.getByRole("button", { name: "Height range filter" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Waist range filter" })).toBeInTheDocument()
+    expect(screen.getAllByText("any").length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("reflects an active range in the trigger summary", () => {
+    const active = applyMeasurementRange(EMPTY_TALENT_FILTERS, "height", { min: 64, max: 70 })
+    render(
+      <TalentToolbarRangeFilters filters={active} onFiltersChange={() => {}} talent={TALENT} />,
+    )
+    expect(screen.getByText("64–70")).toBeInTheDocument()
   })
 })

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -50,4 +50,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureShootSurface")).toBe(false)
     }
   })
+
+  it("defaults featureTalentRosterIA to false (Talent redesign Phase 1a is dark on main)", () => {
+    expect(getFeatureFlags().featureTalentRosterIA).toBe(false)
+    expect(isFeatureEnabled("featureTalentRosterIA")).toBe(false)
+  })
+
+  it("VITE_TALENT_ROSTER_IA='1' or 'true' enables featureTalentRosterIA", () => {
+    vi.stubEnv("VITE_TALENT_ROSTER_IA", "1")
+    expect(isFeatureEnabled("featureTalentRosterIA")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_ROSTER_IA", "true")
+    expect(isFeatureEnabled("featureTalentRosterIA")).toBe(true)
+  })
+
+  it("any other VITE_TALENT_ROSTER_IA value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_TALENT_ROSTER_IA", value)
+      expect(isFeatureEnabled("featureTalentRosterIA")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -51,6 +51,14 @@ export interface FeatureFlags {
    * it. No URL/localStorage override layer.
    */
   readonly featureReviewSurface: boolean
+  /**
+   * Talent redesign Phase 1a — roster IA. Gates the surfaced Height/Waist
+   * toolbar range controls + the result count on LibraryTalentPage. Default
+   * OFF; the flag-off path is byte-identical to trunk. Enabled via
+   * `VITE_TALENT_ROSTER_IA=1` (or `true`) at build/dev time
+   * (featureReviewSurface env-parse precedent). No URL/localStorage layer.
+   */
+  readonly featureTalentRosterIA: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -58,6 +66,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureSurfaceResolver: true,
   featureShootSurface: false,
   featureReviewSurface: false,
+  featureTalentRosterIA: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -86,6 +95,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureReviewSurface:
       DEFAULT_FLAGS.featureReviewSurface ||
       parseEnvFlag(import.meta.env.VITE_REVIEW_SURFACE),
+    featureTalentRosterIA:
+      DEFAULT_FLAGS.featureTalentRosterIA ||
+      parseEnvFlag(import.meta.env.VITE_TALENT_ROSTER_IA),
   }
 }
 


### PR DESCRIPTION
## Phase 1a — surfaced roster filters (Height + Waist) + result count

Third slice of the **Library → Talent redesign** (rest-of-app #2). Behind `featureTalentRosterIA` (default **OFF** in prod). Follows Phase 0a (#456) and 0b (#457).

### What
- **Promote Height + Waist onto the roster toolbar** as compact `Popover` controls (reusing the existing `MeasurementRangeSlider` + `useMeasurementBounds`). Trigger shows the current range or "any".
- **First-class result count** ("N talent" / "Showing X of Y talent"), `data-testid="talent-result-count"`.
- Existing **active-filter chips** retained.
- **Per locked Decision #2:** ONLY Height + Waist are promoted; gender, agency, casting history, and other measurements stay in **"More filters"** (the unchanged `TalentSearchFilterSheet`). No gender control was added to the toolbar.

### Why it's safe
- **Flag-off = byte-identical to trunk:** the toolbar row className is unchanged when off, and both new branches render `{null}`. Now guarded by **explicit negative assertions** in the flag-off test.
- **Filter parity:** the toolbar controls write the same `filters.measurementRanges["height"]/["waist"]` the sheet writes; `filterTalent` applies them identically — filtering behavior matches the existing path. `height`/`waist` are gender-uniform keys.
- New imports/components do no work when the flag is off (the bounds hook only runs inside the conditionally-mounted control); `isFeatureEnabled` is read once and never in a hook dep.

### Verification
- Independent 3-lens adversarial review (flag-isolation · filter-parity · UI/scope/a11y) + arbiter → **unanimous SHIP, zero must-fix.**
- eslint `--max-warnings=0` clean; **tsc delta exactly 0** (160 = 160).
- **Full suite green:** 274 files / 3699 tests pass (1 file / 79 tests skipped — pre-existing QUARANTINE.md items, none touched).
- New/changed tests: `TalentSearchFilters.test.tsx` (+`applyMeasurementRange`/`rangeSummary`/`TalentToolbarRangeFilters`), `LibraryTalentPage.rosterIA.test.tsx` (flag-on: triggers + count + search-narrows-count), `flags.test.ts` (+default/env), `LibraryTalentPage.test.tsx` (flag-off guard, now with explicit absence assertions). Casting matcher (shared slider) untouched, 17/17.

### Notes (non-blocking, from review)
- Toolbar Height/Waist are **bounded convenience sliders** (handle at an extreme = "any"), a strict subset of the sheet's unbounded number inputs — same `{min,max}` shape, no parity bug.
- Display is **raw inches** (consistent with the existing slider/sheet); feet-inches formatting is a possible future polish (would apply app-wide).
- Picking/clearing gender in the sheet still clears measurement ranges (pre-existing rule; height/waist inherit it) — unchanged from trunk.

### Visual sign-off
Flag-off ships zero UI change. The flag-on **`:5174` eyeball / flag-flip is deferred to Ted** (the app is Firebase-authed; I can't sign in to drive a solo eyeball). Structure + logic are covered by the tests above; recommend eyeballing the flag-on path before flipping `VITE_TALENT_ROSTER_IA` on in prod (same pattern as 5f).

### Test plan
- [x] `CI=1 npm test -- --run` (full suite, redirected) — green
- [x] eslint `--max-warnings=0`
- [ ] CI `ui-checks` (`test` job incl. emulator lanes) — the arbiter
- [ ] Flag-on `:5174` eyeball before prod flag-flip (Ted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)