### PR TITLE
feat(captureone): multi-select hero star replacing the cover-product dropdown (CO-2)

### DIFF
--- a/src-vnext/features/shots/components/ProductAssignmentPicker.test.tsx
+++ b/src-vnext/features/shots/components/ProductAssignmentPicker.test.tsx
@@ -95,6 +95,58 @@ describe("ProductAssignmentPicker", () => {
     expect(img).toHaveAttribute("src", "https://img.test/thumb.jpg")
   })
 
+  describe("hero star", () => {
+    it("does not render the star when onToggleHero is omitted", () => {
+      render(<ProductAssignmentPicker selected={EXISTING} onSave={vi.fn()} />)
+      expect(
+        screen.queryByRole("button", { name: /hero product/i }),
+      ).not.toBeInTheDocument()
+    })
+
+    it("renders a pressed star for hero indices and toggles by index on click", () => {
+      const onToggleHero = vi.fn()
+      render(
+        <ProductAssignmentPicker
+          selected={EXISTING}
+          onSave={vi.fn()}
+          heroIndexes={new Set([0])}
+          onToggleHero={onToggleHero}
+        />,
+      )
+      const star = screen.getByRole("button", { name: "Unmark hero product" })
+      expect(star).toHaveAttribute("aria-pressed", "true")
+      fireEvent.click(star)
+      expect(onToggleHero).toHaveBeenCalledWith(0)
+    })
+
+    it("renders an unpressed star for non-hero rows", () => {
+      render(
+        <ProductAssignmentPicker
+          selected={EXISTING}
+          onSave={vi.fn()}
+          heroIndexes={new Set()}
+          onToggleHero={vi.fn()}
+        />,
+      )
+      expect(
+        screen.getByRole("button", { name: "Mark as hero product" }),
+      ).toHaveAttribute("aria-pressed", "false")
+    })
+
+    it("disables the star when the picker is read-only", () => {
+      render(
+        <ProductAssignmentPicker
+          selected={EXISTING}
+          onSave={vi.fn()}
+          disabled
+          heroIndexes={new Set([0])}
+          onToggleHero={vi.fn()}
+        />,
+      )
+      expect(screen.getByRole("button", { name: "Unmark hero product" })).toBeDisabled()
+    })
+  })
+
   describe("save-gated confirm", () => {
     it("keeps dialog open and retains selections when onSave resolves false", async () => {
       onSave.mockResolvedValue(false)

--- a/src-vnext/features/shots/components/ProductAssignmentPicker.tsx
+++ b/src-vnext/features/shots/components/ProductAssignmentPicker.tsx
@@ -26,7 +26,7 @@ import {
 } from "@/features/shots/hooks/usePickerData"
 import { ProductUpsertDialog } from "@/features/products/components/ProductUpsertDialog"
 import { ProductQuickViewPopover } from "@/features/shots/components/ProductQuickViewPopover"
-import { Package, Plus, X, ChevronLeft, Loader2, Search } from "lucide-react"
+import { Package, Plus, X, ChevronLeft, Loader2, Search, Star } from "lucide-react"
 import { resolveStoragePath } from "@/shared/lib/resolveStoragePath"
 import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
 import { getTagColorClasses } from "@/shared/lib/tagColors"
@@ -39,6 +39,10 @@ interface ProductAssignmentPickerProps {
   readonly onSave: (products: ProductAssignment[]) => Promise<boolean>
   readonly disabled?: boolean
   readonly canManageCatalog?: boolean
+  /** Indices of `selected` that are heroes. Renders the always-on star only when paired with onToggleHero. */
+  readonly heroIndexes?: ReadonlySet<number>
+  /** Toggle a product's hero (Capture One filename) state by its index in `selected`. */
+  readonly onToggleHero?: (index: number) => void
 }
 
 type AddStep = "family" | "sku" | "details"
@@ -108,6 +112,8 @@ export function ProductAssignmentPicker({
   onSave,
   disabled,
   canManageCatalog = false,
+  heroIndexes,
+  onToggleHero,
 }: ProductAssignmentPickerProps) {
   const [dialogOpen, setDialogOpen] = useState(false)
   const [step, setStep] = useState<AddStep>("family")
@@ -226,6 +232,8 @@ export function ProductAssignmentPicker({
               key={`${p.familyId}-${p.colourId ?? ""}-${index}`}
               assignment={p}
               disabled={disabled}
+              isHero={heroIndexes?.has(index) ?? false}
+              onToggleHero={onToggleHero ? () => onToggleHero(index) : undefined}
               onEdit={() => openEdit(index)}
               onRemove={() => handleRemove(index)}
             />
@@ -342,11 +350,15 @@ export function ProductAssignmentPicker({
 function AssignmentRow({
   assignment,
   disabled,
+  isHero = false,
+  onToggleHero,
   onEdit,
   onRemove,
 }: {
   readonly assignment: ProductAssignment
   readonly disabled?: boolean
+  readonly isHero?: boolean
+  readonly onToggleHero?: () => void
   readonly onEdit: () => void
   readonly onRemove: () => void
 }) {
@@ -423,6 +435,29 @@ function AssignmentRow({
         )}
       </div>
       <div className="flex items-center gap-1 shrink-0">
+        {onToggleHero && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            disabled={disabled}
+            aria-pressed={isHero}
+            aria-label={isHero ? "Unmark hero product" : "Mark as hero product"}
+            title={isHero ? "Hero product — used for the Capture One filename" : "Mark as hero product"}
+            onClick={(e) => {
+              e.stopPropagation()
+              onToggleHero()
+            }}
+          >
+            <Star
+              className={
+                isHero
+                  ? "h-3.5 w-3.5 fill-amber-400 text-amber-400"
+                  : "h-3.5 w-3.5 text-[var(--color-text-subtle)]"
+              }
+            />
+          </Button>
+        )}
         <ProductQuickViewPopover assignment={assignment}>
           <Button
             variant="ghost"

--- a/src-vnext/features/shots/components/ShotLooksSection.tsx
+++ b/src-vnext/features/shots/components/ShotLooksSection.tsx
@@ -9,13 +9,7 @@ import { useStorageUrl } from "@/shared/hooks/useStorageUrl"
 import { canManageProducts } from "@/shared/lib/rbac"
 import { Button } from "@/ui/button"
 import { Badge } from "@/ui/badge"
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/ui/select"
+import { firstHeroProductId, lookHeroIndexes, reconcileHeroProductId } from "@/features/shots/lib/lookHeroes"
 import { Image, ImagePlus, Plus, Star, Trash2, X, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { InlineEmpty } from "@/shared/components/InlineEmpty"
@@ -32,9 +26,6 @@ function formatUploadError(err: unknown): string {
   if (typeof err === "string") return err
   return "Unknown error"
 }
-
-const HERO_AUTO_VALUE = "__auto__"
-const HERO_NONE_VALUE = "__none__"
 
 function getLookLabel(order: number): string {
   if (order === 0) return "Primary"
@@ -60,19 +51,6 @@ function normalizeLooksForWrite(looks: ReadonlyArray<ShotLook>): ShotLook[] {
     references: look.references ?? [],
     displayImageId: look.displayImageId ?? null,
   }))
-}
-
-function productHeroOptions(products: ReadonlyArray<ProductAssignment>) {
-  const options: Array<{ readonly id: string; readonly label: string }> = []
-  for (const p of products) {
-    const id = p.skuId ?? p.colourId ?? p.familyId
-    if (!id) continue
-    const base = p.familyName ?? p.skuName ?? p.colourName ?? id
-    const color = p.colourName && p.familyName ? ` — ${p.colourName}` : ""
-    options.push({ id, label: `${base}${color}` })
-  }
-  options.sort((a, b) => a.label.localeCompare(b.label))
-  return options
 }
 
 export function ShotLooksSection({
@@ -119,14 +97,10 @@ export function ShotLooksSection({
 
   const [saving, setSaving] = useState(false)
 
-  const selectedHeroValue = useMemo(() => {
-    if (!selectedLook) return HERO_AUTO_VALUE
-    if (selectedLook.heroProductId === null) return HERO_NONE_VALUE
-    if (typeof selectedLook.heroProductId === "string" && selectedLook.heroProductId.length > 0) {
-      return selectedLook.heroProductId
-    }
-    return HERO_AUTO_VALUE
-  }, [selectedLook])
+  const heroIndexes = useMemo<ReadonlySet<number>>(
+    () => new Set(selectedLook ? lookHeroIndexes(selectedLook) : []),
+    [selectedLook],
+  )
 
   const saveLooks = async (
     nextLooks: ReadonlyArray<ShotLook>,
@@ -152,6 +126,25 @@ export function ShotLooksSection({
     } finally {
       setSaving(false)
     }
+  }
+
+  // Toggle a product's hero star, persist explicit isHero flags, and keep the
+  // legacy cover pointer (heroProductId) following the first star.
+  const handleToggleHero = async (index: number) => {
+    if (!selectedLook) return
+    const nextHeroes = new Set(lookHeroIndexes(selectedLook))
+    if (nextHeroes.has(index)) nextHeroes.delete(index)
+    else nextHeroes.add(index)
+    const nextProducts: ProductAssignment[] = selectedLook.products.map((p, i) => ({
+      ...p,
+      isHero: nextHeroes.has(i) ? true : undefined,
+    }))
+    const nextLooks = looks.map((l) =>
+      l.id === selectedLook.id
+        ? { ...l, products: nextProducts, heroProductId: firstHeroProductId(nextProducts) }
+        : l,
+    )
+    await saveLooks(nextLooks)
   }
 
   const [confirmDeleteLookOpen, setConfirmDeleteLookOpen] = useState(false)
@@ -334,56 +327,26 @@ export function ShotLooksSection({
 
           <ProductAssignmentPicker
             selected={selectedLook.products ?? []}
-            disabled={!canEdit}
+            disabled={!canEdit || saving}
             canManageCatalog={canManageCatalog}
+            heroIndexes={heroIndexes}
+            onToggleHero={handleToggleHero}
             onSave={async (products) => {
               const next = looks.map((l) =>
-                l.id === selectedLook.id ? { ...l, products } : l,
+                l.id === selectedLook.id
+                  ? { ...l, products, heroProductId: reconcileHeroProductId(products, l.heroProductId) }
+                  : l,
               )
               return saveLooks(next)
             }}
           />
 
-          {/* Hero product */}
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
-              <Star className="h-4 w-4 text-[var(--color-text-subtle)]" />
-              <p className="text-xs font-medium text-[var(--color-text-subtle)]">Cover product (optional)</p>
-            </div>
-
-            {selectedLook.products.length === 0 ? (
-              <p className="text-xs text-[var(--color-text-subtle)]">Add products to enable hero selection.</p>
-            ) : (
-              <Select
-                value={selectedHeroValue}
-                onValueChange={async (value) => {
-                  const heroProductId =
-                    value === HERO_AUTO_VALUE ? undefined : value === HERO_NONE_VALUE ? null : value
-                  const next = looks.map((l) =>
-                    l.id === selectedLook.id ? { ...l, heroProductId } : l,
-                  )
-                  await saveLooks(next)
-                }}
-                disabled={!canEdit}
-              >
-                <SelectTrigger className="w-full">
-                  <SelectValue placeholder="Auto (first product)" />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value={HERO_AUTO_VALUE}>Auto (first product)</SelectItem>
-                  <SelectItem value={HERO_NONE_VALUE}>None</SelectItem>
-                  {productHeroOptions(selectedLook.products).map((o) => (
-                    <SelectItem key={o.id} value={o.id}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-            <p className="text-xxs text-[var(--color-text-subtle)]">
-              Cover prefers a selected reference image; otherwise it uses the chosen cover product (or auto).
+          {selectedLook.products.length > 0 && (
+            <p className="flex items-center gap-1.5 text-xxs text-[var(--color-text-subtle)]">
+              <Star className="h-3 w-3 shrink-0 fill-amber-400 text-amber-400" />
+              Star hero product(s) — used for the Capture One filename. The cover image follows the first starred product.
             </p>
-          </div>
+          )}
 
           {/* References live in the hero/header rail for this layout mode. */}
           {showReferencesSection && (

--- a/src-vnext/features/shots/components/__tests__/ShotLooksSection.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotLooksSection.test.tsx
@@ -1,15 +1,50 @@
 /// <reference types="@testing-library/jest-dom" />
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen } from "@testing-library/react"
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import { Timestamp } from "firebase/firestore"
-import type { Shot } from "@/shared/types"
+import type { ProductAssignment, Shot } from "@/shared/types"
+
+const { updateShotWithVersionMock } = vi.hoisted(() => ({
+  updateShotWithVersionMock: vi.fn(),
+}))
 
 vi.mock("@/app/providers/AuthProvider", () => ({
   useAuth: () => ({ role: "producer", clientId: "c1", user: { uid: "u1" } }),
 }))
 
+// Stub picker that surfaces the hero-toggle wiring so we can drive handleToggleHero.
 vi.mock("@/features/shots/components/ProductAssignmentPicker", () => ({
-  ProductAssignmentPicker: () => <div>Product picker</div>,
+  ProductAssignmentPicker: ({
+    selected,
+    heroIndexes,
+    onToggleHero,
+    onSave,
+  }: {
+    selected: ReadonlyArray<ProductAssignment>
+    heroIndexes?: ReadonlySet<number>
+    onToggleHero?: (index: number) => void
+    onSave: (products: ProductAssignment[]) => Promise<boolean>
+  }) => (
+    <div>
+      Product picker
+      {selected.map((p, i) => (
+        <button
+          key={i}
+          data-testid={`toggle-hero-${i}`}
+          data-hero={heroIndexes?.has(i) ? "1" : "0"}
+          onClick={() => onToggleHero?.(i)}
+        >
+          {p.familyId}
+        </button>
+      ))}
+      <button
+        data-testid="remove-product-0"
+        onClick={() => void onSave(selected.slice(1))}
+      >
+        remove first
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("@/shared/hooks/useStorageUrl", () => ({
@@ -18,6 +53,11 @@ vi.mock("@/shared/hooks/useStorageUrl", () => ({
 
 vi.mock("@/shared/lib/uploadImage", () => ({
   uploadShotReferenceImage: vi.fn(),
+  validateImageFileForUpload: vi.fn(),
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: updateShotWithVersionMock,
 }))
 
 import { ShotLooksSection } from "@/features/shots/components/ShotLooksSection"
@@ -52,12 +92,21 @@ function makeShot(overrides: Partial<Shot>): Shot {
   }
 }
 
+type WrittenLook = { products: ProductAssignment[]; heroProductId?: string | null }
+
+function lastSavedLooks(): WrittenLook[] {
+  const calls = updateShotWithVersionMock.mock.calls
+  const last = calls[calls.length - 1]?.[0] as { patch: { looks: WrittenLook[] } }
+  return last.patch.looks
+}
+
 describe("ShotLooksSection", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    updateShotWithVersionMock.mockResolvedValue(undefined)
   })
 
-  it("renders hero product select without throwing", () => {
+  it("renders the look section with the hero-star caption (no cover dropdown)", () => {
     const shot = makeShot({
       looks: [
         {
@@ -74,7 +123,124 @@ describe("ShotLooksSection", () => {
 
     render(<ShotLooksSection shot={shot} canEdit />)
 
-    expect(screen.getByText("Cover product (optional)")).toBeInTheDocument()
-    expect(screen.getByText("None")).toBeInTheDocument()
+    expect(screen.getByText("Product picker")).toBeInTheDocument()
+    expect(screen.getByText(/Star hero product/i)).toBeInTheDocument()
+    expect(screen.queryByText("Cover product (optional)")).not.toBeInTheDocument()
+  })
+
+  it("stars a product: persists explicit isHero and syncs heroProductId to the first star", async () => {
+    const shot = makeShot({
+      looks: [
+        {
+          id: "look-1",
+          order: 0,
+          label: "Primary",
+          products: [
+            { familyId: "fam-a", skuId: "sku-a", sizeScope: "pending" },
+            { familyId: "fam-b", skuId: "sku-b", sizeScope: "pending" },
+          ],
+          references: [],
+          displayImageId: null,
+        },
+      ],
+    })
+
+    render(<ShotLooksSection shot={shot} canEdit />)
+    fireEvent.click(screen.getByTestId("toggle-hero-1"))
+
+    await waitFor(() => expect(updateShotWithVersionMock).toHaveBeenCalled())
+    const products = lastSavedLooks()[0]!.products
+    expect(products[0]!.isHero).toBeUndefined()
+    expect(products[1]!.isHero).toBe(true)
+    // heroProductId (the cover pointer) follows the first starred product.
+    expect(lastSavedLooks()[0]!.heroProductId).toBe("sku-b")
+  })
+
+  it("clearing the only star drops heroProductId to AUTO (undefined, not null)", async () => {
+    const shot = makeShot({
+      looks: [
+        {
+          id: "look-1",
+          order: 0,
+          label: "Primary",
+          products: [{ familyId: "fam-a", skuId: "sku-a", isHero: true, sizeScope: "pending" }],
+          heroProductId: "sku-a",
+          references: [],
+          displayImageId: null,
+        },
+      ],
+    })
+
+    render(<ShotLooksSection shot={shot} canEdit />)
+    fireEvent.click(screen.getByTestId("toggle-hero-0"))
+
+    await waitFor(() => expect(updateShotWithVersionMock).toHaveBeenCalled())
+    expect(lastSavedLooks()[0]!.products[0]!.isHero).toBeUndefined()
+    // undefined → sanitizer omits the key → AUTO cover (first-product fallback), not NONE.
+    expect(lastSavedLooks()[0]!.heroProductId).toBeUndefined()
+  })
+
+  it("re-syncs heroProductId when a starred product is removed via the picker (no dangling cover)", async () => {
+    const shot = makeShot({
+      looks: [
+        {
+          id: "look-1",
+          order: 0,
+          label: "Primary",
+          products: [
+            { familyId: "fam-a", skuId: "sku-a", isHero: true, sizeScope: "pending" },
+            { familyId: "fam-b", skuId: "sku-b", sizeScope: "pending" },
+          ],
+          heroProductId: "sku-a",
+          references: [],
+          displayImageId: null,
+        },
+      ],
+    })
+
+    render(<ShotLooksSection shot={shot} canEdit />)
+    // Removing the starred product A (via the picker onSave path) must not leave
+    // heroProductId pointing at the absent A — it should fall back to AUTO.
+    fireEvent.click(screen.getByTestId("remove-product-0"))
+
+    await waitFor(() => expect(updateShotWithVersionMock).toHaveBeenCalled())
+    const look = lastSavedLooks()[0]!
+    expect(look.products.map((p) => p.familyId)).toEqual(["fam-b"])
+    expect(look.heroProductId).toBeUndefined()
+  })
+
+  it("non-destructively migrates a legacy heroProductId when a second product is starred", async () => {
+    const shot = makeShot({
+      looks: [
+        {
+          id: "look-1",
+          order: 0,
+          label: "Primary",
+          products: [
+            { familyId: "fam-a", skuId: "sku-a", sizeScope: "pending" },
+            { familyId: "fam-b", skuId: "sku-b", sizeScope: "pending" },
+          ],
+          // Legacy single cover points at product B; neither product has isHero yet.
+          heroProductId: "sku-b",
+          references: [],
+          displayImageId: null,
+        },
+      ],
+    })
+
+    render(<ShotLooksSection shot={shot} canEdit />)
+    // The legacy hero (B, index 1) should already render as starred.
+    expect(screen.getByTestId("toggle-hero-1").getAttribute("data-hero")).toBe("1")
+    expect(screen.getByTestId("toggle-hero-0").getAttribute("data-hero")).toBe("0")
+
+    // Star A too — the legacy hero must be preserved, not overwritten.
+    fireEvent.click(screen.getByTestId("toggle-hero-0"))
+
+    await waitFor(() => expect(updateShotWithVersionMock).toHaveBeenCalled())
+    const products = lastSavedLooks()[0]!.products
+    expect(products[0]!.isHero).toBe(true)
+    expect(products[1]!.isHero).toBe(true)
+    // First star in array order is A → cover pointer follows it.
+    expect(lastSavedLooks()[0]!.heroProductId).toBe("sku-a")
   })
 })

--- a/src-vnext/features/shots/lib/__tests__/lookHeroes.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/lookHeroes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest"
+import {
+  assignmentHeroId,
+  firstHeroProductId,
+  lookHeroAssignments,
+  lookHeroIndexes,
+  reconcileHeroProductId,
+} from "@/features/shots/lib/lookHeroes"
+import type { ProductAssignment, ShotLook } from "@/shared/types"
+
+const p = (over: Partial<ProductAssignment> & { familyId: string }): ProductAssignment => ({
+  ...over,
+})
+
+const look = (
+  products: ProductAssignment[],
+  heroProductId?: string | null,
+): ShotLook => ({ id: "look-1", products, heroProductId })
+
+describe("assignmentHeroId", () => {
+  it("prefers skuId, then colourId, then familyId", () => {
+    expect(assignmentHeroId(p({ familyId: "fam", colourId: "col", skuId: "sku" }))).toBe("sku")
+    expect(assignmentHeroId(p({ familyId: "fam", colourId: "col" }))).toBe("col")
+    expect(assignmentHeroId(p({ familyId: "fam" }))).toBe("fam")
+  })
+})
+
+describe("lookHeroIndexes", () => {
+  it("returns starred indices when any product has isHero", () => {
+    const l = look([
+      p({ familyId: "a" }),
+      p({ familyId: "b", isHero: true }),
+      p({ familyId: "c", isHero: true }),
+    ])
+    expect(lookHeroIndexes(l)).toEqual([1, 2])
+  })
+
+  it("ignores legacy heroProductId once isHero is present", () => {
+    const l = look(
+      [p({ familyId: "a", isHero: true }), p({ familyId: "b", skuId: "sku-b" })],
+      "sku-b",
+    )
+    expect(lookHeroIndexes(l)).toEqual([0])
+  })
+
+  it("falls back to the legacy heroProductId match when nothing is starred", () => {
+    const l = look(
+      [p({ familyId: "a", skuId: "sku-a" }), p({ familyId: "b", skuId: "sku-b" })],
+      "sku-b",
+    )
+    expect(lookHeroIndexes(l)).toEqual([1])
+  })
+
+  it("matches a legacy heroProductId against familyId or colourId too", () => {
+    expect(lookHeroIndexes(look([p({ familyId: "fam-1" })], "fam-1"))).toEqual([0])
+    expect(lookHeroIndexes(look([p({ familyId: "fam-1", colourId: "col-1" })], "col-1"))).toEqual([0])
+  })
+
+  it("returns [] when legacy heroProductId matches no product", () => {
+    expect(lookHeroIndexes(look([p({ familyId: "a" })], "missing"))).toEqual([])
+  })
+
+  it("returns [] when nothing is starred and there is no heroProductId", () => {
+    expect(lookHeroIndexes(look([p({ familyId: "a" })]))).toEqual([])
+    expect(lookHeroIndexes(look([p({ familyId: "a" })], null))).toEqual([])
+  })
+})
+
+describe("lookHeroAssignments", () => {
+  it("maps indices back to product assignments", () => {
+    const heroes = lookHeroAssignments(
+      look([p({ familyId: "a" }), p({ familyId: "b", isHero: true })]),
+    )
+    expect(heroes.map((x) => x.familyId)).toEqual(["b"])
+  })
+})
+
+describe("firstHeroProductId", () => {
+  it("returns the first starred product's hero id", () => {
+    expect(
+      firstHeroProductId([
+        p({ familyId: "a" }),
+        p({ familyId: "b", skuId: "sku-b", isHero: true }),
+        p({ familyId: "c", isHero: true }),
+      ]),
+    ).toBe("sku-b")
+  })
+
+  it("returns undefined (AUTO cover) when nothing is starred", () => {
+    expect(firstHeroProductId([p({ familyId: "a" })])).toBeUndefined()
+  })
+})
+
+describe("reconcileHeroProductId", () => {
+  it("follows the first star when products are starred", () => {
+    expect(
+      reconcileHeroProductId(
+        [p({ familyId: "a", skuId: "sku-a", isHero: true }), p({ familyId: "b" })],
+        "stale",
+      ),
+    ).toBe("sku-a")
+  })
+
+  it("drops a dangling legacy pointer to AUTO when the referenced product is gone", () => {
+    // Starred product A was removed; the old heroProductId points at A's now-absent id.
+    expect(reconcileHeroProductId([p({ familyId: "b", skuId: "sku-b" })], "sku-a")).toBeUndefined()
+  })
+
+  it("keeps a still-resolvable legacy pointer (non-destructive on add/edit of un-migrated shots)", () => {
+    expect(
+      reconcileHeroProductId(
+        [p({ familyId: "a", skuId: "sku-a" }), p({ familyId: "b", skuId: "sku-b" })],
+        "sku-b",
+      ),
+    ).toBe("sku-b")
+  })
+
+  it("preserves an explicit NONE (null) when nothing is starred", () => {
+    expect(reconcileHeroProductId([p({ familyId: "a" })], null)).toBeNull()
+  })
+
+  it("stays AUTO (undefined) when there is no pointer and nothing is starred", () => {
+    expect(reconcileHeroProductId([p({ familyId: "a" })], undefined)).toBeUndefined()
+  })
+})

--- a/src-vnext/features/shots/lib/__tests__/lookHeroes.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/lookHeroes.test.ts
@@ -119,6 +119,14 @@ describe("reconcileHeroProductId", () => {
     expect(reconcileHeroProductId([p({ familyId: "a" })], null)).toBeNull()
   })
 
+  it("keeps an explicit NONE (null) hidden even when a product is starred (hide-header stays hidden)", () => {
+    // Regression: hiding the header sets heroProductId=null while leaving isHero
+    // stars; a later product edit must NOT resurrect the cover from the star.
+    expect(
+      reconcileHeroProductId([p({ familyId: "a", skuId: "sku-a", isHero: true })], null),
+    ).toBeNull()
+  })
+
   it("stays AUTO (undefined) when there is no pointer and nothing is starred", () => {
     expect(reconcileHeroProductId([p({ familyId: "a" })], undefined)).toBeUndefined()
   })

--- a/src-vnext/features/shots/lib/lookHeroes.ts
+++ b/src-vnext/features/shots/lib/lookHeroes.ts
@@ -1,0 +1,72 @@
+import type { ProductAssignment, ShotLook } from "@/shared/types"
+
+// Resolves a look's hero products. Source of truth is ProductAssignment.isHero;
+// when no product is starred it falls back to the legacy single heroProductId so
+// pre-CO-2 shots keep their cover non-destructively. Shared by the looks editor
+// (star UI + cover sync) and the Capture One share resolver (CO-3).
+//
+// heroProductId is the legacy cover pointer, kept synced to the first star. It can
+// still be explicitly null (NONE) via "hide header" — that suppresses the cover
+// image but does NOT clear the heroes (filename source); a later star toggle resyncs it.
+
+/** The id heroProductId points at for a product — mirrors the legacy cover dropdown + coverProductImage matching. */
+export function assignmentHeroId(p: ProductAssignment): string {
+  return p.skuId ?? p.colourId ?? p.familyId
+}
+
+/** True when `p` is the product the legacy heroProductId referenced. */
+function matchesHeroProductId(p: ProductAssignment, heroId: string): boolean {
+  return p.skuId === heroId || p.colourId === heroId || p.familyId === heroId
+}
+
+/** Indices of a look's hero products: starred ones, else the legacy heroProductId match, else none. */
+export function lookHeroIndexes(look: ShotLook): number[] {
+  const products = look.products ?? []
+  const starred = products.flatMap((p, i) => (p.isHero === true ? [i] : []))
+  if (starred.length > 0) return starred
+
+  const heroId = look.heroProductId
+  if (typeof heroId === "string" && heroId.length > 0) {
+    const i = products.findIndex((p) => matchesHeroProductId(p, heroId))
+    if (i >= 0) return [i]
+  }
+  return []
+}
+
+/** A look's hero product assignments (isHero-first, legacy fallback). */
+export function lookHeroAssignments(look: ShotLook): ProductAssignment[] {
+  const products = look.products ?? []
+  return lookHeroIndexes(look).map((i) => products[i]!).filter(Boolean)
+}
+
+/**
+ * The heroProductId to persist for a products array = the first starred product's id.
+ * Returns undefined when none are starred so the cover stays in AUTO mode (first-product
+ * fallback) rather than NONE (which suppresses the cover entirely).
+ */
+export function firstHeroProductId(
+  products: ReadonlyArray<ProductAssignment>,
+): string | undefined {
+  const first = products.find((p) => p.isHero === true)
+  return first ? assignmentHeroId(first) : undefined
+}
+
+/**
+ * The heroProductId to persist after a products edit (add / colorway edit / remove).
+ * Stars win; otherwise keep a still-resolvable legacy pointer (non-destructive),
+ * but drop a dangling one to undefined (AUTO) so a removed cover product never
+ * leaves the look stuck in EXPLICIT mode pointing at nothing.
+ */
+export function reconcileHeroProductId(
+  products: ReadonlyArray<ProductAssignment>,
+  prevHeroProductId: string | null | undefined,
+): string | null | undefined {
+  const starred = firstHeroProductId(products)
+  if (starred !== undefined) return starred
+  if (typeof prevHeroProductId === "string" && prevHeroProductId.length > 0) {
+    return products.some((p) => matchesHeroProductId(p, prevHeroProductId))
+      ? prevHeroProductId
+      : undefined
+  }
+  return prevHeroProductId
+}

--- a/src-vnext/features/shots/lib/lookHeroes.ts
+++ b/src-vnext/features/shots/lib/lookHeroes.ts
@@ -61,6 +61,10 @@ export function reconcileHeroProductId(
   products: ReadonlyArray<ProductAssignment>,
   prevHeroProductId: string | null | undefined,
 ): string | null | undefined {
+  // An explicit NONE (null) — set by "hide header" — stays hidden across product
+  // edits; only an explicit star toggle (handleToggleHero, which calls
+  // firstHeroProductId directly) re-enables the cover.
+  if (prevHeroProductId === null) return null
   const starred = firstHeroProductId(products)
   if (starred !== undefined) return starred
   if (typeof prevHeroProductId === "string" && prevHeroProductId.length > 0) {

--- a/src-vnext/features/shots/lib/mapShot.test.ts
+++ b/src-vnext/features/shots/lib/mapShot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 import { mapShot } from "@/features/shots/lib/mapShot"
+import { sanitizeForFirestore } from "@/shared/lib/firestoreSanitize"
 
 describe("mapShot", () => {
   it("falls back to legacy name when title is missing", () => {
@@ -313,6 +314,44 @@ describe("mapShot", () => {
     })
 
     expect(shot.heroImage).toBeUndefined()
+  })
+
+  it("round-trips ProductAssignment.isHero through the write sanitizer and read mapper", () => {
+    const sanitizedLooks = sanitizeForFirestore([
+      {
+        id: "look-1",
+        order: 0,
+        products: [
+          { familyId: "fam-1", skuId: "sku-1", isHero: true },
+          { familyId: "fam-2", skuId: "sku-2", isHero: undefined },
+          { familyId: "fam-3", skuId: "sku-3" },
+        ],
+        references: [],
+      },
+    ]) as unknown[]
+
+    const shot = mapShot("s1", {
+      title: "Shot A",
+      projectId: "p1",
+      clientId: "c1",
+      createdAt: { seconds: 1, nanoseconds: 0 },
+      updatedAt: { seconds: 1, nanoseconds: 0 },
+      createdBy: "u1",
+      deleted: false,
+      looks: sanitizedLooks,
+    })
+
+    // Write side: the sanitizer keeps literal true and omits the undefined/absent key.
+    const writtenProducts = (sanitizedLooks[0] as { products: Record<string, unknown>[] }).products
+    expect(writtenProducts[0]?.isHero).toBe(true)
+    expect("isHero" in (writtenProducts[1] ?? {})).toBe(false)
+    expect("isHero" in (writtenProducts[2] ?? {})).toBe(false)
+
+    // Read side: true survives; undefined/absent read back as undefined.
+    const products = shot.looks?.[0]?.products ?? []
+    expect(products[0]?.isHero).toBe(true)
+    expect(products[1]?.isHero).toBeUndefined()
+    expect(products[2]?.isHero).toBeUndefined()
   })
 
   it("maps looks into typed structure", () => {

--- a/src-vnext/features/shots/lib/mapShot.ts
+++ b/src-vnext/features/shots/lib/mapShot.ts
@@ -57,6 +57,8 @@ function normalizeProducts(raw: unknown): ProductAssignment[] {
       thumbUrl: asString(p["thumbUrl"]) ?? legacyThumbPath,
       skuImageUrl: asString(p["skuImageUrl"]) ?? asString(p["colourImagePath"]),
       familyImageUrl: asString(p["familyImageUrl"]) ?? asString(p["thumbnailImagePath"]),
+      // Absent/false stays undefined so the write-side sanitizer omits the key.
+      isHero: p["isHero"] === true ? true : undefined,
     }
   })
 }

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -50,6 +50,8 @@ export interface ProductAssignment {
   readonly thumbUrl?: string
   readonly skuImageUrl?: string
   readonly familyImageUrl?: string
+  /** Marks this product as a hero (Capture One filename source). Multiple per look allowed; absent = not a hero. */
+  readonly isHero?: boolean
 }
 
 export type ShotTagCategory = "priority" | "gender" | "media" | "other"


### PR DESCRIPTION
## CO-2 — multi-select hero star (Capture One digi-tech link)

Second PR in the Capture One digi-tech live-link series (CO-1 filename engine = #474). Replaces the single **"Cover product (optional)"** dropdown in the looks editor with an **always-on per-product ⭐**, so a look can have **multiple** hero products. `isHero` is the new source of truth for Capture One filename generation (consumed by CO-3, the share page); the legacy `heroProductId` stays synced as the cover pointer.

### What changed
- **`shared/types`** — `ProductAssignment.isHero?: boolean`.
- **`mapShot.normalizeProducts`** — reads `isHero` back (the explicit field-by-field literal would otherwise silently drop it on every read; write side already preserves `true` / omits `undefined` via `sanitizeForFirestore`).
- **`features/shots/lib/lookHeroes.ts`** (new, pure) — `lookHeroIndexes` / `lookHeroAssignments` (isHero-first, legacy `heroProductId` fallback), `firstHeroProductId`, `assignmentHeroId`, and `reconcileHeroProductId`.
- **`ProductAssignmentPicker`** — always-on Star toggle in each row's action cluster (renders only when the parent wires `onToggleHero`; optional props, so no other caller is affected).
- **`ShotLooksSection`** — deletes the dropdown + dead helpers, wires the star, syncs `heroProductId` to the first star on toggle **and** re-syncs it on product add/edit/remove, gates the picker on `saving`.

### Design decisions
- **Non-destructive migration, no batch job.** A pre-CO-2 shot's single `heroProductId` renders as the first star (legacy fallback) and is preserved on the next save. `coverProductImage` and `shotProductReadiness` read the synced `heroProductId` and need **zero changes**.
- **Cover modes preserved.** `mapShot`'s cover resolver distinguishes `heroProductId === undefined` (AUTO → first-product cover) from `=== null` (NONE → no cover) from a string (EXPLICIT). Clearing the last star writes `undefined` (AUTO), never `null` — so an un-starred look keeps its auto cover. The dropdown's explicit "None" is dropped from the editor; it remains reachable via "hide header".

### Adversarial verification
Four review lenses (persistence round-trip, migration/cover correctness, React/hook correctness, scope/regression). One real issue found and fixed in this PR: the picker's product add/edit/remove path didn't re-sync `heroProductId`, leaving a dangling cover pointer when a starred product was removed (pre-existing, but one-click starring raised its exposure) → fixed with `reconcileHeroProductId` (keeps a still-resolvable legacy pointer, drops a dangling one to AUTO). Also gated the picker on `saving` to close a rapid-multi-star last-write-wins race. Immutability, hook deps, no-floating-promises, and dead-code removal all verified clean.

### Tests
- `lookHeroes.test.ts` — resolver precedence, legacy fallback, `firstHeroProductId`, and all `reconcileHeroProductId` branches.
- `mapShot.test.ts` — real write(`sanitizeForFirestore`)→read(`mapShot`) `isHero` round-trip.
- `ShotLooksSection.test.tsx` — toggle persists explicit `isHero` + syncs cover pointer; clear-last-star → AUTO; non-destructive legacy migration; remove-starred-product re-syncs to AUTO.
- `ProductAssignmentPicker.test.tsx` — star renders/toggles/disables; absent when `onToggleHero` omitted.

Local gates: scoped vitest 45/45, full suite 3833 passed / 0 failed, `lint --max-warnings=0` clean, `vite build` clean.

### ⏸ Eyeball gate (not auto-merging — needs review)
Please eyeball on a throwaway project at `:5174`:
1. The star appears on each product row; filled gold = hero; multiple can be starred.
2. Open a shot that previously used the old cover dropdown → its cover product shows as the first star (migration), and the cover image is unchanged.
3. Starring/un-starring updates the cover image to follow the first star; clearing all stars returns to the auto first-product cover.

### Open design questions for review (no behavior assumed)
- **"Hide header" + stars:** hiding the header sets the cover pointer to null but leaves the products starred (they're still filename heroes); a later star toggle re-establishes the cover. Should hiding the header also clear the heroes, or keep them? (Currently: keeps them.)
- **Explicit "None":** suppressing the cover while products exist is now only reachable via "hide header", not the looks editor. OK, or surface a control near the star caption?

### Follow-ups (pre-existing, out of scope here)
- `shotProductReadiness` matches `heroProductId` by `familyId` only (not `skuId`/`colourId`), so a SKU-level hero falls back to first-product for readiness. `shotMergeWrites` validates the cover pointer by `familyId` only and can drop a SKU-level pointer on merge (`isHero` survives the merge regardless). Both predate CO-2; worth aligning when CO-3 lands (or have CO-3 read `lookHeroAssignments` directly rather than re-deriving from `heroProductId`).
