### PR TITLE
chore(deploy): flip Talent redesign flags ON in prod

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -44,6 +44,11 @@ jobs:
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
           VITE_FLAG_CALLSHEET_BUILDER:       1
           VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
+          VITE_TALENT_ROSTER_IA:             1   # Talent redesign: Height+Waist toolbar filters
+          VITE_TALENT_DETAIL_IA:             1   # Talent redesign: profile re-group (contact line, fit signals, creative assets)
+          VITE_CASTING_MATCHER_SURFACE:      1   # Talent redesign: casting matcher = its own ranked surface
+          VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
+          VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -73,6 +78,11 @@ jobs:
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
           VITE_FLAG_CALLSHEET_BUILDER:       1
           VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
+          VITE_TALENT_ROSTER_IA:             1   # Talent redesign: Height+Waist toolbar filters
+          VITE_TALENT_DETAIL_IA:             1   # Talent redesign: profile re-group (contact line, fit signals, creative assets)
+          VITE_CASTING_MATCHER_SURFACE:      1   # Talent redesign: casting matcher = its own ranked surface
+          VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
+          VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
Flips the **5 reviewed Talent redesign flags** ON in the live build (added to both build env blocks in `deploy-live.yml`, mirroring the existing `VITE_REVIEW_SURFACE` pattern):

- `VITE_TALENT_ROSTER_IA` — Height + Waist filters on the toolbar
- `VITE_TALENT_DETAIL_IA` — profile re-group (contact meta-line → Fit signals → Creative assets → Projects tag row)
- `VITE_CASTING_MATCHER_SURFACE` — casting matcher = its own ranked, score-first surface
- `VITE_TALENT_AGENCY_COMBOBOX` — agency combobox (the live data was already normalized: 502 talent → 9 clean agencies)
- `VITE_TALENT_LAZY` — lazy portfolio/casting images

**Reviewed flag-on on a local dev server (:5174) by Ted on 2026-06-16 and approved** ("good enough to flip to prod"). Improvements (selectable match cards, sheet-over-surface dismissal, brief-slider range floors) are tracked for later, not blockers.

**Held back:** `featureShotFilterTalentScope` — a separate shots-page surface that wasn't reviewed today and has 2 open flag-on follow-ups (search-resets-on-toggle + checkbox a11y).

Merging this triggers `deploy-live` (build with the flags on → Firebase Hosting), making the Talent redesign live for all users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)