### PR TITLE
fix(export): populate producer notes from notesAddendum (P0-4)

### DIFF
--- a/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
+++ b/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
@@ -25,6 +25,7 @@ const MOCK_SHOTS: readonly Shot[] = [
     description: "Hero shot description",
     tags: [{ id: "tag1", label: "Hero", color: "#000" }],
     notes: "Handle with care",
+    notesAddendum: "Bring the blue jacket",
     projectId: "p1",
     clientId: "c1",
     sortOrder: 1,
@@ -209,5 +210,20 @@ describe("ShotGridBlockView", () => {
 
     expect(screen.getByText("Showing 1 shot")).toBeInTheDocument()
     expect(screen.getByText("LS Merino Crew - Hero")).toBeInTheDocument()
+  })
+
+  it("renders notesAddendum (not the legacy notes field) in the notes column", () => {
+    // P0-4: the app writes producer notes to notesAddendum; shot.notes is legacy.
+    const block = buildBlock({
+      columns: [
+        { key: "shotNumber", label: "#", visible: true, width: "xs" },
+        { key: "notes", label: "Notes", visible: true, width: "lg" },
+      ],
+    })
+    render(<ShotGridBlockView block={block} />)
+
+    // s1 has notesAddendum "Bring the blue jacket" + legacy notes "Handle with care".
+    expect(screen.getByText("Bring the blue jacket")).toBeInTheDocument()
+    expect(screen.queryByText("Handle with care")).not.toBeInTheDocument()
   })
 })

--- a/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
@@ -4,6 +4,7 @@ import type { ShotDetailBlock } from "../../types/exportBuilder"
 import type { Shot, ShotFirestoreStatus } from "@/shared/types"
 import { getShotStatusLabel, getShotStatusColor } from "@/shared/lib/statusMappings"
 import { resolveProductNamesList } from "../../lib/blockDataResolvers"
