### PR TITLE
feat(talent): controlled agency input (flag-gated) + normalization script

### DIFF
--- a/scripts/normalize-agency-names.ts
+++ b/scripts/normalize-agency-names.ts
@@ -1,0 +1,196 @@
+/**
+ * One-time fixup: normalize talent agency names to canonical values.
+ *
+ * Pass 1 — DUMP (dry-run, no mapping): print every distinct agency + count so
+ * the canonical map can be curated by hand from real data:
+ *   npx tsx scripts/normalize-agency-names.ts --clientId=unbound-merino
+ *
+ * Pass 2 — PREVIEW (dry-run, with mapping): show the planned renames:
+ *   npx tsx scripts/normalize-agency-names.ts --clientId=unbound-merino --mapping=agency-map.json
+ *
+ * Pass 3 — WRITE: apply the reviewed mapping:
+ *   npx tsx scripts/normalize-agency-names.ts --clientId=unbound-merino --mapping=agency-map.json --write
+ *
+ * The mapping JSON is a flat object of { "<existing variant>": "<canonical>" }.
+ * Match is on the trimmed, whitespace-collapsed value; unmapped agencies are
+ * left untouched (and reported). Map a variant to "" to clear the field.
+ *
+ * Run this BEFORE the AgencyCombobox flag flips: the agency filter is
+ * exact-equality (talentFilters.ts matchesAgency), so variants only collapse
+ * in the filter once the stored data is normalized.
+ */
+
+import { readFileSync } from "node:fs"
+import { getApp, getApps, initializeApp, applicationDefault } from "firebase-admin/app"
+import { FieldValue, getFirestore } from "firebase-admin/firestore"
+
+const PROJECT_ID = process.env.GCLOUD_PROJECT ?? "um-shotbuilder"
+
+function ensureApp() {
+  if (getApps().length) return getApp()
+  return initializeApp({ credential: applicationDefault(), projectId: PROJECT_ID })
+}
+
+/** Trim + collapse internal whitespace — the key both the dump and the mapping match on. */
+function normalizeKey(value: string): string {
+  return value.trim().replace(/\s+/g, " ")
+}
+
+function parseArgs(): { clientId: string | null; mappingPath: string | null; write: boolean } {
+  const args = process.argv.slice(2)
+  let clientId: string | null = null
+  let mappingPath: string | null = null
+  let write = false
+  for (const arg of args) {
+    if (arg.startsWith("--clientId=")) clientId = arg.slice("--clientId=".length).trim()
+    else if (arg.startsWith("--mapping=")) mappingPath = arg.slice("--mapping=".length).trim()
+    else if (arg === "--write") write = true
+  }
+  return { clientId, mappingPath, write }
+}
+
+/** Load + validate the reviewed { variant -> canonical } mapping, keyed on normalizeKey. */
+function loadMapping(path: string): Record<string, string> {
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("Mapping file must be a JSON object of { variant: canonical }")
+  }
+  const out: Record<string, string> = {}
+  for (const [variant, canonical] of Object.entries(parsed as Record<string, unknown>)) {
+    if (typeof canonical !== "string") {
+      throw new Error(`Mapping value for "${variant}" must be a string`)
+    }
+    const key = normalizeKey(variant)
+    // Two keys differing only by whitespace collapse to the same normalized key;
+    // a silent last-write-wins would misroute records. Stop on a real conflict.
+    if (key in out && out[key] !== canonical) {
+      throw new Error(
+        `Conflicting mapping: "${variant}" normalizes to "${key}" but maps to "${canonical}" ` +
+          `while an earlier entry maps it to "${out[key]}"`,
+      )
+    }
+    out[key] = canonical
+  }
+  return out
+}
+
+;(async () => {
+  const { clientId, mappingPath, write } = parseArgs()
+  if (!clientId) {
+    console.error("ERROR: --clientId is required")
+    process.exit(1)
+  }
+  if (write && !mappingPath) {
+    console.error("ERROR: --write requires --mapping=<path to reviewed JSON>")
+    process.exit(1)
+  }
+
+  const dryRun = !write
+  const prefix = dryRun ? "[DRY RUN]" : "[WRITE]"
+  const mapping = mappingPath ? loadMapping(mappingPath) : null
+
+  console.info("")
+  console.info("=".repeat(60))
+  console.info("FIXUP: Normalize talent agency names")
+  console.info("Mode: %s%s", dryRun ? "DRY RUN" : "WRITE", mapping ? "" : " (dump only — no mapping)")
+  console.info("=".repeat(60))
+  console.info("")
+
+  const app = ensureApp()
+  const db = getFirestore(app)
+  db.settings({ ignoreUndefinedProperties: true })
+
+  const snapshot = await db.collection(`clients/${clientId}/talent`).get()
+  console.info("Loaded %d talent records", snapshot.size)
+  console.info("")
+
+  // --- Always: dump distinct agencies + counts (the curation input). ---
+  const counts = new Map<string, number>()
+  for (const doc of snapshot.docs) {
+    const agency = typeof doc.data().agency === "string" ? (doc.data().agency as string) : ""
+    if (!agency.trim()) continue
+    counts.set(agency, (counts.get(agency) ?? 0) + 1)
+  }
+
+  const distinct = Array.from(counts.entries()).sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
+  )
+  console.info("Distinct agencies (%d):", distinct.length)
+  for (const [agency, count] of distinct) {
+    console.info('  %s  "%s"', String(count).padStart(5), agency)
+  }
+  console.info("")
+
+  if (!mapping) {
+    console.info("No --mapping supplied. Curate a { variant: canonical } JSON from the")
+    console.info("list above, then re-run with --mapping=<file> to preview renames.")
+    return
+  }
+
+  // --- With mapping: preview / apply renames. ---
+  let changed = 0
+  let unchanged = 0
+  const unmapped = new Set<string>()
+
+  for (const doc of snapshot.docs) {
+    const data = doc.data()
+    const raw = typeof data.agency === "string" ? data.agency : ""
+    if (!raw.trim()) continue
+
+    const canonical = mapping[normalizeKey(raw)]
+    if (canonical === undefined) {
+      unmapped.add(raw)
+      continue
+    }
+
+    // Normalize the canonical the same way as the key so a sloppy value can't
+    // reintroduce a near-duplicate the exact-equality filter won't merge.
+    const next = normalizeKey(canonical) || null
+    if (next === raw) {
+      unchanged += 1
+      continue
+    }
+
+    console.info(
+      '%s %s (id: %s) "%s" → %s',
+      prefix,
+      data.name,
+      doc.id,
+      raw,
+      next === null ? "(cleared)" : `"${next}"`,
+    )
+
+    if (!dryRun) {
+      await doc.ref.update({
+        agency: next,
+        updatedAt: FieldValue.serverTimestamp(),
+        updatedBy: "system:fixup",
+      })
+      await new Promise((r) => setTimeout(r, 50))
+    }
+
+    changed += 1
+  }
+
+  console.info("")
+  console.info("=".repeat(60))
+  console.info("Changed: %d  |  Already canonical: %d  |  Unmapped: %d", changed, unchanged, unmapped.size)
+  console.info("=".repeat(60))
+
+  if (unmapped.size > 0) {
+    console.info("")
+    console.info("Agencies with NO mapping entry (left untouched):")
+    for (const agency of Array.from(unmapped).sort()) {
+      console.info('  - "%s"', agency)
+    }
+  }
+
+  if (dryRun && changed > 0) {
+    console.info("")
+    console.info(
+      "To apply: npx tsx scripts/normalize-agency-names.ts --clientId=%s --mapping=%s --write",
+      clientId,
+      mappingPath,
+    )
+  }
+})()

