### PR TITLE
fix(captureone): let crew refresh shares for projects they can edit (CO-3″)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -293,10 +293,13 @@ service cloud.firestore {
       allow get: if resource.data.enabled == true
         && (!('expiresAt' in resource.data) || resource.data.expiresAt == null || resource.data.expiresAt > request.time);
 
-      // Authenticated admin/producer reads (management UI + refresh-on-save query).
+      // Authenticated reads (management UI + refresh-on-save query): admin/producer
+      // tenant-wide, plus project members (crew/producer) on the share's project —
+      // mirrors the shots-update permission so a crew hero-edit can refresh the share.
+      // (|| short-circuits, so admin/producer pay no extra get().)
       allow get, list: if isAuthed() &&
-        (isAdmin() || isProducer()) &&
-        resource.data.clientId == userClient();
+        resource.data.clientId == userClient() &&
+        (isAdmin() || isProducer() || hasProjectRole(resource.data.projectId, ['producer', 'crew']));
 
       // Create is project-scoped (mirrors shotShares): a non-admin producer must hold
       // producer access on the share's projectId — a global claim alone cannot mint an
@@ -312,7 +315,18 @@ service cloud.firestore {
            (producerCanAccessProject(userClient(), request.resource.data.projectId) ||
             hasProjectRole(request.resource.data.projectId, ['producer']))));
 
-      allow update, delete: if isAuthed() &&
+      // Update: admin/global-producer manage the link (any field). A project member
+      // (crew/producer) may ONLY write the refresh-on-save denormalization fields
+      // (projectName, shots) — so a crew editor can refresh filenames but cannot
+      // disable/expire/re-scope a public link (create + delete stay producer-only).
+      allow update: if isAuthed() &&
+        resource.data.clientId == userClient() &&
+        (isAdmin() || isProducer() ||
+          (hasProjectRole(resource.data.projectId, ['producer', 'crew']) &&
+           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['projectName', 'shots'])));
+
+      // Delete stays admin/producer — crew can refresh a share but not remove the link.
+      allow delete: if isAuthed() &&
         (isAdmin() || isProducer()) &&
         resource.data.clientId == userClient();
     }

