### PR TITLE
feat(captureone): no-login digi-tech share page for Capture One filenames (CO-3)

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -95,6 +95,12 @@
         ]
       },
       {
+        "source": "/captureone/shared/**",
+        "headers": [
+          { "key": "X-Frame-Options", "value": "SAMEORIGIN" }
+        ]
+      },
+      {
         "source": "/index.html",
         "headers": [
           { "key": "Cache-Control", "value": "no-store, max-age=0" },

--- a/firestore.rules
+++ b/firestore.rules
@@ -283,6 +283,40 @@ service cloud.firestore {
       }
     }
 
+    // Public Capture One digi-tech sharing — share docs at /captureOneShares/{shareToken}
+    // (doc id = token). Resolved hero filenames are denormalized at creation time so the
+    // public page reads only the one share doc. Read-only: no subcollections.
+    match /captureOneShares/{shareToken} {
+      // Allow unauthenticated get when sharing is enabled and not expired.
+      // Security: requires knowledge of the exact share token (UUID / 32+ chars).
+      // Note: must check field existence before access — missing fields throw in rules.
+      allow get: if resource.data.enabled == true
+        && (!('expiresAt' in resource.data) || resource.data.expiresAt == null || resource.data.expiresAt > request.time);
+
+      // Authenticated admin/producer reads (management UI + refresh-on-save query).
+      allow get, list: if isAuthed() &&
+        (isAdmin() || isProducer()) &&
+        resource.data.clientId == userClient();
+
+      // Create is project-scoped (mirrors shotShares): a non-admin producer must hold
+      // producer access on the share's projectId — a global claim alone cannot mint an
+      // enabled public link for an arbitrary project in the tenant.
+      allow create: if isAuthed() &&
+        request.resource.data.clientId == userClient() &&
+        request.resource.data.projectId is string &&
+        (request.resource.data.shotIds == null || request.resource.data.shotIds is list) &&
+        request.resource.data.enabled is bool &&
+        (isAdmin() ||
+          (isProducer() &&
+           request.resource.data.projectId != '' &&
+           (producerCanAccessProject(userClient(), request.resource.data.projectId) ||
+            hasProjectRole(request.resource.data.projectId, ['producer']))));
+
+      allow update, delete: if isAuthed() &&
+        (isAdmin() || isProducer()) &&
+        resource.data.clientId == userClient();
+    }
+
     // Public call-sheet sharing — Phase 3 publishing.
     // Root-level share docs at /callSheetShares/{shareGroupId} hold a
     // denormalized snapshot of a published call sheet. Each share has a

--- a/src-vnext/app/routes/__tests__/breadcrumbs.test.ts
+++ b/src-vnext/app/routes/__tests__/breadcrumbs.test.ts
@@ -89,6 +89,7 @@ describe("breadcrumbsConfig", () => {
       "/pulls/shared/:shareToken/guide",
       "/shots/shared/:shareToken",
       "/casting/shared/:shareToken",
+      "/captureone/shared/:shareToken",
       "*",
       // Dev-only imports — unreachable in production, not worth wiring.
       "dev/import-q2",

--- a/src-vnext/app/routes/index.tsx
+++ b/src-vnext/app/routes/index.tsx
@@ -24,6 +24,9 @@ const ShotDetailPage = lazy(
 const PublicShotSharePage = lazy(
   () => import("@/features/shots/components/PublicShotSharePage"),
 )
+const PublicCaptureOneSharePage = lazy(
+  () => import("@/features/captureone/components/PublicCaptureOneSharePage"),
+)
 const TagManagementPage = lazy(
   () => import("@/features/shots/components/TagManagementPage"),
 )
@@ -125,6 +128,7 @@ export function AppRoutes() {
         <Route path="/pulls/shared/:shareToken/guide" element={<WarehousePickGuidePage />} />
         <Route path="/shots/shared/:shareToken" element={<PublicShotSharePage />} />
         <Route path="/casting/shared/:shareToken" element={<PublicCastingReviewPage />} />
+        <Route path="/captureone/shared/:shareToken" element={<PublicCaptureOneSharePage />} />
         <Route
           element={
             <RequireAuth>

--- a/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
+++ b/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
@@ -1,0 +1,223 @@
+// @vitest-environment node
+/**
+ * Firestore rules tests for the Capture One digi-tech share (captureOneShares).
+ *
+ * Covers: anonymous get on enabled/disabled/expired; anonymous list denied;
+ * authed admin/producer get scoped by clientId; client-side create/update/delete
+ * scoped by clientId; cross-tenant + non-privileged denials.
+ *
+ * Requires the Firestore emulator. When FIRESTORE_EMULATOR_HOST is not set the
+ * suite self-skips so a plain `CI=1 npm test` stays green without an emulator.
+ * CI (ui-checks.yml) starts the emulator and runs these via the .rules.test.ts glob.
+ */
+
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import {
+  assertFails,
+  assertSucceeds,
+  initializeTestEnvironment,
+  type RulesTestEnvironment,
+} from "@firebase/rules-unit-testing"
+import { deleteDoc, doc, getDoc, collection, getDocs, setDoc, updateDoc, Timestamp } from "firebase/firestore"
+
+const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST
+const skipSuite = !EMULATOR_HOST
+const describeOrSkip = skipSuite ? describe.skip : describe
+
+const PROJECT_ID = "demo-captureone-rules"
+const RULES_PATH = resolve(__dirname, "../../../../firestore.rules")
+
+const CLIENT_A = "client-a"
+const CLIENT_B = "client-b"
+const PROJ_TEAM = "proj-1" // team-visible -> a global producer auto-has access
+const PROJ_PRIVATE = "proj-private" // private -> producer needs an explicit members doc
+const SHARE_OK = "share-ok"
+const SHARE_DISABLED = "share-disabled"
+const SHARE_EXPIRED = "share-expired"
+const SHARE_NO_EXPIRY = "share-no-expiry"
+const SHARE_DELETABLE = "share-deletable"
+
+function inFuture(days: number): Timestamp {
+  return Timestamp.fromMillis(Date.now() + days * 86_400_000)
+}
+function inPast(days: number): Timestamp {
+  return Timestamp.fromMillis(Date.now() - days * 86_400_000)
+}
+
+function makeShare(
+  overrides: {
+    clientId?: string
+    projectId?: string
+    enabled?: boolean
+    expiresAt?: Timestamp | null
+  } = {},
+) {
+  return {
+    clientId: overrides.clientId ?? CLIENT_A,
+    projectId: overrides.projectId ?? PROJ_TEAM,
+    title: "Capture One",
+    enabled: overrides.enabled ?? true,
+    expiresAt: overrides.expiresAt === undefined ? inFuture(14) : overrides.expiresAt,
+    createdAt: Timestamp.now(),
+    createdBy: "creator-uid",
+    shotIds: null,
+    projectName: "Project",
+    shots: [],
+  }
+}
+
+let testEnv: RulesTestEnvironment | null = null
+
+describeOrSkip("firestore.rules — captureOneShares", () => {
+  beforeAll(async () => {
+    if (!EMULATOR_HOST) return
+    const [host, portStr] = EMULATOR_HOST.split(":")
+    const port = Number(portStr || "8080")
+    testEnv = await initializeTestEnvironment({
+      projectId: PROJECT_ID,
+      firestore: { host, port, rules: readFileSync(RULES_PATH, "utf8") },
+    })
+
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      const db = ctx.firestore()
+      // Projects gate the project-scoped create rule (producerCanAccessProject).
+      await setDoc(doc(db, "clients", CLIENT_A, "projects", PROJ_TEAM), { visibility: "team" })
+      await setDoc(doc(db, "clients", CLIENT_A, "projects", PROJ_PRIVATE), { visibility: "private" })
+
+      await setDoc(doc(db, "captureOneShares", SHARE_OK), makeShare())
+      await setDoc(doc(db, "captureOneShares", SHARE_DISABLED), makeShare({ enabled: false }))
+      await setDoc(doc(db, "captureOneShares", SHARE_EXPIRED), makeShare({ expiresAt: inPast(1) }))
+      await setDoc(doc(db, "captureOneShares", SHARE_DELETABLE), makeShare())
+      // A share with the expiresAt field OMITTED entirely (the production writer always
+      // writes expiresAt:null, and the anon rule must not throw on a missing field).
+      await setDoc(doc(db, "captureOneShares", SHARE_NO_EXPIRY), {
+        clientId: CLIENT_A,
+        projectId: PROJ_TEAM,
+        title: "No expiry",
+        enabled: true,
+        createdAt: Timestamp.now(),
+        createdBy: "creator-uid",
+        shotIds: null,
+        projectName: "Project",
+        shots: [],
+      })
+    })
+  })
+
+  afterAll(async () => {
+    if (testEnv) await testEnv.cleanup()
+  })
+
+  function anon() {
+    return testEnv!.unauthenticatedContext().firestore()
+  }
+  function authed(uid: string, clientId: string, role: string) {
+    return testEnv!.authenticatedContext(uid, { clientId, role }).firestore()
+  }
+
+  it("[1] anon GET succeeds on an enabled, non-expired share", async () => {
+    await assertSucceeds(getDoc(doc(anon(), "captureOneShares", SHARE_OK)))
+  })
+
+  it("[2] anon GET fails on a disabled share", async () => {
+    await assertFails(getDoc(doc(anon(), "captureOneShares", SHARE_DISABLED)))
+  })
+
+  it("[3] anon GET fails on an expired share", async () => {
+    await assertFails(getDoc(doc(anon(), "captureOneShares", SHARE_EXPIRED)))
+  })
+
+  it("[3b] anon GET succeeds when the expiresAt field is omitted entirely (existence-guard arm)", async () => {
+    await assertSucceeds(getDoc(doc(anon(), "captureOneShares", SHARE_NO_EXPIRY)))
+  })
+
+  it("[4] anon LIST on captureOneShares fails", async () => {
+    await assertFails(getDocs(collection(anon(), "captureOneShares")))
+  })
+
+  it("[5] authed producer GET succeeds when clientId matches", async () => {
+    await assertSucceeds(getDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", SHARE_OK)))
+  })
+
+  it("[6] foreign-tenant authed producer cannot read a DISABLED share (no anon fallback; the management arm requires clientId match — an ENABLED share is anon-public by design)", async () => {
+    await assertFails(getDoc(doc(authed("prod-b", CLIENT_B, "producer"), "captureOneShares", SHARE_DISABLED)))
+  })
+
+  it("[7] authed non-privileged role GET fails on a disabled share", async () => {
+    await assertFails(getDoc(doc(authed("crew-a", CLIENT_A, "crew"), "captureOneShares", SHARE_DISABLED)))
+  })
+
+  it("[8] authed producer CREATE succeeds for own clientId on a team-visible project", async () => {
+    await assertSucceeds(
+      setDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", "share-new-ok"), makeShare()),
+    )
+  })
+
+  it("[8b] authed producer CREATE fails for a private project they have no access to", async () => {
+    await assertFails(
+      setDoc(
+        doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", "share-new-private"),
+        makeShare({ projectId: PROJ_PRIVATE }),
+      ),
+    )
+  })
+
+  it("[9] authed producer CREATE fails when spoofing another clientId", async () => {
+    await assertFails(
+      setDoc(
+        doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", "share-new-spoof"),
+        makeShare({ clientId: CLIENT_B }),
+      ),
+    )
+  })
+
+  it("[10] CREATE fails when enabled is not a bool", async () => {
+    await assertFails(
+      setDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", "share-new-bad"), {
+        ...makeShare(),
+        enabled: "yes",
+      }),
+    )
+  })
+
+  it("[11] anon CREATE fails", async () => {
+    await assertFails(setDoc(doc(anon(), "captureOneShares", "share-new-anon"), makeShare()))
+  })
+
+  it("[12] authed non-privileged role CREATE fails", async () => {
+    await assertFails(
+      setDoc(doc(authed("crew-a", CLIENT_A, "crew"), "captureOneShares", "share-new-crew"), makeShare()),
+    )
+  })
+
+  it("[13] authed producer UPDATE succeeds for own clientId (refresh-on-save path)", async () => {
+    await assertSucceeds(
+      updateDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", SHARE_OK), {
+        projectName: "Updated",
+      }),
+    )
+  })
+
+  it("[14] authed producer UPDATE fails for a different clientId", async () => {
+    await assertFails(
+      updateDoc(doc(authed("prod-b", CLIENT_B, "producer"), "captureOneShares", SHARE_OK), {
+        projectName: "Hijack",
+      }),
+    )
+  })
+
+  it("[15] authed producer DELETE succeeds for own clientId", async () => {
+    await assertSucceeds(deleteDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", SHARE_DELETABLE)))
+  })
+})
+
+// Visible skip notice so developers know why zero rules tests ran locally.
+if (skipSuite) {
+  describe("firestore.rules — captureOneShares (skipped)", () => {
+    it("skipped: set FIRESTORE_EMULATOR_HOST to run rules unit tests", () => {
+      expect(skipSuite).toBe(true)
+    })
+  })
+}

--- a/src-vnext/features/captureone/components/CaptureOneShareDialog.tsx
+++ b/src-vnext/features/captureone/components/CaptureOneShareDialog.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useMemo, useState } from "react"
+import { toast } from "sonner"
+import { createCaptureOneShareLink } from "@/features/captureone/lib/captureOneShareWrites"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog"
+import { Button } from "@/ui/button"
+import { Input } from "@/ui/input"
+import { Label } from "@/ui/label"
+import { Copy, Link } from "lucide-react"
+
+type ShareScope = "all" | "selected"
+
+interface CaptureOneShareDialogProps {
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+  readonly clientId: string | null
+  readonly projectId: string
+  readonly projectName: string
+  readonly userId: string
+  readonly selectedShotIds?: readonly string[]
+}
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      const el = document.createElement("textarea")
+      el.value = text
+      el.style.position = "fixed"
+      el.style.left = "-9999px"
+      document.body.appendChild(el)
+      el.select()
+      const ok = document.execCommand("copy")
+      el.remove()
+      return ok
+    } catch {
+      return false
+    }
+  }
+}
+
+function formatShareError(err: unknown): string {
+  if (!err || typeof err !== "object") return "Unknown error"
+  const anyErr = err as { code?: unknown; message?: unknown }
+  const code = typeof anyErr.code === "string" ? anyErr.code : null
+  const message = typeof anyErr.message === "string" ? anyErr.message : null
+  const label = code ? `(${code})` : ""
+  if (!message) return label ? `Share failed ${label}` : "Share failed"
+  return label ? `${message} ${label}` : message
+}
+
+export function CaptureOneShareDialog({
+  open,
+  onOpenChange,
+  clientId,
+  projectId,
+  projectName,
+  userId,
+  selectedShotIds,
+}: CaptureOneShareDialogProps) {
+  const selectionCount = selectedShotIds?.length ?? 0
+  const hasSelection = selectionCount > 0
+  const defaultScope: ShareScope = hasSelection ? "selected" : "all"
+
+  const [scope, setScope] = useState<ShareScope>(defaultScope)
+  const [title, setTitle] = useState("")
+  const [creating, setCreating] = useState(false)
+  const [createdUrl, setCreatedUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setScope(defaultScope)
+    setTitle("")
+    setCreating(false)
+    setCreatedUrl(null)
+  }, [defaultScope, open])
+
+  const defaultTitle = useMemo(() => `${projectName} — Capture One names`, [projectName])
+
+  const shareUrlPreview = createdUrl
+    ? createdUrl
+    : `${window.location.origin}/captureone/shared/…`
+
+  const create = async () => {
+    if (!clientId) {
+      toast.error("Failed to create share link", { description: "Missing clientId." })
+      return
+    }
+    setCreating(true)
+    try {
+      const shotIds = scope === "selected" && selectedShotIds ? [...selectedShotIds] : null
+      const shareToken = await createCaptureOneShareLink({
+        clientId,
+        projectId,
+        userId,
+        title: (title.trim() || defaultTitle).trim(),
+        shotIds,
+      })
+      const url = `${window.location.origin}/captureone/shared/${shareToken}`
+      setCreatedUrl(url)
+      const copied = await copyToClipboard(url)
+      toast.success("Share link created", { description: copied ? "Copied to clipboard." : url })
+    } catch (err) {
+      console.error("[CaptureOneShareDialog] Failed to create share link:", err)
+      toast.error("Failed to create share link", { description: formatShareError(err) })
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const handleCopyUrl = async () => {
+    if (!createdUrl) return
+    const copied = await copyToClipboard(createdUrl)
+    if (copied) toast.success("Copied to clipboard")
+    else toast.error("Failed to copy")
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Share Capture One names</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a no-login link to the generated Capture One filenames for the digi-tech.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <Label className="text-xs">Scope</Label>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                type="button"
+                variant={scope === "all" ? "default" : "outline"}
+                size="sm"
+                onClick={() => setScope("all")}
+              >
+                All project shots
+              </Button>
+              {hasSelection && (
+                <Button
+                  type="button"
+                  variant={scope === "selected" ? "default" : "outline"}
+                  size="sm"
+                  onClick={() => setScope("selected")}
+                >
+                  {"Selected (" + selectionCount + ")"}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="captureone-share-title" className="text-xs">
+              Title
+            </Label>
+            <Input
+              id="captureone-share-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={defaultTitle}
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <Label className="text-xs">Link preview</Label>
+            <div className="flex items-center gap-2.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-3 py-2">
+              <Link className="h-3.5 w-3.5 shrink-0 text-[var(--color-text-muted)]" />
+              <span className="flex-1 truncate font-mono text-xs text-[var(--color-text-muted)]">
+                {shareUrlPreview}
+              </span>
+              {createdUrl && (
+                <Button variant="ghost" size="sm" className="h-6 px-2 text-xs" onClick={handleCopyUrl}>
+                  <Copy className="mr-1 h-3 w-3" />
+                  Copy
+                </Button>
+              )}
+            </div>
+            <p className="text-2xs text-[var(--color-text-muted)]">
+              Anyone with this link can view the filenames. No login required.
+            </p>
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
+            <Button variant="outline" onClick={() => onOpenChange(false)} disabled={creating}>
+              Close
+            </Button>
+            <Button onClick={create} disabled={creating}>
+              {creating ? "Creating…" : "Create Link"}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src-vnext/features/captureone/components/PublicCaptureOneSharePage.tsx
+++ b/src-vnext/features/captureone/components/PublicCaptureOneSharePage.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from "react"
+import { useParams } from "react-router-dom"
+import { ErrorBoundary } from "@/shared/components/ErrorBoundary"
+import { doc, getDoc } from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { LoadingState } from "@/shared/components/LoadingState"
+import { DetailPageSkeleton } from "@/shared/components/Skeleton"
+import { Input } from "@/ui/input"
+import { Button } from "@/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/ui/card"
+import { AlertTriangle, Copy, Search } from "lucide-react"
+import { toast } from "sonner"
+
+interface PublicHeroFilename {
+  readonly name: string
+  readonly genderResolved: boolean
+}
+
+interface PublicCaptureOneShot {
+  readonly id: string
+  readonly shotNumber: string | null
+  readonly title: string
+  readonly filenames: readonly PublicHeroFilename[]
+}
+
+type ErrorInfo = { readonly heading: string; readonly message: string }
+
+async function copyToClipboard(text: string): Promise<boolean> {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch {
+    try {
+      const el = document.createElement("textarea")
+      el.value = text
+      el.style.position = "fixed"
+      el.style.left = "-9999px"
+      document.body.appendChild(el)
+      el.select()
+      const ok = document.execCommand("copy")
+      el.remove()
+      return ok
+    } catch {
+      return false
+    }
+  }
+}
+
+async function copyWithToast(text: string, label: string): Promise<void> {
+  const ok = await copyToClipboard(text)
+  if (ok) toast.success(label)
+  else toast.error("Couldn’t copy — copy manually")
+}
+
+function FilenameChip({ file }: { readonly file: PublicHeroFilename }) {
+  return (
+    <button
+      type="button"
+      onClick={() => void copyWithToast(file.name, "Filename copied")}
+      title={
+        file.genderResolved
+          ? "Copy filename"
+          : "Gender unresolved — set the product’s gender so the prefix isn’t a placeholder U_"
+      }
+      className="inline-flex items-center gap-1.5 rounded-md border border-[var(--color-border)] bg-[var(--color-surface-subtle)] px-2 py-1 font-mono text-xs text-[var(--color-text)] hover:bg-[var(--color-surface)]"
+    >
+      {!file.genderResolved && (
+        <AlertTriangle className="h-3 w-3 shrink-0 text-amber-500" aria-label="Gender unresolved" />
+      )}
+      <span className="truncate">{file.name}</span>
+      <Copy className="h-3 w-3 shrink-0 text-[var(--color-text-subtle)]" />
+    </button>
+  )
+}
+
+export default function PublicCaptureOneSharePage() {
+  const { shareToken } = useParams<{ shareToken: string }>()
+  const [shots, setShots] = useState<readonly PublicCaptureOneShot[]>([])
+  const [shareTitle, setShareTitle] = useState<string | null>(null)
+  const [projectName, setProjectName] = useState<string>("Project")
+  const [loading, setLoading] = useState(true)
+  const [errorInfo, setErrorInfo] = useState<ErrorInfo | null>(null)
+  const [query, setQuery] = useState("")
+
+  useEffect(() => {
+    let active = true
+    const load = async () => {
+      if (!shareToken || shareToken.length < 10) {
+        setErrorInfo({ heading: "Invalid link", message: "No share token provided." })
+        setLoading(false)
+        return
+      }
+      setLoading(true)
+      setErrorInfo(null)
+      try {
+        const snap = await getDoc(doc(db, "captureOneShares", shareToken))
+        if (!active) return
+        if (!snap.exists()) {
+          setErrorInfo({ heading: "Link not found", message: "This share link does not exist. It may have been deleted." })
+          setLoading(false)
+          return
+        }
+        const data = snap.data() as Record<string, unknown>
+        if (data.enabled !== true) {
+          setErrorInfo({ heading: "Sharing disabled", message: "Sharing has been disabled for this link." })
+          setLoading(false)
+          return
+        }
+        if (data.expiresAt) {
+          try {
+            const expiresAt = (data.expiresAt as { toDate: () => Date }).toDate()
+            if (expiresAt.getTime() < Date.now()) {
+              setErrorInfo({ heading: "Link expired", message: "This share link has expired. Ask the sender for a new one." })
+              setLoading(false)
+              return
+            }
+          } catch {
+            // Ignore malformed expiresAt
+          }
+        }
+        // Treat the denormalized payload as untrusted — coerce filenames to an array.
+        const resolved = Array.isArray(data.shots)
+          ? (data.shots as PublicCaptureOneShot[]).map((s) => ({
+              ...s,
+              filenames: Array.isArray(s?.filenames) ? s.filenames : [],
+            }))
+          : []
+        setShots(resolved)
+        setProjectName(typeof data.projectName === "string" ? data.projectName : "Project")
+        setShareTitle(typeof data.title === "string" ? data.title : null)
+        setLoading(false)
+      } catch (err) {
+        if (!active) return
+        console.error("[PublicCaptureOneSharePage] Failed to load share:", err)
+        setErrorInfo({ heading: "Failed to load", message: "Something went wrong. Please check the link and try again." })
+        setLoading(false)
+      }
+    }
+    void load()
+    return () => {
+      active = false
+    }
+  }, [shareToken])
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return shots
+    return shots.filter((s) => {
+      const haystack = [s.title, s.shotNumber ?? "", ...s.filenames.map((f) => f.name)]
+        .join(" ")
+        .toLowerCase()
+      return haystack.includes(q)
+    })
+  }, [query, shots])
+
+  const allNames = useMemo(
+    () => filtered.flatMap((s) => s.filenames.map((f) => f.name)),
+    [filtered],
+  )
+  const unresolvedCount = useMemo(
+    () => filtered.reduce((n, s) => n + s.filenames.filter((f) => !f.genderResolved).length, 0),
+    [filtered],
+  )
+
+  if (loading) return <LoadingState loading skeleton={<DetailPageSkeleton />} />
+
+  if (errorInfo) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[var(--color-bg)] px-4">
+        <div className="w-full max-w-md rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] p-6">
+          <h1 className="heading-subsection">{errorInfo.heading}</h1>
+          <p className="mt-2 text-sm text-[var(--color-text-muted)]">{errorInfo.message}</p>
+        </div>
+      </div>
+    )
+  }
+
+  const title = shareTitle || `${projectName} — Capture One names`
+
+  return (
+    <ErrorBoundary>
+      <div className="min-h-screen bg-[var(--color-bg)] px-4 py-8">
+        <div className="mx-auto flex w-full max-w-5xl flex-col gap-4">
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <span className="inline-flex items-center rounded-full border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+                Capture One · digi-tech
+              </span>
+              <div className="flex items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={allNames.length === 0}
+                  onClick={() => void copyWithToast(allNames.join("\n"), `Copied ${allNames.length} filenames`)}
+                >
+                  <Copy className="mr-1.5 h-3.5 w-3.5" />
+                  Copy all
+                </Button>
+                <Button variant="outline" size="sm" onClick={() => window.print()}>
+                  Print
+                </Button>
+              </div>
+            </div>
+            <h1 className="heading-page">{title}</h1>
+            <p className="text-sm text-[var(--color-text-muted)]">
+              {projectName} · {filtered.length} shots · {allNames.length} filenames
+            </p>
+            {unresolvedCount > 0 && (
+              <p className="flex items-center gap-1.5 text-xs text-amber-600">
+                <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+                {unresolvedCount} filename{unresolvedCount === 1 ? "" : "s"} use a placeholder
+                {" "}U_ prefix — set the product’s gender to resolve.
+              </p>
+            )}
+          </div>
+
+          <div className="relative max-w-sm flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-[var(--color-text-subtle)]" />
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={"Search shots or filenames…"}
+              className="pl-9 text-sm"
+            />
+          </div>
+
+          {filtered.length === 0 ? (
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">No shots</CardTitle>
+              </CardHeader>
+              <CardContent className="text-sm text-[var(--color-text-muted)]">
+                No shots match your search.
+              </CardContent>
+            </Card>
+          ) : (
+            <div className="flex flex-col gap-2">
+              {filtered.map((s) => (
+                <div
+                  key={s.id}
+                  className="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] p-3"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-baseline gap-2">
+                      {s.shotNumber && (
+                        <span className="text-xs text-[var(--color-text-subtle)]">#{s.shotNumber}</span>
+                      )}
+                      <span className="font-medium text-[var(--color-text)]">{s.title}</span>
+                    </div>
+                    {s.filenames.length > 1 && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-xs"
+                        onClick={() =>
+                          void copyWithToast(
+                            s.filenames.map((f) => f.name).join("\n"),
+                            `Copied ${s.filenames.length} filenames`,
+                          )
+                        }
+                      >
+                        <Copy className="mr-1 h-3 w-3" />
+                        Copy shot
+                      </Button>
+                    )}
+                  </div>
+                  {s.filenames.length === 0 ? (
+                    <p className="mt-2 text-xs text-[var(--color-text-subtle)]">
+                      No hero products starred for this shot.
+                    </p>
+                  ) : (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {s.filenames.map((file, index) => (
+                        <FilenameChip key={`${file.name}-${index}`} file={file} />
+                      ))}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </ErrorBoundary>
+  )
+}

--- a/src-vnext/features/captureone/lib/__tests__/resolveCaptureOneForShare.test.ts
+++ b/src-vnext/features/captureone/lib/__tests__/resolveCaptureOneForShare.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+import {
+  buildShotFilenames,
+  shotHeroAssignments,
+} from "@/features/captureone/lib/resolveCaptureOneForShare"
+
+describe("shotHeroAssignments", () => {
+  it("collects starred heroes across all looks (dedup deferred to the filename layer)", () => {
+    const heroes = shotHeroAssignments({
+      looks: [
+        {
+          id: "look-1",
+          products: [
+            { familyId: "fam-a", skuId: "sku-a", isHero: true },
+            { familyId: "fam-b", skuId: "sku-b" },
+          ],
+        },
+        {
+          id: "look-2",
+          products: [{ familyId: "fam-c", skuId: "sku-c", isHero: true }],
+        },
+      ],
+    })
+    expect(heroes.map((p) => p.skuId)).toEqual(["sku-a", "sku-c"])
+  })
+
+  it("falls back to a look's legacy heroProductId when no product is starred", () => {
+    const heroes = shotHeroAssignments({
+      looks: [
+        {
+          id: "look-1",
+          heroProductId: "sku-b",
+          products: [
+            { familyId: "fam-a", skuId: "sku-a" },
+            { familyId: "fam-b", skuId: "sku-b" },
+          ],
+        },
+      ],
+    })
+    expect(heroes.map((p) => p.skuId)).toEqual(["sku-b"])
+  })
+
+  it("resolves a legacy heroProductId pointing at a raw productId (normalized to familyId)", () => {
+    const heroes = shotHeroAssignments({
+      looks: [
+        {
+          id: "look-1",
+          heroProductId: "prod-123",
+          products: [
+            { productId: "prod-123", productName: "Merino Tee", colourName: "Black" },
+            { productId: "prod-999", productName: "Other", colourName: "White" },
+          ],
+        },
+      ],
+    })
+    expect(heroes).toHaveLength(1)
+    expect(heroes[0]!.familyId).toBe("prod-123")
+    expect(heroes[0]!.familyName).toBe("Merino Tee")
+  })
+
+  it("returns no heroes for a look-less shot (top-level products without isHero)", () => {
+    expect(
+      shotHeroAssignments({ products: [{ familyId: "fam-a", skuId: "sku-a" }] }),
+    ).toEqual([])
+  })
+})
+
+describe("buildShotFilenames", () => {
+  const gender = new Map<string, string | null>([
+    ["fam-m", "men"],
+    ["fam-w", "women"],
+    ["fam-x", null],
+  ])
+
+  it("builds gender-prefixed PascalCase filenames with colorway, hyphens preserved", () => {
+    const files = buildShotFilenames(
+      [
+        { familyId: "fam-m", familyName: "Merino Flex Jogger", colourName: "Forest" },
+        { familyId: "fam-w", familyName: "Linen Button-Up", colourName: "Light Azure" },
+      ],
+      gender,
+    )
+    expect(files.map((f) => f.name)).toEqual([
+      "M_MerinoFlexJogger_Forest",
+      "W_LinenButton-Up_LightAzure",
+    ])
+    expect(files.every((f) => f.genderResolved)).toBe(true)
+  })
+
+  it("flags an unresolved gender with genderResolved=false and a U_ prefix", () => {
+    const files = buildShotFilenames(
+      [{ familyId: "fam-x", familyName: "Mystery Tee", colourName: "Black" }],
+      gender,
+    )
+    expect(files[0]!.name).toBe("U_MysteryTee_Black")
+    expect(files[0]!.genderResolved).toBe(false)
+  })
+
+  it("keeps distinct colourways with no colourId as separate filenames", () => {
+    const files = buildShotFilenames(
+      [
+        { familyId: "fam-m", familyName: "Tee", colourName: "Black", isHero: true },
+        { familyId: "fam-m", familyName: "Tee", colourName: "White", isHero: true },
+      ],
+      gender,
+    )
+    expect(files.map((f) => f.name)).toEqual(["M_Tee_Black", "M_Tee_White"])
+  })
+
+  it("collapses same garment + colour across different sizes to one filename", () => {
+    const files = buildShotFilenames(
+      [
+        { familyId: "fam-m", familyName: "Tee", colourName: "Black", skuId: "sku-1" },
+        { familyId: "fam-m", familyName: "Tee", colourName: "Black", skuId: "sku-2" },
+      ],
+      gender,
+    )
+    expect(files.map((f) => f.name)).toEqual(["M_Tee_Black"])
+  })
+
+  it("skips a hero with no resolvable product name (never emits an empty-segment filename)", () => {
+    expect(
+      buildShotFilenames([{ familyId: "fam-m", colourName: "Black" }], gender),
+    ).toEqual([])
+  })
+})

--- a/src-vnext/features/captureone/lib/captureOneShareWrites.ts
+++ b/src-vnext/features/captureone/lib/captureOneShareWrites.ts
@@ -1,0 +1,57 @@
+// Capture One share links live at root level: captureOneShares/{shareToken}.
+// Resolved hero filenames are denormalized into the doc at creation time so the
+// public digi-tech page reads only the one share doc (clean setDoc, no Cloud Function).
+
+import { doc, serverTimestamp, setDoc } from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { captureOneShareDocPath } from "@/shared/lib/paths"
+import { resolveCaptureOneForShare } from "@/features/captureone/lib/resolveCaptureOneForShare"
+
+function docRef(path: string[]) {
+  return doc(db, path[0]!, ...path.slice(1))
+}
+
+/** crypto.randomUUID() with a hex getRandomValues fallback. */
+function generateShareToken(): string {
+  try {
+    const token = globalThis.crypto?.randomUUID?.()
+    if (token && token.length >= 10) return token
+  } catch {
+    // fall through to the hex fallback
+  }
+  const bytes = new Uint8Array(16)
+  globalThis.crypto.getRandomValues(bytes)
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")
+}
+
+/** Create a Capture One share link with denormalized hero filenames. Returns the token. */
+export async function createCaptureOneShareLink(args: {
+  readonly clientId: string
+  readonly projectId: string
+  readonly userId: string
+  readonly title: string
+  readonly shotIds: readonly string[] | null
+}): Promise<string> {
+  const { clientId, projectId, userId, title, shotIds } = args
+  const scopedIds = shotIds ? [...shotIds] : null
+  const resolved = await resolveCaptureOneForShare(clientId, projectId, scopedIds)
+  const shareToken = generateShareToken()
+
+  await setDoc(docRef(captureOneShareDocPath(shareToken)), {
+    clientId,
+    projectId,
+    title: title.trim(),
+    enabled: true,
+    expiresAt: null,
+    createdAt: serverTimestamp(),
+    createdBy: userId,
+    shotIds: scopedIds,
+    projectName: resolved.projectName,
+    shots: resolved.shots.map((s) => ({
+      ...s,
+      filenames: s.filenames.map((f) => ({ ...f })),
+    })),
+  })
+
+  return shareToken
+}

--- a/src-vnext/features/captureone/lib/resolveCaptureOneForShare.ts
+++ b/src-vnext/features/captureone/lib/resolveCaptureOneForShare.ts
@@ -1,0 +1,150 @@
+// Resolves per-shot Capture One hero filenames for denormalization into a
+// captureOneShares document. Run at share-create (and refresh) time while the
+// caller is authenticated, so productFamilies reads succeed under normal rules.
+// The public digi-tech page then renders the stored payload with no Firestore reads.
+
+import { collection, doc, getDoc, getDocs, query, where } from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { shotsPath, projectPath, productFamiliesPath } from "@/shared/lib/paths"
+import { buildHeroFilename, type HeroFilename } from "@/features/captureone/lib/captureOneFilename"
+import { lookHeroAssignments } from "@/features/shots/lib/lookHeroes"
+import { normalizeProducts } from "@/features/shots/lib/mapShot"
+import type { ProductAssignment, ShotLook } from "@/shared/types"
+
+export interface ResolvedCaptureOneShot {
+  readonly id: string
+  readonly shotNumber: string | null
+  readonly title: string
+  readonly filenames: readonly HeroFilename[]
+}
+
+export interface ResolvedCaptureOnePayload {
+  readonly projectName: string
+  readonly shots: readonly ResolvedCaptureOneShot[]
+}
+
+function docRef(path: string[], ...extra: string[]) {
+  const segments = [...path, ...extra]
+  return doc(db, segments[0]!, ...segments.slice(1))
+}
+
+function colRef(path: string[]) {
+  return collection(db, path[0]!, ...path.slice(1))
+}
+
+function normaliseString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+/**
+ * Hero product assignments across all looks of a shot (isHero-first, legacy fallback).
+ * Reads RAW Firestore shots, so products are run through normalizeProducts first
+ * (legacy productId->familyId, productName->familyName) before hero resolution.
+ * No dedup here — buildShotFilenames dedupes by the final filename, which is the
+ * identity that actually matters (distinct colourways must not collapse).
+ */
+export function shotHeroAssignments(data: Record<string, unknown>): ProductAssignment[] {
+  const rawLooks = Array.isArray(data.looks) ? (data.looks as Record<string, unknown>[]) : []
+  const sources: ShotLook[] =
+    rawLooks.length > 0
+      ? rawLooks.map((l) => ({
+          id: typeof l.id === "string" ? l.id : "_",
+          products: normalizeProducts(l.products),
+          heroProductId: typeof l.heroProductId === "string" ? l.heroProductId : undefined,
+        }))
+      : Array.isArray(data.products)
+        ? [{ id: "_", products: normalizeProducts(data.products) }]
+        : []
+
+  return sources.flatMap((look) => lookHeroAssignments(look))
+}
+
+export async function resolveCaptureOneForShare(
+  clientId: string,
+  projectId: string,
+  shotIds: readonly string[] | null,
+): Promise<ResolvedCaptureOnePayload> {
+  const projectSnap = await getDoc(docRef(projectPath(projectId, clientId)))
+  const projectName = projectSnap.exists()
+    ? (normaliseString((projectSnap.data() as Record<string, unknown>).name) ?? "Project")
+    : "Project"
+
+  type ShotDoc = { id: string; data: Record<string, unknown> }
+  let shotDocs: ShotDoc[] = []
+  const validShotIds = shotIds
+    ? shotIds.filter((id) => typeof id === "string" && id.trim().length > 0)
+    : null
+
+  if (validShotIds && validShotIds.length > 0) {
+    const refs = validShotIds.map((sid) => docRef(shotsPath(clientId), sid))
+    const snaps = await Promise.all(refs.map((r) => getDoc(r)))
+    shotDocs = snaps
+      .filter((s) => s.exists())
+      .map((s) => ({ id: s.id, data: (s.data() ?? {}) as Record<string, unknown> }))
+  } else {
+    const snaps = await getDocs(query(colRef(shotsPath(clientId)), where("projectId", "==", projectId)))
+    shotDocs = snaps.docs.map((d) => ({ id: d.id, data: (d.data() ?? {}) as Record<string, unknown> }))
+  }
+
+  const shotsRaw = shotDocs
+    .filter((d) => d.data.projectId === projectId && d.data.deleted !== true)
+    .sort((a, b) => {
+      const aNum = a.data.shotNumber != null ? String(a.data.shotNumber) : ""
+      const bNum = b.data.shotNumber != null ? String(b.data.shotNumber) : ""
+      return aNum.localeCompare(bNum, undefined, { numeric: true })
+    })
+
+  // Batch-read hero product families for gender.
+  const familyIdSet = new Set<string>()
+  const heroesByShot = new Map<string, ProductAssignment[]>()
+  for (const s of shotsRaw) {
+    const heroes = shotHeroAssignments(s.data)
+    heroesByShot.set(s.id, heroes)
+    for (const p of heroes) {
+      if (p.familyId) familyIdSet.add(p.familyId)
+    }
+  }
+
+  const genderByFamily = new Map<string, string | null>()
+  if (familyIdSet.size > 0) {
+    const refs = Array.from(familyIdSet).map((fid) => docRef(productFamiliesPath(clientId), fid))
+    const snaps = await Promise.all(refs.map((r) => getDoc(r)))
+    for (const snap of snaps) {
+      if (!snap.exists()) continue
+      genderByFamily.set(snap.id, normaliseString((snap.data() as Record<string, unknown>).gender))
+    }
+  }
+
+  const shots: ResolvedCaptureOneShot[] = shotsRaw.map((s) => ({
+    id: s.id,
+    shotNumber: normaliseString(s.data.shotNumber),
+    title: normaliseString(s.data.title) ?? normaliseString(s.data.name) ?? "Untitled Shot",
+    filenames: buildShotFilenames(heroesByShot.get(s.id) ?? [], genderByFamily),
+  }))
+
+  return { projectName, shots }
+}
+
+/** Build deduped Capture One filenames for a shot's hero products, prefix from each family's gender. */
+export function buildShotFilenames(
+  heroes: ReadonlyArray<ProductAssignment>,
+  genderByFamily: ReadonlyMap<string, string | null>,
+): HeroFilename[] {
+  const filenames: HeroFilename[] = []
+  const seenNames = new Set<string>()
+  for (const p of heroes) {
+    const productName = normaliseString(p.familyName) ?? normaliseString(p.skuName)
+    if (!productName) continue // a nameless hero can't produce a usable filename — skip, don't emit "U_"
+    const file = buildHeroFilename({
+      gender: p.familyId ? genderByFamily.get(p.familyId) ?? null : null,
+      productName,
+      colorway: normaliseString(p.colourName),
+    })
+    if (seenNames.has(file.name)) continue
+    seenNames.add(file.name)
+    filenames.push(file)
+  }
+  return filenames
+}

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -43,6 +43,7 @@ import { persistShotOrder } from "@/features/shots/lib/reorderShots"
 import { useLocations, useTalent, useProductFamilies } from "@/features/shots/hooks/usePickerData"
 import { KeyboardShortcutsDialog } from "@/features/shots/components/KeyboardShortcutsDialog"
 import { ShotsShareDialog } from "@/features/shots/components/ShotsShareDialog"
+import { CaptureOneShareDialog } from "@/features/captureone/components/CaptureOneShareDialog"
 import { BulkActionBar } from "@/features/shots/components/BulkActionBar"
 import { BulkDeleteShotsDialog } from "@/features/shots/components/BulkDeleteShotsDialog"
 import { RenumberShotsDialog } from "@/features/shots/components/RenumberShotsDialog"
@@ -94,6 +95,7 @@ export default function ShotListPage() {
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
   const [createPullOpen, setCreatePullOpen] = useState(false)
   const [shareOpen, setShareOpen] = useState(false)
+  const [captureShareOpen, setCaptureShareOpen] = useState(false)
   const [shortcutsOpen, setShortcutsOpen] = useState(false)
   const [repairOpen, setRepairOpen] = useState(false)
   const [repairing, setRepairing] = useState(false)
@@ -497,6 +499,11 @@ export default function ShotListPage() {
                 {canShare && (
                   <Button variant="outline" onClick={() => setShareOpen(true)}>
                     Share
+                  </Button>
+                )}
+                {canShare && (
+                  <Button variant="outline" onClick={() => setCaptureShareOpen(true)}>
+                    Capture One names
                   </Button>
                 )}
                 {canBulkPull && (
@@ -1114,6 +1121,18 @@ export default function ShotListPage() {
           projectId={projectId}
           projectName={projectName || "Project"}
           user={user}
+          selectedShotIds={selectedShots.map((s) => s.id)}
+        />
+      )}
+
+      {canShare && (
+        <CaptureOneShareDialog
+          open={captureShareOpen}
+          onOpenChange={setCaptureShareOpen}
+          clientId={clientId}
+          projectId={projectId}
+          projectName={projectName || "Project"}
+          userId={user?.uid ?? ""}
           selectedShotIds={selectedShots.map((s) => s.id)}
         />
       )}

--- a/src-vnext/features/shots/lib/mapShot.ts
+++ b/src-vnext/features/shots/lib/mapShot.ts
@@ -29,7 +29,7 @@ function normalizeDate(value: unknown): Timestamp | undefined {
  * Legacy uses productId/productName; vNext uses familyId/familyName.
  * Defaults missing sizeScope to "pending".
  */
-function normalizeProducts(raw: unknown): ProductAssignment[] {
+export function normalizeProducts(raw: unknown): ProductAssignment[] {
   if (!Array.isArray(raw)) return []
 
   const asString = (value: unknown): string | undefined =>

--- a/src-vnext/shared/lib/paths.ts
+++ b/src-vnext/shared/lib/paths.ts
@@ -329,6 +329,15 @@ export const castingShareVoteDocPath = (
   voteId: string,
 ): string[] => ["castingShares", shareToken, "votes", voteId]
 
+// --- Capture One Shares (root-level, like shotShares) ---
+
+export const captureOneSharesPath = (): string[] => ["captureOneShares"]
+
+export const captureOneShareDocPath = (shareToken: string): string[] => [
+  "captureOneShares",
+  shareToken,
+]
+
 // --- Call Sheet Shares (root-level, Phase 3 publishing) ---
 //
 // Per-recipient tokens (Q1 = B) mean we need a doc path per recipient under


### PR DESCRIPTION
## CO-3 — Capture One digi-tech share page (the live link)

Third PR in the Capture One series (CO-1 filename engine #474, CO-2 hero star #475). Adds the **no-login public page** a digi-tech opens on set: `/captureone/shared/:shareToken` lists shots with their generated Capture One filenames as one-click copy chips. Depends on CO-2's `isHero`.

> Stacked on `feat/captureone-hero-star` (CO-2). Retarget to `main` once CO-2 merges.

### What's here
- **`resolveCaptureOneForShare`** — project name + per-shot hero filenames. Heroes = `lookHeroAssignments` across all looks (isHero-first, legacy `heroProductId` fallback); gender from each hero family's `ProductFamily.gender`; filename via the CO-1 `buildHeroFilename`. Reads raw shots **through `normalizeProducts`** so legacy `productId`/`productName` shapes resolve.
- **`createCaptureOneShareLink`** — clean `setDoc` (no Cloud Function), token via `crypto.randomUUID()` + hex fallback, denormalizes the payload at create time. Stores `shotIds` for the deferred live-refresh.
- **`PublicCaptureOneSharePage`** — clones the public-share load/guard/chrome/search; body = per-shot copy chips (per-name, copy-shot, copy-all), a gender-unresolved `U_` warning badge + count, Print.
- **`CaptureOneShareDialog`** + a "Capture One names" button in the Shot List toolbar (gated on `canShare`, scope = all / selected).
- **Route** at `/captureone/shared/:shareToken` (public, outside `RequireAuth`); **`firebase.json`** SAMEORIGIN header (catch-all SPA rewrite already serves it).
- **`firestore.rules`** `captureOneShares` block + a **15→17-case emulator rules test** (passed 17/17 locally against the Firestore emulator).

### Adversarial verification (4 lenses) — issues found and fixed in this PR
- **Legacy heroProductId never resolved** (HIGH): the resolver read raw docs, so a legacy `heroProductId`→`productId` matched nothing → zero heroes. Fixed by normalizing products first.
- **Distinct colourways collapsed** (HIGH): the dedup key used `colourId` but the filename uses `colourName`, so two colourways with no `colourId` merged and one filename was lost. Fixed by deduping on the **final filename** instead.
- **`clientId: string|null → string` type error** (HIGH, invisible to CI): `vite build` strips types and there's no `tsc` gate. Fixed the prop type + added a guard mirroring `ShotsShareDialog`. (Flagging separately: a `tsc --noEmit` CI step would catch this class — current total baseline is 160 pre-existing errors; this PR adds 0.)
- **Create rule was project-unscoped** (MEDIUM): I'd cloned casting's laxer create arm; a global producer could mint a public link for any project in the tenant. Now mirrors `shotShares` — project-scoped via `producerCanAccessProject`/`hasProjectRole` (+ `shotIds` type check). Rules test seeds a team + a private project and proves the private-deny.
- Nameless-hero guard (no empty-segment `M_`), defensive `filenames` array coercion on the page, and a missing-`expiresAt` rules-test case were also added.

### Accepted risks (documented, not blocking)
- The anon page reads the whole share doc, so `clientId`/`projectId`/`createdBy` (uid) are world-readable on enabled links — same pre-existing pattern as `shotShares`/`castingShares`; no PII (only filenames + shot titles). True field-hiding needs a split-doc design — flagged for the live-refresh follow-up.
- Payload size scales with project shot count (Firestore's 1MB doc limit is the backstop; filenames are small).

### Tests
Resolver unit (9, incl. legacy + colourway + same-size dedup + nameless-skip), the emulator rules test (17/17), full suite, `lint --max-warnings=0`, `vite build` — all green. `tsc`: 0 new errors.

### ⏸ Eyeball gate (not auto-merging)
On a throwaway project at `:5174`: open Shots → "Capture One names" → create a link → open it (no login) and confirm the filenames, the copy chips, and the gender-unresolved badge render correctly.

### Follow-up — CO-3′ (live refresh)
Hook `refreshCaptureOneSharesForProject` into `updateShotWithVersion` (best-effort `void…catch`) so the link reflects set-day re-tags. The rules already permit the authed update; the doc already stores `shotIds`. Small, separate PR touching the central write path.
