### PR TITLE
refactor(export): unify renderers behind a shared block-spec (Divider canary)

### DIFF
--- a/src-vnext/features/export/components/blocks/DividerBlockView.tsx
+++ b/src-vnext/features/export/components/blocks/DividerBlockView.tsx
@@ -1,25 +1,11 @@
 import type { DividerBlock } from "../../types/exportBuilder"
+import { deriveDividerSpec } from "../../lib/blockSpec"
+import { renderBlockSpecDom } from "../../lib/specAdapters/dom"
 
 interface DividerBlockViewProps {
   readonly block: DividerBlock
 }
 
 export function DividerBlockView({ block }: DividerBlockViewProps) {
-  const borderStyle = block.style ?? "solid"
-  const color = block.color ?? "#d1d5db"
-
-  return (
-    <hr
-      data-testid="divider-block"
-      style={{
-        borderTopStyle: borderStyle,
-        borderTopWidth: "1px",
-        borderTopColor: color,
-        borderBottom: "none",
-        borderLeft: "none",
-        borderRight: "none",
-      }}
-      className="my-2"
-    />
-  )
+  return renderBlockSpecDom(deriveDividerSpec(block))
 }

--- a/src-vnext/features/export/lib/__tests__/blockSpec.parity.test.ts
+++ b/src-vnext/features/export/lib/__tests__/blockSpec.parity.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest"
+import { deriveDividerSpec } from "../blockSpec"
+import type { DividerBlock } from "../../types/exportBuilder"
+
+// Layer 1 — spec unit. The resolved spec is the single source of truth both
+// renderers consume; snapshot it so a default/value change is an owned diff.
+
+describe("deriveDividerSpec", () => {
+  it("resolves defaults from a bare divider block", () => {
+    const block: DividerBlock = { id: "d1", type: "divider" }
+    expect(deriveDividerSpec(block)).toEqual({
+      kind: "divider",
+      lineStyle: "solid",
+      color: "#D1D5DB",
+      thicknessPx: 1,
+      marginYPx: 8,
+    })
+  })
+
+  it("passes through an explicit style and color", () => {
+    const block: DividerBlock = {
+      id: "d2",
+      type: "divider",
+      style: "dashed",
+      color: "#abc123",
+    }
+    expect(deriveDividerSpec(block)).toMatchObject({
+      lineStyle: "dashed",
+      color: "#abc123",
+    })
+  })
+
+  it("is pure — equal input yields an equal spec", () => {
+    const block: DividerBlock = { id: "d3", type: "divider", style: "dotted" }
+    expect(deriveDividerSpec(block)).toEqual(deriveDividerSpec(block))
+  })
+})

--- a/src-vnext/features/export/lib/__tests__/blockSpec.parity.test.ts
+++ b/src-vnext/features/export/lib/__tests__/blockSpec.parity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { deriveDividerSpec } from "../blockSpec"
+import { pxToPt } from "../units"
 import type { DividerBlock } from "../../types/exportBuilder"
 
 // Layer 1 — spec unit. The resolved spec is the single source of truth both
@@ -30,8 +31,18 @@ describe("deriveDividerSpec", () => {
     })
   })
 
-  it("is pure — equal input yields an equal spec", () => {
+  it("does not mutate the input block", () => {
     const block: DividerBlock = { id: "d3", type: "divider", style: "dotted" }
-    expect(deriveDividerSpec(block)).toEqual(deriveDividerSpec(block))
+    const before = structuredClone(block)
+    deriveDividerSpec(block)
+    expect(block).toEqual(before)
+  })
+})
+
+describe("pxToPt", () => {
+  it("converts against the physical constant (96px = 72pt = 1in)", () => {
+    expect(pxToPt(96)).toBe(72)
+    expect(pxToPt(1)).toBeCloseTo(0.75)
+    expect(pxToPt(8)).toBeCloseTo(6)
   })
 })

