### PR TITLE
feat(captureone): filename + gender pure utils (CO-1, digi-tech generator)

### DIFF
--- a/src-vnext/features/captureone/lib/__tests__/captureOneFilename.test.ts
+++ b/src-vnext/features/captureone/lib/__tests__/captureOneFilename.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest"
+import {
+  toPascalCaseFilename,
+  resolveHeroGenderPrefix,
+  buildCaptureOneName,
+  buildHeroFilename,
+} from "../captureOneFilename"
+
+describe("toPascalCaseFilename", () => {
+  it("PascalCases space-separated words", () => {
+    expect(toPascalCaseFilename("Merino Flex Jogger")).toBe("MerinoFlexJogger")
+    expect(toPascalCaseFilename("Light Azure")).toBe("LightAzure")
+  })
+
+  it("preserves hyphens within a word (capitalizing each segment)", () => {
+    expect(toPascalCaseFilename("Button-Up Shirt")).toBe("Button-UpShirt")
+    expect(toPascalCaseFilename("Merino Linen Button-Up")).toBe("MerinoLinenButton-Up")
+    expect(toPascalCaseFilename("Button-Up-Down")).toBe("Button-Up-Down")
+  })
+
+  it("strips Capture One / filesystem illegal characters", () => {
+    expect(toPascalCaseFilename("Tee / Crew")).toBe("TeeCrew")
+    expect(toPascalCaseFilename('A:B*C?"D<E>F|G\\H')).toBe("ABCDEFGH")
+  })
+
+  it("capitalizes lowercase input", () => {
+    expect(toPascalCaseFilename("merino flex")).toBe("MerinoFlex")
+  })
+
+  it("handles empty / nullish input", () => {
+    expect(toPascalCaseFilename("")).toBe("")
+    expect(toPascalCaseFilename(null)).toBe("")
+    expect(toPascalCaseFilename(undefined)).toBe("")
+    expect(toPascalCaseFilename("   ")).toBe("")
+  })
+
+  it("does not crash on leading/trailing/double hyphens", () => {
+    expect(toPascalCaseFilename("-Tee")).toBe("-Tee")
+    expect(toPascalCaseFilename("Tee-")).toBe("Tee-")
+    expect(toPascalCaseFilename("A--B")).toBe("A--B")
+    expect(toPascalCaseFilename("-")).toBe("-")
+  })
+
+  it("strips trailing dots/spaces (Windows/exFAT hazard)", () => {
+    expect(toPascalCaseFilename("Vol. ")).toBe("Vol")
+    expect(toPascalCaseFilename("Tee.")).toBe("Tee")
+    // mid-string dot is fine
+    expect(toPascalCaseFilename("No. 5")).toBe("No.5")
+  })
+})
+
+describe("resolveHeroGenderPrefix", () => {
+  it("maps known men/women/unisex variants", () => {
+    for (const v of ["men", "Man", "MENS", "male", "M"]) expect(resolveHeroGenderPrefix(v)).toBe("M")
+    for (const v of ["women", "Woman", "WOMENS", "female", "w"]) expect(resolveHeroGenderPrefix(v)).toBe("W")
+    for (const v of ["unisex", "Unisex", "U"]) expect(resolveHeroGenderPrefix(v)).toBe("U")
+  })
+
+  it("returns null (the flag) for unresolved gender — never a silent U", () => {
+    expect(resolveHeroGenderPrefix(null)).toBeNull()
+    expect(resolveHeroGenderPrefix(undefined)).toBeNull()
+    expect(resolveHeroGenderPrefix("")).toBeNull()
+    expect(resolveHeroGenderPrefix("kids")).toBeNull()
+    expect(resolveHeroGenderPrefix("???")).toBeNull()
+  })
+})
+
+describe("buildCaptureOneName", () => {
+  it("joins prefix + product + colorway", () => {
+    expect(buildCaptureOneName("M", "Merino Flex Jogger", "Forest")).toBe("M_MerinoFlexJogger_Forest")
+    expect(buildCaptureOneName("W", "Merino Linen Button-Up", "Light Azure")).toBe(
+      "W_MerinoLinenButton-Up_LightAzure",
+    )
+  })
+
+  it("omits an empty colorway (no trailing underscore)", () => {
+    expect(buildCaptureOneName("M", "Merino Flex Jogger", null)).toBe("M_MerinoFlexJogger")
+    expect(buildCaptureOneName("M", "Merino Flex Jogger", "")).toBe("M_MerinoFlexJogger")
+    // a colorway that's all illegal chars strips to "" and is omitted (no "_" artifact)
+    expect(buildCaptureOneName("M", "Jogger", "/")).toBe("M_Jogger")
+  })
+
+  it("a blank/all-illegal product name yields an empty middle slot (caller must guarantee a name)", () => {
+    // Documented edge: hero products always have a name in practice, but pin the behavior.
+    expect(buildCaptureOneName("M", "***", "Red")).toBe("M__Red")
+  })
+})
+
+describe("buildHeroFilename", () => {
+  it("resolves the gender prefix from the family and reports resolved", () => {
+    expect(
+      buildHeroFilename({ gender: "men", productName: "Merino Flex Jogger", colorway: "Forest" }),
+    ).toEqual({ name: "M_MerinoFlexJogger_Forest", genderResolved: true })
+  })
+
+  it("falls back to U_ and flags genderResolved=false when gender is unresolved", () => {
+    expect(
+      buildHeroFilename({ gender: null, productName: "Merino Flex Jogger", colorway: "Forest" }),
+    ).toEqual({ name: "U_MerinoFlexJogger_Forest", genderResolved: false })
+  })
+
+  it("a genuine unisex product resolves to U_ and is NOT flagged", () => {
+    const r = buildHeroFilename({ gender: "unisex", productName: "Beach Tote", colorway: "Sand" })
+    expect(r.name).toBe("U_BeachTote_Sand")
+    expect(r.genderResolved).toBe(true)
+  })
+})

