### PR TITLE
feat(captureone): live refresh-on-save for digi-tech share filenames (CO-3′)

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -101,6 +101,14 @@
       ]
     },
     {
+      "collectionGroup": "captureOneShares",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "clientId", "order": "ASCENDING" },
+        { "fieldPath": "projectId", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "callSheetShares",
       "queryScope": "COLLECTION",
       "fields": [

--- a/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
+++ b/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
@@ -20,7 +20,7 @@ import {
   initializeTestEnvironment,
   type RulesTestEnvironment,
 } from "@firebase/rules-unit-testing"
-import { deleteDoc, doc, getDoc, collection, getDocs, setDoc, updateDoc, Timestamp } from "firebase/firestore"
+import { deleteDoc, doc, getDoc, collection, getDocs, query, where, setDoc, updateDoc, Timestamp } from "firebase/firestore"
 
 const EMULATOR_HOST = process.env.FIRESTORE_EMULATOR_HOST
 const skipSuite = !EMULATOR_HOST
@@ -210,6 +210,30 @@ describeOrSkip("firestore.rules — captureOneShares", () => {
 
   it("[15] authed producer DELETE succeeds for own clientId", async () => {
     await assertSucceeds(deleteDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", SHARE_DELETABLE)))
+  })
+
+  it("[16] authed producer LIST query (refresh-on-save scope) succeeds for own clientId+projectId", async () => {
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(authed("prod-a", CLIENT_A, "producer"), "captureOneShares"),
+          where("clientId", "==", CLIENT_A),
+          where("projectId", "==", PROJ_TEAM),
+        ),
+      ),
+    )
+  })
+
+  it("[17] authed producer LIST query for a foreign clientId is denied", async () => {
+    await assertFails(
+      getDocs(
+        query(
+          collection(authed("prod-a", CLIENT_A, "producer"), "captureOneShares"),
+          where("clientId", "==", CLIENT_B),
+          where("projectId", "==", PROJ_TEAM),
+        ),
+      ),
+    )
   })
 })
 

