### PR TITLE
feat(talent): suppress empty contact fields for read-only viewers in the detail-IA meta-line

### DIFF
--- a/src-vnext/features/library/components/TalentContactMetaLine.tsx
+++ b/src-vnext/features/library/components/TalentContactMetaLine.tsx
@@ -11,12 +11,11 @@ interface TalentContactMetaLineProps {
 }
 
 // One inline editorial meta-line segment: an uppercase micro-label + its value.
-// The value is width-capped so the edit-mode input can't balloon the wrapping row.
 function Segment({ label, children }: { readonly label: string; readonly children: ReactNode }) {
   return (
     <span className="inline-flex min-w-0 items-baseline gap-1.5">
       <span className="label-meta shrink-0">{label}</span>
-      <span className="min-w-0 max-w-[220px]">{children}</span>
+      <span className="min-w-0">{children}</span>
     </span>
   )
 }

--- a/src-vnext/features/library/components/TalentContactMetaLine.tsx
+++ b/src-vnext/features/library/components/TalentContactMetaLine.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react"
+import { Fragment, type ReactNode } from "react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { ReferenceUrlField } from "@/features/library/components/TalentContactSection"
 import type { TalentRecord } from "@/shared/types"
@@ -11,11 +11,12 @@ interface TalentContactMetaLineProps {
 }
 
 // One inline editorial meta-line segment: an uppercase micro-label + its value.
+// The value is width-capped so the edit-mode input can't balloon the wrapping row.
 function Segment({ label, children }: { readonly label: string; readonly children: ReactNode }) {
   return (
     <span className="inline-flex min-w-0 items-baseline gap-1.5">
       <span className="label-meta shrink-0">{label}</span>
-      <span className="min-w-0">{children}</span>
+      <span className="min-w-0 max-w-[220px]">{children}</span>
     </span>
   )
 }
@@ -28,52 +29,82 @@ function MetaDot() {
   )
 }
 
-// Inline editable contact meta-line — email · phone · web.
+type Field = { readonly key: string; readonly label: string; readonly node: ReactNode }
+
+// Contact block demoted from a bordered card to a single inline editorial line.
 export function TalentContactMetaLine({
   selected,
   canEdit,
   busy,
   savePatch,
 }: TalentContactMetaLineProps) {
+  // Editors see every field (so they can fill blanks in); read-only viewers
+  // only see the fields that actually have a value.
+  const candidates: ReadonlyArray<Field | null> = [
+    canEdit || selected.email
+      ? {
+          key: "email",
+          label: "Email",
+          node: (
+            <InlineEdit
+              value={selected.email ?? ""}
+              disabled={!canEdit || busy}
+              placeholder="—"
+              onSave={(next) => void savePatch(selected.id, { email: next || null })}
+              className="text-sm"
+              showEditIcon={canEdit && !busy}
+            />
+          ),
+        }
+      : null,
+    canEdit || selected.phone
+      ? {
+          key: "phone",
+          label: "Phone",
+          node: (
+            <InlineEdit
+              value={selected.phone ?? ""}
+              disabled={!canEdit || busy}
+              placeholder="—"
+              onSave={(next) => void savePatch(selected.id, { phone: next || null })}
+              className="text-sm"
+              showEditIcon={canEdit && !busy}
+            />
+          ),
+        }
+      : null,
+    canEdit || selected.url
+      ? {
+          key: "web",
+          label: "Web",
+          node: (
+            <ReferenceUrlField
+              url={selected.url}
+              canEdit={canEdit}
+              busy={busy}
+              onSave={(next) => void savePatch(selected.id, { url: next })}
+            />
+          ),
+        }
+      : null,
+  ]
+  const fields = candidates.filter((f): f is Field => f !== null)
+
   return (
     <div
       data-testid="talent-contact-metaline"
       className="flex flex-wrap items-baseline gap-x-3 gap-y-1.5 text-sm"
     >
-      <Segment label="Email">
-        <InlineEdit
-          value={selected.email ?? ""}
-          disabled={!canEdit || busy}
-          placeholder="—"
-          onSave={(next) => void savePatch(selected.id, { email: next || null })}
-          className="text-sm"
-          showEditIcon={canEdit && !busy}
-        />
-      </Segment>
-
-      <MetaDot />
-
-      <Segment label="Phone">
-        <InlineEdit
-          value={selected.phone ?? ""}
-          disabled={!canEdit || busy}
-          placeholder="—"
-          onSave={(next) => void savePatch(selected.id, { phone: next || null })}
-          className="text-sm"
-          showEditIcon={canEdit && !busy}
-        />
-      </Segment>
-
-      <MetaDot />
-
-      <Segment label="Web">
-        <ReferenceUrlField
-          url={selected.url}
-          canEdit={canEdit}
-          busy={busy}
-          onSave={(next) => void savePatch(selected.id, { url: next })}
-        />
-      </Segment>
+      {fields.length === 0 ? (
+        <span className="text-[var(--color-text-subtle)]">No contact details</span>
+      ) : (
+        fields.map((f, i) => (
+          <Fragment key={f.key}>
+            {i > 0 ? <MetaDot /> : null}
+            <Segment label={f.label}>{f.node}</Segment>
+          </Fragment>
+        ))
+      )}
     </div>
   )
 }