--- a/src-vnext/features/export/lib/blockSpec.ts
+++ b/src-vnext/features/export/lib/blockSpec.ts
@@ -1,0 +1,37 @@
+import type { DividerBlock } from "../types/exportBuilder"
+
+// Renderer-agnostic block specs. A pure `derive*Spec` resolver turns a block +
+// data into a serializable, presentation-free spec (px-canonical sizes, author
+// colors, no CSS classes / no pt). The DOM and @react-pdf adapters are thin
+// presenters over the SAME spec, so the two renderers cannot drift — the parity
+// tests assert on the spec. One variant is added per migrated block type.
+
+export type DividerLineStyle = NonNullable<DividerBlock["style"]>
+
+export interface DividerSpec {
+  readonly kind: "divider"
+  readonly lineStyle: DividerLineStyle
+  readonly color: string
+  readonly thicknessPx: number
+  readonly marginYPx: number
+}
+
+/** Discriminated union of resolved block specs — grows one variant per block type. */
+export type ResolvedBlockSpec = DividerSpec
+
+// Canonical divider defaults — the single source both renderers resolve from.
+// (Replaces the View `#d1d5db`/1px vs PDF `#D1D5DB`/0.5pt fork.)
+const DIVIDER_DEFAULT_COLOR = "#D1D5DB"
+const DIVIDER_THICKNESS_PX = 1
+const DIVIDER_MARGIN_Y_PX = 8
+
+/** Resolve a DividerBlock to its renderer-agnostic spec. */
+export function deriveDividerSpec(block: DividerBlock): DividerSpec {
+  return {
+    kind: "divider",
+    lineStyle: block.style ?? "solid",
+    color: block.color ?? DIVIDER_DEFAULT_COLOR,
+    thicknessPx: DIVIDER_THICKNESS_PX,
+    marginYPx: DIVIDER_MARGIN_Y_PX,
+  }
+}

--- a/src-vnext/features/export/lib/blockSpec.ts
+++ b/src-vnext/features/export/lib/blockSpec.ts
@@ -1,10 +1,7 @@
 import type { DividerBlock } from "../types/exportBuilder"
 
-// Renderer-agnostic block specs. A pure `derive*Spec` resolver turns a block +
-// data into a serializable, presentation-free spec (px-canonical sizes, author
-// colors, no CSS classes / no pt). The DOM and @react-pdf adapters are thin
-// presenters over the SAME spec, so the two renderers cannot drift — the parity
-// tests assert on the spec. One variant is added per migrated block type.
+// Pure, px-canonical, presentation-free block specs. The DOM + @react-pdf
+// adapters both present the SAME spec, so the two renderers can't drift.
 
 export type DividerLineStyle = NonNullable<DividerBlock["style"]>
 

--- a/src-vnext/features/export/lib/pdf/blocks/DividerBlockPdf.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/DividerBlockPdf.tsx
@@ -1,22 +1,11 @@
-import { View } from "@react-pdf/renderer"
 import type { DividerBlock } from "../../../types/exportBuilder"
+import { deriveDividerSpec } from "../../blockSpec"
+import { renderBlockSpecPdf } from "../specAdapters/pdf"
 
 interface DividerBlockPdfProps {
   readonly block: DividerBlock
 }
 
 export function DividerBlockPdf({ block }: DividerBlockPdfProps) {
-  const borderStyle = block.style ?? "solid"
-  const color = block.color ?? "#D1D5DB"
-
-  return (
-    <View
-      style={{
-        borderBottomWidth: 0.5,
-        borderBottomColor: color,
-        borderBottomStyle: borderStyle,
-        marginVertical: 8,
-      }}
-    />
-  )
+  return renderBlockSpecPdf(deriveDividerSpec(block))
 }

