### PR TITLE
fix(export): thumbnails in preview AND PDF — the keystone (P0-2) [needs :5174 eyeball]

### DIFF
--- a/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
+++ b/src-vnext/features/export/components/__tests__/ShotGridBlockView.test.tsx
@@ -25,6 +25,7 @@ const MOCK_SHOTS: readonly Shot[] = [
     description: "Hero shot description",
     tags: [{ id: "tag1", label: "Hero", color: "#000" }],
     notes: "Handle with care",
+    heroImage: { path: "shots/s1/hero.jpg", downloadURL: "https://example.com/hero.jpg" },
     projectId: "p1",
     clientId: "c1",
     sortOrder: 1,
@@ -209,5 +210,22 @@ describe("ShotGridBlockView", () => {
 
     expect(screen.getByText("Showing 1 shot")).toBeInTheDocument()
     expect(screen.getByText("LS Merino Crew - Hero")).toBeInTheDocument()
+  })
+
+  it("renders a hero thumbnail image for shots that have one, placeholder otherwise", () => {
+    // P0-2: the thumbnail cell was a gray <div> with no image code.
+    const block = buildBlock({
+      columns: [
+        { key: "shotNumber", label: "#", visible: true, width: "xs" },
+        { key: "thumbnail", label: "Thumbnail", visible: true, width: "sm" },
+      ],
+    })
+    const { container } = render(<ShotGridBlockView block={block} />)
+
+    // Only s1 carries a heroImage.downloadURL -> exactly one <img>; the other
+    // four shots fall back to the gray placeholder (no broken <img>).
+    const imgs = container.querySelectorAll("img")
+    expect(imgs).toHaveLength(1)
+    expect(imgs[0]?.getAttribute("src")).toBe("https://example.com/hero.jpg")
   })
 })

