### PR TITLE
fix(export): render page orientation & size in the on-screen preview (P0-1)

### DIFF
--- a/src-vnext/features/export/components/DocumentPreview.tsx
+++ b/src-vnext/features/export/components/DocumentPreview.tsx
@@ -14,6 +14,7 @@ import type { ExportDocument, ExportVariable, ExportBlock, PageItem } from "../t
 import { isHStackRow } from "../types/exportBuilder"
 import { SortableBlock } from "./SortableBlock"
 import { HStackRowView } from "./HStackRowView"
+import { getPreviewPageDimensions } from "../lib/pageDimensions"
 
 interface DocumentPreviewProps {
   readonly document: ExportDocument
@@ -219,6 +220,12 @@ export function DocumentPreview({
   const totalPages = visualPages.length
   const canDeletePage = doc.pages.length > 1
 
+  // Drive the on-screen page frame from the document's page settings so
+  // orientation/size changes are visible in the preview (not just the PDF).
+  // Fit-to-width: fixed max width, aspect-correct min-height. Shared with the
+  // PDF via getPageDimensionsPt so the preview can't drift from the export.
+  const pageDims = getPreviewPageDimensions(doc.settings.size, doc.settings.layout)
+
   // Collect all non-page-break block IDs for the sortable context
   const allBlocks = doc.pages.flatMap((page) => flattenItems(page.items))
   const sortableIds = allBlocks
@@ -270,7 +277,8 @@ export function DocumentPreview({
             return (
               <div key={visualKey}>
                 <div
-                  className="doc-page relative w-full max-w-[960px] min-h-[1243px]"
+                  className="doc-page relative w-full"
+                  style={{ maxWidth: pageDims.width, minHeight: pageDims.minHeight }}
                   onClick={() => onPageClick?.(currentPageId)}
                 >
                   {/* Page actions menu */}

--- a/src-vnext/features/export/components/__tests__/DocumentPreview.test.tsx
+++ b/src-vnext/features/export/components/__tests__/DocumentPreview.test.tsx
@@ -9,15 +9,31 @@ const VARIABLES: readonly ExportVariable[] = [
 
 function buildDocument(
   items: ExportDocument["pages"][0]["items"] = [],
+  settings: Partial<ExportDocument["settings"]> = {},
 ): ExportDocument {
   return {
     id: "doc-1",
     name: "Test Doc",
     pages: [{ id: "page-1", items }],
-    settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
+    settings: { layout: "portrait", size: "letter", fontFamily: "Inter", ...settings },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
   }
+}
+
+function renderPreview(doc: ExportDocument): HTMLElement {
+  const { container } = render(
+    <DocumentPreview
+      document={doc}
+      selectedBlockId={null}
+      onSelectBlock={vi.fn()}
+      onAddTextBlock={vi.fn()}
+      variables={VARIABLES}
+    />,
+  )
+  const page = container.querySelector(".doc-page")
+  if (!(page instanceof HTMLElement)) throw new Error("no .doc-page rendered")
+  return page
 }
 
 describe("DocumentPreview", () => {
@@ -118,5 +134,49 @@ describe("DocumentPreview", () => {
       />,
     )
     expect(screen.getByText("Page 1 of 1")).toBeInTheDocument()
+  })
+
+  describe("page orientation & size (P0-1)", () => {
+    it("keeps portrait Letter at its historical ~960×1242 frame", () => {
+      const page = renderPreview(buildDocument([], { layout: "portrait", size: "letter" }))
+      expect(page.style.maxWidth).toBe("960px")
+      // 960 * 792/612 ≈ 1242
+      expect(page.style.minHeight).toBe("1242px")
+    })
+
+    it("makes a landscape page shorter than its portrait counterpart", () => {
+      const portrait = renderPreview(buildDocument([], { layout: "portrait", size: "letter" }))
+      const portraitMinH = parseInt(portrait.style.minHeight, 10)
+
+      const landscape = renderPreview(buildDocument([], { layout: "landscape", size: "letter" }))
+      const landscapeMinH = parseInt(landscape.style.minHeight, 10)
+
+      // Same fit-to-width canvas width, but landscape is wider-than-tall → shorter frame.
+      expect(landscape.style.maxWidth).toBe("960px")
+      expect(landscapeMinH).toBeLessThan(portraitMinH)
+      // 960 * 612/792 ≈ 742
+      expect(landscape.style.minHeight).toBe("742px")
+    })
+
+    it("renders A4 and Legal with distinct aspect ratios", () => {
+      const a4 = renderPreview(buildDocument([], { layout: "portrait", size: "a4" }))
+      const legal = renderPreview(buildDocument([], { layout: "portrait", size: "legal" }))
+      expect(a4.style.minHeight).not.toBe(legal.style.minHeight)
+      // 960 * 841.89/595.28 ≈ 1358 ; 960 * 1008/612 ≈ 1581
+      expect(a4.style.minHeight).toBe("1358px")
+      expect(legal.style.minHeight).toBe("1581px")
+    })
+
+    it("falls back to Letter portrait when size/layout are absent", () => {
+      // Legacy docs may omit size/layout; mirror the PDF's defensive defaulting.
+      const doc = buildDocument([])
+      const loose = {
+        ...doc,
+        settings: { ...doc.settings, layout: undefined, size: undefined },
+      } as unknown as ExportDocument
+      const page = renderPreview(loose)
+      expect(page.style.maxWidth).toBe("960px")
+      expect(page.style.minHeight).toBe("1242px")
+    })
   })
 })

--- a/src-vnext/features/export/lib/__tests__/pageDimensions.test.ts
+++ b/src-vnext/features/export/lib/__tests__/pageDimensions.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest"
+import {
+  PAGE_DIMENSIONS_PT,
+  PREVIEW_PAGE_WIDTH_PX,
+  getPageDimensionsPt,
+  getPreviewPageDimensions,
+} from "../pageDimensions"
+
+describe("getPageDimensionsPt", () => {
+  it("returns canonical points for portrait sizes", () => {
+    expect(getPageDimensionsPt("letter", "portrait")).toEqual(PAGE_DIMENSIONS_PT.letter)
+    expect(getPageDimensionsPt("a4", "portrait")).toEqual(PAGE_DIMENSIONS_PT.a4)
+    expect(getPageDimensionsPt("legal", "portrait")).toEqual(PAGE_DIMENSIONS_PT.legal)
+  })
+
+  it("swaps width/height for landscape", () => {
+    const { width, height } = getPageDimensionsPt("letter", "landscape")
+    expect(width).toBe(PAGE_DIMENSIONS_PT.letter.height)
+    expect(height).toBe(PAGE_DIMENSIONS_PT.letter.width)
+    expect(width).toBeGreaterThan(height)
+  })
+
+  it("defaults to Letter portrait for missing/unknown size+layout", () => {
+    expect(getPageDimensionsPt(undefined, undefined)).toEqual(PAGE_DIMENSIONS_PT.letter)
+    // unknown size key still falls back to letter
+    expect(getPageDimensionsPt("tabloid" as never, "portrait")).toEqual(
+      PAGE_DIMENSIONS_PT.letter,
+    )
+  })
+})
+
+describe("getPreviewPageDimensions", () => {
+  it("is fit-to-width: width is constant, min-height tracks the aspect ratio", () => {
+    const portrait = getPreviewPageDimensions("letter", "portrait")
+    expect(portrait.width).toBe(PREVIEW_PAGE_WIDTH_PX)
+    expect(portrait.minHeight).toBe(1242) // 960 * 792/612
+
+    const landscape = getPreviewPageDimensions("letter", "landscape")
+    expect(landscape.width).toBe(PREVIEW_PAGE_WIDTH_PX)
+    expect(landscape.minHeight).toBe(742) // 960 * 612/792
+    expect(landscape.minHeight).toBeLessThan(portrait.minHeight)
+  })
+
+  it("distinguishes A4 from Legal", () => {
+    expect(getPreviewPageDimensions("a4", "portrait").minHeight).toBe(1358)
+    expect(getPreviewPageDimensions("legal", "portrait").minHeight).toBe(1581)
+  })
+})

--- a/src-vnext/features/export/lib/pageDimensions.ts
+++ b/src-vnext/features/export/lib/pageDimensions.ts
@@ -1,0 +1,57 @@
+import type { PageSettings } from "../types/exportBuilder"
+
+/**
+ * Canonical page dimensions in PDF points (1/72 inch).
+ *
+ * Single source of truth shared by the @react-pdf renderer (re-exported as
+ * `PAGE_SIZES` from `pdf/pdfStyles`) and the on-screen `DocumentPreview`, so the
+ * preview's aspect ratio can never drift from the exported PDF.
+ */
+export const PAGE_DIMENSIONS_PT = {
+  letter: { width: 612, height: 792 },
+  a4: { width: 595.28, height: 841.89 },
+  legal: { width: 612, height: 1008 },
+} as const
+
+export type PageSizeKey = keyof typeof PAGE_DIMENSIONS_PT
+
+/**
+ * Page dimensions in points for a given size + orientation. Width/height are
+ * swapped for landscape. This is the one place the orientation swap lives, so
+ * the preview and the PDF can't disagree about what "landscape" means.
+ */
+export function getPageDimensionsPt(
+  size: PageSettings["size"] | undefined,
+  layout: PageSettings["layout"] | undefined,
+): { readonly width: number; readonly height: number } {
+  const dims =
+    PAGE_DIMENSIONS_PT[(size ?? "letter") as PageSizeKey] ?? PAGE_DIMENSIONS_PT.letter
+  return layout === "landscape"
+    ? { width: dims.height, height: dims.width }
+    : { width: dims.width, height: dims.height }
+}
+
+/**
+ * On-screen preview frame width. The preview is fit-to-width: a fixed canvas
+ * width with the page's true aspect ratio driving the min-height. 960px keeps
+ * portrait Letter at ~960×1242 (the historical frame's min-height was 1243px;
+ * the aspect-exact value is 1242) so the default document is visually
+ * unchanged, while landscape / A4 / Legal reshape with no horizontal overflow
+ * of the center column.
+ */
+export const PREVIEW_PAGE_WIDTH_PX = 960
+
+/**
+ * Preview frame dimensions (CSS px) for a given size + orientation. Returns a
+ * fixed `width` and an aspect-correct `minHeight` (content may grow taller).
+ */
+export function getPreviewPageDimensions(
+  size: PageSettings["size"] | undefined,
+  layout: PageSettings["layout"] | undefined,
+): { readonly width: number; readonly minHeight: number } {
+  const { width, height } = getPageDimensionsPt(size, layout)
+  return {
+    width: PREVIEW_PAGE_WIDTH_PX,
+    minHeight: Math.round(PREVIEW_PAGE_WIDTH_PX * (height / width)),
+  }
+}

--- a/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
+++ b/src-vnext/features/export/lib/pdf/ExportPdfDocument.tsx
@@ -6,7 +6,8 @@ import type {
 } from "../../types/exportBuilder"
 import { isHStackRow } from "../../types/exportBuilder"
 import type { ExportData } from "../../hooks/useExportData"
-import { styles, PAGE_SIZES } from "./pdfStyles"
+import { styles } from "./pdfStyles"
+import { getPageDimensionsPt } from "../pageDimensions"
 import { mapFontFamilyBase } from "./fontMapping"
 import { WatermarkOverlay } from "./WatermarkOverlay"
 import { ExportPdfBlockMapper } from "./ExportPdfBlockMapper"
@@ -60,13 +61,7 @@ export function ExportPdfDocument({
   documentName,
   authorName,
 }: ExportPdfDocumentProps) {
-  const sizeKey = settings.size ?? "letter"
-  const dims = PAGE_SIZES[sizeKey] ?? PAGE_SIZES.letter
-
-  const pageSize =
-    settings.layout === "landscape"
-      ? { width: dims.height, height: dims.width }
-      : { width: dims.width, height: dims.height }
+  const pageSize = getPageDimensionsPt(settings.size, settings.layout)
 
   return (
     <Document

--- a/src-vnext/features/export/lib/pdf/pdfStyles.ts
+++ b/src-vnext/features/export/lib/pdf/pdfStyles.ts
@@ -1,11 +1,9 @@
 import { StyleSheet } from "@react-pdf/renderer"
+import { PAGE_DIMENSIONS_PT } from "../pageDimensions"
 
-/** Page size dimensions in points */
-export const PAGE_SIZES = {
-  letter: { width: 612, height: 792 },
-  a4: { width: 595.28, height: 841.89 },
-  legal: { width: 612, height: 1008 },
-} as const
+/** Page size dimensions in points. Re-exported from the shared `pageDimensions`
+ *  module so the PDF and the on-screen preview share one source of truth. */
+export const PAGE_SIZES = PAGE_DIMENSIONS_PT
 
 export const styles = StyleSheet.create({
   page: {


### PR DESCRIPTION
## P0-1 — Landscape/portrait & page size now render in the preview

**Part of the Export & Packaging redesign · Phase 0 (quick wins).**

### Problem
The export builder's on-screen preview hardcoded the page frame to portrait Letter (`max-w-[960px] min-h-[1243px]`) and never read `document.settings.layout`/`size`. Orientation/size changes took effect in the exported **PDF** but were invisible in the **preview** — the canonical proof the two renderers were unsynchronized.

### Fix
- **New `lib/pageDimensions.ts`** — single source of truth: `PAGE_DIMENSIONS_PT` (points) + `getPageDimensionsPt(size, layout)` (landscape swaps w/h) + `getPreviewPageDimensions(size, layout)`.
- **Fit-to-width preview**: width is a fixed 960px for every orientation; the page's true aspect ratio drives the min-height. Portrait Letter is visually unchanged (~960×1242); landscape/A4/Legal reshape correctly with **no horizontal overflow**.
- **No drift**: `pdfStyles.PAGE_SIZES` now re-exports the shared map and `ExportPdfDocument` uses `getPageDimensionsPt`, so the preview and PDF compute orientation identically.
- Frame is driven by an **inline style** on `DocumentPreview` only — the shared `.doc-page` CSS class (also used by the call-sheet builder/print) is untouched.

### Diagnosis discipline
Root cause was code-traced **and** reproduced: an independent audit confirmed the preview was orientation-blind, and the new tests fail against the old hardcoded frame. An adversarial review verified the `ExportPdfDocument` refactor produces **byte-identical** page sizes for all (size × orientation × legacy-undefined) combinations — zero PDF regression.

### Test plan
- [x] `vitest` — `pageDimensions.test.ts` (orientation swap, defaults, fit-to-width) + `DocumentPreview` orientation/size cases. 20/20 green locally.
- [x] `vite build` — passes.
- [x] `eslint` — clean on changed files.
- [ ] **Eyeball (design):** confirm landscape/A4/Legal look right on a `:5174` throwaway project. Fit-to-width = landscape is the same width as portrait but shorter (standard "fit page to width" behavior). Flag if you want landscape to render wider instead.

### Scope
Phase 0 fixes-on-current-structure only. Does **not** unify the renderers (P1) or add data/documents (P2–P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)