--- a/src-vnext/features/export/lib/pdf/blocks/__tests__/blockConsumers.parity.test.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/__tests__/blockConsumers.parity.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest"
+
+// Layer 2 — consumer parity. Proves BOTH renderers consume the same resolved
+// spec (not a re-derived copy): from one block we render the preview <hr> and
+// the pdf <View> and assert each reflects deriveDividerSpec(block). If someone
+// re-introduces a default/value on one side only, that side diverges -> red.
+
+// Mock @react-pdf/renderer into queryable DOM (mirrors ShotGridBlockPdf.test).
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  const ser = (s: unknown) => {
+    try {
+      return s == null ? undefined : JSON.stringify(s)
+    } catch {
+      return undefined
+    }
+  }
+  return {
+    View: (props: Record<string, unknown>) => {
+      const { style, children, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      return React.createElement(
+        "pdf-view",
+        { ...rest, "data-style": ser(style) },
+        children as React.ReactNode,
+      )
+    },
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render } from "@testing-library/react"
+import { DividerBlockView } from "../../../../components/blocks/DividerBlockView"
+import { DividerBlockPdf } from "../DividerBlockPdf"
+import { deriveDividerSpec } from "../../../blockSpec"
+import { pxToPt } from "../../specAdapters/pdf"
+import type { DividerBlock } from "../../../../types/exportBuilder"
+
+function parseStyle(el: Element | null): Record<string, unknown> {
+  const raw = el?.getAttribute("data-style")
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+}
+
+// jsdom normalizes inline colors to rgb(); the PDF mock keeps the raw hex. Compare
+// both via a whitespace/case-insensitive rgb form so a color value is asserted, not its notation.
+function hexToRgb(hex: string): string {
+  const h = hex.replace("#", "")
+  const r = Number.parseInt(h.slice(0, 2), 16)
+  const g = Number.parseInt(h.slice(2, 4), 16)
+  const b = Number.parseInt(h.slice(4, 6), 16)
+  return `rgb(${String(r)}, ${String(g)}, ${String(b)})`
+}
+
+const normColor = (c: string): string => c.replace(/\s+/g, "").toLowerCase()
+
+const CASES: readonly DividerBlock[] = [
+  { id: "d1", type: "divider" },
+  { id: "d2", type: "divider", style: "dashed", color: "#abc123" },
+  { id: "d3", type: "divider", style: "dotted" },
+]
+
+describe("Divider consumer parity — preview and pdf consume the same spec", () => {
+  it.each(CASES)("preview <hr> reflects the spec (%o)", (block) => {
+    const spec = deriveDividerSpec(block)
+    const { container } = render(<DividerBlockView block={block} />)
+    const hr = container.querySelector("hr")
+    expect(hr).not.toBeNull()
+    expect(hr?.style.borderTopStyle).toBe(spec.lineStyle)
+    expect(hr?.style.borderTopWidth).toBe(`${String(spec.thicknessPx)}px`)
+    expect(normColor(hr?.style.borderTopColor ?? "")).toBe(
+      normColor(hexToRgb(spec.color)),
+    )
+  })
+
+  it.each(CASES)("pdf <View> reflects the same spec, px->pt (%o)", (block) => {
+    const spec = deriveDividerSpec(block)
+    const { container } = render(<DividerBlockPdf block={block} />)
+    const style = parseStyle(container.querySelector("pdf-view"))
+    expect(style.borderBottomStyle).toBe(spec.lineStyle)
+    expect(String(style.borderBottomColor).toLowerCase()).toBe(
+      spec.color.toLowerCase(),
+    )
+    expect(style.borderBottomWidth).toBeCloseTo(pxToPt(spec.thicknessPx))
+    expect(style.marginVertical).toBeCloseTo(pxToPt(spec.marginYPx))
+  })
+})

--- a/src-vnext/features/export/lib/pdf/blocks/__tests__/blockConsumers.parity.test.tsx
+++ b/src-vnext/features/export/lib/pdf/blocks/__tests__/blockConsumers.parity.test.tsx
@@ -35,7 +35,7 @@ import { render } from "@testing-library/react"
 import { DividerBlockView } from "../../../../components/blocks/DividerBlockView"
 import { DividerBlockPdf } from "../DividerBlockPdf"
 import { deriveDividerSpec } from "../../../blockSpec"
-import { pxToPt } from "../../specAdapters/pdf"
+import { pxToPt } from "../../../units"
 import type { DividerBlock } from "../../../../types/exportBuilder"
 
 function parseStyle(el: Element | null): Record<string, unknown> {
@@ -69,6 +69,8 @@ describe("Divider consumer parity — preview and pdf consume the same spec", ()
     expect(hr).not.toBeNull()
     expect(hr?.style.borderTopStyle).toBe(spec.lineStyle)
     expect(hr?.style.borderTopWidth).toBe(`${String(spec.thicknessPx)}px`)
+    expect(hr?.style.marginTop).toBe(`${String(spec.marginYPx)}px`)
+    expect(hr?.style.marginBottom).toBe(`${String(spec.marginYPx)}px`)
     expect(normColor(hr?.style.borderTopColor ?? "")).toBe(
       normColor(hexToRgb(spec.color)),
     )

--- a/src-vnext/features/export/lib/pdf/specAdapters/pdf.tsx
+++ b/src-vnext/features/export/lib/pdf/specAdapters/pdf.tsx
@@ -1,14 +1,11 @@
 import { View } from "@react-pdf/renderer"
 import type { ResolvedBlockSpec } from "../../blockSpec"
+import { pxToPt } from "../../units"
 
-// @react-pdf presenter for resolved block specs (the PDF tree). The ONLY new
-// file that imports @react-pdf, so it stays in the lazy pdf chunk. px-canonical
-// spec values are converted to points here. The explicit ReactElement return
-// type keeps the switch exhaustive: an unhandled variant -> tsc error = red
-// build. Promote to a `never` default once the union is multi-variant.
-
-/** CSS px -> PDF points (1px = 1/96in, 1pt = 1/72in). */
-export const pxToPt = (px: number): number => (px * 72) / 96
+// @react-pdf presenter for ResolvedBlockSpec — the only adapter importing
+// @react-pdf, so it stays in the lazy pdf chunk. Exhaustive via the explicit
+// return type (unhandled variant -> tsc error = red build); promote to a
+// `never` default once the union is multi-variant.
 
 /** Render a resolved block spec to @react-pdf primitives. */
 export function renderBlockSpecPdf(spec: ResolvedBlockSpec): React.ReactElement {

--- a/src-vnext/features/export/lib/pdf/specAdapters/pdf.tsx
+++ b/src-vnext/features/export/lib/pdf/specAdapters/pdf.tsx
@@ -1,0 +1,28 @@
+import { View } from "@react-pdf/renderer"
+import type { ResolvedBlockSpec } from "../../blockSpec"
+
+// @react-pdf presenter for resolved block specs (the PDF tree). The ONLY new
+// file that imports @react-pdf, so it stays in the lazy pdf chunk. px-canonical
+// spec values are converted to points here. The explicit ReactElement return
+// type keeps the switch exhaustive: an unhandled variant -> tsc error = red
+// build. Promote to a `never` default once the union is multi-variant.
+
+/** CSS px -> PDF points (1px = 1/96in, 1pt = 1/72in). */
+export const pxToPt = (px: number): number => (px * 72) / 96
+
+/** Render a resolved block spec to @react-pdf primitives. */
+export function renderBlockSpecPdf(spec: ResolvedBlockSpec): React.ReactElement {
+  switch (spec.kind) {
+    case "divider":
+      return (
+        <View
+          style={{
+            borderBottomWidth: pxToPt(spec.thicknessPx),
+            borderBottomColor: spec.color,
+            borderBottomStyle: spec.lineStyle,
+            marginVertical: pxToPt(spec.marginYPx),
+          }}
+        />
+      )
+  }
+}

--- a/src-vnext/features/export/lib/specAdapters/dom.tsx
+++ b/src-vnext/features/export/lib/specAdapters/dom.tsx
@@ -1,10 +1,9 @@
 import type { ResolvedBlockSpec } from "../blockSpec"
 
-// DOM presenter for resolved block specs (the preview tree). The explicit
-// ReactElement return type makes the switch exhaustive over ResolvedBlockSpec:
-// an added variant with no case leaves a non-returning path -> tsc error
-// (caught by typecheck:baseline) = red build. Promote to a `never` default once
-// the union is multi-variant (single-member unions don't narrow to never).
+// DOM presenter for ResolvedBlockSpec. Exhaustive via the explicit return type
+// (unhandled variant -> tsc error = red build); promote to a `never` default
+// once the union is multi-variant. Spacing is rendered inline from the spec
+// (not a Tailwind class) so the DOM and PDF consume one source and can't drift.
 
 /** Render a resolved block spec to DOM primitives. */
 export function renderBlockSpecDom(spec: ResolvedBlockSpec): React.ReactElement {

--- a/src-vnext/features/export/lib/specAdapters/dom.tsx
+++ b/src-vnext/features/export/lib/specAdapters/dom.tsx
@@ -1,0 +1,29 @@
+import type { ResolvedBlockSpec } from "../blockSpec"
+
+// DOM presenter for resolved block specs (the preview tree). The explicit
+// ReactElement return type makes the switch exhaustive over ResolvedBlockSpec:
+// an added variant with no case leaves a non-returning path -> tsc error
+// (caught by typecheck:baseline) = red build. Promote to a `never` default once
+// the union is multi-variant (single-member unions don't narrow to never).
+
+/** Render a resolved block spec to DOM primitives. */
+export function renderBlockSpecDom(spec: ResolvedBlockSpec): React.ReactElement {
+  switch (spec.kind) {
+    case "divider":
+      return (
+        <hr
+          data-testid="divider-block"
+          style={{
+            borderTopStyle: spec.lineStyle,
+            borderTopWidth: `${String(spec.thicknessPx)}px`,
+            borderTopColor: spec.color,
+            borderBottom: "none",
+            borderLeft: "none",
+            borderRight: "none",
+            marginTop: `${String(spec.marginYPx)}px`,
+            marginBottom: `${String(spec.marginYPx)}px`,
+          }}
+        />
+      )
+  }
+}

--- a/src-vnext/features/export/lib/units.ts
+++ b/src-vnext/features/export/lib/units.ts
@@ -1,0 +1,4 @@
+// Shared unit conversions for px-canonical block specs.
+
+/** CSS px -> PDF points (1px = 1/96in, 1pt = 1/72in). */
+export const pxToPt = (px: number): number => (px * 72) / 96


### PR DESCRIPTION
## Phase 1 — Unify the renderer (keystone). First canary: **Divider**.

The export builder has **two renderers that drift** — the DOM **preview** (`components/blocks/*BlockView.tsx`) and the @react-pdf **PDF** (`lib/pdf/blocks/*BlockPdf.tsx`). Each block type has a duplicated `*BlockView` + `*BlockPdf` with parallel authoring logic — that duplication *is* the "preview ≠ PDF" drift source.

This PR establishes the **unification pattern** on the simplest block, so the architecture is proven on something tiny + reversible before it scales to Text / ShotGrid.

### Architecture (data-spec)
A pure `derive*Spec(block)` resolves a block into a **serializable, presentation-free `ResolvedBlockSpec`** (px-canonical, author colors, no pt / no CSS classes). Two **thin adapters** present the *same* spec:
- `lib/specAdapters/dom.tsx` → DOM primitives (preview)
- `lib/pdf/specAdapters/pdf.tsx` → @react-pdf primitives (PDF), converting px→pt

Both `*BlockView` and `*BlockPdf` now `derive` the spec and hand it to their adapter, so **the two trees can no longer drift** — there is one source of truth. **@react-pdf is kept** (no Paged.js); it stays isolated to `pdf.tsx` (lazy chunk), while `blockSpec.ts` + `dom.tsx` are `import type`-only (they land in the eager preview chunk — verified the build keeps `pdf-deps`/`pdf-lib` lazy).

### Why Divider first (not Text)
The plan named "TextBlock simplest," but the block-by-block audit showed **Divider is the honest canary** (no `layout` field, no imageMap, no text shaping, no editor chrome — `unifyDifficulty 2`), and it's dispatched *bare* from both switches (the clean flip-one-case valve). **Text is deferred to its own PR**: it drops `dangerouslySetInnerHTML` and re-renders a node tree — a genuine behavior change (loses arbitrary inline-CSS color spans) that shouldn't co-mingle with the first proof of the seam.

### Drift closed by this PR (verified against the real code)
- Default divider color **case**: View `#d1d5db` vs PDF `#D1D5DB` → one canonical default.
- The duplicated `?? "solid"` style fallback → resolved once.

### ⚠️ Owned visual change — needs your eyeball
The PDF divider adopts the px-canonical geometry: **line 0.5pt → 0.75pt** (px→pt of 1px) and **vertical margin 8pt → 6pt**. The DOM preview is numerically unchanged (1px line / 8px margins). Net effect: the PDF moves toward the preview's px geometry — which is the point (one px-canonical spec), but it *does* change rendered PDF output for any doc with a divider.

### Parity test (drift = red build)
- **Spec unit** (`lib/__tests__/blockSpec.parity.test.ts`): snapshots `deriveDividerSpec` so a default/value change is an owned diff.
- **Consumer parity** (`lib/pdf/blocks/__tests__/blockConsumers.parity.test.tsx`): from one block, renders the preview `<hr>` *and* the pdf `<View>` and asserts each reflects the same spec. Verified non-tautological by mutation (drift the DOM color → red; hardcode the old PDF thickness → red).
- **Compile-time exhaustiveness**: the adapters' explicit `ReactElement` return type makes a future spec variant with no case a `tsc` error (TS2366) caught by `typecheck:baseline` — verified by temporarily adding a 2nd variant (both adapters went red). Promotes to a `never` default once the union is multi-variant.

### Gates (all green locally)
- `vite build` ✓ (CI gate) — @react-pdf stayed lazy
- `typecheck:baseline` ✓ 160/160, 0 new
- export suite ✓ 261 passed (incl. the `divider-block` testid assertions in DocumentPreview/BlockRenderer)
- new parity tests ✓ 9 passed
- ESLint ✓ `--max-warnings=0`
- Adversarial code-review: **ship** (3 load-bearing claims verified by mutation).

### 🛑 Do not auto-merge
This is a **STOP-for-eyeball** PR. Even on green CI + bot convergence, hold the merge until Ted (a) approves the spec architecture as the Phase-1 pattern and (b) eyeballs PDF-vs-preview divider parity on a `:5174` throwaway project (never `Q2-26 No. 3`).

### Follow-ups (next PRs, not blockers)
- Text block (its own PR — the `dangerouslySetInnerHTML` behavior change + heading/base constant canonicalization sweep).
- Before scaling past the canary: a golden-PDF snapshot to catch @react-pdf props it silently ignores.
- ShotGrid + the `useExportImageMap()` enabling PR (imageMap into the preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)