--- a/src-vnext/features/library/components/__tests__/TalentContactMetaLine.test.tsx
+++ b/src-vnext/features/library/components/__tests__/TalentContactMetaLine.test.tsx
@@ -1,0 +1,46 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { TalentContactMetaLine } from "@/features/library/components/TalentContactMetaLine"
+import type { TalentRecord } from "@/shared/types"
+
+function talent(overrides: Partial<TalentRecord> = {}): TalentRecord {
+  return {
+    id: "t1",
+    name: "Alice",
+    email: null,
+    phone: null,
+    url: null,
+    ...overrides,
+  } as TalentRecord
+}
+
+describe("TalentContactMetaLine", () => {
+  it("shows all three fields for an editor even when empty (blanks stay fillable)", () => {
+    render(<TalentContactMetaLine selected={talent()} canEdit busy={false} savePatch={vi.fn()} />)
+    expect(screen.getByText("Email")).toBeInTheDocument()
+    expect(screen.getByText("Phone")).toBeInTheDocument()
+    expect(screen.getByText("Web")).toBeInTheDocument()
+    expect(screen.queryByText("No contact details")).toBeNull()
+  })
+
+  it("suppresses empty fields for a read-only viewer", () => {
+    render(
+      <TalentContactMetaLine
+        selected={talent({ email: "a@b.co" })}
+        canEdit={false}
+        busy={false}
+        savePatch={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("Email")).toBeInTheDocument()
+    expect(screen.queryByText("Phone")).toBeNull()
+    expect(screen.queryByText("Web")).toBeNull()
+  })
+
+  it("shows a placeholder when read-only with no contact details at all", () => {
+    render(<TalentContactMetaLine selected={talent()} canEdit={false} busy={false} savePatch={vi.fn()} />)
+    expect(screen.getByText("No contact details")).toBeInTheDocument()
+    expect(screen.queryByText("Email")).toBeNull()
+  })
+})

--- a/src-vnext/features/library/components/__tests__/TalentContactMetaLine.test.tsx
+++ b/src-vnext/features/library/components/__tests__/TalentContactMetaLine.test.tsx
@@ -43,4 +43,20 @@ describe("TalentContactMetaLine", () => {
     expect(screen.getByText("No contact details")).toBeInTheDocument()
     expect(screen.queryByText("Email")).toBeNull()
   })
+
+  it("places exactly one separator between two shown fields for a viewer", () => {
+    render(
+      <TalentContactMetaLine
+        selected={talent({ email: "a@b.co", url: "https://behance.net/x" })}
+        canEdit={false}
+        busy={false}
+        savePatch={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("Email")).toBeInTheDocument()
+    expect(screen.getByText("Web")).toBeInTheDocument()
+    expect(screen.queryByText("Phone")).toBeNull()
+    // One dot between the two shown fields — no leading, trailing, or doubled separator.
+    expect(screen.getAllByText("·")).toHaveLength(1)
+  })
 })


### PR DESCRIPTION
## Phase 2 detail-IA — polish follow-up

Small follow-up to PR #460, behind the same `featureTalentDetailIA` flag (default OFF). Addresses the empty-field item flagged at #460 review/eyeball time. (Ted confirmed the URL label stays **"Web"**.)

**Empty-field suppression (read-only viewers).** The meta-line previously always rendered all three segments + their separator dots, so a viewer of a talent with no contact info saw `Email — · Phone — · Web —`. Now:
- **Editors** still see all three fields (so blanks stay clickable to fill in).
- **Read-only viewers** only see fields that actually have a value, with a `No contact details` fallback when there are none — and no orphan separator dots.

### Scope / safety
- **Flag-on only.** `TalentContactMetaLine` renders only in the flag-on detail path; the flag-off `else` branch in `TalentDetailPanel` is **untouched** (still byte-identical to trunk).
- New `TalentContactMetaLine.test.tsx` (4 cases): editor-sees-all-when-empty · viewer-suppresses-empties · read-only-all-empty placeholder · exactly-one-separator-between-two-shown-fields.
- Full suite green; tsc delta 0.

### Deferred (not in this PR)
The edit-mode input width/reflow is the one inherently-visual item. An initial `max-w-[220px]` was removed because `DESIGN_SYSTEM.md:219` forbids hardcoded `max-w-[Npx]` on text fields, and the value couldn't be verified without rendering the flag-on path. It's deferred to the flag-on `:5174` eyeball, where a layout-based fix can be confirmed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>