--- a/src-vnext/features/captureone/lib/__tests__/captureOneShareWrites.test.ts
+++ b/src-vnext/features/captureone/lib/__tests__/captureOneShareWrites.test.ts
@@ -1,0 +1,113 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const getDocsMock = vi.fn()
+const updateDocMock = vi.fn()
+const docMock = vi.fn((...segments: unknown[]) => ({ __doc: segments.slice(1) }))
+const queryMock = vi.fn((...args: unknown[]) => ({ __query: args }))
+const whereMock = vi.fn((field: string, op: string, value: unknown) => ({ field, op, value }))
+const resolveMock = vi.fn()
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn((..._args: unknown[]) => ({ __col: true })),
+  doc: (...args: unknown[]) => docMock(...args),
+  getDocs: (...args: unknown[]) => getDocsMock(...args),
+  query: (...args: unknown[]) => queryMock(...args),
+  where: (...args: unknown[]) => whereMock(args[0] as string, args[1] as string, args[2]),
+  updateDoc: (...args: unknown[]) => updateDocMock(...args),
+  setDoc: vi.fn(),
+  serverTimestamp: () => "MOCK_TS",
+}))
+
+vi.mock("@/shared/lib/firebase", () => ({ db: { __fake: true } }))
+
+vi.mock("@/shared/lib/paths", () => ({
+  captureOneSharesPath: () => ["captureOneShares"],
+  captureOneShareDocPath: (token: string) => ["captureOneShares", token],
+}))
+
+vi.mock("@/features/captureone/lib/resolveCaptureOneForShare", () => ({
+  resolveCaptureOneForShare: (...args: unknown[]) => resolveMock(...args),
+}))
+
+import { refreshCaptureOneSharesForProject } from "@/features/captureone/lib/captureOneShareWrites"
+
+function shareDoc(id: string, data: Record<string, unknown>) {
+  return { id, data: () => data }
+}
+
+describe("refreshCaptureOneSharesForProject", () => {
+  beforeEach(() => {
+    getDocsMock.mockReset()
+    updateDocMock.mockReset().mockResolvedValue(undefined)
+    docMock.mockClear()
+    queryMock.mockClear()
+    whereMock.mockClear()
+    resolveMock.mockReset()
+  })
+
+  it("re-resolves and updates only enabled shares, with each share's own shotIds", async () => {
+    getDocsMock.mockResolvedValue({
+      docs: [
+        shareDoc("share-all", { enabled: true, shotIds: null }),
+        shareDoc("share-scoped", { enabled: true, shotIds: ["s1", "s2"] }),
+        shareDoc("share-off", { enabled: false, shotIds: null }),
+      ],
+    })
+    resolveMock.mockImplementation(async (_c: string, _p: string, shotIds: unknown) => ({
+      projectName: "Proj",
+      shots: [{ id: "s1", shotNumber: "1", title: "Look", filenames: [{ name: "M_Tee_Forest", genderResolved: true }] }],
+      __scope: shotIds,
+    }))
+
+    await refreshCaptureOneSharesForProject({ clientId: "client-1", projectId: "proj-1" })
+
+    // Disabled share skipped; both enabled shares resolved + updated.
+    expect(resolveMock).toHaveBeenCalledTimes(2)
+    expect(resolveMock).toHaveBeenCalledWith("client-1", "proj-1", null)
+    expect(resolveMock).toHaveBeenCalledWith("client-1", "proj-1", ["s1", "s2"])
+    expect(updateDocMock).toHaveBeenCalledTimes(2)
+
+    const payloads = updateDocMock.mock.calls.map((c) => c[1] as Record<string, unknown>)
+    for (const payload of payloads) {
+      expect(payload.projectName).toBe("Proj")
+      expect(Array.isArray(payload.shots)).toBe(true)
+      expect(payload).not.toHaveProperty("clientId") // refresh patches only the denormalized fields
+    }
+  })
+
+  it("queries by clientId + projectId (reusing the shared index, enabled filtered client-side)", async () => {
+    getDocsMock.mockResolvedValue({ docs: [] })
+
+    await refreshCaptureOneSharesForProject({ clientId: "client-1", projectId: "proj-1" })
+
+    const wheres = whereMock.mock.calls.map((c) => `${c[0]}${c[1]}${String(c[2])}`)
+    expect(wheres).toContain("clientId==client-1")
+    expect(wheres).toContain("projectId==proj-1")
+    expect(wheres).not.toContain("enabled==true") // enabled is NOT a query filter
+    expect(updateDocMock).not.toHaveBeenCalled()
+  })
+
+  it("returns early without querying when clientId or projectId is missing", async () => {
+    await refreshCaptureOneSharesForProject({ clientId: "", projectId: "proj-1" })
+    await refreshCaptureOneSharesForProject({ clientId: "client-1", projectId: "" })
+    expect(getDocsMock).not.toHaveBeenCalled()
+  })
+
+  it("isolates a single share failure (allSettled) so the rest still refresh", async () => {
+    getDocsMock.mockResolvedValue({
+      docs: [
+        shareDoc("share-bad", { enabled: true, shotIds: null }),
+        shareDoc("share-good", { enabled: true, shotIds: null }),
+      ],
+    })
+    resolveMock
+      .mockRejectedValueOnce(new Error("resolve blew up"))
+      .mockResolvedValueOnce({ projectName: "Proj", shots: [] })
+
+    // Does not throw despite one share rejecting.
+    await expect(
+      refreshCaptureOneSharesForProject({ clientId: "client-1", projectId: "proj-1" }),
+    ).resolves.toBeUndefined()
+    expect(updateDocMock).toHaveBeenCalledTimes(1) // only the good share updated
+  })
+})

--- a/src-vnext/features/captureone/lib/captureOneShareWrites.ts
+++ b/src-vnext/features/captureone/lib/captureOneShareWrites.ts
@@ -2,13 +2,26 @@
 // Resolved hero filenames are denormalized into the doc at creation time so the
 // public digi-tech page reads only the one share doc (clean setDoc, no Cloud Function).
 