+import { resolveExportShotNotes } from "../../lib/exportShotNotes"
 
 interface ShotDetailBlockViewProps {
   readonly block: ShotDetailBlock
@@ -53,6 +54,7 @@ export function ShotDetailBlockView({ block }: ShotDetailBlockViewProps) {
   const showNotes = block.showNotes !== false
   const showProducts = block.showProducts !== false
   const productNames = showProducts ? resolveProductNamesList(shot) : []
+  const notesText = showNotes ? resolveExportShotNotes(shot) : ""
 
   return (
     <div data-testid="shot-detail-block" className="flex gap-4">
@@ -76,8 +78,8 @@ export function ShotDetailBlockView({ block }: ShotDetailBlockViewProps) {
           <p className="text-sm text-[var(--color-text-muted)]">{shot.description}</p>
         )}
 
-        {showNotes && shot.notes && (
-          <p className="text-xs text-[var(--color-text-subtle)]">{shot.notes}</p>
+        {notesText && (
+          <p className="text-xs text-[var(--color-text-subtle)]">{notesText}</p>
         )}
 
         {showProducts && productNames.length > 0 && (

--- a/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
@@ -8,6 +8,7 @@ import {
   filterShots,
   sortShots,
 } from "../../lib/blockDataResolvers"
+import { resolveExportShotNotes } from "../../lib/exportShotNotes"
 import {
   getShotStatusLabel,
   getShotStatusColor,
@@ -57,7 +58,7 @@ function getCellValue(
         ? shot.tags.map((t) => t.label).join(", ")
         : "\u2014"
     case "notes":
-      return shot.notes ?? "\u2014"
+      return resolveExportShotNotes(shot) || "\u2014"
     default:
       return "\u2014"
   }

--- a/src-vnext/features/export/lib/__tests__/exportShotNotes.test.ts
+++ b/src-vnext/features/export/lib/__tests__/exportShotNotes.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest"
+import { resolveExportShotNotes } from "../exportShotNotes"
+
+describe("resolveExportShotNotes", () => {
+  it("returns notesAddendum when present (the field the app actually writes)", () => {
+    expect(
+      resolveExportShotNotes({ notesAddendum: "Bring the blue jacket", notes: undefined }),
+    ).toBe("Bring the blue jacket")
+  })
+
+  it("prefers notesAddendum over the legacy notes field", () => {
+    expect(
+      resolveExportShotNotes({ notesAddendum: "Real note", notes: "<p>Legacy</p>" }),
+    ).toBe("Real note")
+  })
+
+  it("falls back to legacy notes, stripped of HTML, when there is no addendum", () => {
+    expect(
+      resolveExportShotNotes({ notes: "<p>Bring <strong>blue</strong> jacket</p>" }),
+    ).toBe("Bring blue jacket")
+  })
+
+  it("treats empty legacy HTML as no notes", () => {
+    expect(resolveExportShotNotes({ notes: "<p></p>" })).toBe("")
+  })
+
+  it("returns empty when an empty legacy HTML coexists with a real addendum", () => {
+    expect(
+      resolveExportShotNotes({ notesAddendum: "Steamer ready", notes: "<p></p>" }),
+    ).toBe("Steamer ready")
+  })
+
+  it("returns empty string when both fields are absent", () => {
+    expect(resolveExportShotNotes({})).toBe("")
+    expect(resolveExportShotNotes({ notes: undefined, notesAddendum: undefined })).toBe("")
+  })
+
+  it("does not truncate long notes (unlike the card-preview helper)", () => {
+    const long = "word ".repeat(60).trim() // ~300 chars, well past the 120-char preview cap
+    expect(resolveExportShotNotes({ notesAddendum: long })).toBe(long)
+  })
+})

--- a/src-vnext/features/export/lib/exportShotNotes.ts
+++ b/src-vnext/features/export/lib/exportShotNotes.ts
@@ -1,24 +1,11 @@
 import { textPreview } from "@/shared/lib/textPreview"
 import type { Shot } from "@/shared/types"
 
-/** textPreview truncates to a card-preview length by default; exports want the
- *  full note, so we pass an effectively-unbounded max. */
-const NO_TRUNCATE = Number.MAX_SAFE_INTEGER
+const NO_TRUNCATE = Number.MAX_SAFE_INTEGER // exports want the full note, not a card preview
 
-/**
- * Resolve the producer-facing notes text for export surfaces.
- *
- * The app writes producer notes to `notesAddendum`; `shot.notes` is a legacy
- * HTML field that is never written anymore (see `NotesSection`). Every other
- * read surface — shot cards (`getShotNotesPreview`) and the public share page —
- * prioritizes `notesAddendum`; the export was the lone outlier reading the dead
- * `notes` field, so shots that visibly had notes exported blank.
- *
- * This mirrors `getShotNotesPreview` (notesAddendum first, legacy notes
- * fallback) but without the preview-length truncation, and always strips HTML
- * so legacy markup never leaks into a table cell or PDF. Returns `""` when there
- * are no notes.
- */
+// Producer notes for export surfaces: notesAddendum first, legacy `notes` fallback,
+// HTML-stripped, untruncated. The app stopped writing `notes` (see NotesSection);
+// mirrors getShotNotesPreview so exports match the cards + share page. "" when empty.
 export function resolveExportShotNotes(
   shot: Pick<Shot, "notes" | "notesAddendum">,
 ): string {

--- a/src-vnext/features/export/lib/exportShotNotes.ts
+++ b/src-vnext/features/export/lib/exportShotNotes.ts
@@ -1,0 +1,28 @@
+import { textPreview } from "@/shared/lib/textPreview"
+import type { Shot } from "@/shared/types"
+
+/** textPreview truncates to a card-preview length by default; exports want the
+ *  full note, so we pass an effectively-unbounded max. */
+const NO_TRUNCATE = Number.MAX_SAFE_INTEGER
+
+/**
+ * Resolve the producer-facing notes text for export surfaces.
+ *
+ * The app writes producer notes to `notesAddendum`; `shot.notes` is a legacy
+ * HTML field that is never written anymore (see `NotesSection`). Every other
+ * read surface — shot cards (`getShotNotesPreview`) and the public share page —
+ * prioritizes `notesAddendum`; the export was the lone outlier reading the dead
+ * `notes` field, so shots that visibly had notes exported blank.
+ *
+ * This mirrors `getShotNotesPreview` (notesAddendum first, legacy notes
+ * fallback) but without the preview-length truncation, and always strips HTML
+ * so legacy markup never leaks into a table cell or PDF. Returns `""` when there
+ * are no notes.
+ */
+export function resolveExportShotNotes(
+  shot: Pick<Shot, "notes" | "notesAddendum">,
+): string {
+  const addendum = textPreview(shot.notesAddendum, NO_TRUNCATE)
+  if (addendum) return addendum
+  return textPreview(shot.notes, NO_TRUNCATE)
+}

--- a/src-vnext/features/export/lib/pdf/blocks/ShotDetailBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotDetailBlockPdf.tsx
@@ -5,6 +5,7 @@ import type { ShotFirestoreStatus } from "@/shared/types"
 import { getShotStatusLabel, getShotStatusColor } from "@/shared/lib/statusMappings"
 import { styles, PDF_STATUS_COLORS } from "../pdfStyles"
 import { resolveProductNamesList } from "../../blockDataResolvers"
+import { resolveExportShotNotes } from "../../exportShotNotes"
 
 interface ShotDetailBlockPdfProps {
   readonly block: ShotDetailBlock
@@ -25,6 +26,7 @@ export function ShotDetailBlockPdf({ block, data, imageMap }: ShotDetailBlockPdf
   const showProducts = block.showProducts !== false
   const heroSrc = showHero && shot.heroImage?.path ? imageMap.get(shot.heroImage.path) : undefined
   const productNames = showProducts ? resolveProductNamesList(shot).join(", ") : ""
+  const notesText = showNotes ? resolveExportShotNotes(shot) : ""
 
   return (
     <View wrap={false} style={{ flexDirection: "row", gap: 10, marginVertical: 4 }}>
@@ -46,9 +48,9 @@ export function ShotDetailBlockPdf({ block, data, imageMap }: ShotDetailBlockPdf
           <Text style={styles.bodyText}>{shot.description}</Text>
         ) : null}
 
-        {showNotes && shot.notes ? (
+        {notesText ? (
           <Text style={{ ...styles.bodyText, fontSize: 8, color: "#9CA3AF", marginTop: 2 }}>
-            {shot.notes}
+            {notesText}
           </Text>
         ) : null}
 

--- a/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
@@ -14,6 +14,7 @@ import {
   resolveProductNamesString,
   resolveTalentNames,
 } from "../../blockDataResolvers"
+import { resolveExportShotNotes } from "../../exportShotNotes"
 import { computeOrphanGroupIndex } from "../widowOrphan"
 
 interface ShotGridBlockPdfProps {
@@ -31,7 +32,7 @@ function cellText(shot: Shot, key: string, data: ExportData): string {
     case "location": return shot.locationName ?? "\u2014"
     case "description": return shot.description ?? "\u2014"
     case "tags": return shot.tags?.map((t) => t.label).join(", ") || "\u2014"
-    case "notes": return shot.notes ?? "\u2014"
+    case "notes": return resolveExportShotNotes(shot) || "\u2014"
     case "thumbnail": return ""
     default: return "\u2014"
   }


### PR DESCRIPTION
## P0-4 — Notes now populate in exports

**Part of the Export & Packaging redesign · Phase 0 (quick wins).**

### Problem
Producer notes never showed up in exports — "especially when some shots DO have notes." Root cause (confirmed by an independent audit + adversarial review, not just the spec's guess): the app writes producer notes to **`shot.notesAddendum`**; **`shot.notes` is a documented legacy HTML field that is never written anymore** (see `NotesSection`). Every other read surface (shot cards via `getShotNotesPreview`, the public `/s/:token` share page via `resolveShotsForShare`) prioritizes `notesAddendum` — the export's four notes sites were the **lone outliers** reading the dead `shot.notes` field, so shots that visibly had notes exported blank.

### Fix
- **New `lib/exportShotNotes.ts`** — `resolveExportShotNotes(shot)` = `notesAddendum` first, legacy `notes` fallback, both stripped of HTML via the shared `textPreview` (no truncation, unlike the 120-char card preview). Returns `""` when empty.
- Routed **all four** export notes sites through it: `ShotGridBlockView` + `ShotGridBlockPdf` (grid cells, `… || "—"`) and `ShotDetailBlockView` + `ShotDetailBlockPdf` (detail cards, gated on `notesText`).
- Mirrors the app's own `getShotNotesPreview` precedence, so the export finally agrees with the cards and the share page.

### Scope / what this deliberately does NOT do
- **Field-read fix only.** It does **not** flip the notes-column `visible:false` / detail `showNotes:false` **defaults** (theory (a) from the audit). Built-in templates that already enable notes were rendering blank purely because of the wrong field — they're fixed by this change alone. Flipping the defaults is a separate, **Ted-gated** layout decision (and would require updating `blockDefaults.test.ts`).

### Note for review
- `notesAddendum` may contain newlines; `textPreview` collapses them to spaces. Correct for a one-line grid cell; in the **detail card** a multi-line note flattens to one paragraph. Still strictly better than today (blank/raw-HTML) and consistent with every other surface. Preserving line breaks in the detail card can be a later enhancement.

### Test plan
- [x] `vitest` — `exportShotNotes.test.ts` (precedence, HTML strip, empty, no-truncate) + `ShotGridBlockView` render test (notesAddendum wins over legacy notes). 17/17 green; `blockDefaults.test.ts` unaffected (11 green).
- [x] `vite build` — passes.
- [x] `eslint` — clean on changed files.
- [ ] Optional confirm: a real project shot you know has notes now shows them in preview + PDF (`:5174`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)