--- a/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotDetailBlockView.tsx
@@ -56,11 +56,18 @@ export function ShotDetailBlockView({ block }: ShotDetailBlockViewProps) {
 
   return (
     <div data-testid="shot-detail-block" className="flex gap-4">
-      {showHeroImage && (
-        <div className="flex h-24 w-36 shrink-0 items-center justify-center rounded bg-[var(--color-surface-muted)]">
-          <span className="text-xs text-[var(--color-text-subtle)]">Hero Image</span>
-        </div>
-      )}
+      {showHeroImage &&
+        (shot.heroImage?.downloadURL ? (
+          <img
+            src={shot.heroImage.downloadURL}
+            alt=""
+            className="h-24 w-36 shrink-0 rounded object-cover"
+          />
+        ) : (
+          <div className="flex h-24 w-36 shrink-0 items-center justify-center rounded bg-[var(--color-surface-muted)]">
+            <span className="text-xs text-[var(--color-text-subtle)]">Hero Image</span>
+          </div>
+        ))}
 
       <div className="flex min-w-0 flex-1 flex-col gap-1.5">
         <div className="flex items-center gap-2">

--- a/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/ShotGridBlockView.tsx
@@ -31,8 +31,15 @@ function getCellValue(
   switch (columnKey) {
     case "shotNumber":
       return shot.shotNumber || "\u2014"
-    case "thumbnail":
-      return <div className="h-8 w-12 rounded bg-[var(--color-surface-muted)]" />
+    case "thumbnail": {
+      // heroImage.downloadURL is synchronous on the shot — no async resolution needed in the DOM.
+      const src = shot.heroImage?.downloadURL
+      return src ? (
+        <img src={src} alt="" className="h-8 w-12 rounded object-cover" />
+      ) : (
+        <div className="h-8 w-12 rounded bg-[var(--color-surface-muted)]" />
+      )
+    }
     case "title":
       return shot.title
     case "status": {

--- a/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/ShotGridBlockPdf.tsx
@@ -1,4 +1,4 @@
-import { Text, View } from "@react-pdf/renderer"
+import { Text, View, Image } from "@react-pdf/renderer"
 import type { ShotGridBlock, ShotGridColumn } from "../../../types/exportBuilder"
 import { COLUMN_WIDTH_PRESETS } from "../../../types/exportBuilder"
 import type { ExportData } from "../../../hooks/useExportData"
@@ -41,12 +41,12 @@ function colFlex(col: ShotGridColumn): number {
   return COLUMN_WIDTH_PRESETS[col.width ?? "md"].flex
 }
 
-export function ShotGridBlockPdf({ block, data }: ShotGridBlockPdfProps) {
+export function ShotGridBlockPdf({ block, data, imageMap }: ShotGridBlockPdfProps) {
   const filtered = filterShots(data.shots, block.filter)
   const sorted = sortShots(filtered, block.sortBy, block.sortDirection)
   const cols = [...block.columns]
     .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-    .filter((c) => c.visible && c.key !== "thumbnail")
+    .filter((c) => c.visible)
 
   if (sorted.length === 0) return null
 
@@ -66,7 +66,7 @@ export function ShotGridBlockPdf({ block, data }: ShotGridBlockPdfProps) {
         wrap={false}
         style={stripe && i % 2 === 1 ? styles.tableRowStriped : styles.tableRow}
       >
-        {cols.map((col) => renderCell(col, shot, data))}
+        {cols.map((col) => renderCell(col, shot, data, imageMap))}
       </View>
     )
   }
@@ -94,7 +94,16 @@ function renderCell(
   col: ShotGridColumn,
   shot: Shot,
   data: ExportData,
+  imageMap: ReadonlyMap<string, string>,
 ): React.ReactNode {
+  if (col.key === "thumbnail") {
+    const src = shot.heroImage?.path ? imageMap.get(shot.heroImage.path) : undefined
+    return (
+      <View key={col.key} style={{ ...styles.tableCell, flex: colFlex(col) }}>
+        {src ? <Image src={src} style={{ width: 36, height: 24, objectFit: "cover" }} /> : null}
+      </View>
+    )
+  }
   if (col.key === "status") {
     const color = getShotStatusColor(shot.status as ShotFirestoreStatus)
     const sc = PDF_STATUS_COLORS[color] ?? { bg: "#F3F4F6", text: "#374151" }

--- a/src-vnext/features/export/lib/pdf/blocks/__tests__/ShotGridBlockPdf.test.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/__tests__/ShotGridBlockPdf.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest"
+
+// Mock @react-pdf/renderer into queryable DOM elements (mirrors TextBlockPdf.test).
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  const ser = (s: unknown) => {
+    try {
+      return s == null ? undefined : JSON.stringify(s)
+    } catch {
+      return undefined
+    }
+  }
+  return {
+    Text: (props: Record<string, unknown>) => {
+      const { style, children, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      return React.createElement(
+        "pdf-text",
+        { ...rest, "data-style": ser(style) },
+        children as React.ReactNode,
+      )
+    },
+    View: (props: Record<string, unknown>) => {
+      const { style, children, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      return React.createElement(
+        "pdf-view",
+        { ...rest, "data-style": ser(style) },
+        children as React.ReactNode,
+      )
+    },
+    Image: (props: Record<string, unknown>) => {
+      const { style, src, ...rest } = props as {
+        style?: unknown
+        src?: unknown
+      } & Record<string, unknown>
+      return React.createElement("pdf-image", {
+        ...rest,
+        src: src as string,
+        "data-style": ser(style),
+      })
+    },
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render } from "@testing-library/react"
+import { ShotGridBlockPdf } from "../ShotGridBlockPdf"
+import type { ShotGridBlock } from "../../../../types/exportBuilder"
+import type { ExportData } from "../../../../hooks/useExportData"
+import type { Shot } from "@/shared/types"
+
+function buildBlock(): ShotGridBlock {
+  return {
+    id: "sg1",
+    type: "shot-grid",
+    columns: [
+      { key: "shotNumber", label: "#", visible: true, width: "xs" },
+      { key: "thumbnail", label: "Thumbnail", visible: true, width: "sm" },
+      { key: "title", label: "Title", visible: true, width: "md" },
+    ],
+    sortBy: "shotNumber",
+    tableStyle: { showBorders: true, showHeaderBg: true, stripeRows: false },
+  }
+}
+
+const SHOTS = [
+  {
+    id: "s1",
+    shotNumber: "1",
+    title: "Hero shot",
+    status: "todo",
+    heroImage: { path: "shots/s1/hero.jpg", downloadURL: "https://example.com/hero.jpg" },
+  },
+  { id: "s2", shotNumber: "2", title: "No hero", status: "todo" },
+] as unknown as Shot[]
+
+function buildData(): ExportData {
+  return {
+    project: null,
+    shots: SHOTS,
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+  } as unknown as ExportData
+}
+
+const IMAGE_MAP = new Map<string, string>([
+  ["shots/s1/hero.jpg", "data:image/jpeg;base64,AAAA"],
+])
+
+describe("ShotGridBlockPdf — thumbnails (P0-2)", () => {
+  it("keeps the Thumbnail column header (no longer stripped)", () => {
+    const { container } = render(
+      <ShotGridBlockPdf block={buildBlock()} data={buildData()} imageMap={IMAGE_MAP} />,
+    )
+    const headers = Array.from(container.querySelectorAll("pdf-text")).map(
+      (e) => e.textContent,
+    )
+    expect(headers).toContain("Thumbnail")
+  })
+
+  it("embeds the resolved hero image for a shot with a mapped hero", () => {
+    const { container } = render(
+      <ShotGridBlockPdf block={buildBlock()} data={buildData()} imageMap={IMAGE_MAP} />,
+    )
+    const imgs = Array.from(container.querySelectorAll("pdf-image"))
+    expect(imgs).toHaveLength(1)
+    expect(imgs[0]?.getAttribute("src")).toBe("data:image/jpeg;base64,AAAA")
+  })
+
+  it("renders an empty thumbnail cell (no Image, no crash) when the hero is unmapped/absent", () => {
+    const { container } = render(
+      <ShotGridBlockPdf block={buildBlock()} data={buildData()} imageMap={new Map()} />,
+    )
+    expect(container.querySelectorAll("pdf-image")).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## P0-2 — Thumbnails finally render (the Phase-0 keystone) · ⚠️ needs a :5174 eyeball before merge

**Part of the Export & Packaging redesign · Phase 0 (quick wins).**

### Problem
"Thumbnails don't seem to export" — and they didn't show in the preview either. Two confirmed causes:
- **Preview:** the grid thumbnail cell was a literal gray `<div>` with **zero image code**.
- **PDF:** the grid `.filter(c => c.key !== "thumbnail")` **stripped the column**, and the function destructured only `{block, data}` — silently dropping the `imageMap` prop it *already receives* (the detail-card PDF already uses it, proving the pipeline works).

### Fix
- **Preview grid** (`ShotGridBlockView`): render `<img src={shot.heroImage?.downloadURL}>`. `downloadURL` is a **synchronous** field on the shot — no async resolver, no prop-drilling, no loading state (the audit's key simplification vs the original spec). Gray placeholder fallback when absent.
- **PDF grid** (`ShotGridBlockPdf`): consume the already-passed `imageMap`, keep the thumbnail column, render `<Image src={imageMap.get(shot.heroImage.path)}>` **guarded against undefined** (`<Image>` throws on undefined src) → empty cell when a hero is absent/unmapped.
- **Detail preview** (`ShotDetailBlockView`): the "Hero Image" gray placeholder now renders the real image too — the detail *PDF* already did, so this closes the same preview≠PDF asymmetry.

### Why it's the keystone
It proves the kept image pipeline (`resolveExportImages` → `imageMap`) can feed both renderers — the foundation Phase 1 (renderer-unify) relies on.

### ⚠️ Eyeball gate (do NOT merge until reviewed)
Per the plan, P0-2 needs a **:5174 throwaway-project eyeball** (never `Q2-26 No. 3`):
- Thumbnail **sizing/aspect** in both preview (h-8×w-12, `object-cover`) and PDF (36×24pt, `objectFit:cover`) — the PDF grid now has ~30pt image rows vs ~14pt text rows.
- The **no-hero fallback** (currently a blank/placeholder cell) — do you want a product `thumbUrl` fallback instead?
- Whether to gate behind a `featureExportThumbnails` flag for staged rollout (optional — it's a correctness fix, low risk).

### Test plan
- [x] `vitest` — grid-view thumbnail render (img for hero shot, placeholder otherwise) + new `ShotGridBlockPdf.test.tsx` (Thumbnail header kept, data-URL embedded, **empty cell + no crash** when unmapped). 13/13 green.
- [x] `vite build` + `eslint` — pass/clean.
- [x] Adversarial review: undefined-src guarded, `imageMap` genuinely populated for grids in production, keys match, column-width sane, scope clean (no blockDefaults/data changes).
- [ ] **Ted :5174 eyeball** (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)