### PR TITLE
refactor(talent): localize sessionExpanded into CastingSessionList

### DIFF
--- a/src-vnext/features/library/components/CastingSessionList.tsx
+++ b/src-vnext/features/library/components/CastingSessionList.tsx
@@ -1,5 +1,5 @@
 import { Trash2 } from "lucide-react"
-import type { ChangeEvent } from "react"
+import { useState, type ChangeEvent } from "react"
 import {
   DndContext,
   closestCenter,
@@ -37,8 +37,6 @@ interface CastingSessionListProps {
   readonly busy: boolean
   readonly projects: Array<{ id: string; name?: string | null }>
   readonly sensors: ReturnType<typeof useSensors>
-  readonly sessionExpanded: Record<string, boolean>
-  readonly setSessionExpanded: (updater: (prev: Record<string, boolean>) => Record<string, boolean>) => void
   readonly updateCastingSessions: (
     next: CastingSession[],
     removedPaths?: readonly (string | null | undefined)[],
@@ -60,8 +58,6 @@ export function CastingSessionList({
   busy,
   projects,
   sensors,
-  sessionExpanded,
-  setSessionExpanded,
   updateCastingSessions,
   onCastingFiles,
   setGalleryRemoveOpen,
@@ -71,6 +67,8 @@ export function CastingSessionList({
   setCreateSessionOpen,
   setPrintSessionId,
 }: CastingSessionListProps) {
+  const [sessionExpanded, setSessionExpanded] = useState<Record<string, boolean>>({})
+
   return (
     <div className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-4">
       <div className="flex items-center justify-between gap-3">

--- a/src-vnext/features/library/components/LibraryTalentPage.tsx
+++ b/src-vnext/features/library/components/LibraryTalentPage.tsx
@@ -102,7 +102,6 @@ export default function LibraryTalentPage() {
   ])
 
   const [busy, setBusy] = useState(false)
-  const [sessionExpanded, setSessionExpanded] = useState<Record<string, boolean>>({})
   const {
     headshotRemoveOpen,
     setHeadshotRemoveOpen,
@@ -785,8 +784,6 @@ export default function LibraryTalentPage() {
                   setGalleryRemoveTarget={setGalleryRemoveTarget}
                   setSessionRemoveOpen={setSessionRemoveOpen}
                   setSessionRemoveTarget={setSessionRemoveTarget}
-                  sessionExpanded={sessionExpanded}
-                  setSessionExpanded={setSessionExpanded}
                   setDeleteOpen={setDeleteOpen}
                   setCreateSessionOpen={setCreateSessionOpen}
                   setPrintSessionId={setPrintSessionId}

--- a/src-vnext/features/library/components/TalentDetailPanel.tsx
+++ b/src-vnext/features/library/components/TalentDetailPanel.tsx
@@ -51,8 +51,6 @@ interface TalentDetailPanelProps {
   readonly setGalleryRemoveTarget: (target: TalentImage | null) => void
   readonly setSessionRemoveOpen: (open: boolean) => void
   readonly setSessionRemoveTarget: (target: CastingSession | null) => void
-  readonly sessionExpanded: Record<string, boolean>
-  readonly setSessionExpanded: (updater: (prev: Record<string, boolean>) => Record<string, boolean>) => void
   readonly setDeleteOpen: (open: boolean) => void
   readonly setCreateSessionOpen: (open: boolean) => void
   readonly setPrintSessionId: (id: string | null) => void
@@ -87,8 +85,6 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
   setGalleryRemoveTarget,
   setSessionRemoveOpen,
   setSessionRemoveTarget,
-  sessionExpanded,
-  setSessionExpanded,
   setDeleteOpen,
   setCreateSessionOpen,
   setPrintSessionId,
@@ -211,8 +207,6 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
                 busy={busy}
                 projects={projects}
                 sensors={sensors}
-                sessionExpanded={sessionExpanded}
-                setSessionExpanded={setSessionExpanded}
                 updateCastingSessions={updateCastingSessions}
                 onCastingFiles={onCastingFiles}
                 setGalleryRemoveOpen={setGalleryRemoveOpen}
@@ -334,8 +328,6 @@ export const TalentDetailPanel = memo(function TalentDetailPanel({
               busy={busy}
               projects={projects}
               sensors={sensors}
-              sessionExpanded={sessionExpanded}
-              setSessionExpanded={setSessionExpanded}
               updateCastingSessions={updateCastingSessions}
               onCastingFiles={onCastingFiles}
               setGalleryRemoveOpen={setGalleryRemoveOpen}


### PR DESCRIPTION
## Talent redesign — Phase 4 (state-state localization)

Moves the casting-session accordion `sessionExpanded` state out of the `LibraryTalentPage` orchestrator (one fewer `useState`) and out of the `TalentDetailPanel` prop chain, into `CastingSessionList` — **its only consumer** (read at one site, written at one site). **Pure refactor, no flag, no behavior change to the test-covered flows.**

### Why
Per the redesign spec (§4/§5), `sessionExpanded` "belongs inside `CastingSessionList`." It was threaded `LibraryTalentPage → TalentDetailPanel → CastingSessionList` purely as a pass-through.

### Side benefit (perf)
The `memo`'d `TalentDetailPanel` no longer re-renders when a session is expanded/collapsed — the `sessionExpanded` prop (which changed on every toggle) is gone, so a toggle now re-renders only `CastingSessionList`.

### Behavior note
Expand state now resets when the detail Sheet closes and reopens (state is local to `CastingSessionList`). This is the intended localization — a freshly-opened talent starts with sessions collapsed. No flow depends on cross-open persistence (print/export uses `printSessionId`, separate).

### Diff
3 insertions / 16 deletions across `CastingSessionList.tsx` (+local `useState`, −2 props), `TalentDetailPanel.tsx` (−2 props, −2 call-site pairs), `LibraryTalentPage.tsx` (−1 `useState`, −1 prop pair).

### Gates (local)
ESLint clean · `tsc` 160 (= baseline, delta 0) · full `vitest` **282 files / 3766 passed, 79 pre-existing skips, 0 failures**. The casting-session create/export/update tests (which click the session button = the expand toggle) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)