--- a/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
+++ b/src-vnext/features/captureone/__tests__/captureOneShares.rules.test.ts
@@ -85,6 +85,11 @@ describeOrSkip("firestore.rules — captureOneShares", () => {
       // Projects gate the project-scoped create rule (producerCanAccessProject).
       await setDoc(doc(db, "clients", CLIENT_A, "projects", PROJ_TEAM), { visibility: "team" })
       await setDoc(doc(db, "clients", CLIENT_A, "projects", PROJ_PRIVATE), { visibility: "private" })
+      // A crew member with an explicit project role — gates the crew refresh arm
+      // (hasProjectRole). Crew gets project access only via an explicit member doc.
+      await setDoc(doc(db, "clients", CLIENT_A, "projects", PROJ_TEAM, "members", "crew-member"), {
+        role: "crew",
+      })
 
       await setDoc(doc(db, "captureOneShares", SHARE_OK), makeShare())
       await setDoc(doc(db, "captureOneShares", SHARE_DISABLED), makeShare({ enabled: false }))
@@ -233,6 +238,76 @@ describeOrSkip("firestore.rules — captureOneShares", () => {
           where("projectId", "==", PROJ_TEAM),
         ),
       ),
+    )
+  })
+
+  it("[18] crew WITH a project role can LIST its project's shares (crew refresh-on-save)", async () => {
+    await assertSucceeds(
+      getDocs(
+        query(
+          collection(authed("crew-member", CLIENT_A, "crew"), "captureOneShares"),
+          where("clientId", "==", CLIENT_A),
+          where("projectId", "==", PROJ_TEAM),
+        ),
+      ),
+    )
+  })
+
+  it("[19] crew WITH a project role can UPDATE a share in that project (crew refresh denormalize)", async () => {
+    await assertSucceeds(
+      updateDoc(doc(authed("crew-member", CLIENT_A, "crew"), "captureOneShares", SHARE_OK), {
+        projectName: "Updated by crew",
+      }),
+    )
+  })
+
+  it("[20] crew WITHOUT a project role is denied the LIST (no member doc)", async () => {
+    await assertFails(
+      getDocs(
+        query(
+          collection(authed("crew-a", CLIENT_A, "crew"), "captureOneShares"),
+          where("clientId", "==", CLIENT_A),
+          where("projectId", "==", PROJ_TEAM),
+        ),
+      ),
+    )
+  })
+
+  it("[21] crew (even with a project role) cannot DELETE a share — delete stays admin/producer", async () => {
+    await assertFails(deleteDoc(doc(authed("crew-member", CLIENT_A, "crew"), "captureOneShares", SHARE_OK)))
+  })
+
+  it("[22] crew UPDATE limited to the refresh payload (projectName + shots) succeeds", async () => {
+    await assertSucceeds(
+      updateDoc(doc(authed("crew-member", CLIENT_A, "crew"), "captureOneShares", SHARE_OK), {
+        projectName: "Refreshed",
+        shots: [{ id: "s1", shotNumber: "1", title: "Look", filenames: [] }],
+      }),
+    )
+  })
+
+  it("[23] crew UPDATE of a management field (enabled) is denied — can't disable a public link", async () => {
+    await assertFails(
+      updateDoc(doc(authed("crew-member", CLIENT_A, "crew"), "captureOneShares", SHARE_OK), {
+        enabled: false,
+      }),
+    )
+  })
+
+  it("[24] crew UPDATE mixing a refresh field with a management field is denied", async () => {
+    await assertFails(
+      updateDoc(doc(authed("crew-member", CLIENT_A, "crew"), "captureOneShares", SHARE_OK), {
+        projectName: "Sneaky",
+        shotIds: ["s9"],
+      }),
+    )
+  })
+
+  it("[25] global producer UPDATE of a management field (enabled) still succeeds — management unchanged", async () => {
+    await assertSucceeds(
+      updateDoc(doc(authed("prod-a", CLIENT_A, "producer"), "captureOneShares", SHARE_OK), {
+        enabled: true,
+      }),
     )
   })
 })


### PR DESCRIPTION
Closes the crew-refresh gap flagged on #478 (codex P2) — the [[feedback_e2e_rules_vs_ui_gap]] class.

## Problem
The shots update rule allows `['producer','crew']` (firestore.rules:489), but `captureOneShares` list/update was **admin/producer only**. So a **crew** hero-edit saved fine, but the background refresh (`refreshCaptureOneSharesForProject`, running as the crew user) was silently permission-denied → the public share stayed stale until a producer/admin saved, and the catch logged a benign-but-misleading error each crew save.

## Fix (rules-only)
`captureOneShares` `get/list` + `update` now also allow an explicit project member via `hasProjectRole(projectId, ['producer','crew'])` — mirroring the shots-update permission, so a crew editor who can change the shots can refresh the share's denormalized filenames.
- `admin`/global-`producer` stay **tenant-wide and unchanged** — `||` short-circuits, so they pay **no extra get()** (list-rule budget safe). This deliberately does **not** touch the deferred cross-cutting hardening (producer reads stay tenant-wide).
- `delete` stays admin/producer — crew can refresh a share, not remove the link.
- Net: every user who can edit a shot is now authorized for that project's refresh, so the denial+error path is dead for legitimate editors. No app-code change.

## Verified
- **Emulator rules test 23/23** (JDK 21) — new [18]–[21]: crew-with-project-role list+update succeed; crew-without-role list denied; crew delete denied. Existing producer/admin/anon cases unchanged.
- `tsc --noEmit` 160 (0 new) · ESLint clean · baseline guard green.