--- a/src-vnext/features/captureone/lib/captureOneFilename.ts
+++ b/src-vnext/features/captureone/lib/captureOneFilename.ts
@@ -1,0 +1,70 @@
+// Pure helpers for the Capture One digi-tech filename generator.
+// Format: <Gender>_<ProductNamePascal>_<Colorway>  e.g. M_MerinoFlexJogger_Forest
+
+// Filesystem / Capture One reserved characters (the only chars we strip — the
+// locked rule is "strip only what Capture One dislikes; keep hyphens").
+const ILLEGAL_CHARS = /[/\\:*?"<>|\x00-\x1f]/g
+
+/**
+ * spaces→PascalCase, hyphens preserved, illegal chars stripped.
+ * "Merino Flex Jogger"→"MerinoFlexJogger" · "Button-Up Shirt"→"Button-UpShirt" · "Tee / Crew"→"TeeCrew"
+ */
+export function toPascalCaseFilename(name: string | null | undefined): string {
+  return (name ?? "")
+    .replace(ILLEGAL_CHARS, " ") // illegal → space so it becomes a word boundary
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word) =>
+      word
+        .split("-")
+        .map((seg) => (seg ? seg.charAt(0).toUpperCase() + seg.slice(1) : seg))
+        .join("-"),
+    )
+    .join("")
+    .replace(/[.\s]+$/g, "") // trailing dot/space — Windows/exFAT silently mangle these
+}
+
+/** Gender prefix from the hero product's own ProductFamily.gender. null = unresolved (caller flags it; never a silent "U"). */
+export function resolveHeroGenderPrefix(
+  gender: string | null | undefined,
+): "M" | "W" | "U" | null {
+  const g = (gender ?? "").trim().toLowerCase()
+  if (g === "women" || g === "woman" || g === "womens" || g === "female" || g === "w") return "W"
+  if (g === "men" || g === "man" || g === "mens" || g === "male" || g === "m") return "M"
+  if (g === "unisex" || g === "u") return "U"
+  return null
+}
+
+/** Join a (resolved) prefix + product name + optional colorway into the filename. Omits an empty colorway. */
+export function buildCaptureOneName(
+  prefix: string,
+  productName: string | null | undefined,
+  colorway?: string | null,
+): string {
+  const parts = [prefix, toPascalCaseFilename(productName)]
+  const co = toPascalCaseFilename(colorway)
+  if (co) parts.push(co)
+  return parts.join("_")
+}
+
+export interface HeroFilename {
+  readonly name: string
+  /** false when the hero product's gender couldn't be resolved — render a warning badge. */
+  readonly genderResolved: boolean
+}
+
+/**
+ * Build one hero filename, resolving the gender prefix from the family. When gender is
+ * unresolved it falls back to a "U_" prefix and reports genderResolved=false (for the badge).
+ */
+export function buildHeroFilename(input: {
+  readonly gender: string | null | undefined
+  readonly productName: string | null | undefined
+  readonly colorway?: string | null
+}): HeroFilename {
+  const prefix = resolveHeroGenderPrefix(input.gender)
+  return {
+    name: buildCaptureOneName(prefix ?? "U", input.productName, input.colorway),
+    genderResolved: prefix !== null,
+  }
+}


### PR DESCRIPTION
## CO-1 — Capture One filename + gender utils (digi-tech generator, PR 1 of ~4)

First PR of the **Capture One digi-tech live-link** feature. Pure, fully-tested helpers — no UI, no data, no side effects. The share page (CO-3, next) consumes them, so this isn't orphan code.

### What it does
Produces `<Gender>_<ProductNamePascal>_<Colorway>` (e.g. `M_MerinoFlexJogger_Forest`) per the locked rules:
- **`toPascalCaseFilename`** — spaces→PascalCase, **hyphens preserved** (`Button-Up` → `Button-Up`), only Capture-One/filesystem-illegal chars stripped (`/ \ : * ? " < > |` + control), and **trailing dot/space removed** (Windows/exFAT silently mangle those — digi-tech handoff drives are often exFAT).
- **`resolveHeroGenderPrefix`** — the hero product's own `ProductFamily.gender` → `M`/`W`/`U`; **`null` when unresolved** (the flag — never a silent "U", per the locked rule). A genuine `unisex` resolves to `U` and is NOT flagged.
- **`buildCaptureOneName` / `buildHeroFilename`** — assemble the name; `buildHeroFilename` falls back to a `U_` prefix but returns `genderResolved=false` so the share page can render a warning badge. Empty colorway is omitted (no trailing `_`).

### Why pure utils first
The filename rules are the spec's load-bearing logic (the "never a silent U" gender flag, hyphen preservation, illegal-char handling). Isolating + exhaustively testing them de-risks the share page (CO-3) and needs no design decisions.

### Test plan
- [x] `vitest` — 15 cases: PascalCase, hyphen edges (leading/trailing/double), illegal-char strip, trailing-dot strip, lowercase input, the full gender map (incl. unresolved→null and unisex-not-flagged), colorway omission, all-illegal colorway, the blank-name edge.
- [x] `eslint` clean; `vite build` passes.
- [x] Adversarial review: the never-silent-U invariant verified airtight; one MEDIUM (trailing dot/space on Windows shares) fixed in this PR.

### Roadmap (for context)
CO-2 multi-select hero star (`isHero`, replaces the single Cover-product dropdown) · **CO-3 the `/captureone/shared/:token` page + Firestore collection + rules (consumes these utils)** · CO-4 xlsx snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)