### PR TITLE
feat(links): show Capture One share links in the Shared Links manager

### DIFF
--- a/src-vnext/features/links/components/ShareLinkRow.tsx
+++ b/src-vnext/features/links/components/ShareLinkRow.tsx
@@ -26,6 +26,11 @@ const TYPE_STYLES: Record<ShareLink["type"], { label: string; className: string 
     className:
       "bg-[var(--color-status-purple-bg)] text-[var(--color-status-purple-text)] border border-[var(--color-status-purple-border)]",
   },
+  captureone: {
+    label: "Capture One",
+    className:
+      "bg-[var(--color-status-green-bg)] text-[var(--color-status-green-text)] border border-[var(--color-status-green-border)]",
+  },
   pull: {
     label: "Pull",
     className:
@@ -91,7 +96,7 @@ function formatEngagement(link: ShareLink): string {
     return "--"
   }
 
-  if (type === "shots") {
+  if (type === "shots" || type === "captureone") {
     return contentCount !== null ? `${contentCount} shot${contentCount === 1 ? "" : "s"}` : "--"
   }
 

--- a/src-vnext/features/links/components/SharedLinksPage.tsx
+++ b/src-vnext/features/links/components/SharedLinksPage.tsx
@@ -31,6 +31,7 @@ const FILTER_OPTIONS: readonly { key: TypeFilter; label: string }[] = [
   { key: "all", label: "All" },
   { key: "shots", label: "Shots" },
   { key: "casting", label: "Casting" },
+  { key: "captureone", label: "Capture One" },
   { key: "pull", label: "Pulls" },
 ]
 

--- a/src-vnext/features/links/hooks/useShareLinks.ts
+++ b/src-vnext/features/links/hooks/useShareLinks.ts
@@ -1,6 +1,6 @@
 /**
- * Hook that subscribes to all three share link sources (shots, casting, pulls)
- * and merges them into a single sorted array.
+ * Hook that subscribes to all four share link sources (shots, casting,
+ * captureone, pulls) and merges them into a single sorted array.
  */
 
 import { useEffect, useMemo, useState } from "react"
@@ -16,6 +16,7 @@ import { pullsPath } from "@/shared/lib/paths"
 import {
   mapShotShareDoc,
   mapCastingShareDoc,
+  mapCaptureOneShareDoc,
   mapPullToShareLink,
   type ShareLink,
 } from "../lib/shareLinkTypes"
@@ -32,10 +33,12 @@ export function useShareLinks(
 ): UseShareLinksResult {
   const [shotLinks, setShotLinks] = useState<readonly ShareLink[]>([])
   const [castingLinks, setCastingLinks] = useState<readonly ShareLink[]>([])
+  const [captureOneLinks, setCaptureOneLinks] = useState<readonly ShareLink[]>([])
   const [pullLinks, setPullLinks] = useState<readonly ShareLink[]>([])
 
   const [shotLoading, setShotLoading] = useState(true)
   const [castingLoading, setCastingLoading] = useState(true)
+  const [captureOneLoading, setCaptureOneLoading] = useState(true)
   const [pullLoading, setPullLoading] = useState(true)
 
   const [error, setError] = useState<Error | null>(null)
@@ -136,6 +139,42 @@ export function useShareLinks(
   }, [enabled, clientId, projectId])
 
   // -----------------------------------------------------------------------
+  // Capture One shares subscription
+  // -----------------------------------------------------------------------
+  useEffect(() => {
+    if (!enabled) {
+      setCaptureOneLinks([])
+      setCaptureOneLoading(false)
+      return
+    }
+
+    setCaptureOneLoading(true)
+    const q = query(
+      collection(db, "captureOneShares"),
+      where("clientId", "==", clientId),
+      where("projectId", "==", projectId),
+    )
+
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        const mapped = snap.docs.map((d) =>
+          mapCaptureOneShareDoc(d.id, d.data() as Record<string, unknown>),
+        )
+        setCaptureOneLinks(mapped)
+        setCaptureOneLoading(false)
+      },
+      (err) => {
+        console.error("[useShareLinks] captureOneShares error:", err)
+        setError(err)
+        setCaptureOneLoading(false)
+      },
+    )
+
+    return unsub
+  }, [enabled, clientId, projectId])
+
+  // -----------------------------------------------------------------------
   // Pulls subscription (project-scoped, filtered client-side by shareToken presence)
   // -----------------------------------------------------------------------
   useEffect(() => {
@@ -174,16 +213,16 @@ export function useShareLinks(
   // -----------------------------------------------------------------------
   // Merge + sort (newest first)
   // -----------------------------------------------------------------------
-  const loading = shotLoading || castingLoading || pullLoading
+  const loading = shotLoading || castingLoading || captureOneLoading || pullLoading
 
   const links = useMemo(() => {
-    const all = [...shotLinks, ...castingLinks, ...pullLinks]
+    const all = [...shotLinks, ...castingLinks, ...captureOneLinks, ...pullLinks]
     return all.sort((a, b) => {
       const aTime = a.createdAt?.getTime() ?? 0
       const bTime = b.createdAt?.getTime() ?? 0
       return bTime - aTime
     })
-  }, [shotLinks, castingLinks, pullLinks])
+  }, [shotLinks, castingLinks, captureOneLinks, pullLinks])
 
   return { links, loading, error }
 }

