### PR TITLE
feat(export): Shot Detail + Pull Sheet pickers — revive the dead block (P0-3)

### DIFF
--- a/src-vnext/features/export/components/BlockSettingsPanel.tsx
+++ b/src-vnext/features/export/components/BlockSettingsPanel.tsx
@@ -4,9 +4,11 @@ import { Button } from "@/ui/button"
 import type { BlockLayout, ExportBlock } from "../types/exportBuilder"
 import { TextSettings } from "./settings/TextSettings"
 import { ShotGridSettings } from "./settings/ShotGridSettings"
+import { ShotDetailSettings } from "./settings/ShotDetailSettings"
 import { DividerSettings } from "./settings/DividerSettings"
 import { ImageSettings } from "./settings/ImageSettings"
 import { ProductTableSettings } from "./settings/ProductTableSettings"
+import { PullSheetSettings } from "./settings/PullSheetSettings"
 import { BlockLayoutSettings } from "./settings/BlockLayoutSettings"
 
 interface BlockSettingsPanelProps {
@@ -87,6 +89,12 @@ export function BlockSettingsPanel({
         {block.type === "shot-grid" && (
           <ShotGridSettings block={block} onUpdate={handleUpdate} />
         )}
+        {block.type === "shot-detail" && (
+          <ShotDetailSettings block={block} onUpdate={handleUpdate} />
+        )}
+        {block.type === "pull-sheet" && (
+          <PullSheetSettings block={block} onUpdate={handleUpdate} />
+        )}
         {block.type === "divider" && (
           <DividerSettings block={block} onUpdate={handleUpdate} />
         )}
@@ -103,9 +111,11 @@ export function BlockSettingsPanel({
         )}
         {block.type !== "text" &&
           block.type !== "shot-grid" &&
+          block.type !== "shot-detail" &&
           block.type !== "divider" &&
           block.type !== "image" &&
-          block.type !== "product-table" && (
+          block.type !== "product-table" &&
+          block.type !== "pull-sheet" && (
             <p className="text-2xs text-[var(--color-text-muted)]">
               No additional settings for this block type.
             </p>

--- a/src-vnext/features/export/components/__tests__/BlockSettingsPanel.test.tsx
+++ b/src-vnext/features/export/components/__tests__/BlockSettingsPanel.test.tsx
@@ -1,7 +1,29 @@
 import { describe, it, expect, vi } from "vitest"
 import { render, screen, fireEvent } from "@testing-library/react"
 import { BlockSettingsPanel } from "../BlockSettingsPanel"
-import type { TextBlock, ShotGridBlock, DividerBlock } from "../../types/exportBuilder"
+import type {
+  TextBlock,
+  ShotGridBlock,
+  ShotDetailBlock,
+  PullSheetBlock,
+  DividerBlock,
+} from "../../types/exportBuilder"
+
+// ShotDetailSettings / PullSheetSettings read the export data context; provide it.
+vi.mock("../ExportDataProvider", () => ({
+  useExportDataContext: () => ({
+    project: null,
+    shots: [
+      { id: "s1", title: "Hero Shot", shotNumber: "1", status: "todo" },
+      { id: "s2", title: "Detail Shot", status: "todo" }, // no shotNumber (production allows undefined)
+    ],
+    productFamilies: [],
+    pulls: [{ id: "pl1", name: "Day 1 Pull", items: [] }],
+    crew: [],
+    talent: [],
+    loading: false,
+  }),
+}))
 
 describe("BlockSettingsPanel", () => {
   it("shows empty state when no block is selected", () => {
@@ -120,6 +142,61 @@ describe("BlockSettingsPanel", () => {
     expect(onUpdateBlock).toHaveBeenCalledWith("t1", {
       typography: { fontSize: 14, textAlign: "center" },
     })
+  })
+
+  it("shows a shot picker for shot-detail blocks (no longer a dead block)", () => {
+    const block: ShotDetailBlock = {
+      id: "sd1",
+      type: "shot-detail",
+      showHeroImage: true,
+      showDescription: true,
+      showNotes: false,
+      showProducts: true,
+    }
+    render(
+      <BlockSettingsPanel
+        block={block}
+        onUpdateBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("Shot Detail")).toBeInTheDocument()
+    expect(screen.getByTestId("shot-detail-shot-select")).toBeInTheDocument()
+    expect(
+      screen.queryByText(/no additional settings for this block type/i),
+    ).not.toBeInTheDocument()
+  })
+
+  it("writes shotId when a shot is picked", () => {
+    const onUpdateBlock = vi.fn()
+    const block: ShotDetailBlock = { id: "sd1", type: "shot-detail" }
+    render(
+      <BlockSettingsPanel
+        block={block}
+        onUpdateBlock={onUpdateBlock}
+        onDeleteBlock={vi.fn()}
+      />,
+    )
+    fireEvent.change(screen.getByTestId("shot-detail-shot-select"), {
+      target: { value: "s2" },
+    })
+    expect(onUpdateBlock).toHaveBeenCalledWith("sd1", { shotId: "s2" })
+  })
+
+  it("shows a pull picker for pull-sheet blocks", () => {
+    const block: PullSheetBlock = { id: "ps1", type: "pull-sheet" }
+    render(
+      <BlockSettingsPanel
+        block={block}
+        onUpdateBlock={vi.fn()}
+        onDeleteBlock={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("Pull Sheet")).toBeInTheDocument()
+    expect(screen.getByTestId("pull-sheet-pull-select")).toBeInTheDocument()
+    expect(
+      screen.queryByText(/no additional settings for this block type/i),
+    ).not.toBeInTheDocument()
   })
 
   it("shows image settings for image block type", () => {

--- a/src-vnext/features/export/components/__tests__/ShotDetailSettings.test.tsx
+++ b/src-vnext/features/export/components/__tests__/ShotDetailSettings.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { ShotDetailSettings } from "../settings/ShotDetailSettings"
+import type { ShotDetailBlock } from "../../types/exportBuilder"
+
+vi.mock("../ExportDataProvider", () => ({
+  useExportDataContext: () => ({
+    project: null,
+    shots: [
+      { id: "s1", title: "Hero Shot", shotNumber: "1", status: "todo" },
+      { id: "s2", title: "Detail Shot", status: "todo" }, // no shotNumber (production allows undefined)
+    ],
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+  }),
+}))
+
+function baseBlock(overrides: Partial<ShotDetailBlock> = {}): ShotDetailBlock {
+  return { id: "sd1", type: "shot-detail", ...overrides }
+}
+
+describe("ShotDetailSettings", () => {
+  it("lists every shot plus a placeholder, with the current shotId selected", () => {
+    render(<ShotDetailSettings block={baseBlock({ shotId: "s1" })} onUpdate={vi.fn()} />)
+    const select = screen.getByTestId("shot-detail-shot-select") as HTMLSelectElement
+    expect(select.value).toBe("s1")
+    expect(screen.getByRole("option", { name: /Hero Shot/ })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /Detail Shot/ })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: /select a shot/i })).toBeInTheDocument()
+  })
+
+  it("tolerates a shot without a shotNumber (renders an em-dash, no crash)", () => {
+    render(<ShotDetailSettings block={baseBlock()} onUpdate={vi.fn()} />)
+    const detailOption = screen.getByRole("option", { name: /Detail Shot/ }) as HTMLOptionElement
+    expect(detailOption.value).toBe("s2")
+    expect(detailOption.textContent).toContain("—")
+  })
+
+  it("writes the picked shotId", () => {
+    const onUpdate = vi.fn()
+    render(<ShotDetailSettings block={baseBlock()} onUpdate={onUpdate} />)
+    fireEvent.change(screen.getByTestId("shot-detail-shot-select"), { target: { value: "s2" } })
+    expect(onUpdate).toHaveBeenCalledWith({ shotId: "s2" })
+  })
+
+  it("clears the shotId when the placeholder is chosen", () => {
+    const onUpdate = vi.fn()
+    render(<ShotDetailSettings block={baseBlock({ shotId: "s1" })} onUpdate={onUpdate} />)
+    fireEvent.change(screen.getByTestId("shot-detail-shot-select"), { target: { value: "" } })
+    expect(onUpdate).toHaveBeenCalledWith({ shotId: undefined })
+  })
+
+  it("toggles a show flag", () => {
+    const onUpdate = vi.fn()
+    render(<ShotDetailSettings block={baseBlock({ showNotes: false })} onUpdate={onUpdate} />)
+    fireEvent.click(screen.getByTestId("shot-detail-showNotes"))
+    expect(onUpdate).toHaveBeenCalledWith({ showNotes: true })
+  })
+})

--- a/src-vnext/features/export/components/settings/PullSheetSettings.tsx
+++ b/src-vnext/features/export/components/settings/PullSheetSettings.tsx
@@ -1,0 +1,51 @@
+import { useExportDataContext } from "../ExportDataProvider"
+import type { PullSheetBlock } from "../../types/exportBuilder"
+
+const SELECT_CLASS =
+  "mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-text)]"
+
+export function PullSheetSettings({
+  block,
+  onUpdate,
+}: {
+  readonly block: PullSheetBlock
+  readonly onUpdate: (updates: Partial<PullSheetBlock>) => void
+}) {
+  const { pulls } = useExportDataContext()
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <label className="text-2xs font-medium text-[var(--color-text-muted)]">
+          Pull sheet
+        </label>
+        <select
+          value={block.pullId ?? ""}
+          onChange={(e) => onUpdate({ pullId: e.target.value || undefined })}
+          data-testid="pull-sheet-pull-select"
+          className={SELECT_CLASS}
+        >
+          {/* Empty value falls back to the first pull (PullSheetBlockView default). */}
+          <option value="">
+            {pulls.length > 0 ? "First pull sheet" : "No pull sheets"}
+          </option>
+          {pulls.map((p) => (
+            <option key={p.id} value={p.id}>
+              {p.name ?? p.title ?? "Pull Sheet"}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-[var(--color-text)]">
+        <input
+          type="checkbox"
+          checked={block.showFulfillmentStatus !== false}
+          onChange={(e) => onUpdate({ showFulfillmentStatus: e.target.checked })}
+          data-testid="pull-sheet-show-status"
+        />
+        Show fulfillment status
+      </label>
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/settings/ShotDetailSettings.tsx
+++ b/src-vnext/features/export/components/settings/ShotDetailSettings.tsx
@@ -1,0 +1,75 @@
+import { useExportDataContext } from "../ExportDataProvider"
+import type { ShotDetailBlock } from "../../types/exportBuilder"
+
+type ShotDetailToggleKey =
+  | "showHeroImage"
+  | "showDescription"
+  | "showNotes"
+  | "showProducts"
+
+const TOGGLES: readonly { readonly key: ShotDetailToggleKey; readonly label: string }[] = [
+  { key: "showHeroImage", label: "Hero image" },
+  { key: "showDescription", label: "Description" },
+  { key: "showNotes", label: "Notes" },
+  { key: "showProducts", label: "Products" },
+]
+
+const SELECT_CLASS =
+  "mt-1 w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2.5 py-1.5 text-sm text-[var(--color-text)]"
+
+export function ShotDetailSettings({
+  block,
+  onUpdate,
+}: {
+  readonly block: ShotDetailBlock
+  readonly onUpdate: (updates: Partial<ShotDetailBlock>) => void
+}) {
+  const { shots } = useExportDataContext()
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <label className="text-2xs font-medium text-[var(--color-text-muted)]">
+          Shot
+        </label>
+        <select
+          value={block.shotId ?? ""}
+          onChange={(e) => onUpdate({ shotId: e.target.value || undefined })}
+          data-testid="shot-detail-shot-select"
+          className={SELECT_CLASS}
+        >
+          <option value="">Select a shot…</option>
+          {shots.map((s) => (
+            <option key={s.id} value={s.id}>
+              #{s.shotNumber || "—"} {s.title}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div>
+        <span className="text-2xs font-medium text-[var(--color-text-muted)]">
+          Show
+        </span>
+        <div className="mt-1 flex flex-col gap-1.5">
+          {TOGGLES.map((t) => (
+            <label
+              key={t.key}
+              className="flex items-center gap-2 text-sm text-[var(--color-text)]"
+            >
+              <input
+                type="checkbox"
+                checked={block[t.key] !== false}
+                onChange={(e) =>
+                  onUpdate({ [t.key]: e.target.checked } as Partial<ShotDetailBlock>)
+                }
+                data-testid={`shot-detail-${t.key}`}
+              />
+              {t.label}
+            </label>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## P0-3 — The Shot Detail block can finally pick a shot

**Part of the Export & Packaging redesign · Phase 0 (quick wins).**

### Problem
"The shot detail block does nothing / there is no ability to select a shot." Root cause (audit-confirmed): `BlockSettingsPanel` had **no `shot-detail` case**, so `block.shotId` was never settable — the preview showed *"Select a shot in the settings panel."* forever and the PDF rendered `null`. The built-in **Storyboard (4) + Lookbook (3) templates ship 7 unbound shot-detail blocks** that render blank. **Pull Sheet** had the identical settings gap (`pullId`), masked only by its `shots[0]` default.

### Fix
- **`ShotDetailSettings`** — a shot `<select>` (writes `block.shotId`, placeholder clears it) + the four `show*` toggles (hero / description / notes / products), reading `useExportDataContext().shots`.
- **`PullSheetSettings`** — a pull `<select>` (writes `block.pullId`) + a `showFulfillmentStatus` toggle.
- Routed both in `BlockSettingsPanel` and removed them from the *"No additional settings…"* catch-all.

### Scope discipline (deliberate)
**Picker-only.** It does **not** auto-default unbound blocks to the first shot. The audit flagged that an auto-default would silently render all 7 built-in template blocks as **shot #1** — wrong for a multi-shot Storyboard/Lookbook — so that's a separate, **Ted-eyeballed** decision. `blockDefaults.ts`, `builtInTemplates.ts`, and the Shot Detail view/PDF renderers are untouched.

### Test plan
- [x] `vitest` — `ShotDetailSettings.test.tsx` (lists shots, placeholder, writes/clears `shotId`, toggles a flag, tolerates a shot with no `shotNumber`) + `BlockSettingsPanel` shot-detail/pull-sheet cases asserting the picker renders and "No additional settings" is gone. 15/15 green.
- [x] `vite build` — passes. `eslint` — clean.
- [x] Adversarial review: context-throw is prod-safe (panel always inside `ExportDataProvider`), `vi.mock` doesn't leak to other cases, `shotId: undefined` clears correctly, checkbox `!== false` semantics mirror the renderers.
- [ ] Optional eyeball: drop a Shot Detail block on `:5174`, pick a shot, confirm it renders in preview + PDF; confirm the Storyboard template's blocks now bind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)