--- a/src-vnext/features/library/components/AgencyCombobox.tsx
+++ b/src-vnext/features/library/components/AgencyCombobox.tsx
@@ -1,0 +1,143 @@
+import { useMemo, useState } from "react"
+import { Check, ChevronsUpDown, Plus, X } from "lucide-react"
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/ui/command"
+import { cn } from "@/shared/lib/utils"
+
+interface AgencyComboboxProps {
+  readonly value: string | null
+  readonly knownAgencies: readonly string[]
+  readonly onChange: (next: string | null) => void
+  readonly disabled?: boolean
+  readonly placeholder?: string
+  readonly triggerClassName?: string
+}
+
+/**
+ * Single-value, type-to-filter agency picker built on cmdk + Popover. Shows
+ * existing agencies first to curb duplicate variants, but allows free entry of
+ * a new name (an "Add …" row appears for a non-matching query). Trims before
+ * emitting — updateTalent does not trim.
+ */
+export function AgencyCombobox({
+  value,
+  knownAgencies,
+  onChange,
+  disabled,
+  placeholder = "Add agency",
+  triggerClassName,
+}: AgencyComboboxProps) {
+  const [open, setOpen] = useState(false)
+  const [search, setSearch] = useState("")
+
+  const trimmed = search.trim()
+  const normalized = trimmed.toLowerCase()
+
+  const filtered = useMemo(() => {
+    if (!normalized) return knownAgencies
+    return knownAgencies.filter((a) => a.toLowerCase().includes(normalized))
+  }, [knownAgencies, normalized])
+
+  const hasExactMatch = useMemo(
+    () => knownAgencies.some((a) => a.toLowerCase() === normalized),
+    [knownAgencies, normalized],
+  )
+
+  const commit = (next: string | null) => {
+    const cleaned = next?.trim() || null
+    setSearch("")
+    setOpen(false)
+    // Mirror InlineEdit's no-write-on-unchanged guard — avoid a redundant
+    // updatedAt/updatedBy bump when re-selecting the current value.
+    if (cleaned === value) return
+    onChange(cleaned)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (disabled) return
+    setOpen(next)
+    if (!next) setSearch("")
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label="Agency"
+          className={cn(
+            "inline-flex items-center gap-1 rounded text-sm transition-colors",
+            value ? "text-[var(--color-text-muted)]" : "text-[var(--color-text-subtle)]",
+            disabled && "cursor-default",
+            triggerClassName,
+          )}
+        >
+          <span className="truncate">{value || placeholder}</span>
+          <ChevronsUpDown className="h-3 w-3 flex-shrink-0 text-[var(--color-text-subtle)]" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        className="w-64 p-0"
+        align="start"
+        onEscapeKeyDown={(event) => event.stopPropagation()}
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder="Search or add agency…"
+          />
+          <CommandList>
+            {filtered.length === 0 && !trimmed ? (
+              <CommandEmpty>No agencies yet.</CommandEmpty>
+            ) : null}
+            {filtered.length > 0 ? (
+              <CommandGroup heading="Agencies">
+                {filtered.map((agency) => (
+                  <CommandItem key={agency} value={agency} onSelect={() => commit(agency)}>
+                    <Check
+                      className={cn("h-4 w-4", value === agency ? "opacity-100" : "opacity-0")}
+                    />
+                    <span className="truncate">{agency}</span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            ) : null}
+            {trimmed && !hasExactMatch ? (
+              <CommandGroup heading="Add new">
+                <CommandItem
+                  value={`__add__:${trimmed}`}
+                  data-testid="agency-add-new"
+                  onSelect={() => commit(trimmed)}
+                >
+                  <Plus className="h-4 w-4" />
+                  <span className="truncate">Add &ldquo;{trimmed}&rdquo;</span>
+                </CommandItem>
+              </CommandGroup>
+            ) : null}
+            {value ? (
+              <CommandGroup>
+                <CommandItem
+                  value="__clear__"
+                  data-testid="agency-clear"
+                  onSelect={() => commit(null)}
+                >
+                  <X className="h-4 w-4" />
+                  <span>Clear agency</span>
+                </CommandItem>
+              </CommandGroup>
+            ) : null}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src-vnext/features/library/components/AgencyCombobox.tsx
+++ b/src-vnext/features/library/components/AgencyCombobox.tsx
@@ -20,6 +20,11 @@ interface AgencyComboboxProps {
   readonly triggerClassName?: string
 }
 
+/** Trim + collapse internal whitespace runs to a single space. */
+function collapseWhitespace(value: string): string {
+  return value.trim().replace(/\s+/g, " ")
+}
+
 /**
  * Single-value, type-to-filter agency picker built on cmdk + Popover. Shows
  * existing agencies first to curb duplicate variants, but allows free entry of
@@ -37,8 +42,10 @@ export function AgencyCombobox({
   const [open, setOpen] = useState(false)
   const [search, setSearch] = useState("")
 
-  const trimmed = search.trim()
-  const normalized = trimmed.toLowerCase()
+  // Collapse internal whitespace too (not just trim) so "IMG  Models" matches
+  // and persists as "IMG Models" — the exact-equality filter won't merge them.
+  const typed = collapseWhitespace(search)
+  const normalized = typed.toLowerCase()
 
   const filtered = useMemo(() => {
     if (!normalized) return knownAgencies
@@ -46,12 +53,12 @@ export function AgencyCombobox({
   }, [knownAgencies, normalized])
 
   const hasExactMatch = useMemo(
-    () => knownAgencies.some((a) => a.toLowerCase() === normalized),
+    () => knownAgencies.some((a) => collapseWhitespace(a).toLowerCase() === normalized),
     [knownAgencies, normalized],
   )
 
   const commit = (next: string | null) => {
-    const cleaned = next?.trim() || null
+    const cleaned = next ? collapseWhitespace(next) || null : null
     setSearch("")
     setOpen(false)
     // Mirror InlineEdit's no-write-on-unchanged guard — avoid a redundant
@@ -96,7 +103,7 @@ export function AgencyCombobox({
             placeholder="Search or add agency…"
           />
           <CommandList>
-            {filtered.length === 0 && !trimmed ? (
+            {filtered.length === 0 && !typed ? (
               <CommandEmpty>No agencies yet.</CommandEmpty>
             ) : null}
             {filtered.length > 0 ? (
@@ -111,15 +118,15 @@ export function AgencyCombobox({
                 ))}
               </CommandGroup>
             ) : null}
-            {trimmed && !hasExactMatch ? (
+            {typed && !hasExactMatch ? (
               <CommandGroup heading="Add new">
                 <CommandItem
-                  value={`__add__:${trimmed}`}
+                  value={`__add__:${typed}`}
                   data-testid="agency-add-new"
-                  onSelect={() => commit(trimmed)}
+                  onSelect={() => commit(typed)}
                 >
                   <Plus className="h-4 w-4" />
-                  <span className="truncate">Add &ldquo;{trimmed}&rdquo;</span>
+                  <span className="truncate">Add &ldquo;{typed}&rdquo;</span>
                 </CommandItem>
               </CommandGroup>
             ) : null}

--- a/src-vnext/features/library/components/AgencyCombobox.tsx
+++ b/src-vnext/features/library/components/AgencyCombobox.tsx
@@ -20,7 +20,11 @@ interface AgencyComboboxProps {
   readonly triggerClassName?: string
 }
 
-/** Trim + collapse internal whitespace runs to a single space. */
+/**
+ * Trim + collapse internal whitespace runs to a single space. Intentionally
+ * duplicated as `normalizeKey` in scripts/normalize-agency-names.ts — that
+ * script runs server-side via Firebase Admin and can't import the client bundle.
+ */
 function collapseWhitespace(value: string): string {
   return value.trim().replace(/\s+/g, " ")
 }

--- a/src-vnext/features/library/components/AgencyCombobox.tsx
+++ b/src-vnext/features/library/components/AgencyCombobox.tsx
@@ -49,7 +49,9 @@ export function AgencyCombobox({
 
   const filtered = useMemo(() => {
     if (!normalized) return knownAgencies
-    return knownAgencies.filter((a) => a.toLowerCase().includes(normalized))
+    // Collapse `a` too (consistent with hasExactMatch) so a pre-migration
+    // double-spaced agency stays selectable for a collapsed query.
+    return knownAgencies.filter((a) => collapseWhitespace(a).toLowerCase().includes(normalized))
   }, [knownAgencies, normalized])
 
   const hasExactMatch = useMemo(
@@ -130,7 +132,7 @@ export function AgencyCombobox({
                 </CommandItem>
               </CommandGroup>
             ) : null}
-            {value ? (
+            {value && !typed ? (
               <CommandGroup>
                 <CommandItem
                   value="__clear__"

--- a/src-vnext/features/library/components/CreateTalentDialog.tsx
+++ b/src-vnext/features/library/components/CreateTalentDialog.tsx
@@ -17,6 +17,8 @@ import {
   SelectValue,
 } from "@/ui/select"
 import { SELECT_NONE } from "@/features/library/components/talentUtils"
+import { AgencyCombobox } from "@/features/library/components/AgencyCombobox"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 
 export interface CreateTalentFields {
   readonly name: string
@@ -32,6 +34,7 @@ interface CreateTalentDialogProps {
   readonly open: boolean
   readonly onOpenChange: (open: boolean) => void
   readonly busy: boolean
+  readonly knownAgencies: readonly string[]
   readonly onSubmit: (fields: CreateTalentFields) => Promise<boolean>
 }
 
@@ -39,8 +42,10 @@ export function CreateTalentDialog({
   open,
   onOpenChange,
   busy,
+  knownAgencies,
   onSubmit,
 }: CreateTalentDialogProps) {
+  const agencyCombobox = isFeatureEnabled("featureTalentAgencyCombobox")
   const [createName, setCreateName] = useState("")
   const [createAgency, setCreateAgency] = useState("")
   const [createEmail, setCreateEmail] = useState("")
@@ -94,12 +99,23 @@ export function CreateTalentDialog({
             <div className="label-meta">
               Agency
             </div>
-            <Input
-              value={createAgency}
-              onChange={(e) => setCreateAgency(e.target.value)}
-              placeholder="Optional"
-              disabled={busy}
-            />
+            {agencyCombobox ? (
+              <AgencyCombobox
+                value={createAgency || null}
+                knownAgencies={knownAgencies}
+                disabled={busy}
+                onChange={(next) => setCreateAgency(next ?? "")}
+                placeholder="Optional"
+                triggerClassName="h-9 w-full justify-between rounded-md border border-input bg-transparent px-3 py-1"
+              />
+            ) : (
+              <Input
+                value={createAgency}
+                onChange={(e) => setCreateAgency(e.target.value)}
+                placeholder="Optional"
+                disabled={busy}
+              />
+            )}
           </div>
           <div>
             <div className="label-meta">

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -39,7 +39,7 @@ import {
   updateTalent,
 } from "@/features/library/lib/talentWrites"
 import type { TalentSearchFilters } from "@/features/library/lib/talentFilters"
-import { EMPTY_TALENT_FILTERS, filterTalent } from "@/features/library/lib/talentFilters"
+import { EMPTY_TALENT_FILTERS, extractUniqueAgencies, filterTalent } from "@/features/library/lib/talentFilters"
 import { TalentSearchFilterSheet, TalentFilterToolbar, TalentToolbarRangeFilters } from "@/features/library/components/TalentSearchFilters"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { cn } from "@/shared/lib/utils"
@@ -139,6 +139,10 @@ export default function LibraryTalentPage() {
     () => filterTalent(talent, filtersWithQuery),
     [talent, filtersWithQuery],
   )
+
+  // Distinct agency options for the controlled agency input (memoized so the
+  // referentially-stable array doesn't defeat React.memo(TalentDetailPanel)).
+  const knownAgencies = useMemo(() => extractUniqueAgencies(talent), [talent])
 
   const castingHasRequirements = useMemo(
     () => Object.values(castingBrief.requirements).some((r) => r.min !== null || r.max !== null),
@@ -746,6 +750,7 @@ export default function LibraryTalentPage() {
                   setActiveTab={setActiveTab}
                   selectedHeadshotUrl={selectedHeadshotUrl ?? null}
                   selectedHeadshotPath={selectedHeadshotPath}
+                  knownAgencies={knownAgencies}
                   portfolioImages={portfolioImages}
                   castingSessions={castingSessions}
                   projects={projects}
@@ -786,6 +791,7 @@ export default function LibraryTalentPage() {
         open={createOpen}
         onOpenChange={setCreateOpen}
         busy={busy}
+        knownAgencies={knownAgencies}
         onSubmit={submitCreate}
       />
 

--- a/src-vnext/features/library/components/TalentDetailPanel.tsx
+++ b/src-vnext/features/library/components/TalentDetailPanel.tsx
@@ -26,6 +26,7 @@ interface TalentDetailPanelProps {
   readonly setActiveTab: (tab: "detail" | "history") => void
   readonly selectedHeadshotUrl: string | null
   readonly selectedHeadshotPath: string | null
+  readonly knownAgencies: readonly string[]
   readonly portfolioImages: TalentImage[]
   readonly castingSessions: CastingSession[]
   readonly projects: Array<{ id: string; name?: string | null }>
@@ -69,6 +70,7 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
   setActiveTab,
   selectedHeadshotUrl,
   selectedHeadshotPath,
+  knownAgencies,
   portfolioImages,
   castingSessions,
   projects,
@@ -101,6 +103,7 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
         busy={busy}
         selectedHeadshotUrl={selectedHeadshotUrl}
         selectedHeadshotPath={selectedHeadshotPath}
+        knownAgencies={knownAgencies}
         savePatch={savePatch}
         onHeadshotFile={onHeadshotFile}
         setHeadshotRemoveOpen={setHeadshotRemoveOpen}

--- a/src-vnext/features/library/components/TalentHeroZone.tsx
+++ b/src-vnext/features/library/components/TalentHeroZone.tsx
@@ -4,6 +4,8 @@ import { Upload } from "lucide-react"
 import { Button } from "@/ui/button"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { ImageLightbox } from "@/shared/components/ImageLightbox"
+import { AgencyCombobox } from "@/features/library/components/AgencyCombobox"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import {
   genderBadgeClasses,
   genderDisplayLabel,
@@ -28,6 +30,7 @@ interface TalentHeroZoneProps {
   readonly busy: boolean
   readonly selectedHeadshotUrl: string | null
   readonly selectedHeadshotPath: string | null
+  readonly knownAgencies: readonly string[]
   readonly savePatch: (id: string, patch: Record<string, unknown>) => Promise<void>
   readonly onHeadshotFile: (event: ChangeEvent<HTMLInputElement>) => Promise<void>
   readonly setHeadshotRemoveOpen: (open: boolean) => void
@@ -39,12 +42,14 @@ export function TalentHeroZone({
   busy,
   selectedHeadshotUrl,
   selectedHeadshotPath,
+  knownAgencies,
   savePatch,
   onHeadshotFile,
   setHeadshotRemoveOpen,
 }: TalentHeroZoneProps) {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const [lightboxOpen, setLightboxOpen] = useState(false)
+  const agencyCombobox = isFeatureEnabled("featureTalentAgencyCombobox")
 
   const displayName = buildDisplayName(selected)
 
@@ -138,14 +143,24 @@ export function TalentHeroZone({
 
           {/* Agency */}
           {canEdit ? (
-            <InlineEdit
-              value={selected.agency ?? ""}
-              disabled={busy}
-              placeholder="Add agency"
-              onSave={(next) => void savePatch(selected.id, { agency: next || null })}
-              className="text-sm text-[var(--color-text-muted)]"
-              showEditIcon
-            />
+            agencyCombobox ? (
+              <AgencyCombobox
+                value={selected.agency ?? null}
+                knownAgencies={knownAgencies}
+                disabled={busy}
+                onChange={(next) => void savePatch(selected.id, { agency: next })}
+                triggerClassName="px-1 py-0.5 hover:bg-[var(--color-surface-subtle)]"
+              />
+            ) : (
+              <InlineEdit
+                value={selected.agency ?? ""}
+                disabled={busy}
+                placeholder="Add agency"
+                onSave={(next) => void savePatch(selected.id, { agency: next || null })}
+                className="text-sm text-[var(--color-text-muted)]"
+                showEditIcon
+              />
+            )
           ) : selected.agency ? (
             <span className="text-sm text-[var(--color-text-muted)]">{selected.agency}</span>
           ) : null}

--- a/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
+++ b/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
@@ -118,6 +118,28 @@ describe("AgencyCombobox", () => {
     expect(screen.queryByTestId("agency-clear")).not.toBeInTheDocument()
   })
 
+  it("hides the Clear row while searching (avoids an accidental clear)", async () => {
+    renderCombobox({ value: "Elite" })
+    await openCombobox()
+    expect(screen.getByTestId("agency-clear")).toBeInTheDocument()
+    type("img")
+    expect(screen.queryByTestId("agency-clear")).not.toBeInTheDocument()
+  })
+
+  it("keeps a double-spaced known agency selectable for a collapsed query", async () => {
+    const onChange = vi.fn()
+    render(
+      <AgencyCombobox value={null} knownAgencies={["IMG  Models"]} onChange={onChange} />,
+    )
+    fireEvent.click(screen.getByRole("button", { name: "Agency" }))
+    await screen.findByPlaceholderText("Search or add agency…")
+    type("img models")
+    expect(screen.queryByTestId("agency-add-new")).not.toBeInTheDocument()
+    // Testing Library collapses the rendered double-space, so match the single-space form.
+    fireEvent.click(itemFor("IMG Models"))
+    expect(onChange).toHaveBeenCalledWith("IMG Models")
+  })
+
   it("does not open when disabled", () => {
     renderCombobox({ disabled: true })
     fireEvent.click(screen.getByRole("button", { name: "Agency" }))

--- a/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
+++ b/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
@@ -90,6 +90,21 @@ describe("AgencyCombobox", () => {
     expect(screen.queryByTestId("agency-add-new")).not.toBeInTheDocument()
   })
 
+  it("collapses internal whitespace before emitting a new value", async () => {
+    const { onChange } = renderCombobox()
+    await openCombobox()
+    type("Next   Models")
+    fireEvent.click(screen.getByTestId("agency-add-new"))
+    expect(onChange).toHaveBeenCalledWith("Next Models")
+  })
+
+  it("treats an internal-whitespace variant of a known agency as a match (no Add row)", async () => {
+    renderCombobox()
+    await openCombobox()
+    type("IMG  Models")
+    expect(screen.queryByTestId("agency-add-new")).not.toBeInTheDocument()
+  })
+
   it("offers Clear only when a value is set, and clearing emits null", async () => {
     const { onChange } = renderCombobox({ value: "Elite" })
     await openCombobox()

--- a/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
+++ b/src-vnext/features/library/components/__tests__/AgencyCombobox.test.tsx
@@ -1,0 +1,111 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { AgencyCombobox } from "../AgencyCombobox"
+
+const AGENCIES = ["B&M Models", "Elite", "IMG Models"]
+
+function renderCombobox(props: Partial<Parameters<typeof AgencyCombobox>[0]> = {}) {
+  const onChange = vi.fn()
+  render(
+    <AgencyCombobox
+      value={null}
+      knownAgencies={AGENCIES}
+      onChange={onChange}
+      {...props}
+    />,
+  )
+  return { onChange }
+}
+
+/** Opens the popover (the trigger is the button labelled "Agency"). */
+async function openCombobox(): Promise<void> {
+  fireEvent.click(screen.getByRole("button", { name: "Agency" }))
+  await screen.findByPlaceholderText("Search or add agency…")
+}
+
+function type(text: string): void {
+  fireEvent.change(screen.getByPlaceholderText("Search or add agency…"), {
+    target: { value: text },
+  })
+}
+
+function itemFor(name: string): HTMLElement {
+  const el = screen
+    .getAllByText(name)
+    .map((node) => node.closest("[cmdk-item]"))
+    .find((item) => item !== null)
+  if (!el) throw new Error(`No cmdk item for ${name}`)
+  return el as HTMLElement
+}
+
+describe("AgencyCombobox", () => {
+  it("shows the placeholder when there is no value", () => {
+    renderCombobox({ placeholder: "Add agency" })
+    expect(screen.getByRole("button", { name: "Agency" })).toHaveTextContent("Add agency")
+  })
+
+  it("shows the current value on the trigger", () => {
+    renderCombobox({ value: "Elite" })
+    expect(screen.getByRole("button", { name: "Agency" })).toHaveTextContent("Elite")
+  })
+
+  it("lists known agencies and selecting one emits it + closes", async () => {
+    const { onChange } = renderCombobox()
+    await openCombobox()
+    expect(screen.getByText("IMG Models")).toBeInTheDocument()
+
+    fireEvent.click(itemFor("Elite"))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("Elite")
+  })
+
+  it("re-selecting the current value does NOT emit (no redundant write)", async () => {
+    const { onChange } = renderCombobox({ value: "Elite" })
+    await openCombobox()
+    fireEvent.click(itemFor("Elite"))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("filters the list as you type", async () => {
+    renderCombobox()
+    await openCombobox()
+    type("img")
+    expect(screen.getByText("IMG Models")).toBeInTheDocument()
+    expect(screen.queryByText("Elite")).not.toBeInTheDocument()
+  })
+
+  it("offers an Add row for a new name and emits the trimmed value", async () => {
+    const { onChange } = renderCombobox()
+    await openCombobox()
+    type("  Next Models  ")
+    fireEvent.click(screen.getByTestId("agency-add-new"))
+    expect(onChange).toHaveBeenCalledWith("Next Models")
+  })
+
+  it("does NOT offer an Add row when the query matches an existing agency (case-insensitive)", async () => {
+    renderCombobox()
+    await openCombobox()
+    type("elite")
+    expect(screen.queryByTestId("agency-add-new")).not.toBeInTheDocument()
+  })
+
+  it("offers Clear only when a value is set, and clearing emits null", async () => {
+    const { onChange } = renderCombobox({ value: "Elite" })
+    await openCombobox()
+    fireEvent.click(screen.getByTestId("agency-clear"))
+    expect(onChange).toHaveBeenCalledWith(null)
+  })
+
+  it("has no Clear row when there is no value", async () => {
+    renderCombobox({ value: null })
+    await openCombobox()
+    expect(screen.queryByTestId("agency-clear")).not.toBeInTheDocument()
+  })
+
+  it("does not open when disabled", () => {
+    renderCombobox({ disabled: true })
+    fireEvent.click(screen.getByRole("button", { name: "Agency" }))
+    expect(screen.queryByPlaceholderText("Search or add agency…")).not.toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/library/components/__tests__/CreateTalentDialog.agency.test.tsx
+++ b/src-vnext/features/library/components/__tests__/CreateTalentDialog.agency.test.tsx
@@ -1,0 +1,44 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+
+// Toggle the agency-combobox flag per test; the dialog only reads this one flag.
+let agencyComboboxOn = false
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) =>
+    flag === "featureTalentAgencyCombobox" && agencyComboboxOn,
+}))
+
+import { CreateTalentDialog } from "../CreateTalentDialog"
+
+function renderDialog() {
+  render(
+    <CreateTalentDialog
+      open
+      onOpenChange={vi.fn()}
+      busy={false}
+      knownAgencies={["Elite", "IMG Models"]}
+      onSubmit={vi.fn().mockResolvedValue(true)}
+    />,
+  )
+}
+
+describe("CreateTalentDialog — agency field gating", () => {
+  beforeEach(() => {
+    agencyComboboxOn = false
+  })
+
+  it("flag OFF renders the free-text agency Input (no combobox trigger)", () => {
+    agencyComboboxOn = false
+    renderDialog()
+    expect(screen.queryByRole("button", { name: "Agency" })).not.toBeInTheDocument()
+    // The free-text Input shares the "Optional" placeholder with email/phone/url.
+    expect(screen.getAllByPlaceholderText("Optional").length).toBeGreaterThan(0)
+  })
+
+  it("flag ON renders the AgencyCombobox trigger", () => {
+    agencyComboboxOn = true
+    renderDialog()
+    expect(screen.getByRole("button", { name: "Agency" })).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/library/components/__tests__/TalentHeroZone.agency.test.tsx
+++ b/src-vnext/features/library/components/__tests__/TalentHeroZone.agency.test.tsx
@@ -1,0 +1,52 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import type { TalentRecord } from "@/shared/types"
+
+// Toggle the agency-combobox flag per test; nothing else in the TalentHeroZone
+// import chain reads flags, so this mock is isolated to the gated branch.
+let agencyComboboxOn = false
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) =>
+    flag === "featureTalentAgencyCombobox" && agencyComboboxOn,
+}))
+
+import { TalentHeroZone } from "../TalentHeroZone"
+
+const TALENT = { id: "t1", name: "Alice", agency: "IMG Models" } as TalentRecord
+
+function renderHero() {
+  render(
+    <TalentHeroZone
+      selected={TALENT}
+      canEdit
+      busy={false}
+      selectedHeadshotUrl={null}
+      selectedHeadshotPath={null}
+      knownAgencies={["Elite", "IMG Models"]}
+      savePatch={vi.fn().mockResolvedValue(undefined)}
+      onHeadshotFile={vi.fn().mockResolvedValue(undefined)}
+      setHeadshotRemoveOpen={vi.fn()}
+    />,
+  )
+}
+
+describe("TalentHeroZone — agency field gating", () => {
+  beforeEach(() => {
+    agencyComboboxOn = false
+  })
+
+  it("flag OFF renders the free-text InlineEdit (no combobox trigger)", () => {
+    agencyComboboxOn = false
+    renderHero()
+    expect(screen.queryByRole("button", { name: "Agency" })).not.toBeInTheDocument()
+    expect(screen.getByText("IMG Models")).toBeInTheDocument()
+  })
+
+  it("flag ON renders the AgencyCombobox trigger showing the current value", () => {
+    agencyComboboxOn = true
+    renderHero()
+    const trigger = screen.getByRole("button", { name: "Agency" })
+    expect(trigger).toHaveTextContent("IMG Models")
+  })
+})

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -110,4 +110,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureShotFilterTalentScope")).toBe(false)
     }
   })
+
+  it("defaults featureTalentAgencyCombobox to false (agency stays free-text on main; normalize before flip)", () => {
+    expect(getFeatureFlags().featureTalentAgencyCombobox).toBe(false)
+    expect(isFeatureEnabled("featureTalentAgencyCombobox")).toBe(false)
+  })
+
+  it("VITE_TALENT_AGENCY_COMBOBOX='1' or 'true' enables featureTalentAgencyCombobox", () => {
+    vi.stubEnv("VITE_TALENT_AGENCY_COMBOBOX", "1")
+    expect(isFeatureEnabled("featureTalentAgencyCombobox")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_AGENCY_COMBOBOX", "true")
+    expect(isFeatureEnabled("featureTalentAgencyCombobox")).toBe(true)
+  })
+
+  it("any other VITE_TALENT_AGENCY_COMBOBOX value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_TALENT_AGENCY_COMBOBOX", value)
+      expect(isFeatureEnabled("featureTalentAgencyCombobox")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -77,6 +77,17 @@ export interface FeatureFlags {
    * time (featureTalentDetailIA env-parse precedent). No URL/localStorage layer.
    */
   readonly featureShotFilterTalentScope: boolean
+  /**
+   * Maintenance — talent agency controlled input. Gates the AgencyCombobox
+   * (type-to-filter over known agencies + create-new) that replaces the
+   * free-text agency InlineEdit on TalentHeroZone and the agency Input on
+   * CreateTalentDialog. Default OFF; the flag-off path is the byte-identical
+   * free-text InlineEdit / Input. Enabled via `VITE_TALENT_AGENCY_COMBOBOX=1`
+   * (or `true`) at build/dev time (featureShotFilterTalentScope env-parse
+   * precedent). No URL/localStorage layer. Run scripts/normalize-agency-names.ts
+   * before the prod flip — the agency filter is exact-equality.
+   */
+  readonly featureTalentAgencyCombobox: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -87,6 +98,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureTalentRosterIA: false,
   featureTalentDetailIA: false,
   featureShotFilterTalentScope: false,
+  featureTalentAgencyCombobox: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -124,6 +136,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureShotFilterTalentScope:
       DEFAULT_FLAGS.featureShotFilterTalentScope ||
       parseEnvFlag(import.meta.env.VITE_SHOT_FILTER_TALENT_SCOPE),
+    featureTalentAgencyCombobox:
+      DEFAULT_FLAGS.featureTalentAgencyCombobox ||
+      parseEnvFlag(import.meta.env.VITE_TALENT_AGENCY_COMBOBOX),
   }
 }
 


### PR DESCRIPTION
Maintenance item **B** (the last of Session 28's 3 flagged items). Closes the talent agency free-text → duplicate-variants gap with a controlled input + a one-time normalization migration. Built scout → build → adversarial-verify.

## What changed
**1. `AgencyCombobox` (new, cmdk `Command` + `Popover`)** — single-value, type-to-filter agency picker. Shows existing agencies first (to curb dupes), **allows free entry** (B2), **trims on write** (`updateTalent` doesn't trim), and **no-write-on-unchanged** (mirrors the `InlineEdit` guard it replaces). Replaces the free-text agency `InlineEdit` on `TalentHeroZone` **and** the agency `Input` on `CreateTalentDialog`.

**2. Threading** — `knownAgencies` (= `extractUniqueAgencies(talent)`, **memoized** so `React.memo(TalentDetailPanel)` stays stable) from `LibraryTalentPage` → `TalentDetailPanel` → `TalentHeroZone`, and into `CreateTalentDialog`.

**3. `scripts/normalize-agency-names.ts` (new)** — modeled on the proven `scripts/fixup-talent-gender.ts` (Firebase Admin, `--clientId`, dry-run default, chunked + 50ms). Sequencing:
- **Dump** (dry-run, no mapping): prints every distinct agency + count → Ted curates a `{variant → canonical}` JSON.
- **Preview** (`--mapping=…`): shows planned renames.
- **Write** (`--write`, requires `--mapping`): applies the reviewed map. Unmapped agencies left untouched + reported; map a variant to `""` to clear.

## Flag-gating
Behind **`featureTalentAgencyCombobox`** (env `VITE_TALENT_AGENCY_COMBOBOX`, **default OFF**; deploy-live doesn't define it). **Flag-off path is byte-identical** to trunk on both surfaces (the `InlineEdit` / `Input`).

## 🚩 Sequencing (Ted owns these op steps)
The agency filter `matchesAgency` (`talentFilters.ts`) is **exact-equality**, so variants only collapse in the filter once stored data is normalized:
1. Run the dump (`--clientId=…`) → curate the canonical map.
2. Preview (`--mapping`) → `--write`.
3. **Then** flip the flag (flag-on `:5174` eyeball is yours).

## Adversarial verification (4 lenses + confirm pass)
- **Flag-off byte-identical:** no findings.
- **Correctness (low, fixed):** re-selecting the current agency fired a redundant Firestore write the `InlineEdit` suppressed → added a no-write-on-unchanged guard (+ test).
- **Migration (low, fixed):** `loadMapping` silently dropped a row on a normalized-key collision with differing canonicals → now hard-stops at load time (before any Firestore connection).
- **Migration (nit, fixed):** canonical write value now whitespace-normalized (not just trimmed) so a sloppy canonical can't reintroduce a near-dup.
- **Constraints (false-positive, dismissed):** "empty-state never shows" — proven unreachable branch.

## Gates (verified locally)
- **Tests:** full suite **3755 passed, 79 pre-existing QUARANTINE skips, 0 fail**; **12 new** (10 `AgencyCombobox` + 2 `TalentHeroZone` flag-gating).
- **Lint:** clean (`--max-warnings=0`). **Build:** OK. **tsc:** 160 = baseline (**delta 0**); changed files clean.

## Notes
- `CreateTalentDialog` was included beyond the original spec ("consider") because it's the primary *new-agency* drift surface — same flag, `createTalent` already trims.
- The PopoverContent carries the 5d Escape-guard (`onEscapeKeyDown` stopPropagation), matching `LocationPicker`.