-import { doc, serverTimestamp, setDoc } from "firebase/firestore"
+import {
+  collection,
+  doc,
+  getDocs,
+  query,
+  serverTimestamp,
+  setDoc,
+  updateDoc,
+  where,
+} from "firebase/firestore"
 import { db } from "@/shared/lib/firebase"
-import { captureOneShareDocPath } from "@/shared/lib/paths"
+import { captureOneShareDocPath, captureOneSharesPath } from "@/shared/lib/paths"
 import { resolveCaptureOneForShare } from "@/features/captureone/lib/resolveCaptureOneForShare"
 
 function docRef(path: string[]) {
   return doc(db, path[0]!, ...path.slice(1))
+}
+
+function colRef(path: string[]) {
+  return collection(db, path[0]!, ...path.slice(1))
 }
 
 /** crypto.randomUUID() with a hex getRandomValues fallback. */
@@ -54,4 +67,60 @@ export async function createCaptureOneShareLink(args: {
   })
 
   return shareToken
+}
+
+/**
+ * Re-denormalize every active Capture One share for a project so the public
+ * digi-tech page reflects current hero filenames after a shot save/merge.
+ * Best-effort: callers fire-and-forget with `.catch`; per-share failures are
+ * isolated (one bad share never blocks the rest). Writes ONLY captureOneShares
+ * (never shots), so it cannot re-trigger the save hooks that call it.
+ *
+ * Queries by (clientId, projectId) to reuse the proven shotShares/castingShares
+ * index; `enabled` is filtered client-side (kept out of the index, like the
+ * sibling share collections).
+ *
+ * COVERAGE: re-resolves a share's FULL current shot set, so it self-heals — any
+ * project shot save (updateShotWithVersion) or merge (executeShotMerge) refreshes
+ * ALL the project's shares to current state. Rarer writers (bulk create, shot
+ * duplicate/copy/move/soft-delete, product-family merges) don't fire it directly;
+ * their staleness clears on the next normal save. Broadening to those is a deferred
+ * follow-up (CO-3″) if eventual consistency proves too loose.
+ */
+export async function refreshCaptureOneSharesForProject(args: {
+  readonly clientId: string
+  readonly projectId: string
+}): Promise<void> {
+  const { clientId, projectId } = args
+  if (!clientId || !projectId) return
+
+  const snaps = await getDocs(
+    query(
+      colRef(captureOneSharesPath()),
+      where("clientId", "==", clientId),
+      where("projectId", "==", projectId),
+    ),
+  )
+
+  const active = snaps.docs.filter((d) => d.data().enabled === true)
+  const results = await Promise.allSettled(
+    active.map(async (d) => {
+      const raw = d.data().shotIds
+      const shotIds = Array.isArray(raw) ? (raw as string[]) : null
+      const resolved = await resolveCaptureOneForShare(clientId, projectId, shotIds)
+      await updateDoc(docRef(captureOneShareDocPath(d.id)), {
+        projectName: resolved.projectName,
+        shots: resolved.shots.map((s) => ({
+          ...s,
+          filenames: s.filenames.map((f) => ({ ...f })),
+        })),
+      })
+    }),
+  )
+
+  results.forEach((r, i) => {
+    if (r.status === "rejected") {
+      console.error(`[refreshCaptureOneSharesForProject] share ${active[i]!.id} refresh failed`, r.reason)
+    }
+  })
 }

--- a/src-vnext/features/shots/lib/shotMergeWrites.ts
+++ b/src-vnext/features/shots/lib/shotMergeWrites.ts
@@ -4,6 +4,7 @@ import { shotPath } from "@/shared/lib/paths"
 import { sanitizeForFirestore } from "@/shared/lib/firestoreSanitize"
 import { buildShotWritePayload } from "@/features/shots/lib/updateShot"
 import { createShotVersionSnapshot } from "@/features/shots/lib/shotVersioning"
