### PR TITLE
feat(export): shot-report list + recipe picker + looks mode (R2 surface, flag-gated)

### DIFF
--- a/src-vnext/app/routes/breadcrumbs.ts
+++ b/src-vnext/app/routes/breadcrumbs.ts
@@ -101,11 +101,15 @@ export const breadcrumbsConfig: Record<string, BreadcrumbResolver> = {
     ...projectCrumbs(ctx),
     { label: "Export" },
   ],
+  "/projects/:id/export/reports": (ctx) => [
+    ...projectCrumbs(ctx),
+    { label: "Shot Reports" },
+  ],
   "/projects/:id/export/report": (ctx) => [
     ...projectCrumbs(ctx),
     {
-      label: "Export",
-      to: ctx.params["id"] ? `/projects/${ctx.params["id"]}/export` : undefined,
+      label: "Shot Reports",
+      to: ctx.params["id"] ? `/projects/${ctx.params["id"]}/export/reports` : undefined,
     },
     { label: "Shot Report" },
   ],

--- a/src-vnext/app/routes/index.tsx
+++ b/src-vnext/app/routes/index.tsx
@@ -58,6 +58,9 @@ const ExportBuilderPage = lazy(
 const ShotReportPage = lazy(
   () => import("@/features/export/components/report/ShotReportPage"),
 )
+const ShotReportListPage = lazy(
+  () => import("@/features/export/components/report/ShotReportListPage"),
+)
 const OnSetViewerPage = lazy(
   () => import("@/features/schedules/components/OnSetViewerPage"),
 )
@@ -265,6 +268,20 @@ export function AppRoutes() {
               </RouteBoundary>
             }
           />
+          {isFeatureEnabled("featureShotReport") && (
+            <Route
+              path="projects/:id/export/reports"
+              element={
+                <RouteBoundary featureName="Shot reports">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Shot reports">
+                      <ShotReportListPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
           {isFeatureEnabled("featureShotReport") && (
             <Route
               path="projects/:id/export/report"

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -12,6 +12,7 @@ import type {
   ReportConfig,
   ReportGroup,
   ReportGroupBy,
+  ReportLooksMode,
   ReportLook,
   ReportModel,
   ReportProduct,
@@ -452,6 +453,8 @@ function ControlBar({
   onSetPrintMode,
   groupBy,
   onSetGroupBy,
+  looksMode,
+  onSetLooksMode,
   onExportPdf,
   exporting,
 }: {
@@ -459,11 +462,14 @@ function ControlBar({
   readonly onSetPrintMode: (v: boolean) => void
   readonly groupBy: ReportGroupBy
   readonly onSetGroupBy: (v: ReportGroupBy) => void
+  readonly looksMode: ReportLooksMode
+  readonly onSetLooksMode: (v: ReportLooksMode) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
 }): JSX.Element {
   const viewLabelId = useId()
   const groupLabelId = useId()
+  const looksLabelId = useId()
   return (
     <div className="sb-controlbar no-print" role="region" aria-label="Report controls">
       <div className="sb-control-group" role="group" aria-labelledby={viewLabelId}>
@@ -514,6 +520,30 @@ function ControlBar({
         </div>
       </div>
 
+      <div className="sb-control-group" role="group" aria-labelledby={looksLabelId}>
+        <span id={looksLabelId} className="sb-control-label">
+          Looks
+        </span>
+        <div className="sb-seg">
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={looksMode === "all"}
+            onClick={() => onSetLooksMode("all")}
+          >
+            All
+          </button>
+          <button
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={looksMode === "primary-only"}
+            onClick={() => onSetLooksMode("primary-only")}
+          >
+            Primary only
+          </button>
+        </div>
+      </div>
+
       <button
         type="button"
         className="sb-export-btn"
@@ -556,6 +586,12 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, groupBy })
   }
 
+  const looksMode: ReportLooksMode = config.looksMode ?? "all"
+  const setLooksMode = (next: ReportLooksMode): void => {
+    if (next === looksMode) return
+    onConfigChange({ ...config, looksMode: next })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
 
   return (
@@ -567,6 +603,8 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         onSetPrintMode={setPrintMode}
         groupBy={config.groupBy}
         onSetGroupBy={setGroupBy}
+        looksMode={looksMode}
+        onSetLooksMode={setLooksMode}
         onExportPdf={onExportPdf}
         exporting={exporting}
       />

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -3,7 +3,17 @@ import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 import { Copy, FileText, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
-import { Button } from "@/ui/button"
+import { Button, buttonVariants } from "@/ui/button"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/ui/alert-dialog"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
@@ -27,6 +37,7 @@ export default function ShotReportListPage() {
 
   const [newName, setNewName] = useState("")
   const [busy, setBusy] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
 
   const openReport = useCallback(
     (reportId: string) => navigate(`/projects/${projectId}/export/report?reportId=${reportId}`),
@@ -136,7 +147,7 @@ export default function ShotReportListPage() {
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => void handleDelete(r.id)}
+                onClick={() => setPendingDelete({ id: r.id, name: r.name })}
                 aria-label={`Delete ${r.name}`}
               >
                 <Trash2 />
@@ -145,6 +156,33 @@ export default function ShotReportListPage() {
           ))}
         </ul>
       )}
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this report?</AlertDialogTitle>
+            <AlertDialogDescription>
+              “{pendingDelete?.name}” will be permanently deleted. This can’t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => {
+                if (pendingDelete) void handleDelete(pendingDelete.id)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -1,0 +1,150 @@
+import { useCallback, useMemo, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { toast } from "sonner"
+import { Copy, FileText, Plus, Trash2 } from "lucide-react"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { Button } from "@/ui/button"
+import { PageHeader } from "@/shared/components/PageHeader"
+import { EmptyState } from "@/shared/components/EmptyState"
+import { useExportReports } from "../../hooks/useExportReports"
+import { DEFAULT_REPORT_CONFIG } from "../../lib/report/reportTypes"
+
+// Saved shot reports for a project: create (optionally cloning an existing
+// report's config as a recipe), open, and delete. Sits beside the single report
+// page; never touches the legacy block-canvas builder. Flag-gated route.
+
+export default function ShotReportListPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const { clientId } = useAuth()
+  const navigate = useNavigate()
+  const { reports, loading, createShotReport, loadReport, deleteReport } =
+    useExportReports(clientId, projectId)
+
+  const shotReports = useMemo(
+    () => reports.filter((r) => r.reportType === "shot-report"),
+    [reports],
+  )
+
+  const [newName, setNewName] = useState("")
+  const [busy, setBusy] = useState(false)
+
+  const openReport = useCallback(
+    (reportId: string) => navigate(`/projects/${projectId}/export/report?reportId=${reportId}`),
+    [navigate, projectId],
+  )
+
+  const handleCreate = useCallback(async () => {
+    setBusy(true)
+    try {
+      const id = await createShotReport(newName.trim() || "Untitled report", DEFAULT_REPORT_CONFIG)
+      setNewName("")
+      openReport(id)
+    } catch {
+      toast.error("Couldn't create the report")
+    } finally {
+      setBusy(false)
+    }
+  }, [createShotReport, newName, openReport])
+
+  const handleDuplicate = useCallback(
+    async (sourceId: string, sourceName: string) => {
+      setBusy(true)
+      try {
+        const full = await loadReport(sourceId)
+        const id = await createShotReport(`${sourceName} (copy)`, full?.config ?? DEFAULT_REPORT_CONFIG)
+        openReport(id)
+      } catch {
+        toast.error("Couldn't duplicate the report")
+      } finally {
+        setBusy(false)
+      }
+    },
+    [createShotReport, loadReport, openReport],
+  )
+
+  const handleDelete = useCallback(
+    async (reportId: string) => {
+      try {
+        await deleteReport(reportId)
+        toast.success("Report deleted")
+      } catch {
+        toast.error("Couldn't delete the report")
+      }
+    },
+    [deleteReport],
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <PageHeader title="Shot Reports" />
+
+      <div className="mb-6 flex items-center gap-2">
+        <input
+          type="text"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !busy) void handleCreate()
+          }}
+          placeholder="New report name…"
+          aria-label="New report name"
+          className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        />
+        <Button onClick={() => void handleCreate()} disabled={busy}>
+          <Plus /> Create report
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading…</p>
+      ) : shotReports.length === 0 ? (
+        <EmptyState
+          icon={<FileText className="h-8 w-8" />}
+          title="No shot reports yet"
+          description="Create a report above to lay your shots out as an image-led deck, then export it as a PDF."
+        />
+      ) : (
+        <ul className="divide-y divide-[var(--color-border)] rounded-md border border-[var(--color-border)]">
+          {shotReports.map((r) => (
+            <li key={r.id} className="flex items-center gap-2 p-3">
+              <button
+                type="button"
+                onClick={() => openReport(r.id)}
+                className="min-w-0 flex-1 text-left"
+              >
+                <span className="block truncate text-sm font-medium text-[var(--color-text)]">
+                  {r.name}
+                </span>
+                {r.updatedAt && (
+                  <span className="block text-xs text-[var(--color-text-muted)]">
+                    Updated {r.updatedAt.toLocaleDateString()}
+                  </span>
+                )}
+              </button>
+              <Button variant="outline" size="sm" onClick={() => openReport(r.id)}>
+                Open
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => void handleDuplicate(r.id, r.name)}
+                disabled={busy}
+                title="New report from this one's settings"
+              >
+                <Copy /> Recipe
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => void handleDelete(r.id)}
+                aria-label={`Delete ${r.name}`}
+              >
+                <Trash2 />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner"
 import { Copy, FileText, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { Button, buttonVariants } from "@/ui/button"
+import { Input } from "@/ui/input"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -90,8 +91,7 @@ export default function ShotReportListPage() {
       <PageHeader title="Shot Reports" />
 
       <div className="mb-6 flex items-center gap-2">
-        <input
-          type="text"
+        <Input
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
           onKeyDown={(e) => {
@@ -99,7 +99,7 @@ export default function ShotReportListPage() {
           }}
           placeholder="New report name…"
           aria-label="New report name"
-          className="h-9 flex-1 rounded-md border border-input bg-background px-3 text-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          className="flex-1"
         />
         <Button onClick={() => void handleCreate()} disabled={busy}>
           <Plus /> Create report
@@ -148,6 +148,7 @@ export default function ShotReportListPage() {
                 variant="ghost"
                 size="icon"
                 onClick={() => setPendingDelete({ id: r.id, name: r.name })}
+                disabled={busy}
                 aria-label={`Delete ${r.name}`}
               >
                 <Trash2 />

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -156,4 +156,74 @@ describe("deriveShotReportModel", () => {
     expect(model.groups[0]?.key).toBe("all")
     expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["live"])
   })
+
+  const twoLookShot = () =>
+    data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({
+          id: "s1",
+          shotNumber: "01",
+          looks: [
+            { id: "l0", order: 0, products: [{ familyId: "fM" }] },
+            { id: "l1", order: 1, label: "Alt A", products: [{ familyId: "fM" }] },
+          ],
+        }),
+      ],
+    })
+
+  it("looksMode 'primary-only' shows only the primary look; 'all' shows every look", () => {
+    const d = twoLookShot()
+    const all = deriveShotReportModel(d, { groupBy: "gender", excludedShotIds: [], looksMode: "all" })
+    const primary = deriveShotReportModel(d, { groupBy: "gender", excludedShotIds: [], looksMode: "primary-only" })
+    expect(all.groups.flatMap((g) => g.shots)[0]?.looks.map((l) => l.label)).toEqual(["Primary", "Alt A"])
+    const pLooks = primary.groups.flatMap((g) => g.shots)[0]?.looks
+    expect(pLooks?.map((l) => l.label)).toEqual(["Primary"])
+    expect(pLooks?.[0]?.isAlt).toBe(false)
+  })
+
+  it("default looksMode (omitted) shows all looks", () => {
+    const model = deriveShotReportModel(twoLookShot(), { groupBy: "none", excludedShotIds: [] })
+    expect(model.groups.flatMap((g) => g.shots)[0]?.looks).toHaveLength(2)
+  })
+
+  it("hasImage recomputes on the filtered looks (no masthead overcount)", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({
+          id: "s1",
+          shotNumber: "01",
+          looks: [
+            { id: "l0", order: 0, products: [{ familyId: "fM" }] }, // primary: no image
+            { id: "l1", order: 1, references: [{ id: "r", path: "u" }], products: [{ familyId: "fM" }] },
+          ],
+        }),
+      ],
+    })
+    const all = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], looksMode: "all" })
+    const primary = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], looksMode: "primary-only" })
+    expect(all.groups[0]?.shots[0]?.hasImage).toBe(true)
+    expect(primary.groups[0]?.shots[0]?.hasImage).toBe(false)
+  })
+
+  it("looksMode does not change grouping (gender resolves from all looks)", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({
+          id: "s1",
+          shotNumber: "01",
+          looks: [
+            { id: "l0", order: 0, products: [{ familyId: "unknown" }] }, // primary: ungendered
+            { id: "l1", order: 1, products: [{ familyId: "fM" }] }, // alt: men
+          ],
+        }),
+      ],
+    })
+    const all = deriveShotReportModel(d, { groupBy: "gender", excludedShotIds: [], looksMode: "all" })
+    const primary = deriveShotReportModel(d, { groupBy: "gender", excludedShotIds: [], looksMode: "primary-only" })
+    expect(all.groups.find((g) => g.shots.some((s) => s.id === "s1"))?.key).toBe("M")
+    expect(primary.groups.find((g) => g.shots.some((s) => s.id === "s1"))?.key).toBe("M")
+  })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -3,15 +3,17 @@ import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../reportTypes"
 
 describe("ReportConfig persistence round-trip", () => {
   it("survives JSON serialize/parse unchanged (Firestore-safe — no Set/Date)", () => {
-    const config: ReportConfig = { groupBy: "none", excludedShotIds: ["a", "b"] }
+    const config: ReportConfig = { groupBy: "none", excludedShotIds: ["a", "b"], looksMode: "primary-only" }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
   })
 
-  it("default-merges a stored blob, filling any field it omits", () => {
+  it("default-merges a pre-looksMode blob, filling looksMode from the default", () => {
     // How ShotReportPage hydrates a persisted config; forward-compatible by design.
+    // An older blob written before looksMode existed must hydrate to looksMode "all".
     const stored = JSON.parse('{"groupBy":"none","excludedShotIds":["x"]}')
     const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
     expect(hydrated.groupBy).toBe("none")
     expect(hydrated.excludedShotIds).toEqual(["x"])
+    expect(hydrated.looksMode).toBe("all")
   })
 })

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -141,12 +141,16 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
   const talentById = new Map(data.talent.map((t) => [t.id, t]))
   const excluded = new Set(config.excludedShotIds)
+  const primaryOnly = config.looksMode === "primary-only"
 
   const shots: ReportShot[] = data.shots
     .filter((s) => !s.deleted)
     .map((shot): ReportShot => {
       const looks = resolveLooks(shot, familyById)
+      // Gender resolves from ALL looks so grouping stays stable across looksMode.
       const gender = resolveShotGender(shot, looks)
+      // primary-only is a display filter: keep only the primary look (looks[0]).
+      const visibleLooks = primaryOnly ? looks.slice(0, 1) : looks
       return {
         id: shot.id,
         number: shot.shotNumber ?? "",
@@ -156,9 +160,9 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
         gender,
         notes: shot.notesAddendum ?? shot.notes ?? null,
         talent: resolveTalent(shot, talentById),
-        looks,
+        looks: visibleLooks,
         excluded: excluded.has(shot.id),
-        hasImage: looks.some((l) => l.image != null),
+        hasImage: visibleLooks.some((l) => l.image != null),
       }
     })
     .sort((a, b) => {

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -6,16 +6,23 @@
 
 export type ReportGroupBy = "gender" | "none"
 
-/** Light, in-memory report config (MVP). Persistence comes later. */
+/** Which looks each shot shows: every look, or only the primary (alts hidden). */
+export type ReportLooksMode = "all" | "primary-only"
+
+/** Persisted report config (serializable: strings + string[] only). Optional
+ *  fields stay optional so an older stored blob still parses via default-merge. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
   /** Shots the user has excluded — kept visible+struck on screen, omitted from the PDF. */
   readonly excludedShotIds: readonly string[]
+  /** "primary-only" shows just each shot's primary look. Defaults to "all". */
+  readonly looksMode?: ReportLooksMode
 }
 
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   groupBy: "gender",
   excludedShotIds: [],
+  looksMode: "all",
 }
 
 /** Normalized gender bucket. "?" = unresolved (never silently dropped). */

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -9,8 +9,7 @@ export type ReportGroupBy = "gender" | "none"
 /** Which looks each shot shows: every look, or only the primary (alts hidden). */
 export type ReportLooksMode = "all" | "primary-only"
 
-/** Persisted report config (serializable: strings + string[] only). Optional
- *  fields stay optional so an older stored blob still parses via default-merge. */
+/** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
   /** Shots the user has excluded — kept visible+struck on screen, omitted from the PDF. */

--- a/src-vnext/shared/components/AppShell.tsx
+++ b/src-vnext/shared/components/AppShell.tsx
@@ -10,7 +10,8 @@ import { useAuth } from "@/app/providers/AuthProvider"
 import { useProject } from "@/features/projects/hooks/useProject"
 import { useSubmittedRequestCount } from "@/features/requests/hooks/useSubmittedRequestCount"
 import { ROLE } from "@/shared/lib/rbac"
-import { buildNavConfig, getMobileNavConfig } from "./sidebar/nav-config"
+import { buildNavConfig, getMobileNavConfig, withShotReportsNav } from "./sidebar/nav-config"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useSidebarState } from "./sidebar/useSidebarState"
 import { DesktopSidebar } from "./sidebar/DesktopSidebar"
 import { MobileTopBar } from "./sidebar/MobileTopBar"
@@ -55,7 +56,13 @@ export function AppShell() {
     )
   }
 
