### PR TITLE
perf(talent): memoize TalentDetailPanel + stabilize handler/sensor props — Talent redesign Phase 1b-i

### DIFF
--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -68,6 +68,11 @@ const TALENT_VIEW_OPTIONS = [
   { key: "table", icon: Table2, label: "Table view" },
 ] as const
 
+// Module-level: stable identity so @dnd-kit's useSensor memo holds and the `sensors`
+// array stays referentially stable, letting React.memo(TalentDetailPanel) skip re-renders.
+const POINTER_SENSOR_OPTIONS = { activationConstraint: { distance: 8 } }
+const KEYBOARD_SENSOR_OPTIONS = { coordinateGetter: sortableKeyboardCoordinates }
+
 export default function LibraryTalentPage() {
   const { clientId, role, user } = useAuth()
   const isMobile = useIsMobile()
@@ -121,8 +126,8 @@ export default function LibraryTalentPage() {
   } = useTalentDialogs()
 
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+    useSensor(PointerSensor, POINTER_SENSOR_OPTIONS),
+    useSensor(KeyboardSensor, KEYBOARD_SENSOR_OPTIONS),
   )
 
   const filtersWithQuery = useMemo(
@@ -226,7 +231,7 @@ export default function LibraryTalentPage() {
     return () => window.removeEventListener("keydown", handler)
   }, [selectedId, navigatePrev, navigateNext])
 
-  const updateGallery = async (
+  const updateGallery = useCallback(async (
     next: TalentImage[],
     removedPaths: readonly (string | null | undefined)[] = [],
     successLabel?: string,
@@ -253,9 +258,9 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, selected, user])
 
-  const updateCastingSessions = async (
+  const updateCastingSessions = useCallback(async (
     next: CastingSession[],
     removedPaths: readonly (string | null | undefined)[] = [],
     successLabel?: string,
@@ -284,9 +289,9 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, selected, user])
 
-  const savePatch = async (id: string, patch: Record<string, unknown>) => {
+  const savePatch = useCallback(async (id: string, patch: Record<string, unknown>) => {
     if (!clientId) return
     setBusy(true)
     try {
@@ -303,14 +308,14 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, user])
 
   useEffect(() => {
     if (!printSessionId) return
     if (!selected || !printSession) setPrintSessionId(null)
   }, [printSession, printSessionId, selected])
 
-  const onHeadshotFile = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onHeadshotFile = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!clientId || !selected) return
     const file = event.target.files?.[0] ?? null
     event.target.value = ""
@@ -333,9 +338,9 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, selected, user, selectedHeadshotPath])
 
-  const onPortfolioFiles = async (event: React.ChangeEvent<HTMLInputElement>) => {
+  const onPortfolioFiles = useCallback(async (event: React.ChangeEvent<HTMLInputElement>) => {
     if (!clientId || !selected) return
     const files = Array.from(event.target.files ?? [])
     event.target.value = ""
@@ -371,9 +376,9 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, selected, user, portfolioImages])
 
-  const onCastingFiles = async (sessionId: string, event: React.ChangeEvent<HTMLInputElement>) => {
+  const onCastingFiles = useCallback(async (sessionId: string, event: React.ChangeEvent<HTMLInputElement>) => {
     if (!clientId || !selected) return
     const files = Array.from(event.target.files ?? [])
     event.target.value = ""
@@ -418,7 +423,7 @@ export default function LibraryTalentPage() {
     } finally {
       setBusy(false)
     }
-  }
+  }, [clientId, selected, user, castingSessions])
 
   const confirmRemoveHeadshot = async () => {
     if (!clientId || !selected) return

--- a/src-vnext/features/library/components/TalentDetailPanel.tsx
+++ b/src-vnext/features/library/components/TalentDetailPanel.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import type { ChangeEvent } from "react"
+import { memo, type ChangeEvent } from "react"
 import type { useSensors } from "@dnd-kit/core"
 import { Button } from "@/ui/button"
 import { TalentShotHistory } from "@/features/library/components/TalentShotHistory"
@@ -55,7 +55,7 @@ interface TalentDetailPanelProps {
   readonly setPrintSessionId: (id: string | null) => void
 }
 
-export function TalentDetailPanel({
+export const TalentDetailPanel = memo(function TalentDetailPanel({
   selected,
   canEdit,
   isMobile,
@@ -256,4 +256,4 @@ export function TalentDetailPanel({
       ) : null}
     </div>
   )
-}
+})


### PR DESCRIPTION
## Phase 1b-i — roster perf: memoize the detail panel (no flag)

Part of the **Library → Talent redesign**. The first, behavior-preserving slice of Phase 1b's perf work (debounce + virtualization land in a separate flagged PR). Follows 0a/0b/1a.

### What
- **`React.memo(TalentDetailPanel)`** — the heavy 32-prop detail tree (hero image, measurements, notes, portfolio grid, casting sessions).
- **`useCallback` on the 6 async handlers** it receives (`updateGallery`, `updateCastingSessions`, `savePatch`, `onHeadshotFile`, `onPortfolioFiles`, `onCastingFiles`) — required for the memo to hold, since unstable handlers would defeat it.
- **Hoisted the `@dnd-kit` sensor option objects to module-level constants** — inline literals rebuilt the `sensors` array every render, which would have defeated the memo entirely (the detail panel would re-render on every keystroke anyway). **Caught by adversarial review.**

Net effect: typing in search (or other unrelated orchestrator updates) while a detail sheet is open no longer re-renders the detail subtree.

### Why it's safe (behavior-preserving)
- Handler bodies are **byte-identical** — only the `useCallback` wrapper + dep array were added.
- **`react-hooks/exhaustive-deps` is OFF in this repo**, so deps were **hand-audited**; an independent stale-closure reviewer re-verified all 6 dep arrays are complete and minimal (each handler's reactive reads — clientId/selected/user/selectedHeadshotPath/portfolioImages/castingSessions — are covered; `savePatch` correctly omits `selected` since it takes an `id` param).
- `user`/`clientId` from `useAuth` are stable between auth events; the dialog setters are `useMemo([])`-stable; data props are memoized — so `memo` actually skips during search-typing.
- `memo` changes only re-render timing, never observable behavior. Named export preserved.

### Verification
- 3-lens adversarial review (stale-closure · memo-correctness · behavior-preservation). **Stale-closure + behavior lenses: SHIP, zero bugs.** Memo-correctness lens caught the **`sensors`-defeats-memo** issue → **fixed in this PR** (module-level option constants).
- **Full suite green: 274 files / 3700 tests** (1 file / 79 tests skipped — pre-existing QUARANTINE.md). eslint `--max-warnings=0` clean. **tsc delta exactly 0** (160 = 160).
- No new tests: this is a behavior-preserving perf change; the existing component tests (which exercise `savePatch` inline-edit, `updateCastingSessions` create/edit, and the print path) are the stale-closure guard.

### Test plan
- [x] `CI=1 npm test -- --run` (full suite, redirected) — green
- [x] eslint `--max-warnings=0`; tsc delta 0
- [ ] CI `ui-checks` (`test` job incl. emulator lanes) — the arbiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)