### PR TITLE
feat(export): image-led Comprehensive Shot Report (R1, flag-gated)

### DIFF
--- a/src-vnext/app/routes/breadcrumbs.ts
+++ b/src-vnext/app/routes/breadcrumbs.ts
@@ -101,6 +101,14 @@ export const breadcrumbsConfig: Record<string, BreadcrumbResolver> = {
     ...projectCrumbs(ctx),
     { label: "Export" },
   ],
+  "/projects/:id/export/report": (ctx) => [
+    ...projectCrumbs(ctx),
+    {
+      label: "Export",
+      to: ctx.params["id"] ? `/projects/${ctx.params["id"]}/export` : undefined,
+    },
+    { label: "Shot Report" },
+  ],
   "/projects/:id/schedules/:scheduleId/onset": () => [],
 
   "/requests": () => [{ label: "Shot Requests" }],

--- a/src-vnext/app/routes/index.tsx
+++ b/src-vnext/app/routes/index.tsx
@@ -7,6 +7,7 @@ import { RequireDesktop } from "@/app/routes/guards/RequireDesktop"
 import { ProjectScopeProvider } from "@/app/providers/ProjectScopeProvider"
 import { AppShell } from "@/shared/components/AppShell"
 import { RouteBoundary } from "@/app/routes/RouteBoundary"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 
 const LoginPage = lazy(() => import("@/features/auth/components/LoginPage"))
 const ProjectDashboard = lazy(
@@ -53,6 +54,9 @@ const ScheduleListPage = lazy(
 )
 const ExportBuilderPage = lazy(
   () => import("@/features/export/components/ExportBuilderPage"),
+)
+const ShotReportPage = lazy(
+  () => import("@/features/export/components/report/ShotReportPage"),
 )
 const OnSetViewerPage = lazy(
   () => import("@/features/schedules/components/OnSetViewerPage"),
@@ -261,6 +265,20 @@ export function AppRoutes() {
               </RouteBoundary>
             }
           />
+          {isFeatureEnabled("featureShotReport") && (
+            <Route
+              path="projects/:id/export/report"
+              element={
+                <RouteBoundary featureName="Shot report">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Shot report">
+                      <ShotReportPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
           <Route
             path="projects/:id/schedules"
             element={

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -1,0 +1,600 @@
+// Comprehensive Shot Report — DOM renderer (screen + paged print preview).
+// Image-led editorial per the approved north star (Direction A): the photograph
+// leads, product/look info reads as a quiet caption beneath each plate. Pure
+// presentational + interaction callbacks; no data fetching. Consumes the resolved
+// ReportModel (already grouped Women→Men and ordered) and an image *sidecar* map
+// (candidate -> data URL). Red does exactly one job here: the shot number.
+
+import { useId, useMemo, useState } from "react"
+import type { JSX } from "react"
+import { Loader2 } from "lucide-react"
+import type {
+  ReportConfig,
+  ReportGroup,
+  ReportGroupBy,
+  ReportLook,
+  ReportModel,
+  ReportProduct,
+  ReportShot,
+  ReportShotStatus,
+  ReportTalent,
+} from "../../lib/report/reportTypes"
+import { REPORT_STYLES } from "./reportStyles"
+
+export interface ReportViewProps {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly config: ReportConfig
+  readonly onConfigChange: (next: ReportConfig) => void
+  readonly onExportPdf: () => void
+  readonly exporting?: boolean
+}
+
+interface StatusMeta {
+  readonly dotClass: string
+  readonly label: string
+}
+
+const STATUS_META: Record<ReportShotStatus, StatusMeta> = {
+  complete: { dotClass: "sb-status--complete", label: "Shot" },
+  todo: { dotClass: "sb-status--todo", label: "To do" },
+  in_progress: { dotClass: "sb-status--progress", label: "In progress" },
+  on_hold: { dotClass: "sb-status--hold", label: "On hold" },
+}
+
+function statusMeta(status: ReportShotStatus): StatusMeta {
+  return STATUS_META[status] ?? STATUS_META.todo
+}
+
+/** Resolve an image candidate to a usable src via the sidecar map, else null. */
+function resolveSrc(
+  imageMap: ReadonlyMap<string, string>,
+  candidate: string | null,
+): string | null {
+  if (!candidate) return null
+  return imageMap.get(candidate) ?? null
+}
+
+/** Primary look = first; the shot's hero image candidate comes from it. */
+function primaryLookOf(shot: ReportShot): ReportLook | undefined {
+  return shot.looks[0]
+}
+
+// ---------------------------------------------------------------------------
+// Product row — aligned tabular caption (family · style# · colour · size · qty)
+// ---------------------------------------------------------------------------
+function ProductRow({ product }: { readonly product: ReportProduct }): JSX.Element {
+  const sizePending = product.sizeScope === "pending"
+  const sizeText = sizePending
+    ? "Pending"
+    : product.size && product.size.trim() !== ""
+      ? product.size
+      : "Pending"
+  const colourText = product.colour && product.colour.trim() !== "" ? product.colour : "Colour TBD"
+  const colourMuted = !(product.colour && product.colour.trim() !== "")
+  const qtyText = product.qty != null ? `×${product.qty}` : "×—"
+  const styleText = product.style && product.style.trim() !== "" ? product.style : "no style #"
+
+  return (
+    <div className={"sb-prod" + (product.isHero ? " sb-prod--hero" : "")}>
+      <span className="sb-prod-hero-mark" aria-hidden="true" />
+      <div className="sb-prod-fam">
+        {product.family && product.family.trim() !== "" ? product.family : "Unnamed product"}
+        {product.isHero ? <span className="sb-prod-hero-tag"> Hero</span> : null}
+      </div>
+      <div className={"sb-prod-colour" + (colourMuted ? " sb-muted" : "")}>{colourText}</div>
+      <div className={"sb-prod-size sb-tabular" + (sizePending ? " sb-pending" : "")}>{sizeText}</div>
+      <div className="sb-prod-qty sb-tabular">{qtyText}</div>
+      <div className="sb-prod-meta">
+        <span className="sb-prod-style sb-tabular">{styleText}</span>
+      </div>
+    </div>
+  )
+}
+
+function ProductColHead(): JSX.Element {
+  return (
+    <div className="sb-prod-colhead" aria-hidden="true">
+      <span />
+      <span>Family</span>
+      <span>Colour</span>
+      <span className="sb-ch-size">Size</span>
+      <span className="sb-ch-qty">Qty</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// A single look (Primary or Alt) — visually separated + labeled, never a blob.
+// Alt looks carry a small clearly-labeled secondary image.
+// ---------------------------------------------------------------------------
+function LookBlock({
+  look,
+  imageMap,
+}: {
+  readonly look: ReportLook
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const altSrc = look.isAlt ? resolveSrc(imageMap, look.image) : null
+  return (
+    <div className={"sb-look" + (look.isAlt ? " sb-look--alt" : "")}>
+      <div className="sb-look-head">
+        <span className="sb-look-label">{look.label}</span>
+        <span className="sb-look-rule" aria-hidden="true" />
+      </div>
+
+      {look.isAlt ? (
+        <div className="sb-alt-thumb-wrap">
+          {altSrc ? (
+            <img
+              className="sb-alt-thumb sb-img-native"
+              src={altSrc}
+              alt={`${look.label} look reference`}
+              loading="lazy"
+            />
+          ) : (
+            <div className="sb-alt-noimg sb-no-image" role="img" aria-label="Alt look — no reference">
+              Alt — no reference
+            </div>
+          )}
+        </div>
+      ) : null}
+
+      <ProductColHead />
+      <div className="sb-prod-list">
+        {look.products.map((p, i) => (
+          <ProductRow key={`${look.id}-p-${i}`} product={p} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// The photo figure — native aspect, never cropped. No-image => labeled frame.
+// ---------------------------------------------------------------------------
+function PlateFigure({
+  shot,
+  primarySrc,
+}: {
+  readonly shot: ReportShot
+  readonly primarySrc: string | null
+}): JSX.Element {
+  return (
+    <figure className="sb-plate-figure">
+      <div className="sb-plate-frame">
+        {primarySrc ? (
+          <>
+            <img
+              className="sb-plate-img sb-img-native"
+              src={primarySrc}
+              alt={shot.title + (shot.colorway ? ` — ${shot.colorway}` : "")}
+              loading="lazy"
+            />
+            {/* red shot number overprints the image — red's one job */}
+            <div className="sb-plate-no">{shot.number}</div>
+          </>
+        ) : (
+          <div className="sb-plate-img sb-plate-noimg sb-no-image">
+            <div className="sb-plate-no-inline">{shot.number}</div>
+            <div>Awaiting capture</div>
+            <div className="sb-ni-sub">reference photo not yet shot</div>
+          </div>
+        )}
+      </div>
+    </figure>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Talent micro-row — name(s), optional headshot via sidecar.
+// ---------------------------------------------------------------------------
+function TalentRow({
+  talent,
+  imageMap,
+}: {
+  readonly talent: readonly ReportTalent[]
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const named = talent.filter((t) => t.name && t.name.trim() !== "")
+  if (named.length === 0) {
+    return <span className="sb-talent-empty">Talent TBD</span>
+  }
+  const firstSrc = resolveSrc(imageMap, named[0]?.img ?? null)
+  return (
+    <span className="sb-talent-row">
+      {firstSrc ? (
+        <img className="sb-talent-av" src={firstSrc} alt={named[0]?.name ?? ""} loading="lazy" />
+      ) : null}
+      {named.map((t) => (
+        <span key={t.id} className="sb-talent-name">
+          {t.name}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Caption block under the photo (title, colorway, status+talent, note, looks).
+// ---------------------------------------------------------------------------
+function PlateCaption({
+  shot,
+  imageMap,
+}: {
+  readonly shot: ReportShot
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const st = statusMeta(shot.status)
+  return (
+    <div className="sb-plate-caption">
+      <div className="sb-caption-topline">
+        <h3 className="sb-shot-name sb-shot-title">{shot.title}</h3>
+        {shot.gender === "?" ? (
+          <span className="sb-badge-unresolved">Unresolved</span>
+        ) : shot.gender === "Mixed" ? (
+          <span className="sb-badge-unresolved">Mixed</span>
+        ) : null}
+      </div>
+
+      {shot.colorway ? <p className="sb-colorway">{shot.colorway}</p> : null}
+
+      <div className="sb-caption-sub">
+        <span className="sb-status-chip">
+          <span className={"sb-status-dot " + st.dotClass} aria-hidden="true" />
+          {st.label}
+        </span>
+        <TalentRow talent={shot.talent} imageMap={imageMap} />
+      </div>
+
+      {shot.notes ? <p className="sb-shot-note">{shot.notes}</p> : null}
+
+      <div className="sb-looks">
+        {shot.looks.map((look) => (
+          <LookBlock key={look.id} look={look} imageMap={imageMap} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// One plate (figure + caption) with the per-shot exclude toggle.
+// Excluded shots stay visible but struck + dimmed (reversible).
+// ---------------------------------------------------------------------------
+function Plate({
+  shot,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly shot: ReportShot
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}): JSX.Element {
+  const primarySrc = resolveSrc(imageMap, primaryLookOf(shot)?.image ?? null)
+  return (
+    <article className={"sb-plate" + (shot.excluded ? " sb-excluded" : "")}>
+      <button
+        type="button"
+        className="sb-exclude-toggle no-print"
+        aria-pressed={shot.excluded}
+        onClick={() => onToggleExclude(shot.id)}
+        title={shot.excluded ? "Restore this shot to the report" : "Exclude this shot from the report"}
+      >
+        {shot.excluded ? "Restore shot" : "Exclude shot"}
+      </button>
+      <PlateFigure shot={shot} primarySrc={primarySrc} />
+      <PlateCaption shot={shot} imageMap={imageMap} />
+    </article>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Fluid (screen) group section — Women / Men header + counts, lookbook flow.
+// ---------------------------------------------------------------------------
+function GroupSection({
+  group,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly group: ReportGroup
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}): JSX.Element {
+  const withRef = group.shots.filter((s) => s.hasImage).length
+  return (
+    <section className="sb-group" aria-label={group.label}>
+      <div className="sb-group-head">
+        <h2 className="sb-group-name">{group.label}</h2>
+        <span className="sb-group-count">
+          <span className="sb-tnum">{group.count}</span>
+          {group.count === 1 ? " look · " : " looks · "}
+          <span className="sb-tnum">{withRef}</span> with reference
+        </span>
+      </div>
+      <div className="sb-plates">
+        {group.shots.map((shot) => (
+          <Plate key={shot.id} shot={shot} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Masthead band.
+// ---------------------------------------------------------------------------
+function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
+  const imaged = useMemo(
+    () =>
+      model.groups.reduce((acc, g) => acc + g.shots.filter((s) => s.hasImage).length, 0),
+    [model.groups],
+  )
+  const total = model.project.shotCount
+  const projName =
+    model.project.name + (model.project.client ? ` · ${model.project.client}` : "")
+  return (
+    <header className="sb-masthead-band">
+      <div className="sb-masthead-eyebrow">
+        <span className="sb-eyebrow">Shot Builder</span>
+        <span className="sb-eyebrow sb-lede">Look Approval Deck</span>
+      </div>
+      <h1 className="sb-masthead sb-masthead-title">Comprehensive Shot Report</h1>
+      <div className="sb-masthead-meta">
+        <div className="sb-meta-cell">
+          <span className="sb-meta-k">Project</span>
+          <span className="sb-meta-v sb-display">{projName}</span>
+        </div>
+        <div className="sb-meta-cell">
+          <span className="sb-meta-k">Client</span>
+          <span className="sb-meta-v">{model.project.client || "—"}</span>
+        </div>
+        <div className="sb-meta-cell">
+          <span className="sb-meta-k">Shots</span>
+          <span className="sb-meta-v sb-tabular">{total}</span>
+        </div>
+        <div className="sb-meta-cell">
+          <span className="sb-meta-k">References ready</span>
+          <span className="sb-meta-v sb-tabular">
+            {imaged} of {total}
+          </span>
+        </div>
+      </div>
+    </header>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Paged (print preview) — US-Letter LANDSCAPE sheets, two plates per sheet,
+// running header + footer. Only PDF-bound (non-excluded) shots are paginated.
+// ---------------------------------------------------------------------------
+interface Sheet {
+  readonly groupLabel: string
+  readonly rangeFrom: number
+  readonly rangeTo: number
+  readonly groupTotal: number
+  readonly shots: readonly ReportShot[]
+}
+
+function buildSheets(model: ReportModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const printable = group.shots.filter((s) => !s.excluded)
+    for (let i = 0; i < printable.length; i += 2) {
+      sheets.push({
+        groupLabel: group.label,
+        rangeFrom: i + 1,
+        rangeTo: Math.min(i + 2, printable.length),
+        groupTotal: printable.length,
+        shots: printable.slice(i, i + 2),
+      })
+    }
+  }
+  return sheets
+}
+
+function PagedView({
+  model,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}): JSX.Element {
+  const sheets = useMemo(() => buildSheets(model), [model])
+  const projLine =
+    model.project.name + (model.project.client ? ` · ${model.project.client}` : "")
+  const totalPages = sheets.length
+
+  return (
+    <div className="sb-paged">
+      {sheets.map((sheet, idx) => (
+        <section className="sb-sheet" key={`sheet-${idx}`}>
+          <div className="sb-sheet-head">
+            <div>
+              <div className="sb-sh-title">Comprehensive Shot Report</div>
+              <div className="sb-sh-proj">{projLine}</div>
+            </div>
+            <div className="sb-sh-group">
+              {sheet.groupLabel} · {sheet.rangeFrom}
+              {sheet.rangeTo > sheet.rangeFrom ? `–${sheet.rangeTo}` : ""} of {sheet.groupTotal}
+            </div>
+          </div>
+          <div className="sb-sheet-body">
+            {sheet.shots.map((shot) => (
+              <Plate
+                key={shot.id}
+                shot={shot}
+                imageMap={imageMap}
+                onToggleExclude={onToggleExclude}
+              />
+            ))}
+          </div>
+          <div className="sb-sheet-foot">
+            <span>{projLine}</span>
+            <span>
+              Page {idx + 1} / {totalPages}
+            </span>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Sticky control bar (never prints): Screen/Print toggle, Group-by switch,
+// Export PDF button.
+// ---------------------------------------------------------------------------
+function ControlBar({
+  printMode,
+  onSetPrintMode,
+  groupBy,
+  onSetGroupBy,
+  onExportPdf,
+  exporting,
+}: {
+  readonly printMode: boolean
+  readonly onSetPrintMode: (v: boolean) => void
+  readonly groupBy: ReportGroupBy
+  readonly onSetGroupBy: (v: ReportGroupBy) => void
+  readonly onExportPdf: () => void
+  readonly exporting: boolean
+}): JSX.Element {
+  const viewLabelId = useId()
+  const groupLabelId = useId()
+  return (
+    <div className="sb-controlbar no-print" role="region" aria-label="Report controls">
+      <div className="sb-control-group" role="group" aria-labelledby={viewLabelId}>
+        <span id={viewLabelId} className="sb-control-label">
+          View
+        </span>
+        <div className="sb-seg">
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={!printMode}
+            onClick={() => onSetPrintMode(false)}
+          >
+            Screen
+          </button>
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={printMode}
+            onClick={() => onSetPrintMode(true)}
+          >
+            Print preview
+          </button>
+        </div>
+      </div>
+
+      <div className="sb-control-group" role="group" aria-labelledby={groupLabelId}>
+        <span id={groupLabelId} className="sb-control-label">
+          Group by
+        </span>
+        <div className="sb-seg">
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={groupBy === "gender"}
+            onClick={() => onSetGroupBy("gender")}
+          >
+            Gender
+          </button>
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={groupBy === "none"}
+            onClick={() => onSetGroupBy("none")}
+          >
+            None
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="sb-export-btn"
+        onClick={onExportPdf}
+        disabled={exporting}
+        aria-busy={exporting}
+      >
+        {exporting ? (
+          <>
+            <Loader2 className="sb-spin" size={15} aria-hidden="true" />
+            Exporting…
+          </>
+        ) : (
+          "Export PDF"
+        )}
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root.
+// ---------------------------------------------------------------------------
+export function ReportView(props: ReportViewProps): JSX.Element {
+  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false } = props
+  const [printMode, setPrintMode] = useState(false)
+
+  const toggleExclude = (shotId: string): void => {
+    const set = new Set(config.excludedShotIds)
+    if (set.has(shotId)) {
+      set.delete(shotId)
+    } else {
+      set.add(shotId)
+    }
+    onConfigChange({ ...config, excludedShotIds: [...set] })
+  }
+
+  const setGroupBy = (groupBy: ReportGroupBy): void => {
+    if (groupBy === config.groupBy) return
+    onConfigChange({ ...config, groupBy })
+  }
+
+  const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
+
+  return (
+    <div className={"sb-report-root" + (printMode ? " sb-print-mode" : "")}>
+      <style>{REPORT_STYLES}</style>
+
+      <ControlBar
+        printMode={printMode}
+        onSetPrintMode={setPrintMode}
+        groupBy={config.groupBy}
+        onSetGroupBy={setGroupBy}
+        onExportPdf={onExportPdf}
+        exporting={exporting}
+      />
+
+      <main className="sb-report">
+        <Masthead model={model} />
+
+        {isEmpty ? (
+          <p className="sb-empty">No shots to report yet.</p>
+        ) : (
+          <>
+            {/* Fluid lookbook flow (screen) */}
+            <div className="sb-fluid">
+              {model.groups.map((group) => (
+                <GroupSection
+                  key={group.key}
+                  group={group}
+                  imageMap={imageMap}
+                  onToggleExclude={toggleExclude}
+                />
+              ))}
+            </div>
+
+            {/* Paged landscape preview (print mode + @media print) */}
+            <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -1,0 +1,93 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useExportData } from "../../hooks/useExportData"
+import { deriveShotReportModel } from "../../lib/report/reportModel"
+import {
+  collectReportImageCandidates,
+  resolveReportImages,
+} from "../../lib/report/reportImages"
+import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../../lib/report/reportTypes"
+import { ReportView } from "./ReportView"
+
+// Integration layer: live export data -> resolved model -> image sidecar ->
+// ReportView. The model + imageMap feed both the screen render and the PDF, so
+// they can't drift. Mounted only behind the featureShotReport flag (route gate).
+
+export default function ShotReportPage() {
+  const data = useExportData()
+  const [config, setConfig] = useState<ReportConfig>(DEFAULT_REPORT_CONFIG)
+  const [imageMap, setImageMap] = useState<ReadonlyMap<string, string>>(new Map())
+  const [imagesLoading, setImagesLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
+
+  const model = useMemo(() => deriveShotReportModel(data, config), [data, config])
+
+  // Resolve every image candidate to a data URL once the model is known.
+  // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.
+  useEffect(() => {
+    let cancelled = false
+    const candidates = collectReportImageCandidates(model)
+    if (candidates.length === 0) {
+      setImageMap(new Map())
+      return
+    }
+    setImagesLoading(true)
+    resolveReportImages(candidates)
+      .then((resolved) => {
+        if (!cancelled) setImageMap(resolved)
+      })
+      .catch(() => {
+        /* per-image failures already drop out of resolveReportImages */
+      })
+      .finally(() => {
+        if (!cancelled) setImagesLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [model])
+
+  const handleExportPdf = useCallback(() => {
+    setExporting(true)
+    // Lazy-import so @react-pdf (and its heavy deps) load only on export click,
+    // keeping them out of the report route's eager chunk.
+    void (async () => {
+      const { generateShotReportPdf } = await import("../../lib/report/reportPdf")
+      await generateShotReportPdf(
+        model,
+        imageMap,
+        `${model.project.name} — Shot Report.pdf`,
+      )
+    })().finally(() => {
+      setExporting(false)
+    })
+  }, [model, imageMap])
+
+  if (data.loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-[var(--color-text-secondary)]">
+        Loading shots…
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-full">
+      {imagesLoading && (
+        <div
+          role="status"
+          className="absolute right-4 top-4 z-20 rounded bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-secondary)] ring-1 ring-[var(--color-border)]"
+        >
+          Loading images…
+        </div>
+      )}
+      <ReportView
+        model={model}
+        imageMap={imageMap}
+        config={config}
+        onConfigChange={setConfig}
+        onExportPdf={handleExportPdf}
+        exporting={exporting}
+      />
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -1,0 +1,392 @@
+// Scoped stylesheet for the Comprehensive Shot Report DOM renderer.
+// All rules live under `.sb-report-root` and use `sb-`-prefixed classes so they
+// never collide with the app's Tailwind layer. Brand law (docs/DESIGN.md):
+// editorial restraint, ONE decisive red (the shot number, nothing else), Ivy
+// Presto for the editorial moment, Neue Haas for body/labels/tabular, tiering by
+// weight+size never faded gray, no drop shadows. Fonts are loaded app-wide via
+// the Adobe typekit (gph3jzg) in index.html, so these families resolve.
+
+export const REPORT_STYLES = `
+.sb-report-root {
+  /* Type families (app loads typekit gph3jzg) */
+  --sb-font-display: "ivypresto-headline", Georgia, serif;
+  --sb-font-body: "neue-haas-grotesk-text", "Helvetica Neue", Arial, sans-serif;
+  --sb-font-ui: "neue-haas-grotesk-display", "Helvetica Neue", Arial, sans-serif;
+
+  /* Color — tinted neutrals toward the brand hue (OKLCH), never pure #000/#fff */
+  --sb-paper: oklch(0.994 0.001 30);
+  --sb-surface: oklch(0.985 0.002 30);
+  --sb-surface-sub: oklch(0.965 0.003 40);
+  --sb-ink: oklch(0.205 0.008 50);
+  --sb-ink-2: oklch(0.44 0.010 55);
+  --sb-ink-3: oklch(0.58 0.010 55);
+  --sb-ink-disabled: oklch(0.72 0.008 55);
+  --sb-rule: oklch(0.90 0.004 50);
+  --sb-rule-strong: oklch(0.83 0.005 50);
+  --sb-red: #EB1400;            /* Immediate Red — ONE job per surface */
+  --sb-red-ink: oklch(0.55 0.20 28);
+
+  /* Type scale (px) */
+  --sb-t-3xs: 9px; --sb-t-2xs: 10px; --sb-t-xs: 12px; --sb-t-sm: 13px;
+  --sb-t-base: 14px; --sb-t-lg: 16px; --sb-t-xl: 20px;
+
+  /* Lookbook rhythm */
+  --sb-plate-gap-col: clamp(28px, 3.4vw, 64px);
+  --sb-plate-gap-row: clamp(40px, 5vw, 92px);
+
+  box-sizing: border-box;
+  font-family: var(--sb-font-body);
+  font-size: var(--sb-t-base);
+  line-height: 1.5;
+  color: var(--sb-ink);
+  background: var(--sb-surface-sub);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: 100%;
+}
+.sb-report-root *, .sb-report-root *::before, .sb-report-root *::after { box-sizing: border-box; }
+
+/* shared atoms ---------------------------------------------------------- */
+.sb-tabular, .sb-tnum { font-variant-numeric: tabular-nums; font-feature-settings: "tnum" 1; }
+.sb-img-native { display: block; width: 100%; height: auto; object-fit: contain; }
+.sb-muted { color: var(--sb-ink-3); font-style: italic; }
+.sb-pending { color: var(--sb-ink-disabled); font-style: italic; }
+
+.sb-no-image {
+  display: flex; align-items: center; justify-content: center;
+  background: repeating-linear-gradient(135deg, var(--sb-surface) 0 10px, var(--sb-surface-sub) 10px 20px);
+  color: var(--sb-ink-3);
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  border: 1px solid var(--sb-rule);
+}
+
+.sb-status-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+.sb-status--complete { background: oklch(0.62 0.13 150); }   /* green = Shot */
+.sb-status--todo { background: var(--sb-ink-disabled); }     /* gray = To do */
+.sb-status--progress { background: oklch(0.62 0.13 240); }   /* blue = In progress */
+.sb-status--hold { background: oklch(0.74 0.14 75); }        /* amber = On hold */
+
+.sb-badge-unresolved {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--sb-red-ink); border: 1px solid currentColor; border-radius: 2px;
+  padding: 1px 4px; line-height: 1.2;
+}
+
+/* full-width fluid report frame ----------------------------------------- */
+.sb-report {
+  max-width: none; margin: 0;
+  padding: 0 clamp(24px, 5vw, 96px) clamp(48px, 6vw, 120px);
+}
+.sb-empty {
+  font-family: var(--sb-font-ui); color: var(--sb-ink-3); font-size: var(--sb-t-lg);
+  padding: 48px 0;
+}
+
+/* masthead -------------------------------------------------------------- */
+.sb-masthead-band {
+  padding: clamp(40px, 5vw, 88px) 0 clamp(28px, 3vw, 44px);
+  border-bottom: 1px solid var(--sb-rule-strong);
+  margin-bottom: clamp(36px, 4.5vw, 80px);
+}
+.sb-masthead-eyebrow {
+  margin: 0 0 clamp(16px, 1.6vw, 22px);
+  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+}
+.sb-eyebrow {
+  font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-2xs);
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-2);
+}
+.sb-eyebrow.sb-lede { color: var(--sb-ink-3); }
+.sb-masthead { font-family: var(--sb-font-display); font-weight: 700; letter-spacing: -0.01em; color: var(--sb-ink); }
+.sb-masthead-title { font-size: clamp(40px, 6.4vw, 92px); line-height: 0.98; margin: 0; max-width: 18ch; }
+.sb-masthead-meta {
+  display: flex; flex-wrap: wrap; align-items: baseline;
+  gap: clamp(20px, 3vw, 56px); margin-top: clamp(24px, 2.6vw, 40px);
+}
+.sb-meta-cell { display: flex; flex-direction: column; gap: 4px; }
+.sb-meta-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-meta-v {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-lg); font-weight: 500;
+  color: var(--sb-ink); letter-spacing: -0.005em;
+}
+.sb-meta-v.sb-display { font-family: var(--sb-font-display); font-weight: 700; font-size: var(--sb-t-xl); }
+
+/* group header ---------------------------------------------------------- */
+.sb-group { margin-top: clamp(28px, 3.4vw, 56px); }
+.sb-group:first-of-type { margin-top: 0; }
+.sb-group-head {
+  display: flex; align-items: flex-end; justify-content: space-between; gap: 24px;
+  padding-bottom: clamp(14px, 1.4vw, 20px); margin-bottom: clamp(34px, 4vw, 68px);
+  border-bottom: 1px solid var(--sb-rule);
+}
+.sb-group-name {
+  font-family: var(--sb-font-display); font-weight: 700;
+  font-size: clamp(26px, 3.4vw, 48px); line-height: 1; letter-spacing: -0.015em;
+  color: var(--sb-ink); margin: 0;
+}
+.sb-group-count {
+  font-family: var(--sb-font-ui); font-weight: 500; font-size: var(--sb-t-sm);
+  color: var(--sb-ink-2); letter-spacing: 0.02em; white-space: nowrap; padding-bottom: 4px;
+}
+
+/* lookbook flow — true native-aspect masonry via CSS multi-column -------- */
+.sb-plates { column-gap: var(--sb-plate-gap-col); column-width: 360px; }
+@media (min-width: 1100px) { .sb-plates { column-count: 2; column-width: auto; } }
+@media (min-width: 1680px) { .sb-plates { column-count: 3; column-width: auto; } }
+
+.sb-plate {
+  break-inside: avoid; -webkit-column-break-inside: avoid;
+  margin: 0 0 var(--sb-plate-gap-row); display: inline-block; width: 100%;
+  position: relative;
+}
+
+/* per-shot exclude toggle (screen only) */
+.sb-exclude-toggle {
+  position: absolute; top: 10px; right: 0; z-index: 3;
+  appearance: none; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2);
+  background: var(--sb-paper); border: 1px solid var(--sb-rule-strong); border-radius: 999px;
+  padding: 5px 11px; opacity: 0; transition: opacity 0.12s ease;
+}
+.sb-plate:hover .sb-exclude-toggle,
+.sb-plate:focus-within .sb-exclude-toggle { opacity: 1; }
+.sb-exclude-toggle[aria-pressed="true"] { opacity: 1; color: var(--sb-ink); border-color: var(--sb-ink); }
+.sb-exclude-toggle:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; opacity: 1; }
+
+/* excluded — visible but struck + dimmed (reversible) */
+.sb-excluded { opacity: 0.42; }
+.sb-excluded .sb-shot-name { text-decoration: line-through; text-decoration-thickness: 1px; }
+.sb-excluded .sb-exclude-toggle { opacity: 1; }
+
+/* the photo figure ------------------------------------------------------ */
+.sb-plate-figure { margin: 0; position: relative; }
+.sb-plate-frame { position: relative; }
+.sb-plate-frame::before {
+  content: ""; display: block; border-top: 1px solid var(--sb-rule-strong); margin-bottom: 14px;
+}
+.sb-plate-img { background: var(--sb-surface); }
+.sb-plate-noimg {
+  aspect-ratio: 4 / 5; flex-direction: column; gap: 10px;
+  text-align: center; line-height: 1.4;
+}
+.sb-ni-sub {
+  font-family: var(--sb-font-body); text-transform: none; letter-spacing: 0;
+  font-size: var(--sb-t-xs); color: var(--sb-ink-3); font-style: italic;
+}
+
+/* shot number overprint — red, the one job */
+.sb-plate-no {
+  position: absolute; top: 14px; left: 14px;
+  font-family: var(--sb-font-display); font-weight: 700;
+  font-size: clamp(28px, 2.6vw, 40px); line-height: 1; color: var(--sb-red);
+  letter-spacing: -0.02em;
+}
+.sb-plate-no-inline {
+  color: var(--sb-red); font-family: var(--sb-font-display); font-weight: 700;
+  font-size: clamp(30px, 3vw, 44px); line-height: 1; letter-spacing: -0.02em;
+}
+
+/* caption block --------------------------------------------------------- */
+.sb-plate-caption { padding-top: clamp(14px, 1.4vw, 20px); }
+.sb-caption-topline { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 6px; }
+.sb-shot-name { font-family: var(--sb-font-display); font-weight: 600; letter-spacing: -0.005em; line-height: 1.12; }
+.sb-shot-title { font-size: clamp(19px, 1.55vw, 25px); line-height: 1.1; color: var(--sb-ink); margin: 0; }
+.sb-colorway {
+  font-family: var(--sb-font-body); font-style: italic; font-size: var(--sb-t-base);
+  color: var(--sb-ink-2); margin: 2px 0 0;
+}
+.sb-caption-sub {
+  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+  margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--sb-rule);
+}
+.sb-status-chip {
+  display: inline-flex; align-items: center; gap: 7px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-2);
+}
+.sb-talent-row { display: inline-flex; align-items: center; gap: 7px; }
+.sb-talent-av {
+  width: 18px; height: 18px; border-radius: 50%; object-fit: cover;
+  background: var(--sb-surface-sub); border: 1px solid var(--sb-rule);
+}
+.sb-talent-name { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); }
+.sb-talent-name + .sb-talent-name::before { content: "· "; color: var(--sb-ink-3); }
+.sb-talent-empty { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-3); font-style: italic; }
+
+.sb-shot-note {
+  margin-top: 12px; font-family: var(--sb-font-body); font-size: var(--sb-t-sm);
+  line-height: 1.45; color: var(--sb-ink-2); font-style: italic;
+  padding-left: 12px; border-left: 1px solid var(--sb-rule-strong);
+}
+
+/* looks ----------------------------------------------------------------- */
+.sb-looks { margin-top: clamp(16px, 1.6vw, 22px); display: flex; flex-direction: column; gap: 18px; }
+.sb-look-head { display: flex; align-items: baseline; gap: 10px; margin-bottom: 8px; }
+.sb-look-label {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 700;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink);
+}
+.sb-look--alt .sb-look-label { color: var(--sb-ink-2); }
+.sb-look-rule { flex: 1; height: 0; border-top: 1px solid var(--sb-rule); align-self: center; }
+.sb-look--alt {
+  padding: 14px; margin-left: 2px; background: var(--sb-surface-sub); border: 1px solid var(--sb-rule);
+}
+.sb-alt-thumb-wrap { margin-bottom: 12px; }
+.sb-alt-thumb { max-width: 168px; width: 55%; border: 1px solid var(--sb-rule); background: var(--sb-surface); }
+.sb-alt-noimg { max-width: 168px; width: 55%; aspect-ratio: 4 / 5; font-size: var(--sb-t-3xs); }
+
+/* product grid ---------------------------------------------------------- */
+.sb-prod-list { display: flex; flex-direction: column; gap: 9px; }
+.sb-prod {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1.55fr) minmax(0, 1fr) auto auto;
+  align-items: baseline; column-gap: 14px; row-gap: 2px;
+}
+.sb-prod-hero-mark {
+  width: 5px; height: 5px; border-radius: 50%; background: var(--sb-ink);
+  align-self: center; margin-top: 1px; visibility: hidden;
+}
+.sb-prod--hero .sb-prod-hero-mark { visibility: visible; }
+.sb-prod-fam {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-sm); color: var(--sb-ink);
+  line-height: 1.25; overflow-wrap: anywhere;
+}
+.sb-prod--hero .sb-prod-fam { font-weight: 600; }
+.sb-prod-colour {
+  font-family: var(--sb-font-body); font-size: var(--sb-t-xs); color: var(--sb-ink-2);
+  line-height: 1.25; overflow-wrap: anywhere;
+}
+.sb-prod-style {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-3);
+  letter-spacing: 0.01em; white-space: nowrap;
+}
+.sb-prod-size {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2);
+  text-align: right; white-space: nowrap; min-width: 4ch;
+}
+.sb-prod-qty {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-3);
+  text-align: right; white-space: nowrap; min-width: 3ch;
+}
+.sb-prod-meta { grid-column: 2 / 4; display: flex; gap: 8px; align-items: baseline; flex-wrap: wrap; }
+.sb-prod-hero-tag {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-prod-colhead {
+  display: grid;
+  grid-template-columns: 14px minmax(0, 1.55fr) minmax(0, 1fr) auto auto;
+  column-gap: 14px; padding-bottom: 7px; margin-bottom: 9px; border-bottom: 1px solid var(--sb-rule);
+}
+.sb-prod-colhead span {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-prod-colhead .sb-ch-size, .sb-prod-colhead .sb-ch-qty { text-align: right; }
+
+/* control bar (sticky, never prints) ------------------------------------ */
+.sb-controlbar {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; gap: clamp(16px, 2vw, 32px); flex-wrap: wrap;
+  padding: 10px clamp(24px, 5vw, 96px);
+  background: color-mix(in oklch, var(--sb-paper) 88%, transparent);
+  backdrop-filter: saturate(1.4) blur(8px);
+  border-bottom: 1px solid var(--sb-rule);
+}
+.sb-control-group { display: inline-flex; align-items: center; gap: 9px; }
+.sb-control-label {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-seg {
+  display: inline-flex; align-items: stretch;
+  border: 1px solid var(--sb-rule-strong); border-radius: 999px; overflow: hidden;
+  background: var(--sb-paper);
+}
+.sb-seg-btn {
+  appearance: none; border: 0; background: transparent; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 600;
+  letter-spacing: 0.04em; color: var(--sb-ink-2); padding: 7px 15px; line-height: 1;
+}
+.sb-seg-btn + .sb-seg-btn { border-left: 1px solid var(--sb-rule); }
+.sb-seg-btn[aria-pressed="true"] { background: var(--sb-ink); color: var(--sb-paper); }
+.sb-seg-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: -2px; }
+.sb-export-btn {
+  margin-left: auto; appearance: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 700;
+  letter-spacing: 0.04em; color: var(--sb-paper); background: var(--sb-ink);
+  border: 1px solid var(--sb-ink); border-radius: 999px; padding: 9px 20px; line-height: 1;
+}
+.sb-export-btn:hover:not(:disabled) { background: oklch(0.28 0.008 50); }
+.sb-export-btn:disabled { cursor: default; opacity: 0.6; }
+.sb-export-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; }
+.sb-spin { animation: sb-spin 0.9s linear infinite; }
+@keyframes sb-spin { to { transform: rotate(360deg); } }
+
+/* paged (print preview) — hidden on screen until print-mode -------------- */
+.sb-paged { display: none; }
+.sb-sheet { display: none; }
+
+/* PRINT / PAGED MODE — US Letter landscape, two plates per page ---------- */
+.sb-print-mode { background: oklch(0.92 0.003 60); }
+.sb-print-mode .sb-report { padding: clamp(16px, 3vw, 40px) 0; max-width: none; }
+.sb-print-mode .sb-fluid,
+.sb-print-mode .sb-masthead-band { display: none; }
+.sb-print-mode .sb-paged { display: block; }
+.sb-print-mode .sb-sheet {
+  display: grid; grid-template-rows: auto 1fr auto;
+  width: 11in; min-height: 8.5in; height: 8.5in;
+  margin: 0 auto 0.34in; padding: 0.5in 0.6in 0.4in;
+  background: var(--sb-paper); border: 1px solid var(--sb-rule);
+  box-sizing: border-box; overflow: hidden;
+}
+.sb-sheet-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 18px;
+  padding-bottom: 9px; border-bottom: 1px solid var(--sb-rule-strong);
+}
+.sb-sh-title { font-family: var(--sb-font-display); font-weight: 700; font-size: 15px; letter-spacing: -0.005em; color: var(--sb-ink); }
+.sb-sh-proj { font-family: var(--sb-font-ui); font-size: 9px; color: var(--sb-ink-3); letter-spacing: 0.04em; }
+.sb-sh-group {
+  font-family: var(--sb-font-ui); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink-2); white-space: nowrap;
+}
+.sb-sheet-body { display: grid; grid-template-columns: 1fr 1fr; gap: 0.5in; align-items: start; min-height: 0; overflow: hidden; }
+.sb-sheet-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 8px; border-top: 1px solid var(--sb-rule);
+  font-family: var(--sb-font-ui); font-size: 8px; color: var(--sb-ink-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-sheet .sb-plate { margin: 0; display: flex; flex-direction: column; break-inside: avoid; }
+.sb-sheet .sb-plate-frame { display: flex; flex-direction: column; }
+.sb-sheet .sb-plate-img { max-height: 4.4in; width: auto; max-width: 100%; object-fit: contain; align-self: flex-start; }
+.sb-sheet .sb-plate-noimg { aspect-ratio: 4 / 5; max-height: 4.4in; }
+.sb-sheet .sb-plate-no { font-size: 26px; }
+.sb-sheet .sb-shot-title { font-size: 16px; }
+.sb-sheet .sb-looks { gap: 12px; }
+.sb-sheet .sb-look--alt { padding: 9px; }
+.sb-sheet .sb-alt-thumb, .sb-sheet .sb-alt-noimg { max-width: 120px; }
+
+@media print {
+  @page { size: letter landscape; margin: 0; }
+  .no-print { display: none !important; }
+  .sb-report-root { background: #fff; }
+  .sb-fluid, .sb-masthead-band { display: none !important; }
+  .sb-report { padding: 0; }
+  .sb-paged { display: block !important; }
+  .sb-sheet {
+    display: grid !important; grid-template-rows: auto 1fr auto;
+    width: 11in; height: 8.5in; min-height: 8.5in;
+    margin: 0; padding: 0.5in 0.6in 0.4in; border: 0; background: #fff;
+    break-after: page; page-break-after: always; overflow: hidden;
+  }
+  .sb-sheet:last-child { break-after: auto; page-break-after: auto; }
+}
+`

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -8,6 +8,12 @@
 
 export const REPORT_STYLES = `
 .sb-report-root {
+  /* Product table columns — SIZE + QTY are FIXED tracks (not auto) so columns
+     align across every row AND the (sibling) header; an auto track is sized
+     per-grid, which shifted the fr columns row-to-row. Defined here so both
+     .sb-prod-list rows and .sb-prod-colhead inherit one source. */
+  --sb-prod-cols: 14px minmax(0, 1.55fr) minmax(0, 1fr) 4.5rem 2.5rem;
+
   /* Type families (app loads typekit gph3jzg) */
   --sb-font-display: "ivypresto-headline", Georgia, serif;
   --sb-font-body: "neue-haas-grotesk-text", "Helvetica Neue", Arial, sans-serif;
@@ -245,7 +251,7 @@ export const REPORT_STYLES = `
 .sb-prod-list { display: flex; flex-direction: column; gap: 9px; }
 .sb-prod {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1.55fr) minmax(0, 1fr) auto auto;
+  grid-template-columns: var(--sb-prod-cols);
   align-items: baseline; column-gap: 14px; row-gap: 2px;
 }
 .sb-prod-hero-mark {
@@ -281,7 +287,7 @@ export const REPORT_STYLES = `
 }
 .sb-prod-colhead {
   display: grid;
-  grid-template-columns: 14px minmax(0, 1.55fr) minmax(0, 1fr) auto auto;
+  grid-template-columns: var(--sb-prod-cols);
   column-gap: 14px; padding-bottom: 7px; margin-bottom: 9px; border-bottom: 1px solid var(--sb-rule);
 }
 .sb-prod-colhead span {

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from "vitest"
+import { deriveShotReportModel, normalizeGender } from "../reportModel"
+import { DEFAULT_REPORT_CONFIG } from "../reportTypes"
+import type { ExportData } from "../../../hooks/useExportData"
+import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
+
+// Minimal factories — cast past required audit fields the model never reads.
+function fam(id: string, styleNumber: string, gender: string | null): ProductFamily {
+  return { id, styleName: id, styleNumber, gender } as unknown as ProductFamily
+}
+function talent(id: string, name: string): TalentRecord {
+  return { id, name } as unknown as TalentRecord
+}
+function shot(s: Partial<Shot> & { id: string }): Shot {
+  return {
+    title: "Shot",
+    status: "complete",
+    talent: [],
+    products: [],
+    sortOrder: 0,
+    ...s,
+  } as unknown as Shot
+}
+
+function data(over: Partial<ExportData>): ExportData {
+  return {
+    project: { name: "Q2-26 No. 3", clientId: "unbound-merino" } as ExportData["project"],
+    shots: [],
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+    ...over,
+  }
+}
+
+const FAMILIES = [
+  fam("fM", "M-TP-LS-1399", "men"),
+  fam("fW", "W-BT-PN-1048", "women"),
+]
+
+describe("normalizeGender", () => {
+  it("maps common forms to M/W and unknowns to null", () => {
+    expect(normalizeGender("men")).toBe("M")
+    expect(normalizeGender("Women")).toBe("W")
+    expect(normalizeGender("female")).toBe("W")
+    expect(normalizeGender("unisex")).toBeNull()
+    expect(normalizeGender(null)).toBeNull()
+    expect(normalizeGender("")).toBeNull()
+  })
+})
+
+describe("deriveShotReportModel", () => {
+  it("labels looks Primary/Alt and separates them (never merged)", () => {
+    const model = deriveShotReportModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({
+            id: "s1",
+            shotNumber: "01",
+            looks: [
+              { id: "l0", order: 0, products: [{ familyId: "fM" }], heroProductId: "fM" },
+              { id: "l1", order: 1, label: "Alt A", products: [{ familyId: "fM" }] },
+            ],
+          }),
+        ],
+      }),
+      DEFAULT_REPORT_CONFIG,
+    )
+    const s = model.groups.flatMap((g) => g.shots).find((x) => x.id === "s1")
+    expect(s?.looks.map((l) => l.label)).toEqual(["Primary", "Alt A"])
+    expect(s?.looks.map((l) => l.isAlt)).toEqual([false, true])
+  })
+
+  it("resolves style# + hero from the product family and look heroProductId", () => {
+    const model = deriveShotReportModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({
+            id: "s1",
+            shotNumber: "01",
+            looks: [
+              {
+                id: "l0",
+                order: 0,
+                heroProductId: "fM",
+                products: [
+                  { familyId: "fM", familyName: "Crew", colourName: "Black", sizeScope: "pending" },
+                  { familyId: "fW", familyName: "Pant", colourName: "Ivory", size: "M/30", sizeScope: "single", quantity: 1 },
+                ],
+              },
+            ],
+          }),
+        ],
+      }),
+      DEFAULT_REPORT_CONFIG,
+    )
+    const prods = model.groups.flatMap((g) => g.shots)[0]?.looks[0]?.products ?? []
+    expect(prods[0]).toMatchObject({ family: "Crew", style: "M-TP-LS-1399", colour: "Black", isHero: true, sizeScope: "pending", size: null })
+    expect(prods[1]).toMatchObject({ family: "Pant", style: "W-BT-PN-1048", isHero: false, size: "M/30", qty: 1 })
+  })
+
+  it("groups by gender via the tag-then-product cascade, ordered W,M", () => {
+    const model = deriveShotReportModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "m1", shotNumber: "02", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+          shot({ id: "w1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+          shot({
+            id: "tagW", shotNumber: "03",
+            tags: [{ id: "g", label: "Women", color: "blue", category: "gender" }],
+            looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }], // product says M, tag says W -> tag wins
+          }),
+        ],
+      }),
+      DEFAULT_REPORT_CONFIG,
+    )
+    expect(model.groups.map((g) => g.key)).toEqual(["W", "M"])
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["w1", "tagW"]) // sorted by number within group
+    expect(model.groups[1]?.shots.map((s) => s.id)).toEqual(["m1"])
+  })
+
+  it("flags excluded shots and unresolved gender, and detects no-image", () => {
+    const model = deriveShotReportModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "noG", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "unknown" }] }] }),
+        ],
+      }),
+      { groupBy: "gender", excludedShotIds: ["noG"] },
+    )
+    const s = model.groups.flatMap((g) => g.shots)[0]
+    expect(s?.gender).toBe("?")
+    expect(s?.excluded).toBe(true)
+    expect(s?.hasImage).toBe(false)
+    expect(model.groups[0]?.key).toBe("?")
+  })
+
+  it("drops deleted shots and honors groupBy:none", () => {
+    const model = deriveShotReportModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "live", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+          shot({ id: "gone", shotNumber: "02", deleted: true, looks: [] }),
+        ],
+      }),
+      { groupBy: "none", excludedShotIds: [] },
+    )
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.key).toBe("all")
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["live"])
+  })
+})

--- a/src-vnext/features/export/lib/report/reportImages.ts
+++ b/src-vnext/features/export/lib/report/reportImages.ts
@@ -1,0 +1,41 @@
+import { resolvePdfImageSrc } from "@/features/shots/lib/resolvePdfImageSrc"
+import type { ReportModel } from "./reportTypes"
+
+// Walk the resolved model for every image candidate (look display images,
+// product images, talent headshots), then batch-resolve to data URLs via the
+// shared image pipeline. The resulting map (candidate -> dataUrl) is the sidecar
+// both renderers read, so screen and PDF show identical images.
+
+/** Collect every unique image candidate referenced by the model. */
+export function collectReportImageCandidates(model: ReportModel): readonly string[] {
+  const set = new Set<string>()
+  for (const group of model.groups) {
+    for (const shot of group.shots) {
+      for (const t of shot.talent) if (t.img) set.add(t.img)
+      for (const look of shot.looks) {
+        if (look.image) set.add(look.image)
+        for (const p of look.products) if (p.img) set.add(p.img)
+      }
+    }
+  }
+  return [...set]
+}
+
+/** Batch-resolve image candidates to data URLs (concurrency-limited). */
+export async function resolveReportImages(
+  candidates: readonly string[],
+): Promise<Map<string, string>> {
+  if (candidates.length === 0) return new Map()
+  const entries: Array<[string, string]> = []
+  const CONCURRENCY = 4
+  for (let i = 0; i < candidates.length; i += CONCURRENCY) {
+    const batch = candidates.slice(i, i + CONCURRENCY)
+    const results = await Promise.allSettled(
+      batch.map(async (c) => [c, await resolvePdfImageSrc(c)] as const),
+    )
+    for (const r of results) {
+      if (r.status === "fulfilled" && r.value[1]) entries.push([r.value[0], r.value[1]])
+    }
+  }
+  return new Map(entries)
+}

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -1,0 +1,186 @@
+import type {
+  ProductAssignment,
+  ProductFamily,
+  Shot,
+  ShotLook,
+  TalentRecord,
+} from "@/shared/types"
+import type { ExportData } from "../../hooks/useExportData"
+import {
+  type GenderKey,
+  type ReportConfig,
+  type ReportGroup,
+  type ReportLook,
+  type ReportModel,
+  type ReportProduct,
+  type ReportShot,
+  type ReportTalent,
+} from "./reportTypes"
+
+// Pure derivation: ExportData + config -> ReportModel. No async, no image bytes
+// (image fields are path/URL candidates resolved later). The single source both
+// the DOM and PDF renderers consume.
+
+/** Normalize a free-form gender string to M/W, or null when unknown. */
+export function normalizeGender(raw: string | null | undefined): "M" | "W" | null {
+  if (!raw) return null
+  const v = raw.trim().toLowerCase()
+  if (v === "m" || v === "men" || v === "man" || v === "male" || v === "mens") return "M"
+  if (v === "w" || v === "women" || v === "woman" || v === "female" || v === "womens") return "W"
+  return null
+}
+
+function pickLookDisplayImage(look: ShotLook): string | null {
+  const refs = look.references ?? []
+  if (refs.length === 0) return null
+  const chosen =
+    (look.displayImageId && refs.find((r) => r.id === look.displayImageId)) || refs[0]
+  return chosen?.downloadURL ?? chosen?.path ?? null
+}
+
+function pickProductImage(
+  p: ProductAssignment,
+  family: ProductFamily | undefined,
+): string | null {
+  return (
+    p.thumbUrl ?? p.skuImageUrl ?? p.familyImageUrl ?? family?.thumbnailImagePath ?? null
+  )
+}
+
+function resolveProducts(
+  products: readonly ProductAssignment[],
+  heroProductId: string | null | undefined,
+  familyById: ReadonlyMap<string, ProductFamily>,
+): readonly ReportProduct[] {
+  return products.map((p) => {
+    const family = familyById.get(p.familyId)
+    const gender = normalizeGender(p.familyId ? family?.gender : null)
+    return {
+      family: p.familyName ?? family?.styleName ?? "Unspecified product",
+      style: family?.styleNumber ?? null,
+      colour: p.colourName ?? p.skuName ?? null,
+      size: p.size ?? null,
+      sizeScope: p.sizeScope ?? null,
+      qty: p.quantity ?? null,
+      gender: (gender ?? "?") as GenderKey,
+      // hero = explicit isHero flag OR the look's heroProductId points at this family
+      isHero: p.isHero === true || (heroProductId != null && heroProductId === p.familyId),
+      img: pickProductImage(p, family),
+    }
+  })
+}
+
+/** Label looks: explicit label, else Primary for the first by order, else "Alt N". */
+function resolveLooks(
+  shot: Shot,
+  familyById: ReadonlyMap<string, ProductFamily>,
+): readonly ReportLook[] {
+  const looks = [...(shot.looks ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  return looks.map((look, i): ReportLook => {
+    const rawLabel = look.label?.trim()
+    const label = rawLabel && rawLabel.length > 0 ? rawLabel : i === 0 ? "Primary" : `Alt ${i}`
+    const isAlt = i > 0 || /^alt/i.test(label)
+    return {
+      id: look.id,
+      label,
+      isAlt,
+      image: pickLookDisplayImage(look),
+      products: resolveProducts(look.products, look.heroProductId, familyById),
+    }
+  })
+}
+
+/** Shot gender cascade: explicit gender tag -> products' family genders -> "?". */
+function resolveShotGender(shot: Shot, looks: readonly ReportLook[]): GenderKey {
+  const tag = shot.tags?.find((t) => t.category === "gender")
+  const fromTag = normalizeGender(tag?.label)
+  if (fromTag) return fromTag
+
+  const genders = new Set<"M" | "W">()
+  for (const look of looks) {
+    for (const p of look.products) {
+      if (p.gender === "M" || p.gender === "W") genders.add(p.gender)
+    }
+  }
+  const arr = [...genders]
+  if (arr.length === 1 && arr[0]) return arr[0]
+  if (arr.length > 1) return "Mixed"
+  return "?"
+}
+
+function resolveTalent(
+  shot: Shot,
+  talentById: ReadonlyMap<string, TalentRecord>,
+): readonly ReportTalent[] {
+  const ids = shot.talentIds ?? []
+  return ids.map((id): ReportTalent => {
+    const t = talentById.get(id)
+    return {
+      id,
+      name: t?.name ?? "Unknown",
+      img: t?.headshotUrl ?? t?.imageUrl ?? t?.headshotPath ?? null,
+    }
+  })
+}
+
+function shotNumberSortKey(n: string): [number, number, string] {
+  const num = Number.parseInt(n, 10)
+  return Number.isNaN(num) ? [1, 0, n] : [0, num, n]
+}
+
+const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]
+const GROUP_LABEL: Record<GenderKey, string> = {
+  W: "Women",
+  M: "Men",
+  Mixed: "Mixed",
+  "?": "Unresolved",
+}
+
+/** Derive the resolved report model from live export data + config. */
+export function deriveShotReportModel(data: ExportData, config: ReportConfig): ReportModel {
+  const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
+  const talentById = new Map(data.talent.map((t) => [t.id, t]))
+  const excluded = new Set(config.excludedShotIds)
+
+  const shots: ReportShot[] = data.shots
+    .filter((s) => !s.deleted)
+    .map((shot): ReportShot => {
+      const looks = resolveLooks(shot, familyById)
+      const gender = resolveShotGender(shot, looks)
+      return {
+        id: shot.id,
+        number: shot.shotNumber ?? "",
+        title: shot.title || "Untitled shot",
+        colorway: shot.description ?? null,
+        status: shot.status,
+        gender,
+        notes: shot.notesAddendum ?? shot.notes ?? null,
+        talent: resolveTalent(shot, talentById),
+        looks,
+        excluded: excluded.has(shot.id),
+        hasImage: looks.some((l) => l.image != null),
+      }
+    })
+    .sort((a, b) => {
+      const [ak, an, as] = shotNumberSortKey(a.number)
+      const [bk, bn, bs] = shotNumberSortKey(b.number)
+      return ak - bk || an - bn || as.localeCompare(bs)
+    })
+
+  const groups: ReportGroup[] =
+    config.groupBy === "none"
+      ? [{ key: "all", label: "All shots", count: shots.length, shots }]
+      : GROUP_ORDER.map((key): ReportGroup => {
+          const inGroup = shots.filter((s) => s.gender === key)
+          return { key, label: GROUP_LABEL[key], count: inGroup.length, shots: inGroup }
+        }).filter((g) => g.count > 0)
+
+  return {
+    project: {
+      name: data.project?.name ?? "Untitled project",
+      client: data.project?.clientId ?? "",
+      shotCount: shots.length,
+    },
+    groups,
+  }
+}

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -1,0 +1,666 @@
+// @react-pdf landscape renderer for the Comprehensive Shot Report.
+// Parity sibling of the DOM ReportView — both consume the same resolved
+// ReportModel + image sidecar so screen and PDF can't drift. Image-led per the
+// approved north star (Direction A "image-led editorial"): landscape Letter
+// sheets, two large native-aspect hero plates side by side, structured product
+// captions, gender group headers, "Awaiting capture" frame for no-image shots.
+//
+// PDF typography differs from screen by design: @react-pdf only ships the
+// Helvetica / Courier / Times built-ins, so the editorial Ivy Presto serif from
+// the DOM renderer maps to Helvetica here (via the codebase font mapping). Red
+// (#EB1400) does exactly one job on this surface: the shot number.
+
+import type { JSX } from "react"
+import {
+  Document,
+  Page,
+  Text,
+  View,
+  Image,
+  StyleSheet,
+} from "@react-pdf/renderer"
+import { getPageDimensionsPt } from "../pageDimensions"
+import { mapFontFamilyToPdf } from "../pdf/fontMapping"
+import type {
+  ReportModel,
+  ReportGroup,
+  ReportShot,
+  ReportLook,
+  ReportProduct,
+} from "./reportTypes"
+
+// ---------------------------------------------------------------------------
+// Tokens (PDF-side mirror of the brand vars; built-in font families only)
+// ---------------------------------------------------------------------------
+
+const COLOR = {
+  surface: "#FFFFFF",
+  surfaceSubtle: "#F4F4F5",
+  text: "#18181B",
+  textSecondary: "#52525B",
+  textSubtle: "#5B5B60",
+  textDisabled: "#A1A1AA", // placeholder only
+  accent: "#EB1400", // Immediate Red — shot number only
+  rule: "#E4E4E7",
+  ruleStrong: "#D4D4D8",
+} as const
+
+const FONT = {
+  // Editorial serif on screen → Times here would read closer to Ivy Presto, but
+  // the codebase standard is Helvetica via mapFontFamilyToPdf; keep parity with
+  // the rest of the export PDFs and let the type differ from screen as expected.
+  display: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
+  displayRegular: mapFontFamilyToPdf(undefined), // Helvetica
+  body: mapFontFamilyToPdf(undefined), // Helvetica
+  bodyItalic: mapFontFamilyToPdf(undefined, false, true), // Helvetica-Oblique
+  ui: mapFontFamilyToPdf(undefined), // Helvetica
+  uiBold: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
+} as const
+
+const PAGE = getPageDimensionsPt("letter", "landscape") // 792 x 612 pt
+const PAD_X = 40
+const PAD_TOP = 36
+const PAD_BOTTOM = 34
+const COLUMN_GAP = 36
+// Two plates fill the content width; each plate's image is width-only so its
+// height is the photo's native aspect (never cropped/squashed).
+const CONTENT_WIDTH = PAGE.width - PAD_X * 2
+const PLATE_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
+// Cap the hero so the caption always fits the sheet — width still drives aspect
+// up to the cap; only an unusually tall portrait is bounded by maxHeight.
+const HERO_MAX_HEIGHT = 300
+
+const styles = StyleSheet.create({
+  page: {
+    paddingTop: PAD_TOP,
+    paddingBottom: PAD_BOTTOM,
+    paddingHorizontal: PAD_X,
+    fontFamily: FONT.body,
+    fontSize: 9,
+    color: COLOR.text,
+    backgroundColor: COLOR.surface,
+  },
+
+  // Running header
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    paddingBottom: 8,
+    marginBottom: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: COLOR.ruleStrong,
+  },
+  headerTitle: {
+    fontFamily: FONT.display,
+    fontSize: 13,
+    color: COLOR.text,
+    letterSpacing: -0.1,
+  },
+  headerProject: {
+    fontFamily: FONT.ui,
+    fontSize: 8,
+    color: COLOR.textSubtle,
+    marginTop: 2,
+  },
+  headerGroup: {
+    fontFamily: FONT.uiBold,
+    fontSize: 8,
+    color: COLOR.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    textAlign: "right",
+  },
+
+  // Footer (page number)
+  footer: {
+    position: "absolute",
+    bottom: 16,
+    left: PAD_X,
+    right: PAD_X,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    fontFamily: FONT.ui,
+    fontSize: 7,
+    color: COLOR.textDisabled,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+    borderTopWidth: 0.5,
+    borderTopColor: COLOR.rule,
+    paddingTop: 6,
+  },
+
+  // Body: two plate columns
+  body: {
+    flexDirection: "row",
+    gap: COLUMN_GAP,
+  },
+  plate: {
+    width: PLATE_WIDTH,
+  },
+
+  // Figure (image + overprinted red number)
+  figure: {
+    position: "relative",
+    borderTopWidth: 1,
+    borderTopColor: COLOR.ruleStrong,
+    paddingTop: 12,
+  },
+  heroImage: {
+    // WIDTH ONLY drives the native aspect; maxHeight only bounds tall portraits.
+    width: PLATE_WIDTH,
+    maxHeight: HERO_MAX_HEIGHT,
+    objectFit: "contain",
+  },
+  plateNumber: {
+    position: "absolute",
+    top: 18,
+    left: 8,
+    fontFamily: FONT.display,
+    fontSize: 22,
+    color: COLOR.accent, // << red's one job
+    letterSpacing: -0.5,
+  },
+
+  // No-image frame
+  noImage: {
+    width: PLATE_WIDTH,
+    height: 230,
+    backgroundColor: COLOR.surfaceSubtle,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 16,
+  },
+  noImageNumber: {
+    fontFamily: FONT.display,
+    fontSize: 24,
+    color: COLOR.accent, // still red, the one job
+    letterSpacing: -0.5,
+    marginBottom: 8,
+  },
+  noImageLabel: {
+    fontFamily: FONT.ui,
+    fontSize: 9,
+    color: COLOR.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  noImageSub: {
+    fontFamily: FONT.bodyItalic,
+    fontSize: 7.5,
+    color: COLOR.textSubtle,
+    marginTop: 4,
+    textAlign: "center",
+  },
+
+  // Caption
+  caption: {
+    paddingTop: 12,
+  },
+  shotTitle: {
+    fontFamily: FONT.display,
+    fontSize: 14,
+    color: COLOR.text,
+    letterSpacing: -0.2,
+    lineHeight: 1.1,
+  },
+  colorway: {
+    fontFamily: FONT.bodyItalic,
+    fontSize: 9,
+    color: COLOR.textSecondary,
+    marginTop: 2,
+  },
+  subRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    flexWrap: "wrap",
+    marginTop: 8,
+    paddingTop: 7,
+    borderTopWidth: 0.5,
+    borderTopColor: COLOR.rule,
+  },
+  statusChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginRight: 14,
+  },
+  statusDot: {
+    width: 5,
+    height: 5,
+    borderRadius: 2.5,
+    marginRight: 5,
+  },
+  statusLabel: {
+    fontFamily: FONT.uiBold,
+    fontSize: 7,
+    color: COLOR.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+  },
+  talentText: {
+    fontFamily: FONT.ui,
+    fontSize: 7.5,
+    color: COLOR.textSecondary,
+  },
+  talentEmpty: {
+    fontFamily: FONT.bodyItalic,
+    fontSize: 7.5,
+    color: COLOR.textSubtle,
+  },
+  note: {
+    fontFamily: FONT.bodyItalic,
+    fontSize: 7.5,
+    lineHeight: 1.4,
+    color: COLOR.textSecondary,
+    marginTop: 8,
+    paddingLeft: 8,
+    borderLeftWidth: 1,
+    borderLeftColor: COLOR.ruleStrong,
+  },
+
+  // Looks
+  looks: {
+    marginTop: 12,
+  },
+  look: {
+    marginTop: 10,
+  },
+  lookAlt: {
+    marginTop: 10,
+    backgroundColor: COLOR.surfaceSubtle,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    padding: 8,
+  },
+  lookHead: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 6,
+  },
+  lookLabel: {
+    fontFamily: FONT.uiBold,
+    fontSize: 7,
+    color: COLOR.text,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  lookLabelAlt: {
+    color: COLOR.textSecondary,
+  },
+  lookRule: {
+    flex: 1,
+    height: 0.5,
+    backgroundColor: COLOR.rule,
+    marginLeft: 8,
+  },
+  altThumb: {
+    width: 90,
+    maxHeight: 110,
+    objectFit: "contain",
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    marginBottom: 8,
+  },
+  altNoImage: {
+    width: 90,
+    height: 110,
+    backgroundColor: COLOR.surface,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    alignItems: "center",
+    justifyContent: "center",
+    marginBottom: 8,
+  },
+  altNoImageText: {
+    fontFamily: FONT.bodyItalic,
+    fontSize: 6.5,
+    color: COLOR.textSubtle,
+    textAlign: "center",
+  },
+
+  // Product grid
+  prodColHead: {
+    flexDirection: "row",
+    paddingBottom: 5,
+    marginBottom: 5,
+    borderBottomWidth: 0.5,
+    borderBottomColor: COLOR.rule,
+  },
+  prodRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    marginBottom: 5,
+  },
+  // column widths inside a plate
+  colHero: { width: 8 },
+  colFamily: { flex: 1.55, paddingRight: 8 },
+  colColour: { flex: 1, paddingRight: 8 },
+  colStyle: { width: 60, paddingRight: 8 },
+  colSize: { width: 42, textAlign: "right", paddingRight: 6 },
+  colQty: { width: 26, textAlign: "right" },
+
+  chText: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    color: COLOR.textSubtle,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+  },
+  heroDot: {
+    width: 4,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: COLOR.text,
+    marginTop: 3,
+  },
+  prodFamily: {
+    fontFamily: FONT.ui,
+    fontSize: 8,
+    color: COLOR.text,
+    lineHeight: 1.2,
+  },
+  prodFamilyHero: {
+    fontFamily: FONT.uiBold,
+  },
+  prodStyle: {
+    fontFamily: FONT.ui,
+    fontSize: 7,
+    color: COLOR.textSubtle,
+  },
+  prodColour: {
+    fontFamily: FONT.ui,
+    fontSize: 7.5,
+    color: COLOR.textSecondary,
+    lineHeight: 1.2,
+  },
+  prodColourMuted: {
+    fontFamily: FONT.bodyItalic,
+    color: COLOR.textSubtle,
+  },
+  prodSize: {
+    fontFamily: FONT.ui,
+    fontSize: 7.5,
+    color: COLOR.textSecondary,
+  },
+  prodSizePending: {
+    fontFamily: FONT.bodyItalic,
+    color: COLOR.textSubtle,
+  },
+  prodQty: {
+    fontFamily: FONT.ui,
+    fontSize: 7.5,
+    color: COLOR.textSubtle,
+  },
+})
+
+// Status dot colors — green/amber/gray reserved set (no red here).
+const STATUS: Record<
+  ReportShot["status"],
+  { readonly color: string; readonly label: string }
+> = {
+  complete: { color: "#16A34A", label: "Shot" },
+  in_progress: { color: "#2563EB", label: "In progress" },
+  todo: { color: COLOR.textDisabled, label: "To do" },
+  on_hold: { color: "#D97706", label: "On hold" },
+}
+
+function has(v: string | null | undefined): v is string {
+  return v != null && v.trim() !== ""
+}
+
+// ---------------------------------------------------------------------------
+// Pagination: two non-excluded plates per landscape sheet, never spanning a
+// gender group (a new group starts a fresh sheet, mirroring the north star).
+// ---------------------------------------------------------------------------
+
+interface Sheet {
+  readonly group: ReportGroup
+  readonly groupShotCount: number
+  /** 1-based index of the first shot on this sheet within its group. */
+  readonly fromIndex: number
+  readonly shots: readonly ReportShot[]
+}
+
+function paginate(model: ReportModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const visible = group.shots.filter((s) => !s.excluded)
+    if (visible.length === 0) continue
+    for (let i = 0; i < visible.length; i += 2) {
+      sheets.push({
+        group,
+        groupShotCount: visible.length,
+        fromIndex: i + 1,
+        shots: visible.slice(i, i + 2),
+      })
+    }
+  }
+  return sheets
+}
+
+// ---------------------------------------------------------------------------
+// Pieces
+// ---------------------------------------------------------------------------
+
+function ProductRow({ p }: { readonly p: ReportProduct }) {
+  const sizePending = p.sizeScope === "pending" || !has(p.size)
+  const sizeText = sizePending ? "Pending" : (p.size as string)
+  return (
+    <View style={styles.prodRow} wrap={false}>
+      <View style={styles.colHero}>{p.isHero ? <View style={styles.heroDot} /> : null}</View>
+      <View style={styles.colFamily}>
+        <Text>
+          <Text style={[styles.prodFamily, ...(p.isHero ? [styles.prodFamilyHero] : [])]}>
+            {has(p.family) ? p.family : "Unnamed product"}
+          </Text>
+          {p.isHero ? <Text style={styles.prodStyle}>{"  Hero"}</Text> : null}
+        </Text>
+      </View>
+      <Text style={styles.colColour}>
+        {has(p.colour) ? (
+          <Text style={styles.prodColour}>{p.colour}</Text>
+        ) : (
+          <Text style={[styles.prodColour, styles.prodColourMuted]}>Colour TBD</Text>
+        )}
+      </Text>
+      <Text style={[styles.prodStyle, styles.colStyle]}>{has(p.style) ? p.style : "—"}</Text>
+      <Text style={[styles.prodSize, styles.colSize, ...(sizePending ? [styles.prodSizePending] : [])]}>
+        {sizeText}
+      </Text>
+      <Text style={[styles.prodQty, styles.colQty]}>{p.qty != null ? `×${p.qty}` : "×—"}</Text>
+    </View>
+  )
+}
+
+function ProductColHead() {
+  return (
+    <View style={styles.prodColHead}>
+      <View style={styles.colHero} />
+      <Text style={[styles.chText, styles.colFamily]}>Family</Text>
+      <Text style={[styles.chText, styles.colColour]}>Colour</Text>
+      <Text style={[styles.chText, styles.colStyle]}>Style</Text>
+      <Text style={[styles.chText, styles.colSize]}>Size</Text>
+      <Text style={[styles.chText, styles.colQty]}>Qty</Text>
+    </View>
+  )
+}
+
+function LookBlock({
+  look,
+  imageMap,
+}: {
+  readonly look: ReportLook
+  readonly imageMap: ReadonlyMap<string, string>
+}) {
+  const altSrc = look.isAlt && look.image ? imageMap.get(look.image) : undefined
+  return (
+    <View style={look.isAlt ? styles.lookAlt : styles.look} wrap={false}>
+      <View style={styles.lookHead}>
+        <Text style={[styles.lookLabel, ...(look.isAlt ? [styles.lookLabelAlt] : [])]}>
+          {has(look.label) ? look.label : look.isAlt ? "Alt" : "Primary"}
+        </Text>
+        <View style={styles.lookRule} />
+      </View>
+
+      {look.isAlt ? (
+        altSrc ? (
+          <Image src={altSrc} style={styles.altThumb} />
+        ) : (
+          <View style={styles.altNoImage}>
+            <Text style={styles.altNoImageText}>Alt — no reference</Text>
+          </View>
+        )
+      ) : null}
+
+      <ProductColHead />
+      {look.products.map((p, i) => (
+        <ProductRow key={i} p={p} />
+      ))}
+    </View>
+  )
+}
+
+function Plate({
+  shot,
+  imageMap,
+}: {
+  readonly shot: ReportShot
+  readonly imageMap: ReadonlyMap<string, string>
+}) {
+  const primary = shot.looks[0]
+  const heroCandidate = primary?.image ?? null
+  const heroSrc = has(heroCandidate) ? imageMap.get(heroCandidate) : undefined
+  const status = STATUS[shot.status]
+  const talent = shot.talent.filter((t) => has(t.name))
+
+  // Width + keep-together are owned by the column wrapper in the Page; this is
+  // just the plate's vertical content stack.
+  return (
+    <View>
+      {/* Figure */}
+      {heroSrc ? (
+        <View style={styles.figure}>
+          <Image src={heroSrc} style={styles.heroImage} />
+          <Text style={styles.plateNumber}>{shot.number}</Text>
+        </View>
+      ) : (
+        <View style={styles.figure}>
+          <View style={styles.noImage}>
+            <Text style={styles.noImageNumber}>{shot.number}</Text>
+            <Text style={styles.noImageLabel}>Awaiting capture</Text>
+            <Text style={styles.noImageSub}>reference photo not yet shot</Text>
+          </View>
+        </View>
+      )}
+
+      {/* Caption */}
+      <View style={styles.caption}>
+        <Text style={styles.shotTitle}>{shot.title}</Text>
+        {has(shot.colorway) ? <Text style={styles.colorway}>{shot.colorway}</Text> : null}
+
+        <View style={styles.subRow}>
+          <View style={styles.statusChip}>
+            <View style={[styles.statusDot, { backgroundColor: status.color }]} />
+            <Text style={styles.statusLabel}>{status.label}</Text>
+          </View>
+          {talent.length > 0 ? (
+            <Text style={styles.talentText}>{talent.map((t) => t.name).join(" · ")}</Text>
+          ) : (
+            <Text style={styles.talentEmpty}>Talent TBD</Text>
+          )}
+        </View>
+
+        {has(shot.notes) ? <Text style={styles.note}>{shot.notes}</Text> : null}
+
+        <View style={styles.looks}>
+          {shot.looks.map((look) => (
+            <LookBlock key={look.id} look={look} imageMap={imageMap} />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+export function ShotReportPdfDocument(props: {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const { model, imageMap } = props
+  const sheets = paginate(model)
+  const projectLine = has(model.project.client)
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+
+  return (
+    <Document
+      title="Comprehensive Shot Report"
+      author={model.project.client || ""}
+      producer="Shot Builder"
+    >
+      {sheets.map((sheet, i) => {
+        const toIndex = sheet.fromIndex + sheet.shots.length - 1
+        return (
+          <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={styles.page} wrap>
+            {/* Running header */}
+            <View style={styles.header} fixed>
+              <View>
+                <Text style={styles.headerTitle}>Comprehensive Shot Report</Text>
+                <Text style={styles.headerProject}>{projectLine}</Text>
+              </View>
+              <Text style={styles.headerGroup}>
+                {`${sheet.group.label} · ${sheet.fromIndex}–${toIndex} of ${sheet.groupShotCount}`}
+              </Text>
+            </View>
+
+            {/* Two plates, each in its own column — wrap=false keeps a plate intact */}
+            <View style={styles.body}>
+              {sheet.shots.map((shot) => (
+                <View key={shot.id} style={styles.plate} wrap={false}>
+                  <Plate shot={shot} imageMap={imageMap} />
+                </View>
+              ))}
+            </View>
+
+            {/* Footer with page number */}
+            <View style={styles.footer} fixed>
+              <Text>{projectLine}</Text>
+              <Text
+                render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
+              />
+            </View>
+          </Page>
+        )
+      })}
+    </Document>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Generate + download — mirrors generateExportPdf (lazy import, toBlob, anchor).
+// ---------------------------------------------------------------------------
+
+export async function generateShotReportPdf(
+  model: ReportModel,
+  imageMap: ReadonlyMap<string, string>,
+  filename = "comprehensive-shot-report.pdf",
+): Promise<void> {
+  const { pdf } = await import("@react-pdf/renderer")
+  const element = <ShotReportPdfDocument model={model} imageMap={imageMap} />
+  const blob = await pdf(element).toBlob()
+
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename.endsWith(".pdf") ? filename : `${filename}.pdf`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -1,0 +1,80 @@
+// Resolved, presentation-free model for the Comprehensive Shot Report.
+// One pure model both renderers consume (DOM ReportView + @react-pdf reportPdf),
+// so screen and PDF can't drift. Image fields are *candidates* (a Storage path
+// or URL) resolved to data URLs once via reportImages, keyed in a sidecar map —
+// the model stays pure (no async, no image bytes).
+
+export type ReportGroupBy = "gender" | "none"
+
+/** Light, in-memory report config (MVP). Persistence comes later. */
+export interface ReportConfig {
+  readonly groupBy: ReportGroupBy
+  /** Shots the user has excluded — kept visible+struck on screen, omitted from the PDF. */
+  readonly excludedShotIds: readonly string[]
+}
+
+export const DEFAULT_REPORT_CONFIG: ReportConfig = {
+  groupBy: "gender",
+  excludedShotIds: [],
+}
+
+/** Normalized gender bucket. "?" = unresolved (never silently dropped). */
+export type GenderKey = "W" | "M" | "Mixed" | "?"
+
+export interface ReportProduct {
+  readonly family: string
+  readonly style: string | null
+  readonly colour: string | null
+  readonly size: string | null
+  readonly sizeScope: import("@/shared/types").SizeScope | null
+  readonly qty: number | null
+  readonly gender: GenderKey
+  readonly isHero: boolean
+  /** Image candidate (path/URL) or null. */
+  readonly img: string | null
+}
+
+export interface ReportLook {
+  readonly id: string
+  readonly label: string
+  readonly isAlt: boolean
+  /** Look display image candidate (path/URL) or null. */
+  readonly image: string | null
+  readonly products: readonly ReportProduct[]
+}
+
+export interface ReportTalent {
+  readonly id: string
+  readonly name: string
+  /** Headshot candidate (path/URL) or null. */
+  readonly img: string | null
+}
+
+export type ReportShotStatus = "complete" | "todo" | "in_progress" | "on_hold"
+
+export interface ReportShot {
+  readonly id: string
+  readonly number: string
+  readonly title: string
+  readonly colorway: string | null
+  readonly status: ReportShotStatus
+  readonly gender: GenderKey
+  readonly notes: string | null
+  readonly talent: readonly ReportTalent[]
+  readonly looks: readonly ReportLook[]
+  /** True when the user excluded this shot (struck on screen, omitted from PDF). */
+  readonly excluded: boolean
+  readonly hasImage: boolean
+}
+
+export interface ReportGroup {
+  readonly key: GenderKey | "all"
+  readonly label: string
+  readonly count: number
+  readonly shots: readonly ReportShot[]
+}
+
+export interface ReportModel {
+  readonly project: { readonly name: string; readonly client: string; readonly shotCount: number }
+  readonly groups: readonly ReportGroup[]
+}

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -108,6 +108,15 @@ export interface FeatureFlags {
    * layer.
    */
   readonly featureTalentLazy: boolean
+  /**
+   * Export reimagine R1 — the image-led Comprehensive Shot Report (client-review
+   * recipe) that replaces the free-form block canvas. Gates the report route
+   * (projects/:id/export/report) + its entry. Default OFF; the flag-off path is
+   * byte-identical to trunk (route renders NotFound, no entry). Enabled via
+   * `VITE_SHOT_REPORT=1` (or `true`) at build/dev time (featureTalentLazy
+   * env-parse precedent). No URL/localStorage layer.
+   */
+  readonly featureShotReport: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -121,6 +130,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureTalentAgencyCombobox: false,
   featureCastingMatcherSurface: false,
   featureTalentLazy: false,
+  featureShotReport: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -167,6 +177,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureTalentLazy:
       DEFAULT_FLAGS.featureTalentLazy ||
       parseEnvFlag(import.meta.env.VITE_TALENT_LAZY),
+    featureShotReport:
+      DEFAULT_FLAGS.featureShotReport ||
+      parseEnvFlag(import.meta.env.VITE_SHOT_REPORT),
   }
 }
 


### PR DESCRIPTION
## What

R1 of the export **reimagine**: replaces the free-form block canvas with a purpose-built, data-driven **image-led Comprehensive Shot Report** (Direction A — client-review), behind `featureShotReport` (default OFF, `VITE_SHOT_REPORT=1`). Supersedes the block-renderer unification (closed #485).

Background + decisions: `Projects/Shot Builder/outputs/2026-06-21-export-reimagine/BUILD-PLAN.md`.

## Architecture (reuses the export plumbing, builds the report on top)

- **`lib/report/reportModel.ts`** — pure `deriveShotReportModel(ExportData, config) → ReportModel`, the single resolved source **both** renderers consume (the dual-renderer + parity pattern, applied at report scope). Gender cascade (gender tag → product-family genders → "?"), look labeling (Primary/Alt), hero resolution, talent, `normalizeGender`. + `reportTypes.ts` (contract), `reportImages.ts` (reuses the battle-hardened `resolvePdfImageSrc` pipeline).
- **`components/report/ReportView.tsx`** — DOM renderer: image-led, full-width fluid on screen + landscape **paged print preview**. Native-aspect images (no crop), looks/alt-looks separated, structured product cells (`family · style# · colour · size · qty`, "Pending" honest), no-image "Awaiting capture" frame, excluded shots struck + restorable. Light config: Gender/None group-by + per-shot exclude. **Red's one job: the shot number.**
- **`lib/report/reportPdf.tsx`** — landscape `@react-pdf` document over the **same model** (native-aspect width-only images, per-shot page breaks, running header/footer). **Lazy-imported on export click** → `@react-pdf` stays out of the report route's eager chunk (verified: `reportPdf` is its own split chunk; `pdf-deps`/`pdf-lib` stay lazy).
- **`ShotReportPage.tsx`** — integration: live `useExportData` → model → async image resolution → `ReportView`.
- Route `projects/:id/export/report` + `featureShotReport` flag (default OFF, byte-identical-off).

## Verification

- `reportModel` unit tests (6) — gender cascade, look labeling, hero, pending sizes, excluded, grouping.
- tsc baseline **160/160** (0 new); eslint clean; `vite build` green with correct lazy chunking.
- **`ReportView` eyeballed headless (Playwright) against real Q2-26 No. 3 data** — 35 shots, real images, screen + landscape print, **0 console errors, 0 broken/cropped images.** Screenshots in the outputs folder.

## ⚠️ Held for Ted's eyeball before merge

- **PDF runtime**: the `reportPdf` document typechecks/builds and mirrors the validated print-preview layout, but the actual `@react-pdf` **Export PDF** output needs a click in the live app (image data URLs + pagination) — I can't auth. Run with `VITE_SHOT_REPORT=1`, open `projects/HKZ4nFxmcdtM3t2slBUh/export/report`, click **Export PDF**.
- This is R1 (one report). R2+ (config/recipes, the on-set + all-rounder reports, Product Info + Talent, retiring the block canvas) follow per the BUILD-PLAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)