### PR TITLE
feat(talent): detail IA re-group — contact meta-line + Fit-signals/Creative-assets zones — Talent redesign Phase 2

### DIFF
--- a/src-vnext/features/library/components/TalentContactMetaLine.tsx
+++ b/src-vnext/features/library/components/TalentContactMetaLine.tsx
@@ -1,0 +1,84 @@
+import type { ReactNode } from "react"
+import { InlineEdit } from "@/shared/components/InlineEdit"
+import { ReferenceUrlField } from "@/features/library/components/TalentContactSection"
+import type { TalentRecord } from "@/shared/types"
+
+interface TalentContactMetaLineProps {
+  readonly selected: TalentRecord
+  readonly canEdit: boolean
+  readonly busy: boolean
+  readonly savePatch: (id: string, patch: Record<string, unknown>) => Promise<void>
+}
+
+// One inline editorial meta-line segment: an uppercase micro-label + its value.
+function Segment({ label, children }: { readonly label: string; readonly children: ReactNode }) {
+  return (
+    <span className="inline-flex min-w-0 items-baseline gap-1.5">
+      <span className="label-meta shrink-0">{label}</span>
+      <span className="min-w-0">{children}</span>
+    </span>
+  )
+}
+
+function MetaDot() {
+  return (
+    <span aria-hidden="true" className="text-[var(--color-text-subtle)]">
+      &middot;
+    </span>
+  )
+}
+
+/**
+ * Phase-2 detail IA — the contact block demoted from a bordered card to a single
+ * inline editorial meta-line below the hero (locked Decision #3). Email / Phone /
+ * Web stay individually editable (same InlineEdit + ReferenceUrlField wiring as
+ * the flag-off TalentContactSection), just laid out as one wrapping line.
+ */
+export function TalentContactMetaLine({
+  selected,
+  canEdit,
+  busy,
+  savePatch,
+}: TalentContactMetaLineProps) {
+  return (
+    <div
+      data-testid="talent-contact-metaline"
+      className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 text-sm"
+    >
+      <Segment label="Email">
+        <InlineEdit
+          value={selected.email ?? ""}
+          disabled={!canEdit || busy}
+          placeholder="—"
+          onSave={(next) => void savePatch(selected.id, { email: next || null })}
+          className="text-sm"
+          showEditIcon={canEdit && !busy}
+        />
+      </Segment>
+
+      <MetaDot />
+
+      <Segment label="Phone">
+        <InlineEdit
+          value={selected.phone ?? ""}
+          disabled={!canEdit || busy}
+          placeholder="—"
+          onSave={(next) => void savePatch(selected.id, { phone: next || null })}
+          className="text-sm"
+          showEditIcon={canEdit && !busy}
+        />
+      </Segment>
+
+      <MetaDot />
+
+      <Segment label="Web">
+        <ReferenceUrlField
+          url={selected.url}
+          canEdit={canEdit}
+          busy={busy}
+          onSave={(next) => void savePatch(selected.id, { url: next })}
+        />
+      </Segment>
+    </div>
+  )
+}

--- a/src-vnext/features/library/components/TalentContactMetaLine.tsx
+++ b/src-vnext/features/library/components/TalentContactMetaLine.tsx
@@ -28,12 +28,7 @@ function MetaDot() {
   )
 }
 
