### PR TITLE
test(products): de-flake sortByUrgency (shared now → identical same-window launch dates)

### DIFF
--- a/src-vnext/features/products/lib/shootReadiness.test.ts
+++ b/src-vnext/features/products/lib/shootReadiness.test.ts
@@ -224,10 +224,13 @@ describe("computeSuggestedShootWindow", () => {
 
 describe("sortByUrgency", () => {
   it("sorts by launch date ascending, then readiness ascending", () => {
+    // Shared `now` so the two same-window items get an identical launch date.
+    const now = Date.now()
+    const at = (offsetMs: number) => Timestamp.fromDate(new Date(now + offsetMs))
     const items = [
-      { familyId: "a", familyName: "Late", launchDate: ts(30 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 0, samplesTotal: 1, readinessPct: 50, shootWindow: null },
-      { familyId: "b", familyName: "Soon", launchDate: ts(5 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 1, samplesTotal: 1, readinessPct: 100, shootWindow: null },
-      { familyId: "c", familyName: "Soon2", launchDate: ts(5 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 0, samplesTotal: 2, readinessPct: 0, shootWindow: null },
+      { familyId: "a", familyName: "Late", launchDate: at(30 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 0, samplesTotal: 1, readinessPct: 50, shootWindow: null },
+      { familyId: "b", familyName: "Soon", launchDate: at(5 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 1, samplesTotal: 1, readinessPct: 100, shootWindow: null },
+      { familyId: "c", familyName: "Soon2", launchDate: at(5 * DAY_MS), totalSkus: 1, skusWithFlags: 0, samplesArrived: 0, samplesTotal: 2, readinessPct: 0, shootWindow: null },
     ]
 
     const sorted = sortByUrgency(items)


### PR DESCRIPTION
## De-flake `sortByUrgency`

The `shootReadiness.test.ts > sortByUrgency` case intermittently failed in CI (e.g. on Talent PR #460's `vitest` job) — `expected ['b','c','a'] to deeply equal ['c','b','a']`.

**Root cause (test-only, not the impl):** the two items intended to share a launch window (`b`, `c`) each call the `Date.now()`-relative `ts(5 * DAY_MS)` helper. When the millisecond clock ticks between constructing `b` and `c`, their launch dates differ by ~1ms, so the date comparison (not the readiness tie-break) decides their order → `b` (earlier date) sorts before `c` → `['b','c','a']`. When both land in the same millisecond (the common case), the dates tie and the readiness tie-break correctly yields `['c','b','a']`.

**Fix:** capture `now` once and build all three dates from it, so `b` and `c` get a byte-identical `launchDate` and the readiness tie-break applies deterministically. The `sortByUrgency` implementation is **unchanged** — it was correct; only the test's date construction was non-deterministic.

Verified deterministic across 5 consecutive runs (20/20 each).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>