+import { refreshCaptureOneSharesForProject } from "@/features/captureone/lib/captureOneShareWrites"
 import type {
   AuthUser,
   ProductAssignment,
@@ -376,6 +377,12 @@ export async function executeShotMerge(args: {
     ...auditFields,
   })
   await batch.commit()
+
+  // A merge rewrites the primary's looks/hero products — re-denormalize the project's
+  // public Capture One shares (best-effort; same project for both shots).
+  void refreshCaptureOneSharesForProject({ clientId, projectId: primary.projectId }).catch((err) => {
+    console.error("[executeShotMerge] Capture One share refresh failed", err)
+  })
 
   // Best-effort version snapshots (audit, not core state) — never block or fail
   // the merge if they error.

--- a/src-vnext/features/shots/lib/updateShotWithVersion.ts
+++ b/src-vnext/features/shots/lib/updateShotWithVersion.ts
@@ -4,6 +4,7 @@ import { shotPath } from "@/shared/lib/paths"
 import type { AuthUser, Shot } from "@/shared/types"
 import { buildShotWritePayload } from "@/features/shots/lib/updateShot"
 import { createShotVersionSnapshot } from "@/features/shots/lib/shotVersioning"
+import { refreshCaptureOneSharesForProject } from "@/features/captureone/lib/captureOneShareWrites"
 
 /**
  * Update a shot document and (best-effort) write a version snapshot.
@@ -30,6 +31,11 @@ export async function updateShotWithVersion(args: {
     ...payload,
     updatedAt: serverTimestamp(),
     ...(user?.uid ? { updatedBy: user.uid } : {}),
+  })
+
+  // Keep public Capture One share filenames current (best-effort, never blocks the save).
+  void refreshCaptureOneSharesForProject({ clientId, projectId: shot.projectId }).catch((err) => {
+    console.error(`[updateShotWithVersion] Capture One share refresh failed (source=${source})`, err)
   })
 
   if (!user?.uid) return


### PR DESCRIPTION
**Stacked on #476 (CO-3).** Merge after CO-2 (#475) → CO-3 (#476); base then retargets to `main`.

## What
CO-3 only denormalized Capture One filenames at share-create time, so the no-login digi-tech page went stale after later edits. This makes it **live**: re-denormalize a project's active `captureOneShares` whenever its shots change.

- `refreshCaptureOneSharesForProject({clientId, projectId})`: query `(clientId, projectId)`, filter `enabled` client-side, re-run `resolveCaptureOneForShare` per share, `updateDoc` the `{projectName, shots}`. Best-effort + **per-share isolated** (`allSettled`, logs each rejection by share id); writes **only** `captureOneShares` so it can't re-trigger its callers.
- Hooked into **`updateShotWithVersion`** (the looks-editor hero-star save path + field saves) and **`executeShotMerge`** (after `batch.commit`; merges rewrite looks/hero). `updateShotField` is dead code (zero callers) — skipped.
- Composite index `(clientId, projectId)` mirroring shotShares/castingShares; `enabled` stays out of the index.

## Coverage (explicit)
The refresh re-resolves a share's **full current shot set**, so it self-heals: any normal project save refreshes **all** the project's shares. Rarer writers (bulk-create, shot duplicate/copy/move/soft-delete, product-family merges) don't fire it directly — their staleness clears on the next normal save. Broadening to those is a deferred follow-up (CO-3″) if eventual consistency proves too loose.

## Rules
No `firestore.rules` change: L297 already permits authed `get, list` scoped by `clientId` (the refresh runs as the authed editor, who has Firestore auth by virtue of the shot write that just succeeded). New rules tests **[16]/[17]** cover the authed-list query (success for own client+project; denial for a foreign client).

## Verified (hand-run)
- vitest 4/4 (refresh unit test: enabled-only, payload, early-return, allSettled isolation)
- **emulator rules test 19/19** (the 17 originals + [16]/[17], JDK 21)
- `tsc --noEmit` 160 (0 new) · ESLint clean (`no-floating-promises` satisfied via `void…catch`)