### PR TITLE
feat(talent): lazy-load portfolio/casting images behind featureTalentLazy (Phase 6)

### DIFF
--- a/src-vnext/features/library/components/SortableImageTile.tsx
+++ b/src-vnext/features/library/components/SortableImageTile.tsx
@@ -3,14 +3,18 @@ import { CSS } from "@dnd-kit/utilities"
 import { GripVertical, Trash2 } from "lucide-react"
 import { InlineEdit } from "@/shared/components/InlineEdit"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import type { TalentImage } from "@/features/library/components/talentUtils"
 
 function ImageThumb({ image, alt }: { readonly image: TalentImage; readonly alt: string }) {
   const url = useStorageUrl(image.downloadURL ?? image.path)
+  // Phase 6 (featureTalentLazy): defer offscreen portfolio / casting-session
+  // grid images. Flag-off omits the attribute (byte-identical).
+  const loading = isFeatureEnabled("featureTalentLazy") ? "lazy" : undefined
   return (
     <div className="aspect-square overflow-hidden rounded-md border border-[var(--color-border)] bg-[var(--color-surface-subtle)]">
       {url ? (
-        <img src={url} alt={alt} className="h-full w-full object-cover" />
+        <img src={url} alt={alt} loading={loading} className="h-full w-full object-cover" />
       ) : (
         <div className="flex h-full w-full items-center justify-center text-xs text-[var(--color-text-muted)]">
           —

--- a/src-vnext/features/library/components/SortableImageTile.tsx
+++ b/src-vnext/features/library/components/SortableImageTile.tsx
@@ -8,8 +8,6 @@ import type { TalentImage } from "@/features/library/components/talentUtils"
 
 function ImageThumb({ image, alt }: { readonly image: TalentImage; readonly alt: string }) {
   const url = useStorageUrl(image.downloadURL ?? image.path)
-  // Phase 6 (featureTalentLazy): defer offscreen portfolio / casting-session
-  // grid images. Flag-off omits the attribute (byte-identical).
   const loading = isFeatureEnabled("featureTalentLazy") ? "lazy" : undefined
   return (
     <div className="aspect-square overflow-hidden rounded-md border border-[var(--color-border)] bg-[var(--color-surface-subtle)]">

--- a/src-vnext/features/library/components/__tests__/SortableImageTile.lazy.test.tsx
+++ b/src-vnext/features/library/components/__tests__/SortableImageTile.lazy.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { DndContext } from "@dnd-kit/core"
+import { SortableContext } from "@dnd-kit/sortable"
+import { SortableImageTile } from "@/features/library/components/SortableImageTile"
+import type { TalentImage } from "@/features/library/components/talentUtils"
+
+vi.mock("@/shared/hooks/useStorageUrl", () => ({
+  useStorageUrl: () => "https://example.test/img.jpg",
+}))
+
+const image: TalentImage = { id: "img-1", path: "talent/t1/img-1.jpg" }
+
+function renderTile() {
+  return render(
+    <DndContext>
+      <SortableContext items={[image.id]}>
+        <SortableImageTile
+          image={image}
+          disabled={false}
+          onDelete={() => {}}
+          onCaptionSave={() => {}}
+        />
+      </SortableContext>
+    </DndContext>,
+  )
+}
+
+describe("SortableImageTile — Phase 6 lazy images (featureTalentLazy)", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("omits loading=\"lazy\" when the flag is off (byte-identical default)", () => {
+    renderTile()
+    expect(screen.getByRole("img")).not.toHaveAttribute("loading")
+  })
+
+  it("sets loading=\"lazy\" when VITE_TALENT_LAZY is enabled", () => {
+    vi.stubEnv("VITE_TALENT_LAZY", "1")
+    renderTile()
+    expect(screen.getByRole("img")).toHaveAttribute("loading", "lazy")
+  })
+})

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -150,4 +150,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureCastingMatcherSurface")).toBe(false)
     }
   })
+
+  it("defaults featureTalentLazy to false (Talent redesign Phase 6 is dark on main)", () => {
+    expect(getFeatureFlags().featureTalentLazy).toBe(false)
+    expect(isFeatureEnabled("featureTalentLazy")).toBe(false)
+  })
+
+  it("VITE_TALENT_LAZY='1' or 'true' enables featureTalentLazy", () => {
+    vi.stubEnv("VITE_TALENT_LAZY", "1")
+    expect(isFeatureEnabled("featureTalentLazy")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_LAZY", "true")
+    expect(isFeatureEnabled("featureTalentLazy")).toBe(true)
+  })
+
+  it("any other VITE_TALENT_LAZY value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_TALENT_LAZY", value)
+      expect(isFeatureEnabled("featureTalentLazy")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -105,9 +105,7 @@ export interface FeatureFlags {
    * Default OFF; the flag-off path omits the attribute (byte-identical).
    * Enabled via `VITE_TALENT_LAZY=1` (or `true`) at build/dev time
    * (featureCastingMatcherSurface env-parse precedent). No URL/localStorage
-   * layer. (The React.lazy code-split half of Phase 6 was dropped: a bundler
-   * can't split a still-statically-imported module, so it can't be both
-   * flag-gated and flag-off byte-identical.)
+   * layer.
    */
   readonly featureTalentLazy: boolean
 }

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -99,6 +99,17 @@ export interface FeatureFlags {
    * URL/localStorage layer.
    */
   readonly featureCastingMatcherSurface: boolean
+  /**
+   * Talent redesign Phase 6 — lazy images. Gates `loading="lazy"` on the
+   * portfolio / casting-session image grids (the shared SortableImageTile).
+   * Default OFF; the flag-off path omits the attribute (byte-identical).
+   * Enabled via `VITE_TALENT_LAZY=1` (or `true`) at build/dev time
+   * (featureCastingMatcherSurface env-parse precedent). No URL/localStorage
+   * layer. (The React.lazy code-split half of Phase 6 was dropped: a bundler
+   * can't split a still-statically-imported module, so it can't be both
+   * flag-gated and flag-off byte-identical.)
+   */
+  readonly featureTalentLazy: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -111,6 +122,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureShotFilterTalentScope: false,
   featureTalentAgencyCombobox: false,
   featureCastingMatcherSurface: false,
+  featureTalentLazy: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -154,6 +166,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureCastingMatcherSurface:
       DEFAULT_FLAGS.featureCastingMatcherSurface ||
       parseEnvFlag(import.meta.env.VITE_CASTING_MATCHER_SURFACE),
+    featureTalentLazy:
+      DEFAULT_FLAGS.featureTalentLazy ||
+      parseEnvFlag(import.meta.env.VITE_TALENT_LAZY),
   }
 }
 


### PR DESCRIPTION
## Talent redesign — Phase 6 (scoped to lazy images + index verification)

Per §5 row 6 of the build spec. **Auto-mergeable**: flag-off byte-identical, off in prod.

### What shipped
- **Lazy images** — new `featureTalentLazy` flag (`VITE_TALENT_LAZY`, default **OFF**), mirroring `featureCastingMatcherSurface`. Gates `loading="lazy"` on the shared **`SortableImageTile`**, which is the single tile used by **both** the portfolio grid (`TalentPortfolioSection`) **and** the casting-session grids (`CastingSessionList`) — so one central edit covers both. Flag-off omits the attribute → **byte-identical** to today.
- **Hero headshots stay un-lazy** — the hero `<img>` lives in `TalentHeroZone` (separate, not via `SortableImageTile`), so no LCP/above-the-fold regression. Verified by importer grep.
- **Composite index — verified, no change.** The shot-history index already exists field-for-field in `firestore.indexes.json` (`shots` COLLECTION: `talentIds` CONTAINS + `deleted` ASC + `updatedAt` DESC), added 2026-03-01, and matches `useTalentShotHistory`'s query exactly. Adding a duplicate would error on deploy → intentionally untouched.

### What was dropped (and why)
The **React.lazy code-split** half (detail/history/print) was dropped. A bundler can't move a module into a separate chunk while it's *also* statically imported — and the static import is required to keep the flag-off path byte-identical. So it's structurally impossible to be **both** flag-gated **and** flag-off byte-identical (proven via `vite build`: Rollup emits "dynamic import will not move module into another chunk" and the chunk stays merged). Decided with Ted (option A): ship the clean image win, skip the code-split (small payoff — those screens already load only within the route-lazy talent page). A real split would need to drop the eager import → a visible skeleton-on-open UX change requiring a `:5174` eyeball; left as a possible future eyeball-gated change.

### Verification
- `flags.test.ts` +3 cases; new `SortableImageTile.lazy.test.tsx` (asserts no `loading` attr off / `loading="lazy"` on). All targeted tests green.
- `vite build` clean — **0** coexistence warnings. `tsc` delta **0** (160 baseline). `eslint --max-warnings=0` clean.
- Independent adversarial review: SHIP.

### Disposition (non-blocking)
The flag read sits in `ImageThumb` (per-tile) — the established per-call-site house pattern in this repo; cost is negligible (9 booleans, sync), and hoisting to the grid parent would widen blast radius into `CastingSessionList` for no measurable gain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)