--- a/src-vnext/features/links/lib/__tests__/shareLinkTypes.test.ts
+++ b/src-vnext/features/links/lib/__tests__/shareLinkTypes.test.ts
@@ -3,6 +3,7 @@ import {
   computeShareLinkStatus,
   mapShotShareDoc,
   mapCastingShareDoc,
+  mapCaptureOneShareDoc,
   mapPullToShareLink,
 } from "../shareLinkTypes"
 
@@ -360,5 +361,101 @@ describe("mapCastingShareDoc", () => {
     })
 
     expect(result.type).toBe("casting")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// mapCaptureOneShareDoc
+// ---------------------------------------------------------------------------
+
+describe("mapCaptureOneShareDoc", () => {
+  it("sets type, url and default title", () => {
+    const result = mapCaptureOneShareDoc("co-1", {
+      enabled: true,
+      projectId: "proj-1",
+      clientId: "client-1",
+    })
+
+    expect(result.type).toBe("captureone")
+    expect(result.url).toBe("/captureone/shared/co-1")
+    expect(result.title).toBe("Capture One Names")
+  })
+
+  it("extracts contentCount and per-shot filename counts from the shots array", () => {
+    const result = mapCaptureOneShareDoc("co-2", {
+      enabled: true,
+      shots: [
+        { shotNumber: "001", title: "Opening", filenames: [{ name: "M_Jogger_Forest" }] },
+        {
+          shotNumber: "002",
+          title: "Close-up",
+          filenames: [{ name: "W_Tee_Black" }, { name: "W_Tee_White" }],
+        },
+      ],
+      shotIds: ["a", "b", "c"],
+      projectId: "proj-1",
+      clientId: "client-1",
+    })
+
+    // shots takes precedence over shotIds for the count
+    expect(result.contentCount).toBe(2)
+    expect(result.contentItems).toHaveLength(2)
+    expect(result.contentItems![0]).toEqual({ label: "001", sublabel: "1 filename" })
+    expect(result.contentItems![1]).toEqual({ label: "002", sublabel: "2 filenames" })
+  })
+
+  it("falls back to shotIds length when shots is absent", () => {
+    const result = mapCaptureOneShareDoc("co-3", {
+      enabled: true,
+      shotIds: ["a", "b"],
+      projectId: "proj-1",
+      clientId: "client-1",
+    })
+
+    expect(result.contentCount).toBe(2)
+    expect(result.contentItems).toBeNull()
+  })
+
+  it("uses the shot title as label when shotNumber is absent, and omits sublabel for zero filenames", () => {
+    const result = mapCaptureOneShareDoc("co-4", {
+      enabled: true,
+      shots: [{ title: "Hero Look", filenames: [] }],
+      projectId: "proj-1",
+      clientId: "client-1",
+    })
+
+    const items = result.contentItems!
+    expect(items[0]!.label).toBe("Hero Look")
+    expect(items[0]!.sublabel).toBeUndefined()
+  })
+
+  it("caps contentItems at 10", () => {
+    const shots = Array.from({ length: 12 }, (_, i) => ({ shotNumber: `${i + 1}` }))
+
+    const result = mapCaptureOneShareDoc("co-5", {
+      enabled: true,
+      shots,
+      projectId: "proj-1",
+      clientId: "client-1",
+    })
+
+    expect(result.contentCount).toBe(12)
+    expect(result.contentItems).toHaveLength(10)
+  })
+
+  it("computes disabled/expired status like the other share types", () => {
+    expect(
+      mapCaptureOneShareDoc("co-6", { enabled: false, projectId: "p", clientId: "c" }).status,
+    ).toBe("disabled")
+
+    const past = { toDate: () => new Date(Date.now() - 1_000) }
+    expect(
+      mapCaptureOneShareDoc("co-7", {
+        enabled: true,
+        expiresAt: past,
+        projectId: "p",
+        clientId: "c",
+      }).status,
+    ).toBe("expired")
   })
 })

