### PR TITLE
chore(deploy): flip featureShotReport ON in prod (Shot Report + R2 live)

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -49,6 +49,7 @@ jobs:
           VITE_CASTING_MATCHER_SURFACE:      1   # Talent redesign: casting matcher = its own ranked surface
           VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
+          VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -91,6 +92,7 @@ jobs:
           VITE_CASTING_MATCHER_SURFACE:      1   # Talent redesign: casting matcher = its own ranked surface
           VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
+          VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
## Flip `featureShotReport` ON for all users

Ted's call: the current block-canvas export is "not even usable" — turn on the reimagined Shot Report.

Adds `VITE_SHOT_REPORT=1` to **both** `deploy-live.yml` build blocks (mirroring the Talent redesign flags). This makes live:
- **R1 (#486)** — the image-led Comprehensive Shot Report + landscape PDF export (Ted validated the PDF live).
- **R2 (#487/#488)** — the saved Shot Reports list, "Recipe" duplication, the Looks (All / Primary-only) toggle, and the **Shot Reports** sidebar nav entry (which is what made the feature reachable).

All of the above were eyeballed + approved by Ted on `:5174`.

### Safety
- **Env name verified:** `VITE_SHOT_REPORT` in the YAML === `import.meta.env.VITE_SHOT_REPORT` read at `flags.ts:182` (grep-confirmed — a typo here would be a silent no-op flip).
- Both build blocks updated (preview + prod), so the flag is consistent.
- Rollback = revert these 2 YAML lines + redeploy.

On merge, `deploy-live` fires and ships to `um-shotbuilder.web.app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)