### PR TITLE
ci: deploy Firestore rules + indexes on every prod deploy

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -65,6 +65,14 @@ jobs:
           create_credentials_file: true
           export_environment_variables: true
 
+      # Ship Firestore rules + indexes with every prod deploy so they never drift
+      # behind main (hosting-only deploys silently left captureOneShares rules
+      # undeployed → "Missing or insufficient permissions"). Additive only:
+      # --non-interactive (no --force) means orphan prod indexes are warned, never
+      # deleted. Requires the deploy SA to hold firebaserules.admin + datastore.indexAdmin.
+      - name: Deploy Firestore rules + indexes
+        run: npx firebase-tools deploy --only firestore:rules,firestore:indexes --project um-shotbuilder --non-interactive
+
       # Capture deploy JSON so we can extract the live URL robustly
       - name: Deploy to Firebase Hosting (live)
         env:

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -85,6 +85,23 @@
       ]
     },
     {
+      "collectionGroup": "shots",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "deleted", "order": "ASCENDING" },
+        { "fieldPath": "projectId", "order": "ASCENDING" },
+        { "fieldPath": "sortOrder", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "shots",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "projectId", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "shotShares",
       "queryScope": "COLLECTION",
       "fields": [


### PR DESCRIPTION
## Problem

`deploy-live.yml` ran `firebase deploy --only hosting` — it shipped the app bundle but **never deployed Firestore rules or indexes**. So the `captureOneShares` rules block (merged in #480/#481) and its composite index sat in the repo but never reached the live project. Creating a Capture One digi-tech share link failed with **"Missing or insufficient permissions"** (Firestore is deny-by-default; the absent match block = denial for everyone, including admins).

I already deployed the current rules + index to prod manually to unblock, so the feature works now. This PR fixes the **pipeline** so it never recurs.

## Change

Adds a `Deploy Firestore rules + indexes` step to `deploy-live.yml`, before the hosting deploy (rules go live before the app that depends on them), reusing the same WIF credentials.

- **Additive only:** `--non-interactive` (no `--force`) → orphan prod indexes are warned, never deleted.
- Rules ship with every prod deploy, so they can't drift behind `main` again.

## Prerequisite (DONE)

The `github-actions-deploy@um-shotbuilder.iam.gserviceaccount.com` SA was granted **Firebase Rules Admin** + **Cloud Datastore Index Admin** in the GCP console. Without these the new step would fail.

## Note

There are 2 indexes in prod not present in `firestore.indexes.json` (surfaced during the manual deploy). They were **not** touched. Worth reconciling separately (commit them to the file or confirm safe to drop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)