### PR TITLE
feat(talent): casting matcher = its own ranked surface (flag-gated)

### DIFF
--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -161,9 +161,7 @@ export default function LibraryTalentPage() {
     return m
   }, [castingResults])
 
-  // Flag-off keeps the legacy in-place re-sort mode. Flag-on (Phase 3) routes
-  // ranking to the dedicated matcher surface, so the roster never re-sorts or
-  // shows score badges.
+  // Flag-on: the matcher is a dedicated surface, not an in-place roster re-sort.
   const castingMode = !matcherSurface && castingPanelOpen && castingHasRequirements
   const castingSurfaceActive = matcherSurface && castingPanelOpen
 

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -83,6 +83,7 @@ export default function LibraryTalentPage() {
   const canCreate = canManageTalent(role)
   const canEdit = canCreate && !isMobile
   const rosterIA = isFeatureEnabled("featureTalentRosterIA")
+  const matcherSurface = isFeatureEnabled("featureCastingMatcherSurface")
   const { data: talent, loading, error } = useTalentLibrary()
   const { data: projects } = useProjects()
   const projectIds = useMemo(() => projects.map((p) => p.id), [projects])
@@ -160,7 +161,11 @@ export default function LibraryTalentPage() {
     return m
   }, [castingResults])
 
-  const castingMode = castingPanelOpen && castingHasRequirements
+  // Flag-off keeps the legacy in-place re-sort mode. Flag-on (Phase 3) routes
+  // ranking to the dedicated matcher surface, so the roster never re-sorts or
+  // shows score badges.
+  const castingMode = !matcherSurface && castingPanelOpen && castingHasRequirements
+  const castingSurfaceActive = matcherSurface && castingPanelOpen
 
   const displayTalent = useMemo(() => {
     if (!castingMode) return filtered
@@ -594,119 +599,134 @@ export default function LibraryTalentPage() {
         />
       ) : (
         <div className="flex flex-col gap-4">
-          <div className={cn("flex items-center gap-2", rosterIA && "flex-wrap")}>
-            <SearchBar
-              value={query}
-              onChange={setQuery}
-              placeholder="Search talent…"
-              className="max-w-sm flex-1"
-            />
-            {rosterIA ? (
-              <TalentToolbarRangeFilters
-                filters={filters}
-                onFiltersChange={handleFiltersChange}
-                talent={talent}
-              />
-            ) : null}
-            <TalentFilterToolbar
-              filters={filters}
-              onFiltersChange={handleFiltersChange}
-              onOpenSheet={() => setFilterSheetOpen(true)}
-            />
-            <ViewModeToggle
-              modes={TALENT_VIEW_OPTIONS}
-              activeMode={viewMode}
-              onChange={(mode) => setViewMode(mode as "grid" | "table")}
-            />
-            <CastingModeButton
-              active={castingPanelOpen}
-              onToggle={() => setCastingPanelOpen((prev) => !prev)}
+          {castingSurfaceActive ? (
+            <CastingBriefPanel
+              open
+              onToggle={() => setCastingPanelOpen(false)}
+              talent={talent}
+              brief={castingBrief}
+              onBriefChange={setCastingBrief}
+              hasRequirements={castingHasRequirements}
               matchCount={castingResults.length}
-            />
-          </div>
-
-          <CastingBriefPanel
-            open={castingPanelOpen}
-            onToggle={() => setCastingPanelOpen(false)}
-            talent={talent}
-            brief={castingBrief}
-            onBriefChange={setCastingBrief}
-            hasRequirements={castingHasRequirements}
-            matchCount={castingResults.length}
-            results={castingResults}
-          />
-
-          {rosterIA ? (
-            <div
-              className="text-xs text-[var(--color-text-muted)]"
-              data-testid="talent-result-count"
-            >
-              {filtered.length === talent.length
-                ? `${talent.length} talent`
-                : `Showing ${filtered.length} of ${talent.length} talent`}
-            </div>
-          ) : null}
-
-          {filtered.length === 0 ? (
-            <EmptyState
-              icon={<Search className="h-12 w-12" />}
-              title="No matching talent"
-              description="Try adjusting your search."
-              actionLabel="Clear search"
-              onAction={() => setQuery("")}
+              results={castingResults}
             />
           ) : (
             <>
-              {viewMode === "table" ? (
-                <TalentTable
-                  talent={displayTalent}
-                  selectedId={selectedId}
-                  onSelect={(id) => {
-                    setSelectedId((prev) => (prev === id ? null : id))
-                    setActiveTab("detail")
-                  }}
+              <div className={cn("flex items-center gap-2", rosterIA && "flex-wrap")}>
+                <SearchBar
+                  value={query}
+                  onChange={setQuery}
+                  placeholder="Search talent…"
+                  className="max-w-sm flex-1"
+                />
+                {rosterIA ? (
+                  <TalentToolbarRangeFilters
+                    filters={filters}
+                    onFiltersChange={handleFiltersChange}
+                    talent={talent}
+                  />
+                ) : null}
+                <TalentFilterToolbar
+                  filters={filters}
+                  onFiltersChange={handleFiltersChange}
+                  onOpenSheet={() => setFilterSheetOpen(true)}
+                />
+                <ViewModeToggle
+                  modes={TALENT_VIEW_OPTIONS}
+                  activeMode={viewMode}
+                  onChange={(mode) => setViewMode(mode as "grid" | "table")}
+                />
+                <CastingModeButton
+                  active={castingPanelOpen}
+                  onToggle={() => setCastingPanelOpen((prev) => !prev)}
+                  matchCount={castingResults.length}
+                />
+              </div>
+
+              <CastingBriefPanel
+                open={castingPanelOpen}
+                onToggle={() => setCastingPanelOpen(false)}
+                talent={talent}
+                brief={castingBrief}
+                onBriefChange={setCastingBrief}
+                hasRequirements={castingHasRequirements}
+                matchCount={castingResults.length}
+                results={castingResults}
+              />
+
+              {rosterIA ? (
+                <div
+                  className="text-xs text-[var(--color-text-muted)]"
+                  data-testid="talent-result-count"
+                >
+                  {filtered.length === talent.length
+                    ? `${talent.length} talent`
+                    : `Showing ${filtered.length} of ${talent.length} talent`}
+                </div>
+              ) : null}
+
+              {filtered.length === 0 ? (
+                <EmptyState
+                  icon={<Search className="h-12 w-12" />}
+                  title="No matching talent"
+                  description="Try adjusting your search."
+                  actionLabel="Clear search"
+                  onAction={() => setQuery("")}
                 />
               ) : (
-                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-                  {displayTalent.map((t) => {
-                    const isSelected = selectedId === t.id
-                    const score = castingMode ? castingScoreMap.get(t.id) : undefined
-                    return (
-                      <button
-                        key={t.id}
-                        type="button"
-                        onClick={() => {
-                          setSelectedId((prev) => (prev === t.id ? null : t.id))
-                          setActiveTab("detail")
-                        }}
-                        className={`relative rounded-md border p-3 text-left transition-[colors,box-shadow] ${
-                          isSelected
-                            ? "ring-2 ring-[var(--color-primary)] border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
-                            : "border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-subtle)] hover:shadow-md"
-                        }`}
-                      >
-                        {score !== undefined ? <ScoreBadge score={score} /> : null}
-                        <div className="flex items-center gap-3">
-                          <HeadshotThumb talent={t} />
-                          <div className="min-w-0">
-                            <div className="truncate text-sm font-medium text-[var(--color-text)]">
-                              {buildDisplayName(t)}
+                <>
+                  {viewMode === "table" ? (
+                    <TalentTable
+                      talent={displayTalent}
+                      selectedId={selectedId}
+                      onSelect={(id) => {
+                        setSelectedId((prev) => (prev === id ? null : id))
+                        setActiveTab("detail")
+                      }}
+                    />
+                  ) : (
+                    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                      {displayTalent.map((t) => {
+                        const isSelected = selectedId === t.id
+                        const score = castingMode ? castingScoreMap.get(t.id) : undefined
+                        return (
+                          <button
+                            key={t.id}
+                            type="button"
+                            onClick={() => {
+                              setSelectedId((prev) => (prev === t.id ? null : t.id))
+                              setActiveTab("detail")
+                            }}
+                            className={`relative rounded-md border p-3 text-left transition-[colors,box-shadow] ${
+                              isSelected
+                                ? "ring-2 ring-[var(--color-primary)] border-[var(--color-primary)] bg-[var(--color-surface-subtle)]"
+                                : "border-[var(--color-border)] bg-[var(--color-surface)] hover:bg-[var(--color-surface-subtle)] hover:shadow-md"
+                            }`}
+                          >
+                            {score !== undefined ? <ScoreBadge score={score} /> : null}
+                            <div className="flex items-center gap-3">
+                              <HeadshotThumb talent={t} />
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-[var(--color-text)]">
+                                  {buildDisplayName(t)}
+                                </div>
+                                {t.agency ? (
+                                  <div className="mt-1 truncate text-xs text-[var(--color-text-muted)]">
+                                    {t.agency}
+                                  </div>
+                                ) : (
+                                  <div className="mt-1 text-xs text-[var(--color-text-muted)]">
+                                    —
+                                  </div>
+                                )}
+                              </div>
                             </div>
-                            {t.agency ? (
-                              <div className="mt-1 truncate text-xs text-[var(--color-text-muted)]">
-                                {t.agency}
-                              </div>
-                            ) : (
-                              <div className="mt-1 text-xs text-[var(--color-text-muted)]">
-                                —
-                              </div>
-                            )}
-                          </div>
-                        </div>
-                      </button>
-                    )
-                  })}
-                </div>
+                          </button>
+                        )
+                      })}
+                    </div>
+                  )}
+                </>
               )}
             </>
           )}

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.castingSurface.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.castingSurface.test.tsx
@@ -1,0 +1,129 @@
+/// <reference types="@testing-library/jest-dom" />
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", role: "producer", user: { uid: "u1" } }),
+}))
+
+vi.mock("@/shared/hooks/useMediaQuery", () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock("@/features/library/hooks/useTalentLibrary", () => ({
+  useTalentLibrary: vi.fn(),
+}))
+
+vi.mock("@/shared/lib/resolveStoragePath", () => ({
+  isUrl: (value: string) => value.startsWith("https://") || value.startsWith("http://"),
+  resolveStoragePath: async (path: string) => path,
+  getCachedUrl: (path: string) =>
+    path.startsWith("https://") || path.startsWith("http://") ? path : undefined,
+}))
+
+vi.mock("@/features/projects/hooks/useProjects", () => ({
+  useProjects: () => ({ data: [], loading: false, error: null }),
+}))
+
+vi.mock("@/features/library/lib/talentWrites", () => ({
+  createTalent: vi.fn(),
+  updateTalent: vi.fn(),
+  setTalentHeadshot: vi.fn(),
+  removeTalentHeadshot: vi.fn(),
+  uploadTalentPortfolioImages: vi.fn(),
+  uploadTalentCastingImages: vi.fn(),
+  deleteTalentImagePaths: vi.fn(),
+}))
+
+// Flag ON for this file — exercises the Phase 3 casting matcher surface.
+vi.mock("@/shared/lib/flags", () => ({
+  isFeatureEnabled: (flag: string) => flag === "featureCastingMatcherSurface",
+  getFeatureFlags: () => ({
+    featurePublishing: false,
+    featureSurfaceResolver: true,
+    featureShootSurface: false,
+    featureReviewSurface: false,
+    featureTalentRosterIA: false,
+    featureTalentDetailIA: false,
+    featureShotFilterTalentScope: false,
+    featureTalentAgencyCombobox: false,
+    featureCastingMatcherSurface: true,
+  }),
+}))
+
+import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
+import LibraryTalentPage from "@/features/library/components/LibraryTalentPage"
+
+function talent(id: string, name: string) {
+  return {
+    id,
+    name,
+    agency: "IMG",
+    email: null,
+    phone: null,
+    url: null,
+    gender: "women",
+    notes: "",
+    measurements: { height: 68, waist: 26 },
+    headshotPath: null,
+    headshotUrl: null,
+    galleryImages: [],
+    castingSessions: [],
+  }
+}
+
+function seed(rows: ReturnType<typeof talent>[]) {
+  ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+    data: rows,
+    loading: false,
+    error: null,
+  })
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <LibraryTalentPage />
+    </MemoryRouter>,
+  )
+}
+
+describe("LibraryTalentPage — casting matcher surface (flag on)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("shows the roster (not the matcher surface) by default", () => {
+    seed([talent("t1", "Sara Martinez"), talent("t2", "Bob Brown")])
+    renderPage()
+    expect(screen.getByText("Sara Martinez")).toBeInTheDocument()
+    expect(screen.queryByRole("heading", { name: "Casting Brief" })).toBeNull()
+    expect(screen.getByRole("button", { name: "Open casting brief" })).toBeInTheDocument()
+  })
+
+  it("swaps the roster for a dedicated ranked surface when casting is opened", () => {
+    seed([talent("t1", "Sara Martinez"), talent("t2", "Bob Brown")])
+    renderPage()
+    fireEvent.click(screen.getByRole("button", { name: "Open casting brief" }))
+    // The matcher is now the surface: its brief + ranked results are shown…
+    expect(screen.getByRole("heading", { name: "Casting Brief" })).toBeInTheDocument()
+    expect(screen.getByText("Requirements")).toBeInTheDocument()
+    // …and the roster grid is gone (no in-place re-sort to bleed into).
+    expect(screen.queryByText("Sara Martinez")).toBeNull()
+  })
+
+  it("returns to the roster when the surface is closed", () => {
+    seed([talent("t1", "Sara Martinez"), talent("t2", "Bob Brown")])
+    renderPage()
+    fireEvent.click(screen.getByRole("button", { name: "Open casting brief" }))
+    expect(screen.getByRole("heading", { name: "Casting Brief" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Close casting brief" }))
+    expect(screen.queryByRole("heading", { name: "Casting Brief" })).toBeNull()
+    expect(screen.getByText("Sara Martinez")).toBeInTheDocument()
+  })
+})

--- a/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
+++ b/src-vnext/features/library/components/__tests__/LibraryTalentPage.test.tsx
@@ -103,6 +103,37 @@ describe("LibraryTalentPage", { timeout: 60_000 }, () => {
     expect(screen.queryByRole("button", { name: /range filter/i })).toBeNull()
   })
 
+  it("keeps the casting brief above the roster (not a dedicated surface) when the matcher flag is off", () => {
+    ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      data: [
+        {
+          id: "t1",
+          name: "Alex Rivera",
+          agency: "IMG",
+          email: null,
+          phone: null,
+          url: null,
+          gender: null,
+          notes: "",
+          measurements: null,
+          headshotPath: null,
+          headshotUrl: null,
+          galleryImages: [],
+          castingSessions: [],
+        },
+      ],
+      loading: false,
+      error: null,
+    })
+
+    renderPage()
+    expect(screen.getByText("Alex Rivera")).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("button", { name: "Open casting brief" }))
+    // Flag-off legacy mode: the brief panel opens above the roster, which stays visible.
+    expect(screen.getByRole("heading", { name: "Casting Brief" })).toBeInTheDocument()
+    expect(screen.getByText("Alex Rivera")).toBeInTheDocument()
+  })
+
   it("renders the Contact card (not the Phase-2 detail meta-line) when the detail IA flag is off", () => {
     ;(useTalentLibrary as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
       data: [

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -130,4 +130,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureTalentAgencyCombobox")).toBe(false)
     }
   })
+
+  it("defaults featureCastingMatcherSurface to false (Talent redesign Phase 3 is dark on main)", () => {
+    expect(getFeatureFlags().featureCastingMatcherSurface).toBe(false)
+    expect(isFeatureEnabled("featureCastingMatcherSurface")).toBe(false)
+  })
+
+  it("VITE_CASTING_MATCHER_SURFACE='1' or 'true' enables featureCastingMatcherSurface", () => {
+    vi.stubEnv("VITE_CASTING_MATCHER_SURFACE", "1")
+    expect(isFeatureEnabled("featureCastingMatcherSurface")).toBe(true)
+
+    vi.stubEnv("VITE_CASTING_MATCHER_SURFACE", "true")
+    expect(isFeatureEnabled("featureCastingMatcherSurface")).toBe(true)
+  })
+
+  it("any other VITE_CASTING_MATCHER_SURFACE value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_CASTING_MATCHER_SURFACE", value)
+      expect(isFeatureEnabled("featureCastingMatcherSurface")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -88,6 +88,17 @@ export interface FeatureFlags {
    * before the prod flip — the agency filter is exact-equality.
    */
   readonly featureTalentAgencyCombobox: boolean
+  /**
+   * Talent redesign Phase 3 — casting matcher = its own ranked surface. Gates
+   * promoting the casting brief from an in-place roster re-sort mode to a
+   * dedicated score-first surface on LibraryTalentPage (brief + ranked
+   * results replace the roster; no in-place re-sort or roster score badges).
+   * Default OFF; the flag-off path is the byte-identical panel-above-roster
+   * mode. Enabled via `VITE_CASTING_MATCHER_SURFACE=1` (or `true`) at
+   * build/dev time (featureTalentAgencyCombobox env-parse precedent). No
+   * URL/localStorage layer.
+   */
+  readonly featureCastingMatcherSurface: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -99,6 +110,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureTalentDetailIA: false,
   featureShotFilterTalentScope: false,
   featureTalentAgencyCombobox: false,
+  featureCastingMatcherSurface: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -139,6 +151,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureTalentAgencyCombobox:
       DEFAULT_FLAGS.featureTalentAgencyCombobox ||
       parseEnvFlag(import.meta.env.VITE_TALENT_AGENCY_COMBOBOX),
+    featureCastingMatcherSurface:
+      DEFAULT_FLAGS.featureCastingMatcherSurface ||
+      parseEnvFlag(import.meta.env.VITE_CASTING_MATCHER_SURFACE),
   }
 }
 


### PR DESCRIPTION
## Talent redesign — Phase 3 (LOCKED Decision #1)

Promotes the casting brief matcher from an in-place roster re-sort **mode** to its own score-first **surface**, behind a new build-time flag `featureCastingMatcherSurface` (env `VITE_CASTING_MATCHER_SURFACE`, default **OFF**; mirrors `featureTalentAgencyCombobox`).

### What changes
- **Flag ON:** when the casting brief is open, it renders as the **sole surface** (brief form + ranked results) replacing the roster. `castingMode` is forced off → the roster never re-sorts in place and never shows score badges. Built as a panel that can later graduate to a route.
- **Flag OFF:** the verbatim trunk behavior (brief panel above the re-sorting roster). **Byte-identical.**

### Diff note (please review with “hide whitespace”)
The `LibraryTalentPage.tsx` diff looks large but the **true functional change is 21 insertions / 1 deletion** — confirm with:
```
git diff -w main...feat/casting-matcher-surface -- src-vnext/features/library/components/LibraryTalentPage.tsx
```
The rest is a +4 re-indent of the **unchanged** flag-off block, now nested under the surface conditional. The flag-off JSX shows as unchanged context under `-w`, which is the proof of byte-identical flag-off.

### Blast radius — contained
`CastingBriefPanel` / `ScoreBadge` / `rankTalentForBrief` are imported **only** by `LibraryTalentPage`. This PR does **not** touch `AdminTalentDetailSheet` (board), the public `TalentDetailSheet` (`/s/:token`), or `CastingBoardPage` — so the §8 shared-component blast radius does not fire and **no casting-board write** is added. `rankTalentForBrief` (engine) and `CastingBriefMatcher` are unchanged.

### Tests
- `flags.test.ts`: 3 cases for the new flag (default-off, `1`/`true` enables, other values stay off).
- **New** `LibraryTalentPage.castingSurface.test.tsx` (flag-ON): roster shown by default → opening casting **swaps** to the dedicated surface (roster hidden) → closing returns to the roster.
- `LibraryTalentPage.test.tsx` (flag-OFF): opening casting keeps the **panel above the roster** (roster stays visible) — the discriminating coexistence assertion.

### Gates (local)
- ESLint: clean · `tsc`: 160 (= baseline, delta 0) · full `vitest`: **282 files / 3766 passed, 79 pre-existing skips, 0 failures**.

### Adversarial verify (5 read-only lenses on the diff)
flag-off-byte-identical **clean** · hook-deps/state **clean** · regression/blast-radius **clean**. Deferred-with-tracking (non-blocking, both for Ted's flag-on `:5174` eyeball):
1. **Flag-on integration coverage of the ranked cards** (matcher producing `MatchCard`s from a real requirement) is left to the eyeball — driving the Radix slider in jsdom is flake-prone, and the ranked path is fully covered at the unit level (`castingMatch.test.ts`, `CastingBriefMatcher.test.tsx`) and wired identically flag-on/off.
2. **Detail Sheet can stay layered over the surface** if a talent was selected before opening casting (functional; nav + close behave). An IA judgment call — whether entering the surface should also dismiss the Sheet — to decide at the eyeball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)