-/**
- * Phase-2 detail IA — the contact block demoted from a bordered card to a single
- * inline editorial meta-line below the hero (locked Decision #3). Email / Phone /
- * Web stay individually editable (same InlineEdit + ReferenceUrlField wiring as
- * the flag-off TalentContactSection), just laid out as one wrapping line.
- */
+// Inline editable contact meta-line — email · phone · web.
 export function TalentContactMetaLine({
   selected,
   canEdit,

--- a/src-vnext/features/library/components/TalentContactSection.tsx
+++ b/src-vnext/features/library/components/TalentContactSection.tsx
@@ -20,8 +20,6 @@ interface ReferenceUrlFieldProps {
 }
 
 // Reference URL row: clickable hostname link as the display; full URL only while editing.
-// Exported so the Phase-2 detail-IA contact meta-line (TalentContactMetaLine) can
-// reuse the exact same edit/display affordance instead of duplicating it.
 export function ReferenceUrlField({ url, canEdit, busy, onSave }: ReferenceUrlFieldProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(url ?? "")

--- a/src-vnext/features/library/components/TalentContactSection.tsx
+++ b/src-vnext/features/library/components/TalentContactSection.tsx
@@ -20,7 +20,9 @@ interface ReferenceUrlFieldProps {
 }
 
 // Reference URL row: clickable hostname link as the display; full URL only while editing.
-function ReferenceUrlField({ url, canEdit, busy, onSave }: ReferenceUrlFieldProps) {
+// Exported so the Phase-2 detail-IA contact meta-line (TalentContactMetaLine) can
+// reuse the exact same edit/display affordance instead of duplicating it.
+export function ReferenceUrlField({ url, canEdit, busy, onSave }: ReferenceUrlFieldProps) {
   const [editing, setEditing] = useState(false)
   const [draft, setDraft] = useState(url ?? "")
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src-vnext/features/library/components/TalentDetailPanel.tsx
+++ b/src-vnext/features/library/components/TalentDetailPanel.tsx
@@ -5,10 +5,12 @@ import { Button } from "@/ui/button"
 import { TalentShotHistory } from "@/features/library/components/TalentShotHistory"
 import { TalentHeroZone } from "@/features/library/components/TalentHeroZone"
 import { TalentContactSection } from "@/features/library/components/TalentContactSection"
+import { TalentContactMetaLine } from "@/features/library/components/TalentContactMetaLine"
 import { TalentMeasurementsSection } from "@/features/library/components/TalentMeasurementsSection"
 import { TalentNotesSection } from "@/features/library/components/TalentNotesSection"
 import { TalentPortfolioSection } from "@/features/library/components/TalentPortfolioSection"
 import { CastingSessionList } from "@/features/library/components/CastingSessionList"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import type { TalentRecord } from "@/shared/types"
 import type { TalentImage, CastingSession } from "@/features/library/components/talentUtils"
 
@@ -89,6 +91,8 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
   setCreateSessionOpen,
   setPrintSessionId,
 }: TalentDetailPanelProps) {
+  // Phase-2 detail IA (flag OFF in prod; flag-off path is byte-identical to trunk).
+  const detailIA = isFeatureEnabled("featureTalentDetailIA")
   return (
     <div className="flex flex-col">
       {/* Hero zone: headshot + name + agency + gender */}
@@ -158,101 +162,206 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
 
       {/* Profile tab */}
       {activeTab === "detail" ? (
-        <div className="flex flex-col gap-5 p-5">
-          <TalentContactSection
-            selected={selected}
-            canEdit={canEdit}
-            busy={busy}
-            savePatch={savePatch}
-          />
+        detailIA ? (
+          <div className="flex flex-col gap-6 p-5">
+            {/* Contact — inline editorial meta-line, demoted from a card (Decision #3) */}
+            <TalentContactMetaLine
+              selected={selected}
+              canEdit={canEdit}
+              busy={busy}
+              savePatch={savePatch}
+            />
 
-          <TalentMeasurementsSection
-            selected={selected}
-            canEdit={canEdit}
-            busy={busy}
-            savePatch={savePatch}
-          />
+            {/* Fit signals — the "does she fit?" zone (Decision #4) */}
+            <section className="flex flex-col gap-4">
+              <div className="heading-section">Fit signals</div>
+              <TalentMeasurementsSection
+                selected={selected}
+                canEdit={canEdit}
+                busy={busy}
+                savePatch={savePatch}
+              />
+              <TalentNotesSection
+                selected={selected}
+                canEdit={canEdit}
+                busy={busy}
+                savePatch={savePatch}
+              />
+            </section>
 
-          <TalentNotesSection
-            selected={selected}
-            canEdit={canEdit}
-            busy={busy}
-            savePatch={savePatch}
-          />
+            {/* Creative assets — image-heavy group */}
+            <section className="flex flex-col gap-4">
+              <div className="heading-section">Creative assets</div>
+              <TalentPortfolioSection
+                canEdit={canEdit}
+                busy={busy}
+                portfolioImages={portfolioImages}
+                sensors={sensors}
+                updateGallery={updateGallery}
+                onPortfolioFiles={onPortfolioFiles}
+                setGalleryRemoveOpen={setGalleryRemoveOpen}
+                setGalleryRemoveTarget={setGalleryRemoveTarget}
+              />
+              <CastingSessionList
+                castingSessions={castingSessions}
+                canEdit={canEdit}
+                isMobile={isMobile}
+                busy={busy}
+                projects={projects}
+                sensors={sensors}
+                sessionExpanded={sessionExpanded}
+                setSessionExpanded={setSessionExpanded}
+                updateCastingSessions={updateCastingSessions}
+                onCastingFiles={onCastingFiles}
+                setGalleryRemoveOpen={setGalleryRemoveOpen}
+                setGalleryRemoveTarget={setGalleryRemoveTarget}
+                setSessionRemoveOpen={setSessionRemoveOpen}
+                setSessionRemoveTarget={setSessionRemoveTarget}
+                setCreateSessionOpen={setCreateSessionOpen}
+                setPrintSessionId={setPrintSessionId}
+              />
+            </section>
 
-          {/* Projects */}
-          <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
-            <div className="heading-subsection mb-3">Projects</div>
-            {(selected.projectIds ?? []).length === 0 ? (
-              <div className="text-sm text-[var(--color-text-muted)]">
-                Not linked to any projects.
-              </div>
-            ) : (
-              <div className="flex flex-wrap gap-2">
-                {(selected.projectIds ?? []).map((pid) => {
-                  const projectName = projectLookup.get(pid) ?? pid
-                  return (
-                    <Link
-                      key={pid}
-                      to={`/projects/${pid}/assets`}
-                      className="inline-block max-w-[220px] truncate rounded-full border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-3 py-1 text-xs text-[var(--color-text)] transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-surface)]"
-                      title={projectName}
+            {/* Meta / actions — read-only project tags (demoted) + isolated destructive action */}
+            {(selected.projectIds ?? []).length > 0 || canEdit ? (
+              <div className="flex flex-col gap-4 border-t border-[var(--color-border)] pt-4">
+                {(selected.projectIds ?? []).length > 0 ? (
+                  <div
+                    data-testid="talent-projects-tags"
+                    className="flex flex-wrap items-center gap-2"
+                  >
+                    <span className="label-meta shrink-0">Projects</span>
+                    {(selected.projectIds ?? []).map((pid) => {
+                      const projectName = projectLookup.get(pid) ?? pid
+                      return (
+                        <Link
+                          key={pid}
+                          to={`/projects/${pid}/assets`}
+                          className="inline-block max-w-[220px] truncate rounded-full border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-3 py-1 text-xs text-[var(--color-text)] transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-surface)]"
+                          title={projectName}
+                        >
+                          {projectName}
+                        </Link>
+                      )
+                    })}
+                  </div>
+                ) : null}
+
+                {canEdit ? (
+                  <div>
+                    <Button
+                      variant="ghost"
+                      className="text-[var(--color-error)] hover:text-[var(--color-error)]"
+                      disabled={busy}
+                      onClick={() => setDeleteOpen(true)}
                     >
-                      {projectName}
-                    </Link>
-                  )
-                })}
+                      Delete talent
+                    </Button>
+                    <p className="caption mt-1 text-[var(--color-text-subtle)]">
+                      Permanently removes this profile.
+                    </p>
+                  </div>
+                ) : null}
               </div>
-            )}
+            ) : null}
           </div>
+        ) : (
+          <div className="flex flex-col gap-5 p-5">
+            <TalentContactSection
+              selected={selected}
+              canEdit={canEdit}
+              busy={busy}
+              savePatch={savePatch}
+            />
 
-          <TalentPortfolioSection
-            canEdit={canEdit}
-            busy={busy}
-            portfolioImages={portfolioImages}
-            sensors={sensors}
-            updateGallery={updateGallery}
-            onPortfolioFiles={onPortfolioFiles}
-            setGalleryRemoveOpen={setGalleryRemoveOpen}
-            setGalleryRemoveTarget={setGalleryRemoveTarget}
-          />
+            <TalentMeasurementsSection
+              selected={selected}
+              canEdit={canEdit}
+              busy={busy}
+              savePatch={savePatch}
+            />
 
-          <CastingSessionList
-            castingSessions={castingSessions}
-            canEdit={canEdit}
-            isMobile={isMobile}
-            busy={busy}
-            projects={projects}
-            sensors={sensors}
-            sessionExpanded={sessionExpanded}
-            setSessionExpanded={setSessionExpanded}
-            updateCastingSessions={updateCastingSessions}
-            onCastingFiles={onCastingFiles}
-            setGalleryRemoveOpen={setGalleryRemoveOpen}
-            setGalleryRemoveTarget={setGalleryRemoveTarget}
-            setSessionRemoveOpen={setSessionRemoveOpen}
-            setSessionRemoveTarget={setSessionRemoveTarget}
-            setCreateSessionOpen={setCreateSessionOpen}
-            setPrintSessionId={setPrintSessionId}
-          />
+            <TalentNotesSection
+              selected={selected}
+              canEdit={canEdit}
+              busy={busy}
+              savePatch={savePatch}
+            />
 
-          {/* Delete zone */}
-          {canEdit ? (
-            <div className="mt-2 border-t border-[var(--color-border)] pt-4">
-              <Button
-                variant="ghost"
-                className="text-[var(--color-error)] hover:text-[var(--color-error)]"
-                disabled={busy}
-                onClick={() => setDeleteOpen(true)}
-              >
-                Delete talent
-              </Button>
-              <p className="caption mt-1 text-[var(--color-text-subtle)]">
-                Permanently removes this profile.
-              </p>
+            {/* Projects */}
+            <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
+              <div className="heading-subsection mb-3">Projects</div>
+              {(selected.projectIds ?? []).length === 0 ? (
+                <div className="text-sm text-[var(--color-text-muted)]">
+                  Not linked to any projects.
+                </div>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {(selected.projectIds ?? []).map((pid) => {
+                    const projectName = projectLookup.get(pid) ?? pid
+                    return (
+                      <Link
+                        key={pid}
+                        to={`/projects/${pid}/assets`}
+                        className="inline-block max-w-[220px] truncate rounded-full border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-3 py-1 text-xs text-[var(--color-text)] transition-colors hover:border-[var(--color-border-strong)] hover:bg-[var(--color-surface)]"
+                        title={projectName}
+                      >
+                        {projectName}
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
             </div>
-          ) : null}
-        </div>
+
+            <TalentPortfolioSection
+              canEdit={canEdit}
+              busy={busy}
+              portfolioImages={portfolioImages}
+              sensors={sensors}
+              updateGallery={updateGallery}
+              onPortfolioFiles={onPortfolioFiles}
+              setGalleryRemoveOpen={setGalleryRemoveOpen}
+              setGalleryRemoveTarget={setGalleryRemoveTarget}
+            />
+
+            <CastingSessionList
+              castingSessions={castingSessions}
+              canEdit={canEdit}
+              isMobile={isMobile}
+              busy={busy}
+              projects={projects}
+              sensors={sensors}
+              sessionExpanded={sessionExpanded}
+              setSessionExpanded={setSessionExpanded}
+              updateCastingSessions={updateCastingSessions}
+              onCastingFiles={onCastingFiles}
+              setGalleryRemoveOpen={setGalleryRemoveOpen}
+              setGalleryRemoveTarget={setGalleryRemoveTarget}
+              setSessionRemoveOpen={setSessionRemoveOpen}
+              setSessionRemoveTarget={setSessionRemoveTarget}
+              setCreateSessionOpen={setCreateSessionOpen}
+              setPrintSessionId={setPrintSessionId}
+            />
+
+            {/* Delete zone */}
+            {canEdit ? (
+              <div className="mt-2 border-t border-[var(--color-border)] pt-4">
+                <Button
+                  variant="ghost"
+                  className="text-[var(--color-error)] hover:text-[var(--color-error)]"
+                  disabled={busy}
+                  onClick={() => setDeleteOpen(true)}
+                >
+                  Delete talent
+                </Button>
+                <p className="caption mt-1 text-[var(--color-text-subtle)]">
+                  Permanently removes this profile.
+                </p>
+              </div>
+            ) : null}
+          </div>
+        )
       ) : null}
     </div>
   )

--- a/src-vnext/features/library/components/TalentDetailPanel.tsx
+++ b/src-vnext/features/library/components/TalentDetailPanel.tsx
@@ -91,7 +91,6 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
   setCreateSessionOpen,
   setPrintSessionId,
 }: TalentDetailPanelProps) {
-  // Phase-2 detail IA (flag OFF in prod; flag-off path is byte-identical to trunk).
   const detailIA = isFeatureEnabled("featureTalentDetailIA")
   return (
     <div className="flex flex-col">
@@ -164,7 +163,7 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
       {activeTab === "detail" ? (
         detailIA ? (
           <div className="flex flex-col gap-6 p-5">
-            {/* Contact — inline editorial meta-line, demoted from a card (Decision #3) */}
+            {/* Contact meta-line */}
             <TalentContactMetaLine
               selected={selected}
               canEdit={canEdit}
@@ -172,8 +171,8 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
               savePatch={savePatch}
             />
 
-            {/* Fit signals — the "does she fit?" zone (Decision #4) */}
-            <section className="flex flex-col gap-4">
+            {/* Fit signals */}
+            <div className="flex flex-col gap-4">
               <div className="heading-section">Fit signals</div>
               <TalentMeasurementsSection
                 selected={selected}
@@ -187,10 +186,10 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
                 busy={busy}
                 savePatch={savePatch}
               />
-            </section>
+            </div>
 
-            {/* Creative assets — image-heavy group */}
-            <section className="flex flex-col gap-4">
+            {/* Creative assets */}
+            <div className="flex flex-col gap-4">
               <div className="heading-section">Creative assets</div>
               <TalentPortfolioSection
                 canEdit={canEdit}
@@ -220,9 +219,9 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
                 setCreateSessionOpen={setCreateSessionOpen}
                 setPrintSessionId={setPrintSessionId}
               />
-            </section>
+            </div>
 
-            {/* Meta / actions — read-only project tags (demoted) + isolated destructive action */}
+            {/* Meta / actions */}
             {(selected.projectIds ?? []).length > 0 || canEdit ? (
               <div className="flex flex-col gap-4 border-t border-[var(--color-border)] pt-4">
                 {(selected.projectIds ?? []).length > 0 ? (

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.detailIA.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.detailIA.test.tsx
@@ -1,0 +1,132 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", role: "producer", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock("@/features/library/hooks/useTalentLibrary", () => ({
+  useTalentLibrary: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/resolveStoragePath", () => ({
+  isUrl: (value: string) => value.startsWith("https://") || value.startsWith("http://"),
+  resolveStoragePath: async (path: string) => path,
+  getCachedUrl: (path: string) =>
+    path.startsWith("https://") || path.startsWith("http://") ? path : undefined,
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/library/lib/talentWrites", () => ({
+  createTalent: vi.fn(),
+  updateTalent: vi.fn(),
+  setTalentHeadshot: vi.fn(),
+  removeTalentHeadshot: vi.fn(),
+  uploadTalentPortfolioImages: vi.fn(),
+  uploadTalentCastingImages: vi.fn(),
+  deleteTalentImagePaths: vi.fn(),
+}))
+
+// Flag ON for this file — exercises the Phase 2 detail IA surface only
+// (roster IA stays OFF so the roster renders unchanged).
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) => flag === "featureTalentDetailIA",
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: true,
+    featureShootSurface: false,
+    featureReviewSurface: false,
+    featureTalentRosterIA: false,
+    featureTalentDetailIA: true,
+  }),
+}))
+
+import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
+import LibraryTalentPage from "@/features/library/components/LibraryTalentPage"
+
+function talent(id: string, name: string, projectIds: string[] = []) {
+  return {
+    id,
+    name,
+    agency: "IMG",
+    email: "a@b.co",
+    phone: "555-0100",
+    url: null,
+    gender: null,
+    notes: "",
+    measurements: null,
+    headshotPath: null,
+    headshotUrl: null,
+    galleryImages: [],
+    castingSessions: [],
+    projectIds,
+  }
+}
+
+function seed(rows: ReturnType<typeof talent>[]) {
+  ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: rows,
+    loading: false,
+    error: null,
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LibraryTalentPage />
+    </MemoryRouter>,
+  )
+}
+
+describe("LibraryTalentPage — detail IA (flag on)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("demotes Contact to an inline meta-line and groups Fit signals / Creative assets", () => {
+    seed([talent("t1", "Alice Adams")])
+    renderPage()
+    fireEvent.click(screen.getByText("Alice Adams"))
+
+    // Contact is now an inline editorial meta-line, not a bordered "Contact" card.
+    expect(screen.getByTestId("talent-contact-metaline")).toBeInTheDocument()
+    expect(screen.queryByText("Contact")).toBeNull()
+
+    // The two regrouped zones each carry a section eyebrow.
+    expect(screen.getByText("Fit signals")).toBeInTheDocument()
+    expect(screen.getByText("Creative assets")).toBeInTheDocument()
+  })
+
+  it("renders Projects as a read-only tag row (demoted from the bordered card)", () => {
+    seed([talent("t1", "Alice Adams", ["p1"])])
+    renderPage()
+    fireEvent.click(screen.getByText("Alice Adams"))
+
+    const tags = screen.getByTestId("talent-projects-tags")
+    expect(tags).toBeInTheDocument()
+    // The flag-off bordered card's empty-state copy is gone in the demoted row.
+    expect(screen.queryByText("Not linked to any projects.")).toBeNull()
+  })
+
+  it("hides the project tag row when the talent has no projects", () => {
+    seed([talent("t1", "Alice Adams")])
+    renderPage()
+    fireEvent.click(screen.getByText("Alice Adams"))
+
+    expect(screen.queryByTestId("talent-projects-tags")).toBeNull()
+  })
+})

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
@@ -103,6 +103,38 @@ describe("LibraryTalentPage", { timeout: 60_000 }, () => {
     expect(screen.queryByRole("button", { name: /range filter/i })).toBeNull()
   })
 
+  it("renders the Contact card (not the Phase-2 detail meta-line) when the detail IA flag is off", () => {
+    ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [
+        {
+          id: "t1",
+          name: "Alex Rivera",
+          agency: "IMG",
+          email: null,
+          phone: null,
+          url: null,
+          gender: null,
+          notes: "",
+          measurements: null,
+          headshotPath: null,
+          headshotUrl: null,
+          galleryImages: [],
+          castingSessions: [],
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderPage()
+    fireEvent.click(screen.getByText("Alex Rivera"))
+    // Flag-off detail keeps the bordered Contact card and the unzoned flat stack.
+    expect(screen.getByText("Contact")).toBeInTheDocument()
+    expect(screen.queryByTestId("talent-contact-metaline")).toBeNull()
+    expect(screen.queryByText("Fit signals")).toBeNull()
+    expect(screen.queryByText("Creative assets")).toBeNull()
+  })
+
   it("creates a talent from the dialog", async () => {
     ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [],

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -70,4 +70,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureTalentRosterIA")).toBe(false)
     }
   })
+
+  it("defaults featureTalentDetailIA to false (Talent redesign Phase 2 is dark on main)", () => {
+    expect(getFeatureFlags().featureTalentDetailIA).toBe(false)
+    expect(isFeatureEnabled("featureTalentDetailIA")).toBe(false)
+  })
+
+  it("VITE_TALENT_DETAIL_IA='1' or 'true' enables featureTalentDetailIA", () => {
+    vi.stubEnv("VITE_TALENT_DETAIL_IA", "1")
+    expect(isFeatureEnabled("featureTalentDetailIA")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_DETAIL_IA", "true")
+    expect(isFeatureEnabled("featureTalentDetailIA")).toBe(true)
+  })
+
+  it("any other VITE_TALENT_DETAIL_IA value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_TALENT_DETAIL_IA", value)
+      expect(isFeatureEnabled("featureTalentDetailIA")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -59,6 +59,15 @@ export interface FeatureFlags {
    * (featureReviewSurface env-parse precedent). No URL/localStorage layer.
    */
   readonly featureTalentRosterIA: boolean
+  /**
+   * Talent redesign Phase 2 — detail IA. Gates the regrouped talent detail
+   * panel (inline contact meta-line + Fit-signals / Creative-assets zones +
+   * Projects demoted to a read-only tag row) on TalentDetailPanel. Default
+   * OFF; the flag-off path is byte-identical to trunk. Enabled via
+   * `VITE_TALENT_DETAIL_IA=1` (or `true`) at build/dev time
+   * (featureTalentRosterIA env-parse precedent). No URL/localStorage layer.
+   */
+  readonly featureTalentDetailIA: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -67,6 +76,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureShootSurface: false,
   featureReviewSurface: false,
   featureTalentRosterIA: false,
+  featureTalentDetailIA: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -98,6 +108,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureTalentRosterIA:
       DEFAULT_FLAGS.featureTalentRosterIA ||
       parseEnvFlag(import.meta.env.VITE_TALENT_ROSTER_IA),
+    featureTalentDetailIA:
+      DEFAULT_FLAGS.featureTalentDetailIA ||
+      parseEnvFlag(import.meta.env.VITE_TALENT_DETAIL_IA),
   }
 }
 


### PR DESCRIPTION
## Talent redesign — Phase 2 (detail IA)

Re-groups the talent **detail panel's Profile tab** from a flat 6-section stack into a tiered information architecture, behind a new feature flag. Continues the Talent redesign after 0a (#456), 0b (#457), 1a (#458), 1b-i (#459).

**Flag:** `featureTalentDetailIA` (env `VITE_TALENT_DETAIL_IA`, **default OFF**). The flag-off render path is **byte-identical to trunk** — verified by a normalized zero-token diff of the `else` branch against `main`.

### What flag-ON does (per the locked spec decisions, `outputs/2026-06-13-talent-redesign-build-spec.md` §7 + §5)
- **Contact → inline editable meta-line** (locked Decision #3). New `TalentContactMetaLine` renders `Email · Phone · Web` as one editorial line below the hero. Each field stays individually editable via the same `InlineEdit` + the now-exported `ReferenceUrlField` (no duplication); `savePatch` wiring is byte-identical to the old card.
- **Measurements + Notes → "Fit signals" zone** (locked Decision #4) — the "does she fit?" group, ahead of creative assets.
- **Portfolio + Casting → "Creative assets" zone** — the image-heavy group (§5 goal).
- **Projects → read-only tag row** in a meta/actions zone (demoted from a bordered card; links preserved; hidden when empty).
- **Delete** preserved, isolated in the meta/actions zone.
- **Hero (gender badge), the Shot History tab, and all sub-component internals are untouched.**

Zones use `heading-section` (16px) eyebrows over the cards' existing `heading-subsection` (14px) — correct two-tier hierarchy, token-backed.

### Verification
- **Targeted tests** ✅ — flags 13, `LibraryTalentPage.detailIA.test.tsx` 3 (new), `rosterIA` 3 (unbroken), main `LibraryTalentPage` 8 (incl. a new flag-OFF byte-identical assertion).
- **Full suite** ✅ — 275 files / 3707 tests pass; 79 skips = the documented quarantine (unchanged).
- **tsc** ✅ — 160 = baseline exactly, **0 in changed files** (delta 0).
- **3-lens adversarial verify** ✅ PASS on all three (flag-off byte-identical · faithful-IA/decisions · hand-audit/regression). No correctness defects.

### Flag-ON eyeball items for Ted (at flip time, not blockers)
The feature is invisible in prod until `VITE_TALENT_DETAIL_IA` is flipped. When you eyeball flag-on on `:5174`, two cosmetic items to judge (cheap follow-ups if you want changes):
1. **URL micro-label** is shortened to **"Web"** (from "Reference URL") to fit the inline meta-line — confirm the word, or swap to "URL"/"Link".
2. **Edit-mode input width** — clicking a meta-line field opens a `w-full` input that can briefly reflow the inline row; reverts on blur. Tighten with a `max-w` on the segment if it bothers you.

### Notes
- IA ships behind its flag (off in prod); **flag-removal is a follow-up after your eyeball/approval**, per the phase model.
- No scope creep: no virtualization/debounce (1b-virtual), no matcher re-sort (Phase 3), no shared-sub-component extraction (Phase 5).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>