### PR TITLE
fix(shots): show explicit cover product's catalog image when its URL wasn't denormalized

### DIFF
--- a/src-vnext/features/shots/components/HeroImageSection.tsx
+++ b/src-vnext/features/shots/components/HeroImageSection.tsx
@@ -4,6 +4,8 @@ import { updateShotWithVersion } from "@/features/shots/lib/updateShotWithVersio
 import { useAuth } from "@/app/providers/AuthProvider"
 import { Button } from "@/ui/button"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
+import { useProductFamilyDoc, useProductSkuDoc } from "@/features/shots/hooks/usePickerData"
+import { findExplicitCoverAssignment } from "@/features/shots/lib/coverProductImage"
 import { ImagePlus, Loader2, RotateCcw } from "lucide-react"
 import { toast } from "sonner"
 import type { Shot } from "@/shared/types"
@@ -41,7 +43,22 @@ export function HeroImageSection({
   const fileRef = useRef<HTMLInputElement>(null)
   const [uploading, setUploading] = useState(false)
 
-  const heroCandidate = heroImage?.downloadURL ?? heroImage?.path
+  // Catalog-image fallback for an explicit cover product whose URL was never denormalized.
+  const coverAssignment = heroImage ? null : findExplicitCoverAssignment(shot)
+  const coverFamilyId = coverAssignment?.familyId ?? null
+  const coverSkuId = coverAssignment ? (coverAssignment.skuId ?? coverAssignment.colourId ?? null) : null
+  const { data: coverFamily } = useProductFamilyDoc(coverFamilyId)
+  const { data: coverSku } = useProductSkuDoc(coverFamilyId, coverSkuId)
+  const coverFallbackSrc = coverAssignment
+    ? (coverAssignment.thumbUrl ??
+       coverAssignment.skuImageUrl ??
+       coverAssignment.familyImageUrl ??
+       coverSku?.imagePath ??
+       coverFamily?.thumbnailImagePath ??
+       coverFamily?.headerImagePath)
+    : undefined
+
+  const heroCandidate = heroImage?.downloadURL ?? heroImage?.path ?? coverFallbackSrc
   const resolvedHeroUrl = useStorageUrl(heroCandidate)
   const canResetManual = !!heroImage?.path && heroImage.path.includes("/hero.webp")
 

--- a/src-vnext/features/shots/components/HeroImageSection.tsx
+++ b/src-vnext/features/shots/components/HeroImageSection.tsx
@@ -45,18 +45,20 @@ export function HeroImageSection({
 
   // Catalog-image fallback for an explicit cover product whose URL was never denormalized.
   const coverAssignment = heroImage ? null : findExplicitCoverAssignment(shot)
-  const coverFamilyId = coverAssignment?.familyId ?? null
-  const coverSkuId = coverAssignment ? (coverAssignment.skuId ?? coverAssignment.colourId ?? null) : null
+  const coverDenormalized = coverAssignment
+    ? (coverAssignment.thumbUrl ?? coverAssignment.skuImageUrl ?? coverAssignment.familyImageUrl)
+    : undefined
+  // Only read catalog docs when the assignment carries no denormalized URL.
+  const coverFamilyId = coverAssignment && !coverDenormalized ? coverAssignment.familyId : null
+  const coverSkuId =
+    coverAssignment && !coverDenormalized ? (coverAssignment.skuId ?? coverAssignment.colourId ?? null) : null
   const { data: coverFamily } = useProductFamilyDoc(coverFamilyId)
   const { data: coverSku } = useProductSkuDoc(coverFamilyId, coverSkuId)
-  const coverFallbackSrc = coverAssignment
-    ? (coverAssignment.thumbUrl ??
-       coverAssignment.skuImageUrl ??
-       coverAssignment.familyImageUrl ??
-       coverSku?.imagePath ??
-       coverFamily?.thumbnailImagePath ??
-       coverFamily?.headerImagePath)
-    : undefined
+  // Ignore doc data still carried over from a prior id.
+  const coverSkuImage = coverSku?.id === coverSkuId ? coverSku?.imagePath : undefined
+  const coverFamilyImage =
+    coverFamily?.id === coverFamilyId ? (coverFamily?.thumbnailImagePath ?? coverFamily?.headerImagePath) : undefined
+  const coverFallbackSrc = coverDenormalized ?? coverSkuImage ?? coverFamilyImage
 
   const heroCandidate = heroImage?.downloadURL ?? heroImage?.path ?? coverFallbackSrc
   const resolvedHeroUrl = useStorageUrl(heroCandidate)

--- a/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 import { render, screen } from "@testing-library/react"
 import { HeroImageSection } from "../HeroImageSection"
 import type { Shot } from "@/shared/types"
+
+const catalogMocks = vi.hoisted(() => ({
+  family: { data: undefined as undefined | { thumbnailImagePath?: string; headerImagePath?: string } },
+  sku: { data: undefined as undefined | { imagePath?: string } },
+}))
 
 vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ clientId: "c1", user: { uid: "u1" }, role: "producer" }),
@@ -9,6 +14,11 @@ vi.mock("@/app/providers/AuthProvider", () => ({
 
 vi.mock("@/shared/hooks/useStorageUrl", () => ({
   useStorageUrl: (candidate: string | undefined) => candidate ?? null,
+}))
+
+vi.mock("@/features/shots/hooks/usePickerData", () => ({
+  useProductFamilyDoc: () => catalogMocks.family,
+  useProductSkuDoc: () => catalogMocks.sku,
 }))
 
 vi.mock("@/shared/lib/uploadImage", () => ({
@@ -36,6 +46,19 @@ const heroImage = {
   path: "clients/c1/shots/shot-1/hero.webp",
   downloadURL: "https://example.test/hero.webp",
 } as Shot["heroImage"]
+
+const coverShot = {
+  ...(baseShot as object),
+  activeLookId: "look-1",
+  looks: [
+    { id: "look-1", products: [{ familyId: "fam-X", familyName: "Tee" }], heroProductId: "fam-X" },
+  ],
+} as unknown as Shot
+
+beforeEach(() => {
+  catalogMocks.family = { data: undefined }
+  catalogMocks.sku = { data: undefined }
+})
 
 describe("HeroImageSection frame variants", () => {
   it('default "fixed" frame keeps the legacy fixed-height container', () => {
@@ -88,5 +111,39 @@ describe("HeroImageSection frame variants", () => {
     )
     expect(screen.getByText("Add hero image")).toBeInTheDocument()
     expect(screen.getByTestId("hero-image-file-input")).toBeInTheDocument()
+  })
+})
+
+describe("HeroImageSection cover-product fallback", () => {
+  it("renders the explicit cover product's catalog image when no hero image is resolved", () => {
+    catalogMocks.family = { data: { thumbnailImagePath: "clients/c1/products/fam-X/thumb.webp" } }
+    render(<HeroImageSection heroImage={undefined} shot={coverShot} shotId="shot-1" canUpload={true} />)
+    const img = screen.getByAltText("Hero")
+    expect(img).toHaveAttribute("src", "clients/c1/products/fam-X/thumb.webp")
+    expect(screen.queryByText("Add hero image")).not.toBeInTheDocument()
+  })
+
+  it("does not fall back when the cover product was explicitly cleared", () => {
+    catalogMocks.family = { data: { thumbnailImagePath: "clients/c1/products/fam-X/thumb.webp" } }
+    const cleared = {
+      ...(coverShot as object),
+      looks: [{ id: "look-1", products: [{ familyId: "fam-X" }], heroProductId: null }],
+    } as unknown as Shot
+    render(<HeroImageSection heroImage={undefined} shot={cleared} shotId="shot-1" canUpload={true} />)
+    expect(screen.queryByAltText("Hero")).not.toBeInTheDocument()
+    expect(screen.getByText("Add hero image")).toBeInTheDocument()
+  })
+
+  it("falls back gracefully to the empty state when the cover product has no catalog image", () => {
+    render(<HeroImageSection heroImage={undefined} shot={coverShot} shotId="shot-1" canUpload={true} />)
+    expect(screen.queryByAltText("Hero")).not.toBeInTheDocument()
+    expect(screen.getByText("Add hero image")).toBeInTheDocument()
+  })
+
+  it("uses the resolved hero image and ignores the cover fallback when both exist", () => {
+    catalogMocks.family = { data: { thumbnailImagePath: "clients/c1/products/fam-X/thumb.webp" } }
+    render(<HeroImageSection heroImage={heroImage} shot={coverShot} shotId="shot-1" canUpload={false} />)
+    const img = screen.getByAltText("Hero")
+    expect(img).toHaveAttribute("src", "https://example.test/hero.webp")
   })
 })

--- a/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/HeroImageSection.test.tsx
@@ -4,8 +4,8 @@ import { HeroImageSection } from "../HeroImageSection"
 import type { Shot } from "@/shared/types"
 
 const catalogMocks = vi.hoisted(() => ({
-  family: { data: undefined as undefined | { thumbnailImagePath?: string; headerImagePath?: string } },
-  sku: { data: undefined as undefined | { imagePath?: string } },
+  family: { data: undefined as undefined | { id?: string; thumbnailImagePath?: string; headerImagePath?: string } },
+  sku: { data: undefined as undefined | { id?: string; imagePath?: string } },
 }))
 
 vi.mock("@/app/providers/AuthProvider", () => ({
@@ -116,11 +116,18 @@ describe("HeroImageSection frame variants", () => {
 
 describe("HeroImageSection cover-product fallback", () => {
   it("renders the explicit cover product's catalog image when no hero image is resolved", () => {
-    catalogMocks.family = { data: { thumbnailImagePath: "clients/c1/products/fam-X/thumb.webp" } }
+    catalogMocks.family = { data: { id: "fam-X", thumbnailImagePath: "clients/c1/products/fam-X/thumb.webp" } }
     render(<HeroImageSection heroImage={undefined} shot={coverShot} shotId="shot-1" canUpload={true} />)
     const img = screen.getByAltText("Hero")
     expect(img).toHaveAttribute("src", "clients/c1/products/fam-X/thumb.webp")
     expect(screen.queryByText("Add hero image")).not.toBeInTheDocument()
+  })
+
+  it("ignores stale catalog doc data carried over from a different product id", () => {
+    catalogMocks.family = { data: { id: "fam-OTHER", thumbnailImagePath: "clients/c1/products/fam-OTHER/thumb.webp" } }
+    render(<HeroImageSection heroImage={undefined} shot={coverShot} shotId="shot-1" canUpload={true} />)
+    expect(screen.queryByAltText("Hero")).not.toBeInTheDocument()
+    expect(screen.getByText("Add hero image")).toBeInTheDocument()
   })
 
   it("does not fall back when the cover product was explicitly cleared", () => {

--- a/src-vnext/features/shots/lib/__tests__/coverProductImage.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/coverProductImage.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest"
+import { findExplicitCoverAssignment } from "../coverProductImage"
+import type { ProductAssignment, Shot, ShotLook } from "@/shared/types"
+
+function shotWith(looks: ShotLook[], activeLookId?: string | null): Shot {
+  return { id: "shot-1", looks, activeLookId } as unknown as Shot
+}
+
+const tee: ProductAssignment = { familyId: "fam-X", familyName: "Tee" }
+const skued: ProductAssignment = { familyId: "fam-Y", familyName: "Pant", skuId: "sku-Y1", colourId: "col-Y1" }
+
+function look(partial: Partial<ShotLook>): ShotLook {
+  return { id: "look-1", products: [], ...partial }
+}
+
+describe("findExplicitCoverAssignment", () => {
+  it("returns null when there are no looks", () => {
+    expect(findExplicitCoverAssignment(shotWith([]))).toBeNull()
+  })
+
+  it("returns the assignment whose familyId matches an explicit heroProductId", () => {
+    const l = look({ id: "look-1", heroProductId: "fam-X", products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toEqual(tee)
+  })
+
+  it("matches by skuId", () => {
+    const l = look({ id: "look-1", heroProductId: "sku-Y1", products: [skued] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toEqual(skued)
+  })
+
+  it("matches by colourId", () => {
+    const l = look({ id: "look-1", heroProductId: "col-Y1", products: [skued] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toEqual(skued)
+  })
+
+  it("returns null when the cover is explicitly cleared (heroProductId null)", () => {
+    const l = look({ id: "look-1", heroProductId: null, products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toBeNull()
+  })
+
+  it("returns null in auto mode (heroProductId undefined)", () => {
+    const l = look({ id: "look-1", heroProductId: undefined, products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toBeNull()
+  })
+
+  it("locks to the active look: ignores an explicit cover on a non-active look", () => {
+    const active = look({ id: "look-1", heroProductId: undefined, products: [tee] })
+    const other = look({ id: "look-2", heroProductId: "fam-X", products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([active, other], "look-1"))).toBeNull()
+  })
+
+  it("falls through to scan looks when activeLookId is stale (look not found)", () => {
+    const l = look({ id: "look-2", heroProductId: "fam-X", products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-missing"))).toEqual(tee)
+  })
+
+  it("uses the first look with an explicit cover when there is no active look", () => {
+    const first = look({ id: "look-1", heroProductId: undefined, products: [tee] })
+    const second = look({ id: "look-2", heroProductId: "fam-X", products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([first, second]))).toEqual(tee)
+  })
+
+  it("returns null when the explicit heroProductId matches no product in the look", () => {
+    const l = look({ id: "look-1", heroProductId: "fam-ZZZ", products: [tee] })
+    expect(findExplicitCoverAssignment(shotWith([l], "look-1"))).toBeNull()
+  })
+})

--- a/src-vnext/features/shots/lib/coverProductImage.ts
+++ b/src-vnext/features/shots/lib/coverProductImage.ts
@@ -1,0 +1,29 @@
+import type { ProductAssignment, Shot, ShotLook } from "@/shared/types"
+
+/** The product assignment explicitly chosen as a look's cover. */
+export function findExplicitCoverAssignment(shot: Shot): ProductAssignment | null {
+  const looks = shot.looks ?? []
+  if (looks.length === 0) return null
+
+  const fromLook = (look: ShotLook | undefined): ProductAssignment | null => {
+    if (!look) return null
+    const heroId = look.heroProductId
+    if (typeof heroId !== "string" || heroId.length === 0) return null
+    return (
+      look.products.find(
+        (p) => p.skuId === heroId || p.colourId === heroId || p.familyId === heroId,
+      ) ?? null
+    )
+  }
+
+  if (typeof shot.activeLookId === "string" && shot.activeLookId.length > 0) {
+    const active = looks.find((l) => l.id === shot.activeLookId)
+    if (active) return fromLook(active)
+  }
+
+  for (const look of looks) {
+    const found = fromLook(look)
+    if (found) return found
+  }
+  return null
+}


### PR DESCRIPTION
## Bug (confirmed regression)
A product **with a thumbnail**, selected as a look's **cover product** in the shots editor, renders **blank** as the cover — while the product still shows its thumbnail in the product row. Reported as "it used to show."

## Root cause
`mapShot.normalizeHeroImage` is a pure sync mapper that resolves a cover product's image **only** from denormalized URL fields on the look's assignment (`skuImageUrl/thumbUrl/familyImageUrl`); it has **no catalog fallback**. Commits `73af543f` ("make cover product selection explicit") and `bd9a1160` ("improve cover image rendering and clearing") — both intentional UX fixes — removed the older fallback chain so an explicit cover shows *exactly* the chosen product and a cleared cover stays cleared. The unhandled edge: a cover product whose catalog image was **never denormalized onto the assignment** (legacy assignment, or a catalog image added *after* the product was assigned — editing doesn't backfill it) resolves to `undefined`, so the cover is blank. The product **row** still shows the thumbnail because `AssignmentRow` (`1900bf28`) *does* fall back to the catalog family/sku doc.

> Note: the audit's first hypothesis (editing a cover product wipes its image URLs) was **refuted** — `handleConfirm`'s patch omits undefined image keys (`if (thumbUrl) …`), so the edit spread *preserves* the existing URL. The real fault is the render path's missing fallback.

## Fix
- New pure helper `coverProductImage.ts` `findExplicitCoverAssignment(shot)` — returns the assignment explicitly chosen as the cover, faithfully mirroring `normalizeHeroImage`'s resolution order (active-look **lock**; stale activeLookId falls through; first explicit look otherwise; match by sku/colour/family id).
- `HeroImageSection` — when `heroImage` is unresolved **and** a look has an explicit cover product, resolves that product's catalog image (mirroring `AssignmentRow`'s exact `thumbUrl ?? skuImageUrl ?? familyImageUrl ?? sku.imagePath ?? family.thumbnailImagePath ?? family.headerImagePath` chain via `useProductFamilyDoc`/`useProductSkuDoc` + `useStorageUrl`).
- **Does not revert** the Feb-4 intent: cover-cleared → still blank; explicit cover → only the chosen product; a resolved `heroImage` always wins.

## Tests
- `coverProductImage.test.ts` (10) — active-look lock, cleared/auto, match by family/sku/colour, stale-active fall-through, first-explicit-wins, no-match.
- `HeroImageSection.test.tsx` (+4) — renders the cover product's catalog image on fallback; no fallback when cleared; graceful empty-state when no catalog image; resolved hero image wins. (The new fallback test fails against pre-fix code — load-bearing.)
- Full suite: **277 files / 3725 tests pass** (79 pre-existing QUARANTINE skips), tsc delta 0.

## Scope
Editor hero only (the reported bug). The shot **grid card** (`ShotCard.tsx`) and **table thumbnail column** (`shotColumnRenderers.tsx`) share the same blank-cover root cause and are a **tracked follow-up** (shared cover-thumb component; the table cell needs a render-fn→component wrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)