--- a/src-vnext/features/links/lib/shareLinkActions.ts
+++ b/src-vnext/features/links/lib/shareLinkActions.ts
@@ -1,9 +1,10 @@
 /**
  * Firestore write operations for share link management.
  *
- * Handles three share link sources:
+ * Handles four share link sources:
  *   - shotShares/{token} (root collection)
  *   - castingShares/{token} (root collection)
+ *   - captureOneShares/{token} (root collection)
  *   - pulls/{pullId} (project-scoped subcollection)
  */
 
@@ -30,6 +31,10 @@ function castingShareRef(token: string) {
   return doc(db, "castingShares", token)
 }
 
+function captureOneShareRef(token: string) {
+  return doc(db, "captureOneShares", token)
+}
+
 function pullDocRef(link: ShareLink) {
   const path = pullPath(link.sourceDocId, link.projectId, link.clientId)
   return doc(db, path[0]!, ...path.slice(1))
@@ -46,6 +51,8 @@ export async function toggleShareLink(link: ShareLink): Promise<void> {
     await updateDoc(shotShareRef(link.id), { enabled: newEnabled })
   } else if (link.type === "casting") {
     await updateDoc(castingShareRef(link.id), { enabled: newEnabled })
+  } else if (link.type === "captureone") {
+    await updateDoc(captureOneShareRef(link.id), { enabled: newEnabled })
   } else {
     await updateDoc(pullDocRef(link), {
       shareEnabled: newEnabled,
@@ -68,6 +75,8 @@ export async function setShareLinkExpiry(
     await updateDoc(shotShareRef(link.id), { expiresAt: tsValue })
   } else if (link.type === "casting") {
     await updateDoc(castingShareRef(link.id), { expiresAt: tsValue })
+  } else if (link.type === "captureone") {
+    await updateDoc(captureOneShareRef(link.id), { expiresAt: tsValue })
   } else {
     await updateDoc(pullDocRef(link), {
       shareExpireAt: tsValue,
@@ -85,6 +94,8 @@ export async function deleteShareLink(link: ShareLink): Promise<void> {
     await deleteDoc(shotShareRef(link.id))
   } else if (link.type === "casting") {
     await deleteDoc(castingShareRef(link.id))
+  } else if (link.type === "captureone") {
+    await deleteDoc(captureOneShareRef(link.id))
   } else {
     await updateDoc(pullDocRef(link), {
       shareEnabled: false,

--- a/src-vnext/features/links/lib/shareLinkTypes.ts
+++ b/src-vnext/features/links/lib/shareLinkTypes.ts
@@ -1,15 +1,16 @@
 /**
  * Unified share link types and mappers.
  *
- * Three share link sources are normalized into a single ShareLink shape:
+ * Four share link sources are normalized into a single ShareLink shape:
  *   - shotShares (root collection, doc id = token)
  *   - castingShares (root collection, doc id = token)
+ *   - captureOneShares (root collection, doc id = token)
  *   - pulls (project-scoped, shareToken field on pull doc)
  */
 
 import type { Timestamp } from "firebase/firestore"
 
-export type ShareLinkType = "shots" | "casting" | "pull"
+export type ShareLinkType = "shots" | "casting" | "captureone" | "pull"
 export type ShareLinkStatus = "active" | "disabled" | "expired"
 
 export interface ShareLinkContentItem {
@@ -173,6 +174,69 @@ export function mapCastingShareDoc(
     createdAt,
     createdBy: typeof data["createdBy"] === "string" ? data["createdBy"] : null,
     engagement: voteCount ?? null,
+    projectId,
+    clientId,
+    sourceDocId: id,
+    contentCount,
+    contentItems,
+  }
+}
+
+export function mapCaptureOneShareDoc(
+  id: string,
+  data: Record<string, unknown>,
+): ShareLink {
+  const enabled = data["enabled"] === true
+  const expiresAt = timestampToDate(data["expiresAt"])
+  const createdAt = timestampToDate(data["createdAt"])
+  const projectId = (typeof data["projectId"] === "string" ? data["projectId"] : "") as string
+  const clientId = (typeof data["clientId"] === "string" ? data["clientId"] : "") as string
+  const title =
+    (typeof data["title"] === "string" && data["title"].length > 0
+      ? data["title"]
+      : "Capture One Names") as string
+
+  // Created docs denormalize resolved shots into `shots`; fall back to `shotIds`
+  // for the count if an older doc predates that field.
+  const shots = Array.isArray(data["shots"]) ? (data["shots"] as unknown[]) : null
+  const shotIds = Array.isArray(data["shotIds"]) ? (data["shotIds"] as unknown[]) : null
+
+  const contentCount = shots !== null
+    ? shots.length
+    : shotIds !== null
+      ? shotIds.length
+      : null
+
+  const contentItems: ShareLinkContentItem[] | null = shots !== null
+    ? shots.slice(0, MAX_CONTENT_ITEMS).map((shot) => {
+        const s = shot as Record<string, unknown>
+        const filenames = Array.isArray(s["filenames"]) ? (s["filenames"] as unknown[]) : []
+        const label =
+          typeof s["shotNumber"] === "string" && s["shotNumber"].length > 0
+            ? (s["shotNumber"] as string)
+            : typeof s["title"] === "string" && s["title"].length > 0
+              ? (s["title"] as string)
+              : "Shot"
+        return {
+          label,
+          sublabel: filenames.length > 0
+            ? `${filenames.length} filename${filenames.length === 1 ? "" : "s"}`
+            : undefined,
+        }
+      })
+    : null
+
+  return {
+    id,
+    type: "captureone",
+    title,
+    url: `/captureone/shared/${id}`,
+    status: computeShareLinkStatus(enabled, expiresAt),
+    enabled,
+    expiresAt,
+    createdAt,
+    createdBy: typeof data["createdBy"] === "string" ? data["createdBy"] : null,
+    engagement: null,
     projectId,
     clientId,
     sourceDocId: id,


### PR DESCRIPTION
## Problem

You created a Capture One digi-tech link, it copied to your clipboard — but it **never appeared in the Shared Links page**, so it couldn't be revisited, disabled, expired, or deleted from there. The manager only knew about `shotShares`, `castingShares`, and `pulls`. Wiring `captureOneShares` in was explicitly deferred as "optional, skippable for v1" when the feature shipped — this is that follow-up.

## Change

Adds `captureOneShares` as the 4th source in the Shared Links manager, mirroring the `shotShares` pattern exactly:

| File | What |
|---|---|
| `lib/shareLinkTypes.ts` | `'captureone'` in `ShareLinkType` + `mapCaptureOneShareDoc` (title, status, per-shot filename counts) |
| `hooks/useShareLinks.ts` | 4th `onSnapshot` subscription (`clientId`+`projectId`), merged + folded into loading |
| `lib/shareLinkActions.ts` | enable/disable · set expiry · delete branches (root-collection writes) |
| `components/ShareLinkRow.tsx` | green "Capture One" type badge + shot-count engagement |
| `components/SharedLinksPage.tsx` | "Capture One" type filter chip |
| `lib/__tests__/shareLinkTypes.test.ts` | 7 mapper tests |

## Why it's safe to read/write captureOneShares from the manager

- **Rules + index already live in prod** (deployed manually + via #482's pipeline). The list query is `clientId`+`projectId`, matching the existing composite index.
- **No rules-vs-UI gap** (adversarial code-review confirmed): the manager page is gated on the *global* admin/producer claim (`canManageCasting`), which is *stricter* than the Firestore rules — crew/viewer never see an action the rules would reject.
- **Disabling sticks:** the refresh-on-save hook only writes `{projectName, shots}` to *enabled* docs; it never resurrects a disabled link.

## Gates

- vitest: **35/35** (7 new)
- tsc baseline guard: **160/160**, no new type errors
- vite build: ✓

## Note for review
New badge color is **green** (shots=blue, casting=purple, pull=amber were taken). It shares the green hue with the "active" status dot, but they're in different columns. Easy to swap if you'd prefer another.

🤖 Generated with [Claude Code](https://claude.com/claude-code)