-  const desktopConfig = buildNavConfig(projectId, role)
+  const baseDesktopConfig = buildNavConfig(projectId, role)
+  // featureShotReport adds a project-scoped Shot Reports nav item; flag check
+  // lives here so nav-config stays pure (and the report route is desktop-only).
+  const desktopConfig =
+    isFeatureEnabled("featureShotReport") && projectId
+      ? withShotReportsNav(baseDesktopConfig, projectId)
+      : baseDesktopConfig
   const mobileConfig = getMobileNavConfig(projectId, role)
 
   return (

--- a/src-vnext/shared/components/sidebar/nav-config.test.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { buildNavConfig, getMobileNavConfig } from "./nav-config"
+import { buildNavConfig, getMobileNavConfig, withShotReportsNav, type NavConfig } from "./nav-config"
 
 describe("buildNavConfig", () => {
   it("returns org variant when no projectId", () => {
@@ -193,5 +193,43 @@ describe("getMobileNavConfig", () => {
       (e) => e.type === "item" && e.item.label === "Admin",
     )
     expect(admin).toBeUndefined()
+  })
+})
+
+describe("withShotReportsNav", () => {
+  const itemLabels = (config: NavConfig) =>
+    config.entries
+      .filter((e) => e.type === "item")
+      .map((e) => (e as { type: "item"; item: { label: string } }).item.label)
+
+  it("inserts a Shot Reports item right after Export", () => {
+    const labels = itemLabels(withShotReportsNav(buildNavConfig("p1"), "p1"))
+    const exportIdx = labels.indexOf("Export")
+    expect(exportIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[exportIdx + 1]).toBe("Shot Reports")
+  })
+
+  it("points the item at the project-scoped reports route", () => {
+    const next = withShotReportsNav(buildNavConfig("p1"), "p1")
+    const item = next.entries.find((e) => e.type === "item" && e.item.label === "Shot Reports")
+    expect(item && item.type === "item" ? item.item.to : null).toBe("/projects/p1/export/reports")
+  })
+
+  it("appends Shot Reports when no Export entry exists (fallback)", () => {
+    const stub: NavConfig = {
+      variant: "project",
+      entries: [{ type: "item", item: { label: "Shots", to: "/projects/p1/shots", iconName: "camera" } }],
+    }
+    const next = withShotReportsNav(stub, "p1")
+    const last = next.entries[next.entries.length - 1]
+    expect(last && last.type === "item" ? last.item.label : null).toBe("Shot Reports")
+  })
+
+  it("does not mutate the input config", () => {
+    const base = buildNavConfig("p1")
+    const beforeLen = base.entries.length
+    withShotReportsNav(base, "p1")
+    expect(base.entries.length).toBe(beforeLen)
+    expect(base.entries.some((e) => e.type === "item" && e.item.label === "Shot Reports")).toBe(false)
   })
 })

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -182,3 +182,27 @@ export function getMobileNavConfig(projectId?: string, role?: string): NavConfig
 
   return { ...config, entries: cleaned }
 }
+
+/**
+ * Insert a project-scoped "Shot Reports" item right after "Export". Pure — the
+ * featureShotReport check stays at the AppShell call site so buildNavConfig
+ * stays flag-free and its unit tests are unaffected.
+ */
+export function withShotReportsNav(config: NavConfig, projectId: string): NavConfig {
+  const item: NavEntry = {
+    type: "item",
+    item: {
+      label: "Shot Reports",
+      to: `/projects/${projectId}/export/reports`,
+      iconName: "file-output",
+      desktopOnly: true,
+    },
+  }
+  const exportTo = `/projects/${projectId}/export`
+  const idx = config.entries.findIndex((e) => e.type === "item" && e.item.to === exportTo)
+  const entries =
+    idx === -1
+      ? [...config.entries, item]
+      : [...config.entries.slice(0, idx + 1), item, ...config.entries.slice(idx + 1)]
+  return { ...config, entries }
+}


### PR DESCRIPTION
## R2 — surface layer (PR-B of 2) · ⏸ awaits Ted's eyeball before merge

The visible surface for the export **reimagine R2**, built on the merged PR #487 persistence spine. All behind `featureShotReport` (OFF in trunk). **Do not auto-merge** — this stops at a `:5174` eyeball.

### What it adds
- **`looksMode` (`all` | `primary-only`)** — a `deriveShotReportModel` *display* filter: gender stays resolved on the **full** looks so grouping is stable, and `hasImage` recomputes on the **visible** looks so the masthead "references ready" count can't overcount. A "Looks" segmented control in `ReportView` (cloned from Group-by). The PDF honors it automatically via the shared model (no renderer fork).
- **`ShotReportListPage`** — list saved shot reports; create (names at creation); **"Recipe"** = duplicate an existing report's config under a new name; open; delete. Decoupled from the legacy block-canvas builder.
- **Flag-gated route** `projects/:id/export/reports` + breadcrumb entry (the single report route's parent crumb now points to the list).
- **Flag-gated "Shot Reports" sidebar item**, injected in `AppShell` via a pure `withShotReportsNav` helper so `nav-config` stays flag-free and flag-off is byte-identical.

### Verification
- Tests: `looksMode` model cases (primary-only filter, default, `hasImage` recompute, grouping-stable) + `looksMode` config round-trip / forward-compat default-merge. `reportModel` 10, `reportTypes` 2, `breadcrumbs` 8 (new route auto-covered), `nav-config` 20.
- `npm run typecheck:baseline` 160/160 (0 new), `npm run build` ✓, eslint clean.
- Adversarial code-review: no CRITICAL/HIGH. One MEDIUM — **delete has no confirmation** (matches the *existing* block-canvas report delete; not a blocker for the eyeball, decide before flag-on).

### Eyeball checklist (on `:5174`, `VITE_SHOT_REPORT=1`, a throwaway project — never `Q2-26 No. 3`)
1. Sidebar shows a **Shot Reports** item under a project → opens the list.
2. **Create report** (name it) → lands on the report; **Looks → Primary only** drops alt looks live; **All** restores them.
3. Reload the report URL → config persisted (groupBy / excludes / looksMode round-trip).
4. Back to the list → **Recipe** clones the config into a new report.
5. **Export PDF** reflects the current looksMode.
6. Decide: confirmation step on **delete**?

🤖 Generated with [Claude Code](https://claude.com/claude-code)