### PR TITLE
feat(export): report recipes R3 — on-set sheet + all-rounder (flag-gated; HOLD for :5174 eyeball)

### DIFF
--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -1,0 +1,325 @@
+// Balanced-rows layout (comp-c) — one shot per full-width horizontal band:
+// native-aspect hero letterboxed on the LEFT, structured data panel on the
+// RIGHT, subtle zebra rhythm. Consumes the SAME resolved ReportModel + image
+// sidecar as the other two layouts (no second model). Red does exactly ONE job
+// here: the HERO-PRODUCT MARKER (rail + "HERO" tag) inside each look.
+
+import { useMemo } from "react"
+import type { JSX } from "react"
+import type {
+  GenderKey,
+  ReportGroup,
+  ReportLook,
+  ReportModel,
+  ReportProduct,
+  ReportShot,
+} from "../../lib/report/reportTypes"
+import { present, primaryLookImage, resolveSrc, statusMeta } from "./reportShared"
+
+interface BodyProps {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}
+
+const GENDER_LABEL: Record<GenderKey, string> = { W: "Women", M: "Men", Mixed: "Mixed", "?": "Unresolved" }
+
+// product row: hero-rail(RED) · family(+HERO tag) · style# · colour · size · qty
+function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
+  const sizePending = p.sizeScope === "pending" || !present(p.size)
+  return (
+    <div className={"sb-br-prow" + (p.isHero ? " sb-br-prow--hero" : "")}>
+      <div className="sb-br-pr-mark" aria-hidden="true" />
+      <div className="sb-br-pr-fam">
+        {present(p.family) ? p.family : "Unnamed product"}
+        {p.isHero ? <span className="sb-br-hero-tag"> HERO</span> : null}
+      </div>
+      <div className={"sb-br-pr-style sb-tabular" + (present(p.style) ? "" : " sb-muted")}>
+        {present(p.style) ? p.style : "—"}
+      </div>
+      <div className={"sb-br-pr-colour" + (present(p.colour) ? "" : " sb-muted")}>
+        {present(p.colour) ? p.colour : "—"}
+      </div>
+      <div className={"sb-br-pr-size sb-tabular" + (sizePending ? " sb-pending" : "")}>
+        {sizePending ? "Pending" : p.size}
+      </div>
+      <div className={"sb-br-pr-qty sb-tabular" + (p.qty != null ? "" : " sb-muted")}>
+        {p.qty != null ? `×${p.qty}` : "—"}
+      </div>
+    </div>
+  )
+}
+
+function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
+  const n = look.products.length
+  return (
+    <div className={"sb-br-look" + (look.isAlt ? " sb-br-look--alt" : "")}>
+      <div className="sb-br-look-label">
+        {look.label}
+        <span className="sb-br-lk-tag">{n === 1 ? "1 piece" : `${n} pieces`}</span>
+      </div>
+      <div className="sb-br-prows">
+        <div className="sb-br-prow--head">
+          <span />
+          <span>Product family</span>
+          <span>Style #</span>
+          <span>Colour</span>
+          <span>Size</span>
+          <span>Qty</span>
+        </div>
+        {look.products.map((p, i) => (
+          <ProductRow key={`${look.id}-p-${i}`} p={p} />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Band({
+  shot,
+  imageMap,
+  zebra,
+  onToggleExclude,
+}: {
+  readonly shot: ReportShot
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly zebra: boolean
+  readonly onToggleExclude: (shotId: string) => void
+}): JSX.Element {
+  const imgSrc = resolveSrc(imageMap, primaryLookImage(shot))
+  const st = statusMeta(shot.status)
+  const talent = shot.talent.map((t) => t.name).filter((n) => present(n))
+  return (
+    <div className={"sb-br-band" + (zebra ? " sb-br-zebra" : "") + (shot.excluded ? " sb-excluded" : "")}>
+      <div className="sb-br-img">
+        {imgSrc ? (
+          <img className="sb-img-native sb-br-img-native" src={imgSrc} alt={`${shot.title} — ${shot.colorway ?? ""}`} loading="lazy" />
+        ) : (
+          <div className="sb-no-image sb-br-noimg">No image yet</div>
+        )}
+      </div>
+
+      <div className="sb-br-panel">
+        <button
+          type="button"
+          className="sb-exclude-toggle no-print"
+          aria-pressed={shot.excluded}
+          onClick={() => onToggleExclude(shot.id)}
+          title={shot.excluded ? "Restore this shot to the report" : "Exclude this shot from the report"}
+        >
+          {shot.excluded ? "Restore shot" : "Exclude shot"}
+        </button>
+        <div className="sb-br-panel-head">
+          <div className="sb-br-shot-no sb-tabular">{shot.number}</div>
+          <div className="sb-br-head-main">
+            <h3 className="sb-shot-name sb-br-title">{shot.title}</h3>
+            <div className="sb-br-sub">
+              {present(shot.colorway) ? (
+                <>
+                  <span className="sb-br-colorway">{shot.colorway}</span>
+                  <span className="sb-br-subdot" />
+                </>
+              ) : null}
+              {shot.gender === "?" ? (
+                <span className="sb-badge-unresolved">Gender ?</span>
+              ) : (
+                <span className="sb-br-gender-chip">{GENDER_LABEL[shot.gender]}</span>
+              )}
+              <span className="sb-br-subdot" />
+              {talent.length ? (
+                <span className="sb-br-talent">
+                  Talent <span className="sb-br-tname">{talent.join(" · ")}</span>
+                </span>
+              ) : (
+                <span className="sb-br-talent">Talent TBD</span>
+              )}
+            </div>
+          </div>
+          <div className="sb-br-status">
+            <span className={"sb-status-dot " + st.dotClass} />
+            {st.label}
+          </div>
+        </div>
+
+        {present(shot.notes) ? (
+          <p className="sb-br-note">
+            <span className="sb-br-note-k">Note</span>
+            {shot.notes}
+          </p>
+        ) : null}
+
+        <div className="sb-br-looks">
+          {shot.looks.map((lk) => (
+            <LookBlock key={lk.id} look={lk} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function GroupHead({ group }: { readonly group: ReportGroup }): JSX.Element {
+  return (
+    <div className="sb-br-group-head">
+      <h2 className="sb-masthead sb-br-group-title">{group.label}</h2>
+      <span className="sb-br-group-count">{group.count === 1 ? "1 shot" : `${group.count} shots`}</span>
+      <span className="sb-br-group-note">Grouped · sorted by shot no.</span>
+    </div>
+  )
+}
+
+function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
+  const all = useMemo(() => model.groups.flatMap((g) => g.shots), [model.groups])
+  const withImg = all.filter((s) => s.hasImage).length
+  const total = model.project.shotCount
+  return (
+    <header className="sb-br-masthead">
+      <div className="sb-br-lede">
+        <p className="sb-eyebrow">Production · Comprehensive shot report</p>
+        <h1 className="sb-masthead sb-br-mast-title">Comprehensive Shot Report</h1>
+        <p className="sb-br-proj">
+          <strong>{model.project.name}</strong>
+          {model.project.client ? `  ·  ${model.project.client}` : ""}
+        </p>
+      </div>
+      <div className="sb-br-facts">
+        <div className="sb-br-fact">
+          <div className="sb-br-fact-k">Shots</div>
+          <div className="sb-br-fact-v sb-tabular">{total}</div>
+        </div>
+        <div className="sb-br-fact">
+          <div className="sb-br-fact-k">Captured</div>
+          <div className="sb-br-fact-v sb-tabular">
+            {withImg}
+            <small> / {total} shot</small>
+          </div>
+        </div>
+        {model.project.dateRange ? (
+          <div className="sb-br-fact">
+            <div className="sb-br-fact-k">Window</div>
+            <div className="sb-br-fact-v">{model.project.dateRange}</div>
+          </div>
+        ) : null}
+      </div>
+    </header>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Print pagination — ~4 single-look bands per landscape sheet (multi-look
+// weighs more). Masthead + first group head ride page 1.
+// ---------------------------------------------------------------------------
+type Item =
+  | { readonly kind: "mast"; readonly h: number }
+  | { readonly kind: "group"; readonly group: ReportGroup; readonly h: number }
+  | { readonly kind: "band"; readonly shot: ReportShot; readonly zebra: boolean; readonly h: number }
+
+const PAGE_CAP = 4.0
+
+function buildStream(model: ReportModel): readonly Item[] {
+  const stream: Item[] = [{ kind: "mast", h: 1.6 }]
+  let z = 0
+  for (const group of model.groups) {
+    const printable = group.shots.filter((s) => !s.excluded)
+    if (printable.length === 0) continue
+    stream.push({ kind: "group", group: { ...group, count: printable.length }, h: 0.8 })
+    for (const shot of printable) {
+      const multi = shot.looks.length > 1
+      stream.push({ kind: "band", shot, zebra: z % 2 === 1, h: multi ? 1.7 : 1.0 })
+      z += 1
+    }
+  }
+  return stream
+}
+
+function paginate(model: ReportModel): readonly (readonly Item[])[] {
+  const stream = buildStream(model)
+  const pages: Item[][] = [[]]
+  let curH = 0
+  stream.forEach((item, i) => {
+    const cur = pages[pages.length - 1]!
+    if (item.kind !== "band" && i < 2) {
+      cur.push(item)
+      curH += item.h
+      return
+    }
+    if (item.kind === "group" && curH > PAGE_CAP - 1.3) {
+      pages.push([])
+      curH = 0
+    }
+    if (item.kind === "band" && curH + item.h > PAGE_CAP && curH > 0) {
+      pages.push([])
+      curH = 0
+    }
+    pages[pages.length - 1]!.push(item)
+    curH += item.h
+  })
+  return pages
+}
+
+function PagedView({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
+  const pages = useMemo(() => paginate(model), [model])
+  const projLine = model.project.client
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+  return (
+    <div className="sb-br-paged">
+      {pages.map((items, pi) => (
+        <section className="sb-br-page" key={`br-page-${pi}`}>
+          {items.map((item, ii) => {
+            if (item.kind === "mast") return <Masthead key={`m-${pi}`} model={model} />
+            if (item.kind === "group") return <GroupHead key={`g-${pi}-${ii}`} group={item.group} />
+            return (
+              <Band
+                key={item.shot.id}
+                shot={item.shot}
+                imageMap={imageMap}
+                zebra={item.zebra}
+                onToggleExclude={onToggleExclude}
+              />
+            )
+          })}
+          <div className="sb-br-foot">
+            <span>Comprehensive Shot Report · {projLine}</span>
+            <span>
+              Page {pi + 1} of {pages.length}
+            </span>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
+  const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
+  if (isEmpty) return <p className="sb-empty">No shots to report yet.</p>
+  // Continuous zebra across groups on screen (matches comp-c rhythm).
+  let z = 0
+  return (
+    <div className="sb-br">
+      <div className="sb-br-fluid">
+        <Masthead model={model} />
+        {model.groups.map((group) => (
+          <div className="sb-br-group" key={group.key}>
+            <GroupHead group={group} />
+            {group.shots.map((shot) => {
+              const zebra = z % 2 === 1
+              z += 1
+              return (
+                <Band
+                  key={shot.id}
+                  shot={shot}
+                  imageMap={imageMap}
+                  zebra={zebra}
+                  onToggleExclude={onToggleExclude}
+                />
+              )
+            })}
+          </div>
+        ))}
+      </div>
+      <PagedView model={model} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -296,10 +296,21 @@ function PagedView({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element
 }
 
 export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
+  // Continuous zebra across groups (matches comp-c rhythm) — precomputed so the
+  // render body stays pure.
+  const zebraById = useMemo(() => {
+    const m = new Map<string, boolean>()
+    let i = 0
+    for (const g of model.groups)
+      for (const s of g.shots) {
+        m.set(s.id, i % 2 === 1)
+        i += 1
+      }
+    return m
+  }, [model.groups])
+
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
   if (isEmpty) return <p className="sb-empty">No shots to report yet.</p>
-  // Continuous zebra across groups on screen (matches comp-c rhythm).
-  let z = 0
   return (
     <div className="sb-br">
       <div className="sb-br-fluid">
@@ -308,19 +319,15 @@ export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyPro
           <div className="sb-br-group" key={group.key}>
             {/* count = printable; excluded bands still shown struck below */}
             <GroupHead group={{ ...group, count: group.shots.filter((s) => !s.excluded).length }} />
-            {group.shots.map((shot) => {
-              const zebra = z % 2 === 1
-              z += 1
-              return (
-                <Band
-                  key={shot.id}
-                  shot={shot}
-                  imageMap={imageMap}
-                  zebra={zebra}
-                  onToggleExclude={onToggleExclude}
-                />
-              )
-            })}
+            {group.shots.map((shot) => (
+              <Band
+                key={shot.id}
+                shot={shot}
+                imageMap={imageMap}
+                zebra={zebraById.get(shot.id) ?? false}
+                onToggleExclude={onToggleExclude}
+              />
+            ))}
           </div>
         ))}
       </div>

--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -297,12 +297,15 @@ function PagedView({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element
 
 export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
   // Continuous zebra across groups (matches comp-c rhythm) — precomputed so the
-  // render body stays pure.
+  // render body stays pure. Counts printable shots only, so the screen rhythm
+  // matches the paged/PDF stream (which filters excluded). Excluded (struck) rows
+  // fall through to false.
   const zebraById = useMemo(() => {
     const m = new Map<string, boolean>()
     let i = 0
     for (const g of model.groups)
       for (const s of g.shots) {
+        if (s.excluded) continue
         m.set(s.id, i % 2 === 1)
         i += 1
       }

--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -169,9 +169,13 @@ function GroupHead({ group }: { readonly group: ReportGroup }): JSX.Element {
 }
 
 function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
-  const all = useMemo(() => model.groups.flatMap((g) => g.shots), [model.groups])
+  // Printable count (excluded shots are struck on screen + omitted from the PDF).
+  const all = useMemo(
+    () => model.groups.flatMap((g) => g.shots).filter((s) => !s.excluded),
+    [model.groups],
+  )
   const withImg = all.filter((s) => s.hasImage).length
-  const total = model.project.shotCount
+  const total = all.length
   return (
     <header className="sb-br-masthead">
       <div className="sb-br-lede">
@@ -302,7 +306,8 @@ export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyPro
         <Masthead model={model} />
         {model.groups.map((group) => (
           <div className="sb-br-group" key={group.key}>
-            <GroupHead group={group} />
+            {/* count = printable; excluded bands still shown struck below */}
+            <GroupHead group={{ ...group, count: group.shots.filter((s) => !s.excluded).length }} />
             {group.shots.map((shot) => {
               const zebra = z % 2 === 1
               z += 1

--- a/src-vnext/features/export/components/report/ProductionSheetReport.tsx
+++ b/src-vnext/features/export/components/report/ProductionSheetReport.tsx
@@ -1,0 +1,338 @@
+// Production-sheet layout (comp-b) — dense, columnar spec sheet for on-set crew
+// + warehouse. Each shot is a row [status-spine | thumbnail | body w/ look
+// mini-tables]. Consumes the SAME resolved ReportModel + image sidecar as the
+// image-led + balanced-rows layouts (no second model). Red does exactly ONE job
+// here: the on-hold FLAG spine; the hero product carries a neutral triangle.
+
+import { useMemo } from "react"
+import type { JSX } from "react"
+import type {
+  ReportGroup,
+  ReportLook,
+  ReportModel,
+  ReportProduct,
+  ReportShot,
+} from "../../lib/report/reportTypes"
+import { isFlagged, present, primaryLookImage, resolveSrc, statusMeta } from "./reportShared"
+
+interface BodyProps {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}
+
+// --- product mini-table row: hero(neutral ▲) · family · style# · colour · size · qty
+function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
+  const sizePending = p.sizeScope === "pending" || !present(p.size)
+  return (
+    <div className={"sb-ps-pt" + (p.isHero ? " sb-ps-pt--hero" : "")}>
+      <div className="sb-ps-pt-hero">{p.isHero ? <span aria-label="Hero product">▲</span> : null}</div>
+      <div className="sb-ps-pt-fam">{present(p.family) ? p.family : "Unnamed product"}</div>
+      <div className={"sb-ps-pt-style sb-tabular" + (present(p.style) ? "" : " sb-muted")}>
+        {present(p.style) ? p.style : "no style #"}
+      </div>
+      <div className={"sb-ps-pt-colour" + (present(p.colour) ? "" : " sb-muted")}>
+        {present(p.colour) ? p.colour : "Unspecified"}
+      </div>
+      <div className={"sb-ps-pt-size sb-tabular" + (sizePending ? " sb-pending" : "")}>
+        {sizePending ? "Pending" : p.size}
+      </div>
+      <div className={"sb-ps-pt-qty sb-tabular" + (p.qty != null ? "" : " sb-muted")}>
+        {p.qty != null ? `×${p.qty}` : "—"}
+      </div>
+    </div>
+  )
+}
+
+function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
+  const n = look.products.length
+  return (
+    <div className={"sb-ps-look" + (look.isAlt ? " sb-ps-look--alt" : "")}>
+      <div className="sb-ps-look-label">
+        <span className="sb-ps-ll-tag">{look.label.toUpperCase()}</span>
+        <span className="sb-ps-ll-count">{n === 1 ? "1 piece" : `${n} pieces`}</span>
+      </div>
+      {look.products.map((p, i) => (
+        <ProductRow key={`${look.id}-p-${i}`} p={p} />
+      ))}
+    </div>
+  )
+}
+
+function ShotRow({
+  shot,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly shot: ReportShot
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (shotId: string) => void
+}): JSX.Element {
+  const flagged = isFlagged(shot.status)
+  const st = statusMeta(shot.status)
+  const imgSrc = resolveSrc(imageMap, primaryLookImage(shot))
+  const talent = shot.talent.filter((t) => present(t.name))
+
+  return (
+    <div className={"sb-ps-row" + (shot.excluded ? " sb-excluded" : "")}>
+      {/* status spine — RED's ONE JOB (on-hold flag) */}
+      <div className={"sb-ps-spine" + (flagged ? " sb-ps-spine--flagged" : "")}>
+        <span className={"sb-status-dot " + st.dotClass} title={st.label} />
+        {flagged ? <span className="sb-ps-spine-flag">Hold</span> : null}
+      </div>
+
+      {/* thumbnail + talent */}
+      <div className="sb-ps-thumb-col">
+        <div className={"sb-ps-thumb-frame" + (imgSrc ? "" : " sb-no-image sb-ps-noimg")}>
+          {imgSrc ? (
+            <img className="sb-img-native" src={imgSrc} alt={`${shot.title} — reference`} loading="lazy" />
+          ) : (
+            "No reference"
+          )}
+        </div>
+        <div className="sb-ps-talent">
+          <span className="sb-ps-talent-label">Talent</span>
+          {talent.length ? talent.map((t) => t.name).join(", ") : "Unassigned"}
+        </div>
+      </div>
+
+      {/* body */}
+      <div className="sb-ps-body">
+        <button
+          type="button"
+          className="sb-exclude-toggle no-print"
+          aria-pressed={shot.excluded}
+          onClick={() => onToggleExclude(shot.id)}
+          title={shot.excluded ? "Restore this shot to the report" : "Exclude this shot from the report"}
+        >
+          {shot.excluded ? "Restore shot" : "Exclude shot"}
+        </button>
+        <div className="sb-ps-ident">
+          <span className="sb-ps-num sb-tabular">{shot.number}</span>
+          <h3 className="sb-shot-name sb-ps-name">{shot.title}</h3>
+          {present(shot.colorway) ? <span className="sb-ps-colorway">{shot.colorway}</span> : null}
+          <span className="sb-ps-status">
+            <span className={"sb-status-dot " + st.dotClass} />
+            {st.label}
+            {shot.gender === "?" ? <span className="sb-badge-unresolved">Gender ?</span> : null}
+          </span>
+        </div>
+        {present(shot.notes) ? <p className="sb-ps-note">{shot.notes}</p> : null}
+        <div className="sb-ps-looks">
+          {shot.looks.map((lk) => (
+            <LookBlock key={lk.id} look={lk} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ColumnRuler(): JSX.Element {
+  return (
+    <div className="sb-ps-ruler">
+      <div className="sb-ps-ruler-spacer" />
+      <div className="sb-ps-ruler-shot">Shot / Reference</div>
+      <div className="sb-ps-ruler-prod">
+        <span />
+        <span>Product family</span>
+        <span>Style #</span>
+        <span>Colour</span>
+        <span className="sb-ps-num-h">Size</span>
+        <span className="sb-ps-num-h">Qty</span>
+      </div>
+    </div>
+  )
+}
+
+function GroupBand({
+  group,
+  cont,
+}: {
+  readonly group: ReportGroup
+  readonly cont?: boolean
+}): JSX.Element {
+  return (
+    <>
+      <div className="sb-ps-group-head">
+        <span className="sb-ps-g-name">{cont ? `${group.label} (cont.)` : group.label}</span>
+        <span className="sb-ps-g-rule" aria-hidden="true" />
+        <span className="sb-ps-g-count">{group.count === 1 ? "1 shot" : `${group.count} shots`}</span>
+      </div>
+      <ColumnRuler />
+    </>
+  )
+}
+
+function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
+  const all = useMemo(() => model.groups.flatMap((g) => g.shots), [model.groups])
+  const women = all.filter((s) => s.gender === "W").length
+  const men = all.filter((s) => s.gender === "M").length
+  const holds = all.filter((s) => isFlagged(s.status)).length
+  const projSub = model.project.client
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+
+  const cell = (num: string | number, label: string) => (
+    <div className="sb-ps-meta-cell" key={label}>
+      <span className="sb-ps-meta-num sb-tabular">{num}</span>
+      <span className="sb-ps-meta-label">{label}</span>
+    </div>
+  )
+
+  return (
+    <header className="sb-ps-head-band">
+      <div className="sb-ps-head-left">
+        <div className="sb-eyebrow">Production Pull Sheet · For Crew &amp; Warehouse</div>
+        <h1 className="sb-masthead sb-ps-title">Comprehensive Shot Report</h1>
+        <p className="sb-ps-sub">{projSub}</p>
+      </div>
+      <div className="sb-ps-meta">
+        {cell(model.project.shotCount, "Shots")}
+        {women > 0 ? cell(women, "Women") : null}
+        {men > 0 ? cell(men, "Men") : null}
+        {holds > 0 ? cell(holds, "On Hold") : null}
+        {model.project.dateRange ? cell(model.project.dateRange, "Window") : null}
+      </div>
+    </header>
+  )
+}
+
+function Legend(): JSX.Element {
+  return (
+    <div className="sb-ps-legend">
+      <span className="sb-ps-lg">
+        <span className="sb-ps-lg-tri">▲</span> Hero product
+      </span>
+      <span className="sb-ps-lg">
+        <span className="sb-ps-flag-chip">Hold</span> Flagged — not cleared to shoot
+      </span>
+      <span className="sb-ps-lg">
+        <span className="sb-pending">Pending</span> Size to be confirmed
+      </span>
+      <span className="sb-ps-lg">Looks separated: Primary, then Alt sub-rows</span>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Print pagination — weight-pack rows into landscape sheets, re-emit a
+// continuation group band/ruler so columns stay labeled across a page break.
+// ---------------------------------------------------------------------------
+type Block =
+  | { readonly type: "group"; readonly group: ReportGroup; readonly cont?: boolean }
+  | { readonly type: "shot"; readonly shot: ReportShot; readonly group: ReportGroup }
+
+interface PsPage {
+  readonly blocks: readonly Block[]
+}
+
+const PAGE_CAP_FIRST = 13.0
+const PAGE_CAP_FULL = 15.2
+const GROUP_W = 1.4 + 0.9 // band + ruler
+
+function shotWeight(shot: ReportShot): number {
+  let prodRows = 0
+  for (const l of shot.looks) prodRows += l.products.length
+  let w = 1.7 + shot.looks.length * 0.55 + prodRows * 0.42
+  if (present(shot.notes)) w += 0.6
+  return Math.max(w, 2.4) // thumbnail floor
+}
+
+function paginate(model: ReportModel): readonly PsPage[] {
+  const pages: Block[][] = []
+  let cur: Block[] = []
+  let used = 0
+  let cap = PAGE_CAP_FIRST
+  const flush = () => {
+    pages.push(cur)
+    cur = []
+    used = 0
+    cap = PAGE_CAP_FULL
+  }
+
+  for (const group of model.groups) {
+    const printable = group.shots.filter((s) => !s.excluded)
+    if (printable.length === 0) continue
+    // Never strand a group band: start fresh if it + its first shot won't fit.
+    const firstW = printable[0] ? shotWeight(printable[0]) : 2.4
+    if (used > 0 && used + GROUP_W + firstW > cap) flush()
+    cur.push({ type: "group", group })
+    used += GROUP_W
+    for (const shot of printable) {
+      const w = shotWeight(shot)
+      if (used + w > cap && cur.length > 0) {
+        flush()
+        cur.push({ type: "group", group, cont: true }) // continuation ruler
+        used += GROUP_W
+      }
+      cur.push({ type: "shot", shot, group })
+      used += w
+    }
+  }
+  if (cur.length > 0) pages.push(cur)
+  return pages.map((blocks) => ({ blocks }))
+}
+
+function PagedView({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
+  const pages = useMemo(() => paginate(model), [model])
+  const projLine = model.project.client
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+  return (
+    <div className="sb-ps-paged">
+      {pages.map((page, pi) => (
+        <section className="sb-ps-page" key={`ps-page-${pi}`}>
+          {pi === 0 ? (
+            <>
+              <Masthead model={model} />
+              <Legend />
+            </>
+          ) : null}
+          {page.blocks.map((blk, bi) =>
+            blk.type === "group" ? (
+              <GroupBand key={`g-${pi}-${bi}`} group={blk.group} cont={blk.cont} />
+            ) : (
+              <ShotRow
+                key={blk.shot.id}
+                shot={blk.shot}
+                imageMap={imageMap}
+                onToggleExclude={onToggleExclude}
+              />
+            ),
+          )}
+          <div className="sb-ps-foot">
+            <span>Comprehensive Shot Report · {projLine}</span>
+            <span>
+              Page {pi + 1} of {pages.length}
+            </span>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+export function ProductionSheetReport({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element {
+  const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
+  if (isEmpty) return <p className="sb-empty">No shots to report yet.</p>
+  return (
+    <div className="sb-ps">
+      {/* Fluid (screen) */}
+      <div className="sb-ps-fluid">
+        <Masthead model={model} />
+        <Legend />
+        {model.groups.map((group) => (
+          <div className="sb-ps-group" key={group.key}>
+            <GroupBand group={group} />
+            {group.shots.map((shot) => (
+              <ShotRow key={shot.id} shot={shot} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+            ))}
+          </div>
+        ))}
+      </div>
+      {/* Paged (print preview + @media print) */}
+      <PagedView model={model} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/ProductionSheetReport.tsx
+++ b/src-vnext/features/export/components/report/ProductionSheetReport.tsx
@@ -165,7 +165,12 @@ function GroupBand({
 }
 
 function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
-  const all = useMemo(() => model.groups.flatMap((g) => g.shots), [model.groups])
+  // Count what's in the report (excluded shots are struck on screen + omitted
+  // from the PDF), so the head-count never over-claims vs the printed rows.
+  const all = useMemo(
+    () => model.groups.flatMap((g) => g.shots).filter((s) => !s.excluded),
+    [model.groups],
+  )
   const women = all.filter((s) => s.gender === "W").length
   const men = all.filter((s) => s.gender === "M").length
   const holds = all.filter((s) => isFlagged(s.status)).length
@@ -188,7 +193,7 @@ function Masthead({ model }: { readonly model: ReportModel }): JSX.Element {
         <p className="sb-ps-sub">{projSub}</p>
       </div>
       <div className="sb-ps-meta">
-        {cell(model.project.shotCount, "Shots")}
+        {cell(all.length, "Shots")}
         {women > 0 ? cell(women, "Women") : null}
         {men > 0 ? cell(men, "Men") : null}
         {holds > 0 ? cell(holds, "On Hold") : null}
@@ -324,7 +329,8 @@ export function ProductionSheetReport({ model, imageMap, onToggleExclude }: Body
         <Legend />
         {model.groups.map((group) => (
           <div className="sb-ps-group" key={group.key}>
-            <GroupBand group={group} />
+            {/* count = printable; excluded rows still shown struck below */}
+            <GroupBand group={{ ...group, count: group.shots.filter((s) => !s.excluded).length }} />
             {group.shots.map((shot) => (
               <ShotRow key={shot.id} shot={shot} imageMap={imageMap} onToggleExclude={onToggleExclude} />
             ))}

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -23,7 +23,7 @@ import type {
 } from "../../lib/report/reportTypes"
 import { REPORT_LAYOUT_OPTIONS } from "../../lib/report/reportTypes"
 import { REPORT_STYLES } from "./reportStyles"
-import { resolveSrc, statusMeta } from "./reportShared"
+import { resolveSrc, statusMetaLegacy } from "./reportShared"
 import { ProductionSheetReport } from "./ProductionSheetReport"
 import { BalancedRowsReport } from "./BalancedRowsReport"
 
@@ -207,7 +207,7 @@ function PlateCaption({
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
 }): JSX.Element {
-  const st = statusMeta(shot.status)
+  const st = statusMetaLegacy(shot.status)
   return (
     <div className="sb-plate-caption">
       <div className="sb-caption-topline">

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -21,6 +21,7 @@ import type {
   ReportShot,
   ReportTalent,
 } from "../../lib/report/reportTypes"
+import { REPORT_LAYOUT_OPTIONS } from "../../lib/report/reportTypes"
 import { REPORT_STYLES } from "./reportStyles"
 import { resolveSrc, statusMeta } from "./reportShared"
 import { ProductionSheetReport } from "./ProductionSheetReport"
@@ -35,13 +36,8 @@ export interface ReportViewProps {
   readonly exporting?: boolean
 }
 
-const LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
-  { value: "image-led", label: "Image-led" },
-  { value: "production-sheet", label: "On-set sheet" },
-  { value: "balanced-rows", label: "All-rounder" },
-]
-
-/** Primary look = first; the shot's hero image candidate comes from it. */
+/** Primary look = first (image-led's whole-look accessor; distinct from the
+ *  shared primaryLookImage which returns just the image candidate). */
 function primaryLookOf(shot: ReportShot): ReportLook | undefined {
   return shot.looks[0]
 }
@@ -470,7 +466,7 @@ function ControlBar({
             Recipe
           </span>
           <div className="sb-seg">
-            {LAYOUT_OPTIONS.map((opt) => (
+            {REPORT_LAYOUT_OPTIONS.map((opt) => (
               <button
                 key={opt.value}
                 type="button"

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -8,19 +8,23 @@
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import type {
   ReportConfig,
   ReportGroup,
   ReportGroupBy,
+  ReportLayout,
   ReportLooksMode,
   ReportLook,
   ReportModel,
   ReportProduct,
   ReportShot,
-  ReportShotStatus,
   ReportTalent,
 } from "../../lib/report/reportTypes"
 import { REPORT_STYLES } from "./reportStyles"
+import { resolveSrc, statusMeta } from "./reportShared"
+import { ProductionSheetReport } from "./ProductionSheetReport"
+import { BalancedRowsReport } from "./BalancedRowsReport"
 
 export interface ReportViewProps {
   readonly model: ReportModel
@@ -31,30 +35,11 @@ export interface ReportViewProps {
   readonly exporting?: boolean
 }
 
-interface StatusMeta {
-  readonly dotClass: string
-  readonly label: string
-}
-
-const STATUS_META: Record<ReportShotStatus, StatusMeta> = {
-  complete: { dotClass: "sb-status--complete", label: "Shot" },
-  todo: { dotClass: "sb-status--todo", label: "To do" },
-  in_progress: { dotClass: "sb-status--progress", label: "In progress" },
-  on_hold: { dotClass: "sb-status--hold", label: "On hold" },
-}
-
-function statusMeta(status: ReportShotStatus): StatusMeta {
-  return STATUS_META[status] ?? STATUS_META.todo
-}
-
-/** Resolve an image candidate to a usable src via the sidecar map, else null. */
-function resolveSrc(
-  imageMap: ReadonlyMap<string, string>,
-  candidate: string | null,
-): string | null {
-  if (!candidate) return null
-  return imageMap.get(candidate) ?? null
-}
+const LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
+  { value: "image-led", label: "Image-led" },
+  { value: "production-sheet", label: "On-set sheet" },
+  { value: "balanced-rows", label: "All-rounder" },
+]
 
 /** Primary look = first; the shot's hero image candidate comes from it. */
 function primaryLookOf(shot: ReportShot): ReportLook | undefined {
@@ -455,6 +440,9 @@ function ControlBar({
   onSetGroupBy,
   looksMode,
   onSetLooksMode,
+  layout,
+  onSetLayout,
+  showLayout,
   onExportPdf,
   exporting,
 }: {
@@ -464,14 +452,39 @@ function ControlBar({
   readonly onSetGroupBy: (v: ReportGroupBy) => void
   readonly looksMode: ReportLooksMode
   readonly onSetLooksMode: (v: ReportLooksMode) => void
+  readonly layout: ReportLayout
+  readonly onSetLayout: (v: ReportLayout) => void
+  readonly showLayout: boolean
   readonly onExportPdf: () => void
   readonly exporting: boolean
 }): JSX.Element {
   const viewLabelId = useId()
   const groupLabelId = useId()
   const looksLabelId = useId()
+  const recipeLabelId = useId()
   return (
     <div className="sb-controlbar no-print" role="region" aria-label="Report controls">
+      {showLayout ? (
+        <div className="sb-control-group" role="group" aria-labelledby={recipeLabelId}>
+          <span id={recipeLabelId} className="sb-control-label">
+            Recipe
+          </span>
+          <div className="sb-seg">
+            {LAYOUT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-seg-btn"
+                aria-pressed={layout === opt.value}
+                onClick={() => onSetLayout(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
       <div className="sb-control-group" role="group" aria-labelledby={viewLabelId}>
         <span id={viewLabelId} className="sb-control-label">
           View
@@ -571,6 +584,11 @@ export function ReportView(props: ReportViewProps): JSX.Element {
   const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false } = props
   const [printMode, setPrintMode] = useState(false)
 
+  // Recipes ride their own flag; flag-off forces image-led so prod is byte-identical
+  // to the live R1/R2 report regardless of any persisted config.layout.
+  const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
+  const layout: ReportLayout = recipesEnabled ? (config.layout ?? "image-led") : "image-led"
+
   const toggleExclude = (shotId: string): void => {
     const set = new Set(config.excludedShotIds)
     if (set.has(shotId)) {
@@ -592,10 +610,15 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, looksMode: next })
   }
 
+  const setLayout = (next: ReportLayout): void => {
+    if (next === layout) return
+    onConfigChange({ ...config, layout: next })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
 
   return (
-    <div className={"sb-report-root" + (printMode ? " sb-print-mode" : "")}>
+    <div className={"sb-report-root" + (printMode ? " sb-print-mode" : "")} data-layout={layout}>
       <style>{REPORT_STYLES}</style>
 
       <ControlBar
@@ -605,31 +628,42 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         onSetGroupBy={setGroupBy}
         looksMode={looksMode}
         onSetLooksMode={setLooksMode}
+        layout={layout}
+        onSetLayout={setLayout}
+        showLayout={recipesEnabled}
         onExportPdf={onExportPdf}
         exporting={exporting}
       />
 
       <main className="sb-report">
-        <Masthead model={model} />
-
-        {isEmpty ? (
-          <p className="sb-empty">No shots to report yet.</p>
+        {layout === "production-sheet" ? (
+          <ProductionSheetReport model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+        ) : layout === "balanced-rows" ? (
+          <BalancedRowsReport model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
         ) : (
           <>
-            {/* Fluid lookbook flow (screen) */}
-            <div className="sb-fluid">
-              {model.groups.map((group) => (
-                <GroupSection
-                  key={group.key}
-                  group={group}
-                  imageMap={imageMap}
-                  onToggleExclude={toggleExclude}
-                />
-              ))}
-            </div>
+            <Masthead model={model} />
 
-            {/* Paged landscape preview (print mode + @media print) */}
-            <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+            {isEmpty ? (
+              <p className="sb-empty">No shots to report yet.</p>
+            ) : (
+              <>
+                {/* Fluid lookbook flow (screen) */}
+                <div className="sb-fluid">
+                  {model.groups.map((group) => (
+                    <GroupSection
+                      key={group.key}
+                      group={group}
+                      imageMap={imageMap}
+                      onToggleExclude={toggleExclude}
+                    />
+                  ))}
+                </div>
+
+                {/* Paged landscape preview (print mode + @media print) */}
+                <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+              </>
+            )}
           </>
         )}
       </main>

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -19,18 +19,12 @@ import {
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
-import { DEFAULT_REPORT_CONFIG, type ReportLayout } from "../../lib/report/reportTypes"
-
-const LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
-  { value: "image-led", label: "Image-led" },
-  { value: "production-sheet", label: "On-set sheet" },
-  { value: "balanced-rows", label: "All-rounder" },
-]
-const LAYOUT_LABEL: Record<ReportLayout, string> = {
-  "image-led": "Image-led",
-  "production-sheet": "On-set sheet",
-  "balanced-rows": "All-rounder",
-}
+import {
+  DEFAULT_REPORT_CONFIG,
+  REPORT_LAYOUT_LABEL,
+  REPORT_LAYOUT_OPTIONS,
+  type ReportLayout,
+} from "../../lib/report/reportTypes"
 
 // Saved shot reports for a project: create (optionally cloning an existing
 // report's config as a recipe), open, and delete. Sits beside the single report
@@ -127,7 +121,7 @@ export default function ShotReportListPage() {
             aria-label="Report recipe"
             className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 text-sm text-[var(--color-text)]"
           >
-            {LAYOUT_OPTIONS.map((opt) => (
+            {REPORT_LAYOUT_OPTIONS.map((opt) => (
               <option key={opt.value} value={opt.value}>
                 {opt.label}
               </option>
@@ -163,7 +157,7 @@ export default function ShotReportListPage() {
                   <span className="block text-xs text-[var(--color-text-muted)]">
                     {recipesEnabled && (
                       <span className="mr-2 rounded-sm bg-[var(--color-surface-muted)] px-1.5 py-0.5 text-[var(--color-text-secondary)]">
-                        {LAYOUT_LABEL[r.layout]}
+                        {REPORT_LAYOUT_LABEL[r.layout]}
                       </span>
                     )}
                     {r.updatedAt ? `Updated ${r.updatedAt.toLocaleDateString()}` : null}

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -6,6 +6,7 @@ import { useAuth } from "@/app/providers/AuthProvider"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -115,18 +116,18 @@ export default function ShotReportListPage() {
           className="flex-1"
         />
         {recipesEnabled && (
-          <select
-            value={recipe}
-            onChange={(e) => setRecipe(e.target.value as ReportLayout)}
-            aria-label="Report recipe"
-            className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 text-sm text-[var(--color-text)]"
-          >
-            {REPORT_LAYOUT_OPTIONS.map((opt) => (
-              <option key={opt.value} value={opt.value}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
+          <Select value={recipe} onValueChange={(v) => setRecipe(v as ReportLayout)}>
+            <SelectTrigger className="w-40" aria-label="Report recipe">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {REPORT_LAYOUT_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         )}
         <Button onClick={() => void handleCreate()} disabled={busy}>
           <Plus /> Create report

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner"
 import { Copy, FileText, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { isFeatureEnabled } from "@/shared/lib/flags"
+import { badgeVariants } from "@/ui/badge"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select"
@@ -157,7 +158,7 @@ export default function ShotReportListPage() {
                 {(recipesEnabled || r.updatedAt) && (
                   <span className="block text-xs text-[var(--color-text-muted)]">
                     {recipesEnabled && (
-                      <span className="mr-2 rounded-sm bg-[var(--color-surface-muted)] px-1.5 py-0.5 text-[var(--color-text-secondary)]">
+                      <span className={`${badgeVariants({ variant: "secondary" })} mr-2`}>
                         {REPORT_LAYOUT_LABEL[r.layout]}
                       </span>
                     )}

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
 import { Copy, FileText, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
 import {
@@ -18,7 +19,18 @@ import {
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
-import { DEFAULT_REPORT_CONFIG } from "../../lib/report/reportTypes"
+import { DEFAULT_REPORT_CONFIG, type ReportLayout } from "../../lib/report/reportTypes"
+
+const LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
+  { value: "image-led", label: "Image-led" },
+  { value: "production-sheet", label: "On-set sheet" },
+  { value: "balanced-rows", label: "All-rounder" },
+]
+const LAYOUT_LABEL: Record<ReportLayout, string> = {
+  "image-led": "Image-led",
+  "production-sheet": "On-set sheet",
+  "balanced-rows": "All-rounder",
+}
 
 // Saved shot reports for a project: create (optionally cloning an existing
 // report's config as a recipe), open, and delete. Sits beside the single report
@@ -36,7 +48,9 @@ export default function ShotReportListPage() {
     [reports],
   )
 
+  const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
   const [newName, setNewName] = useState("")
+  const [recipe, setRecipe] = useState<ReportLayout>("image-led")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
 
@@ -48,7 +62,12 @@ export default function ShotReportListPage() {
   const handleCreate = useCallback(async () => {
     setBusy(true)
     try {
-      const id = await createShotReport(newName.trim() || "Untitled report", DEFAULT_REPORT_CONFIG)
+      // Recipes flag-off => always image-led, so the create config can't smuggle
+      // an unreviewed layout into prod.
+      const config = recipesEnabled
+        ? { ...DEFAULT_REPORT_CONFIG, layout: recipe }
+        : DEFAULT_REPORT_CONFIG
+      const id = await createShotReport(newName.trim() || "Untitled report", config)
       setNewName("")
       openReport(id)
     } catch {
@@ -56,7 +75,7 @@ export default function ShotReportListPage() {
     } finally {
       setBusy(false)
     }
-  }, [createShotReport, newName, openReport])
+  }, [createShotReport, newName, openReport, recipe, recipesEnabled])
 
   const handleDuplicate = useCallback(
     async (sourceId: string, sourceName: string) => {
@@ -101,6 +120,20 @@ export default function ShotReportListPage() {
           aria-label="New report name"
           className="flex-1"
         />
+        {recipesEnabled && (
+          <select
+            value={recipe}
+            onChange={(e) => setRecipe(e.target.value as ReportLayout)}
+            aria-label="Report recipe"
+            className="h-9 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-2 text-sm text-[var(--color-text)]"
+          >
+            {LAYOUT_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        )}
         <Button onClick={() => void handleCreate()} disabled={busy}>
           <Plus /> Create report
         </Button>
@@ -126,9 +159,14 @@ export default function ShotReportListPage() {
                 <span className="block truncate text-sm font-medium text-[var(--color-text)]">
                   {r.name}
                 </span>
-                {r.updatedAt && (
+                {(recipesEnabled || r.updatedAt) && (
                   <span className="block text-xs text-[var(--color-text-muted)]">
-                    Updated {r.updatedAt.toLocaleDateString()}
+                    {recipesEnabled && (
+                      <span className="mr-2 rounded-sm bg-[var(--color-surface-muted)] px-1.5 py-0.5 text-[var(--color-text-secondary)]">
+                        {LAYOUT_LABEL[r.layout]}
+                      </span>
+                    )}
+                    {r.updatedAt ? `Updated ${r.updatedAt.toLocaleDateString()}` : null}
                   </span>
                 )}
               </button>

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
 import { deriveShotReportModel } from "../../lib/report/reportModel"
@@ -115,15 +116,21 @@ export default function ShotReportPage() {
     // keeping them out of the report route's eager chunk.
     void (async () => {
       const { generateShotReportPdf } = await import("../../lib/report/reportPdf")
+      // Recipes ride their own flag; flag-off forces image-led so the PDF matches
+      // the on-screen layout (which ReportView also forces to image-led).
+      const layout = isFeatureEnabled("featureShotReportRecipes")
+        ? (config.layout ?? "image-led")
+        : "image-led"
       await generateShotReportPdf(
         model,
         imageMap,
         `${model.project.name} — Shot Report.pdf`,
+        layout,
       )
     })().finally(() => {
       setExporting(false)
     })
-  }, [model, imageMap])
+  }, [model, imageMap, config.layout])
 
   if (data.loading) {
     return (

--- a/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest"
+import { render } from "@testing-library/react"
+import { ProductionSheetReport } from "../ProductionSheetReport"
+import { BalancedRowsReport } from "../BalancedRowsReport"
+import type { ReportModel } from "../../../lib/report/reportTypes"
+
+// Smoke + behavior tests for the two R3 layout variants: they render without
+// throwing, use the canonical status labels (statusMappings.ts), and count only
+// printable (non-excluded) shots in the masthead.
+function model(): ReportModel {
+  return {
+    project: { name: "Q2-26 No. 3", client: "unbound-merino", shotCount: 3, dateRange: "Jun 2–6, 2026" },
+    groups: [
+      {
+        key: "W", label: "Women", count: 2,
+        shots: [
+          {
+            id: "s1", number: "01", title: "Trail Crew", colorway: "Black", status: "complete",
+            gender: "W", notes: null, talent: [{ id: "t1", name: "Model A", img: null }],
+            excluded: false, hasImage: false,
+            looks: [{ id: "l1", label: "Primary", isAlt: false, image: null, products: [
+              { family: "Crew", style: "W-TP-1399", colour: "Black", size: "S", sizeScope: "single", qty: 1, gender: "W", isHero: true, img: null },
+            ] }],
+          },
+          {
+            id: "s2", number: "02", title: "Excluded one", colorway: null, status: "todo",
+            gender: "W", notes: null, talent: [], excluded: true, hasImage: false,
+            looks: [{ id: "l2", label: "Primary", isAlt: false, image: null, products: [] }],
+          },
+        ],
+      },
+      {
+        key: "?", label: "Unresolved", count: 1,
+        shots: [
+          {
+            id: "s3", number: "03", title: "On hold one", colorway: null, status: "on_hold",
+            gender: "?", notes: "Pending wardrobe.", talent: [], excluded: false, hasImage: false,
+            looks: [{ id: "l3", label: "Primary", isAlt: false, image: null, products: [
+              { family: "Pant", style: null, colour: null, size: null, sizeScope: "pending", qty: 2, gender: "?", isHero: true, img: null },
+            ] }],
+          },
+        ],
+      },
+    ],
+  }
+}
+
+const noop = () => {}
+
+describe("ProductionSheetReport (comp-b)", () => {
+  it("renders, uses canonical labels, counts printable shots", () => {
+    const { container, getAllByText } = render(
+      <ProductionSheetReport model={model()} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    // canonical status label (was "On hold" pre-fix)
+    expect(getAllByText("On Hold").length).toBeGreaterThan(0)
+    // on-hold flag spine
+    expect(getAllByText("Hold").length).toBeGreaterThan(0)
+    // masthead "Shots" = 2 printable (excludes s2), not 3
+    expect(container.querySelector(".sb-ps-meta-num")?.textContent).toBe("2")
+    expect(getAllByText("Trail Crew").length).toBeGreaterThan(0)
+  })
+})
+
+describe("BalancedRowsReport (comp-c)", () => {
+  it("renders, shows the hero marker, counts printable shots", () => {
+    const { container, getAllByText } = render(
+      <BalancedRowsReport model={model()} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    expect(getAllByText("HERO").length).toBeGreaterThan(0)
+    // first fact value ("Shots") = 2 printable
+    expect(container.querySelector(".sb-br-fact-v")?.textContent).toBe("2")
+    expect(getAllByText("Trail Crew").length).toBeGreaterThan(0)
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/reportShared.test.ts
+++ b/src-vnext/features/export/components/report/__tests__/reportShared.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest"
+import { statusMeta, statusMetaLegacy } from "../reportShared"
+
+// Locks the R3 label scoping: the two new recipes use the CLAUDE.md canonical
+// labels; the shipped image-led report keeps its original labels unchanged.
+describe("report status labels", () => {
+  it("statusMeta (new recipes) uses canonical labels", () => {
+    expect(statusMeta("on_hold").label).toBe("On Hold")
+    expect(statusMeta("todo").label).toBe("Draft")
+    expect(statusMeta("in_progress").label).toBe("In Progress")
+    expect(statusMeta("complete").label).toBe("Shot")
+  })
+
+  it("statusMetaLegacy (image-led) keeps the original live labels", () => {
+    expect(statusMetaLegacy("on_hold").label).toBe("On hold")
+    expect(statusMetaLegacy("todo").label).toBe("To do")
+    expect(statusMetaLegacy("in_progress").label).toBe("In progress")
+    expect(statusMetaLegacy("complete").label).toBe("Shot")
+  })
+
+  it("both keep the same reserved dot palette", () => {
+    expect(statusMeta("on_hold").dotClass).toBe(statusMetaLegacy("on_hold").dotClass)
+  })
+})

--- a/src-vnext/features/export/components/report/reportShared.ts
+++ b/src-vnext/features/export/components/report/reportShared.ts
@@ -1,0 +1,46 @@
+// Shared DOM atoms for the report layouts (image-led / production-sheet /
+// balanced-rows). One status map + one image resolver so the three layouts
+// can't drift in status labeling or image lookup.
+
+import type { ReportShot, ReportShotStatus } from "../../lib/report/reportTypes"
+
+export interface StatusMeta {
+  readonly dotClass: string
+  readonly label: string
+}
+
+export const STATUS_META: Record<ReportShotStatus, StatusMeta> = {
+  complete: { dotClass: "sb-status--complete", label: "Shot" },
+  todo: { dotClass: "sb-status--todo", label: "To do" },
+  in_progress: { dotClass: "sb-status--progress", label: "In progress" },
+  on_hold: { dotClass: "sb-status--hold", label: "On hold" },
+}
+
+export function statusMeta(status: ReportShotStatus): StatusMeta {
+  return STATUS_META[status] ?? STATUS_META.todo
+}
+
+/** Resolve an image candidate to a usable src via the sidecar map, else null. */
+export function resolveSrc(
+  imageMap: ReadonlyMap<string, string>,
+  candidate: string | null,
+): string | null {
+  if (!candidate) return null
+  return imageMap.get(candidate) ?? null
+}
+
+/** Non-empty string guard for honest "TBD/Pending" rendering. */
+export function present(v: string | null | undefined): v is string {
+  return v != null && v.trim() !== ""
+}
+
+/** On-hold = the one shot status the production sheet flags red ("not cleared to shoot"). */
+export function isFlagged(status: ReportShotStatus): boolean {
+  return status === "on_hold"
+}
+
+/** The shot's primary image candidate. Model sorts looks by order, so looks[0]
+ *  is the primary — same definition image-led uses (one canonical primary). */
+export function primaryLookImage(shot: ReportShot): string | null {
+  return shot.looks[0]?.image ?? null
+}

--- a/src-vnext/features/export/components/report/reportShared.ts
+++ b/src-vnext/features/export/components/report/reportShared.ts
@@ -11,8 +11,6 @@ export interface StatusMeta {
 }
 
 // Report-specific status DOT classes (reserved green/amber/blue/gray palette).
-// Labels come from statusMappings.ts so they match the CLAUDE.md canonical
-// (Draft / In Progress / On Hold / Shot) everywhere.
 const STATUS_DOT: Record<ReportShotStatus, string> = {
   complete: "sb-status--complete",
   todo: "sb-status--todo",
@@ -20,8 +18,23 @@ const STATUS_DOT: Record<ReportShotStatus, string> = {
   on_hold: "sb-status--hold",
 }
 
+// The shipped image-led report keeps its original (pre-canonical) labels so its
+// live output is unchanged. The two R3 recipes use the CLAUDE.md canonical labels.
+const LEGACY_LABEL: Record<ReportShotStatus, string> = {
+  complete: "Shot",
+  todo: "To do",
+  in_progress: "In progress",
+  on_hold: "On hold",
+}
+
+/** Canonical labels (statusMappings.ts) — used by the production-sheet + balanced-rows recipes. */
 export function statusMeta(status: ReportShotStatus): StatusMeta {
   return { dotClass: STATUS_DOT[status] ?? STATUS_DOT.todo, label: getShotStatusLabel(status) }
+}
+
+/** Original image-led labels — keeps the live report byte-identical. */
+export function statusMetaLegacy(status: ReportShotStatus): StatusMeta {
+  return { dotClass: STATUS_DOT[status] ?? STATUS_DOT.todo, label: LEGACY_LABEL[status] ?? LEGACY_LABEL.todo }
 }
 
 /** Resolve an image candidate to a usable src via the sidecar map, else null. */

--- a/src-vnext/features/export/components/report/reportShared.ts
+++ b/src-vnext/features/export/components/report/reportShared.ts
@@ -2,6 +2,7 @@
 // balanced-rows). One status map + one image resolver so the three layouts
 // can't drift in status labeling or image lookup.
 
+import { getShotStatusLabel } from "@/shared/lib/statusMappings"
 import type { ReportShot, ReportShotStatus } from "../../lib/report/reportTypes"
 
 export interface StatusMeta {
@@ -9,15 +10,18 @@ export interface StatusMeta {
   readonly label: string
 }
 
-export const STATUS_META: Record<ReportShotStatus, StatusMeta> = {
-  complete: { dotClass: "sb-status--complete", label: "Shot" },
-  todo: { dotClass: "sb-status--todo", label: "To do" },
-  in_progress: { dotClass: "sb-status--progress", label: "In progress" },
-  on_hold: { dotClass: "sb-status--hold", label: "On hold" },
+// Report-specific status DOT classes (reserved green/amber/blue/gray palette).
+// Labels come from statusMappings.ts so they match the CLAUDE.md canonical
+// (Draft / In Progress / On Hold / Shot) everywhere.
+const STATUS_DOT: Record<ReportShotStatus, string> = {
+  complete: "sb-status--complete",
+  todo: "sb-status--todo",
+  in_progress: "sb-status--progress",
+  on_hold: "sb-status--hold",
 }
 
 export function statusMeta(status: ReportShotStatus): StatusMeta {
-  return STATUS_META[status] ?? STATUS_META.todo
+  return { dotClass: STATUS_DOT[status] ?? STATUS_DOT.todo, label: getShotStatusLabel(status) }
 }
 
 /** Resolve an image candidate to a usable src via the sidecar map, else null. */

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -572,6 +572,11 @@ export const REPORT_STYLES = `
 .sb-br-foot { margin-top: auto; padding-top: 10px; border-top: 1px solid var(--sb-rule); justify-content: space-between; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); }
 .sb-print-mode .sb-br-foot { display: flex; }
 
+/* desktop-only surface, but guard the fixed image column against narrow widths */
+@media (max-width: 880px) {
+  .sb-br { --br-img-col: 200px; --br-band-h: 180px; }
+}
+
 @media print {
   .sb-report-root[data-layout="production-sheet"] .sb-ps-fluid,
   .sb-report-root[data-layout="balanced-rows"] .sb-br-fluid { display: none !important; }

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -395,4 +395,193 @@ export const REPORT_STYLES = `
   }
   .sb-sheet:last-child { break-after: auto; page-break-after: auto; }
 }
+
+/* =======================================================================
+   PRODUCTION-SHEET layout (comp-b) — dense spec sheet. RED = on-hold flag.
+   ======================================================================= */
+.sb-ps {
+  --ps-col-status: 30px;
+  --ps-col-thumb: 132px;
+  --ps-pt-grid: 22px minmax(150px, 1.7fr) 124px minmax(96px, 1fr) 72px 44px;
+}
+.sb-ps-head-band {
+  display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 32px;
+  padding: clamp(28px, 4vw, 56px) 0 14px; border-bottom: 2px solid var(--sb-ink); margin-bottom: 6px;
+}
+.sb-ps-title { font-size: clamp(30px, 4.4vw, 48px); line-height: 0.98; margin: 8px 0 0; }
+.sb-ps-sub { font-family: var(--sb-font-ui); font-size: var(--sb-t-lg); color: var(--sb-ink-2); font-weight: 500; margin: 8px 0 0; }
+.sb-ps-meta { display: flex; align-items: stretch; text-align: right; }
+.sb-ps-meta-cell { display: flex; flex-direction: column; justify-content: flex-end; gap: 3px; padding: 0 18px; border-left: 1px solid var(--sb-rule); }
+.sb-ps-meta-cell:first-child { padding-left: 0; border-left: 0; }
+.sb-ps-meta-cell:last-child { padding-right: 0; }
+.sb-ps-meta-num { font-family: var(--sb-font-display); font-weight: 700; font-size: 24px; line-height: 1; color: var(--sb-ink); }
+.sb-ps-meta-label { font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3); font-weight: 600; }
+.sb-ps-legend { display: flex; flex-wrap: wrap; align-items: center; gap: 18px; padding: 9px 0 0; font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); color: var(--sb-ink-2); }
+.sb-ps-lg { display: inline-flex; align-items: center; gap: 6px; }
+.sb-ps-lg-tri { color: var(--sb-ink); }
+.sb-ps-flag-chip { font-family: var(--sb-font-ui); font-weight: 700; font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-red); border: 1px solid var(--sb-red); border-radius: 2px; padding: 0 4px; line-height: 1.5; }
+
+.sb-ps-group-head { display: flex; align-items: baseline; gap: 14px; margin: 34px 0 0; padding: 7px 12px; background: var(--sb-ink); color: var(--sb-paper); }
+.sb-ps-group:first-of-type .sb-ps-group-head { margin-top: 22px; }
+.sb-ps-g-name { font-family: var(--sb-font-ui); font-weight: 700; font-size: var(--sb-t-xs); letter-spacing: 0.22em; text-transform: uppercase; }
+.sb-ps-g-rule { flex: 1; height: 1px; background: oklch(0.45 0.01 50); align-self: center; }
+.sb-ps-g-count { font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); letter-spacing: 0.10em; text-transform: uppercase; color: oklch(0.80 0.01 50); }
+
+.sb-ps-ruler { display: grid; grid-template-columns: var(--ps-col-status) var(--ps-col-thumb) 1fr; border-bottom: 1px solid var(--sb-rule-strong); background: var(--sb-surface); }
+.sb-ps-ruler-spacer { border-right: 1px solid var(--sb-rule); }
+.sb-ps-ruler-shot { padding: 6px 12px; border-right: 1px solid var(--sb-rule); font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3); font-weight: 600; }
+.sb-ps-ruler-prod { display: grid; grid-template-columns: var(--ps-pt-grid); gap: 0 14px; padding: 6px 14px; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); font-weight: 600; }
+.sb-ps-ruler-prod .sb-ps-num-h { text-align: right; }
+
+.sb-ps-row { display: grid; grid-template-columns: var(--ps-col-status) var(--ps-col-thumb) 1fr; border-bottom: 1px solid var(--sb-rule); background: var(--sb-paper); break-inside: avoid; page-break-inside: avoid; }
+.sb-ps-row:nth-of-type(even) { background: var(--sb-surface); }
+
+.sb-ps-spine { border-right: 1px solid var(--sb-rule); display: flex; flex-direction: column; align-items: center; padding: 12px 0; gap: 7px; }
+.sb-ps-spine--flagged { background: linear-gradient(var(--sb-red), var(--sb-red)) left / 4px 100% no-repeat; }
+.sb-ps-spine-flag { writing-mode: vertical-rl; transform: rotate(180deg); font-family: var(--sb-font-ui); font-weight: 700; font-size: var(--sb-t-3xs); letter-spacing: 0.14em; text-transform: uppercase; color: var(--sb-red); margin-top: 2px; }
+
+.sb-ps-thumb-col { border-right: 1px solid var(--sb-rule); padding: 12px; display: flex; flex-direction: column; gap: 8px; }
+.sb-ps-thumb-frame { width: 100%; background: var(--sb-surface-sub); border: 1px solid var(--sb-rule); display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.sb-ps-thumb-frame .sb-img-native { width: auto; max-width: 100%; }
+.sb-ps-noimg { aspect-ratio: 4 / 5; min-height: 110px; }
+.sb-ps-talent { font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); color: var(--sb-ink-3); line-height: 1.3; }
+.sb-ps-talent-label { display: block; text-transform: uppercase; letter-spacing: 0.10em; color: var(--sb-ink-disabled); font-weight: 600; margin-bottom: 1px; }
+
+.sb-ps-body { padding: 11px 14px 13px; min-width: 0; position: relative; }
+.sb-ps-ident { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 2px; }
+.sb-ps-num { font-family: var(--sb-font-ui); font-weight: 700; font-size: var(--sb-t-sm); color: var(--sb-ink-2); letter-spacing: 0.04em; }
+.sb-ps-name { font-size: var(--sb-t-xl); color: var(--sb-ink); margin: 0; min-width: 0; }
+.sb-ps-colorway { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); }
+.sb-ps-colorway::before { content: "·"; margin-right: 8px; color: var(--sb-ink-disabled); }
+.sb-ps-status { display: inline-flex; align-items: center; gap: 5px; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); font-weight: 600; margin-left: auto; }
+.sb-ps-note { font-family: var(--sb-font-body); font-size: var(--sb-t-xs); color: var(--sb-ink-2); font-style: italic; margin: 4px 0 0; padding-left: 11px; border-left: 2px solid var(--sb-rule-strong); line-height: 1.4; }
+
+.sb-ps-looks { margin-top: 9px; display: flex; flex-direction: column; gap: 7px; }
+.sb-ps-look { border: 1px solid var(--sb-rule); border-radius: 2px; overflow: hidden; }
+.sb-ps-look--alt { margin-left: 18px; border-style: dashed; background: var(--sb-surface-sub); }
+.sb-ps-look-label { display: flex; align-items: center; gap: 8px; padding: 4px 10px; background: var(--sb-surface-sub); border-bottom: 1px solid var(--sb-rule); font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.12em; text-transform: uppercase; font-weight: 700; color: var(--sb-ink-2); }
+.sb-ps-ll-tag { font-weight: 700; color: var(--sb-ink); }
+.sb-ps-look--alt .sb-ps-ll-tag { color: var(--sb-ink-2); }
+.sb-ps-ll-count { margin-left: auto; color: var(--sb-ink-disabled); letter-spacing: 0.08em; font-weight: 600; }
+
+.sb-ps-pt { display: grid; grid-template-columns: var(--ps-pt-grid); gap: 0 14px; align-items: baseline; padding: 5px 10px; border-bottom: 1px solid var(--sb-rule); font-size: var(--sb-t-sm); }
+.sb-ps-pt:last-child { border-bottom: 0; }
+.sb-ps-pt--hero { background: oklch(0.975 0.004 60); }
+.sb-ps-pt-hero { text-align: center; font-size: var(--sb-t-sm); color: var(--sb-ink); line-height: 1.1; }
+.sb-ps-pt-fam { color: var(--sb-ink); min-width: 0; overflow-wrap: anywhere; line-height: 1.25; }
+.sb-ps-pt--hero .sb-ps-pt-fam { font-weight: 600; }
+.sb-ps-pt-style { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); letter-spacing: 0.01em; }
+.sb-ps-pt-colour { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink); }
+.sb-ps-pt-size { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink); text-align: right; }
+.sb-ps-pt-qty { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); text-align: right; }
+
+/* production-sheet paged (print preview + @media print) */
+.sb-ps-paged { display: none; }
+.sb-ps-foot { display: none; }
+.sb-print-mode[data-layout="production-sheet"] { background: oklch(0.86 0.004 50); }
+.sb-print-mode .sb-ps-fluid { display: none; }
+.sb-print-mode .sb-ps-paged { display: block; }
+.sb-print-mode .sb-ps-foot { display: flex; }
+.sb-ps-page { display: block; width: 11in; height: 8.5in; background: var(--sb-paper); margin: 0 auto 18px; padding: 0.42in 0.5in 0.48in; overflow: hidden; position: relative; box-sizing: border-box; }
+.sb-print-mode .sb-ps { --ps-col-thumb: 112px; }
+.sb-print-mode .sb-ps-page .sb-ps-group-head:first-child { margin-top: 0; }
+.sb-print-mode .sb-ps-head-band { padding-top: 4px; margin-bottom: 4px; }
+.sb-print-mode .sb-ps-title { font-size: 30px; }
+.sb-ps-foot { position: absolute; left: 0.5in; right: 0.5in; bottom: 0.2in; border-top: 1px solid var(--sb-rule); padding-top: 4px; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-3); justify-content: space-between; }
+
+@media (max-width: 880px) {
+  .sb-ps { --ps-pt-grid: 20px 1fr 100px 90px 60px 38px; }
+}
+
+/* =======================================================================
+   BALANCED-ROWS layout (comp-c) — one band per shot. RED = hero marker.
+   ======================================================================= */
+.sb-br { --br-img-col: 300px; --br-band-h: 232px; }
+.sb-br-masthead { display: grid; grid-template-columns: 1fr auto; align-items: end; gap: 32px; padding: clamp(28px, 4vw, 48px) 0 22px; border-bottom: 2px solid var(--sb-rule-strong); }
+.sb-br-lede { min-width: 0; }
+.sb-br-mast-title { font-size: clamp(34px, 4.4vw, 52px); line-height: 1; margin: 0; }
+.sb-br-proj { font-family: var(--sb-font-ui); font-size: var(--sb-t-lg); font-weight: 500; color: var(--sb-ink-2); margin: 14px 0 0; }
+.sb-br-proj strong { color: var(--sb-ink); font-weight: 600; }
+.sb-br-facts { display: flex; gap: 34px; text-align: right; white-space: nowrap; }
+.sb-br-fact-k { font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600; letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink-3); margin: 0 0 4px; }
+.sb-br-fact-v { font-family: var(--sb-font-display); font-weight: 700; font-size: 24px; line-height: 1; color: var(--sb-ink); }
+.sb-br-fact-v small { font-family: var(--sb-font-ui); font-weight: 500; font-size: var(--sb-t-xs); color: var(--sb-ink-2); }
+
+.sb-br-group-head { display: flex; align-items: baseline; gap: 16px; padding: 34px 0 12px; border-bottom: 1px solid var(--sb-rule); margin-bottom: 4px; }
+.sb-br-group:first-of-type .sb-br-group-head { padding-top: 22px; }
+.sb-br-group-title { font-family: var(--sb-font-display); font-weight: 700; font-size: 32px; line-height: 1; letter-spacing: -0.01em; color: var(--sb-ink); }
+.sb-br-group-count { font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 600; letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-2); }
+.sb-br-group-note { margin-left: auto; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); }
+
+.sb-br-band { display: grid; grid-template-columns: var(--br-img-col) 1fr; gap: 30px; padding: 22px 18px; border-bottom: 1px solid var(--sb-rule); align-items: start; }
+.sb-br-zebra { background: var(--sb-surface-sub); }
+.sb-br-img { height: var(--br-band-h); display: flex; align-items: center; justify-content: center; overflow: hidden; }
+.sb-br-img-native { width: auto; height: auto; max-width: 100%; max-height: 100%; }
+.sb-br-noimg { width: 100%; height: 100%; }
+
+.sb-br-panel { min-width: 0; position: relative; }
+.sb-br-panel-head { display: grid; grid-template-columns: auto 1fr auto; align-items: baseline; gap: 14px; padding-bottom: 12px; border-bottom: 1px solid var(--sb-rule); }
+.sb-br-shot-no { font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-sm); letter-spacing: 0.06em; color: var(--sb-ink-3); padding-top: 3px; }
+.sb-br-head-main { min-width: 0; }
+.sb-br-title { font-size: var(--sb-t-xl); margin: 0; color: var(--sb-ink); }
+.sb-br-sub { display: flex; flex-wrap: wrap; align-items: center; gap: 8px 14px; margin-top: 7px; font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); }
+.sb-br-colorway { font-weight: 500; color: var(--sb-ink); }
+.sb-br-subdot { width: 3px; height: 3px; border-radius: 50%; background: var(--sb-rule-strong); display: inline-block; }
+.sb-br-gender-chip { font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2); border: 1px solid var(--sb-rule-strong); border-radius: 2px; padding: 1px 6px; }
+.sb-br-talent { color: var(--sb-ink-2); }
+.sb-br-tname { color: var(--sb-ink); font-weight: 500; }
+.sb-br-status { display: flex; align-items: center; gap: 7px; font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2); white-space: nowrap; }
+.sb-br-note { margin: 11px 0 0; font-size: var(--sb-t-sm); color: var(--sb-ink-2); line-height: 1.45; }
+.sb-br-note-k { font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-3xs); letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3); margin-right: 8px; }
+
+.sb-br-looks { margin-top: 14px; display: flex; flex-direction: column; gap: 12px; }
+.sb-br-look { padding: 2px 0 0; }
+.sb-br-look--alt { margin-left: 16px; padding: 12px 0 2px 18px; border-left: 2px solid var(--sb-rule-strong); background: linear-gradient(90deg, var(--sb-surface) 0, transparent 56px); }
+.sb-br-look-label { display: inline-flex; align-items: center; gap: 8px; font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-2xs); letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink-2); margin-bottom: 7px; }
+.sb-br-look--alt .sb-br-look-label { color: var(--sb-ink-3); }
+.sb-br-lk-tag { font-size: var(--sb-t-3xs); font-weight: 600; letter-spacing: 0.06em; color: var(--sb-ink-3); border: 1px solid var(--sb-rule); border-radius: 2px; padding: 0 5px; text-transform: none; }
+
+.sb-br-prows { display: grid; grid-template-columns: 14px minmax(0, 1.9fr) minmax(96px, 0.9fr) minmax(76px, 0.7fr) minmax(64px, auto) 36px; column-gap: 14px; row-gap: 0; align-items: baseline; }
+.sb-br-prow--head { display: contents; }
+.sb-br-prow--head > span { font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600; letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3); padding-bottom: 5px; border-bottom: 1px solid var(--sb-rule); }
+.sb-br-prow { display: contents; }
+.sb-br-prow > * { padding: 7px 0 6px; border-bottom: 1px solid var(--sb-rule); line-height: 1.3; }
+.sb-br-prow:last-child > * { border-bottom: 0; }
+.sb-br-pr-mark { position: relative; }
+.sb-br-prow--hero .sb-br-pr-mark::before { content: ""; position: absolute; left: 0; top: 9px; width: 4px; height: 14px; background: var(--sb-red); border-radius: 1px; }
+.sb-br-pr-fam { font-weight: 500; color: var(--sb-ink); overflow-wrap: anywhere; }
+.sb-br-hero-tag { margin-left: 8px; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700; letter-spacing: 0.10em; color: var(--sb-red); vertical-align: 1px; }
+.sb-br-pr-style { color: var(--sb-ink-2); font-size: var(--sb-t-sm); }
+.sb-br-pr-colour { color: var(--sb-ink-2); }
+.sb-br-pr-size { color: var(--sb-ink); }
+.sb-br-pr-qty { text-align: right; color: var(--sb-ink-2); }
+
+/* balanced-rows paged (print preview + @media print) */
+.sb-br-paged { display: none; }
+.sb-br-foot { display: none; }
+.sb-print-mode[data-layout="balanced-rows"] { background: oklch(0.86 0.004 50); }
+.sb-print-mode .sb-br-fluid { display: none; }
+.sb-print-mode .sb-br-paged { display: block; }
+.sb-print-mode .sb-br { --br-img-col: 250px; --br-band-h: 150px; }
+.sb-br-page { width: 11in; min-height: 8.5in; margin: 16px auto; background: var(--sb-paper); padding: 0.5in 0.55in 0.6in; display: flex; flex-direction: column; box-sizing: border-box; }
+.sb-print-mode .sb-br-masthead { padding-top: 4px; }
+.sb-print-mode .sb-br-mast-title { font-size: 38px; }
+.sb-print-mode .sb-br-group-head { padding-top: 16px; }
+.sb-print-mode .sb-br-band { padding: 14px 4px; gap: 22px; }
+.sb-print-mode .sb-br-look--alt { margin-left: 12px; }
+.sb-br-foot { margin-top: auto; padding-top: 10px; border-top: 1px solid var(--sb-rule); justify-content: space-between; font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); }
+.sb-print-mode .sb-br-foot { display: flex; }
+
+@media print {
+  .sb-report-root[data-layout="production-sheet"] .sb-ps-fluid,
+  .sb-report-root[data-layout="balanced-rows"] .sb-br-fluid { display: none !important; }
+  .sb-report-root[data-layout="production-sheet"] .sb-ps-paged,
+  .sb-report-root[data-layout="balanced-rows"] .sb-br-paged { display: block !important; }
+  .sb-ps-page { break-after: page; page-break-after: always; margin: 0; }
+  .sb-ps-page:last-child { break-after: auto; page-break-after: auto; }
+  .sb-ps-foot, .sb-br-foot { display: flex !important; }
+  .sb-br-page { break-after: page; page-break-after: always; margin: 0; }
+  .sb-br-page:last-child { break-after: auto; page-break-after: auto; }
+  .sb-ps-row, .sb-ps-look, .sb-br-band { break-inside: avoid; page-break-inside: avoid; }
+}
 `

--- a/src-vnext/features/export/hooks/__tests__/useExportReports.map.test.ts
+++ b/src-vnext/features/export/hooks/__tests__/useExportReports.map.test.ts
@@ -18,6 +18,22 @@ describe("mapReport reportType discriminator", () => {
   })
 })
 
+describe("mapReport layout (R3 recipe surfacing)", () => {
+  it("defaults a missing config.layout to image-led (pre-R3 docs)", () => {
+    expect(mapReport("a", { name: "x" }).layout).toBe("image-led")
+    expect(mapReport("b", { name: "x", config: { groupBy: "gender" } }).layout).toBe("image-led")
+  })
+
+  it("surfaces config.layout from the config blob", () => {
+    expect(mapReport("c", { name: "x", config: { layout: "production-sheet" } }).layout).toBe(
+      "production-sheet",
+    )
+    expect(mapReport("d", { name: "x", config: { layout: "balanced-rows" } }).layout).toBe(
+      "balanced-rows",
+    )
+  })
+})
+
 describe("block-canvas compat filter (legacy list safety)", () => {
   // Mirrors ExportBuilderPage: only block-canvas docs may enter the block editor,
   // so a shot-report doc can never be auto-selected and auto-save-clobbered.

--- a/src-vnext/features/export/hooks/useExportReports.ts
+++ b/src-vnext/features/export/hooks/useExportReports.ts
@@ -21,7 +21,7 @@ import type {
   PageSettings,
   CustomVariable,
 } from "../types/exportBuilder"
-import type { ReportConfig } from "../lib/report/reportTypes"
+import type { ReportConfig, ReportLayout } from "../lib/report/reportTypes"
 
 // Discriminates a saved shot-report doc from a legacy block-canvas doc. Absent
 // on disk for every pre-R2 doc -> defaulted to "block-canvas" at READ time, so
@@ -32,6 +32,8 @@ export interface ExportReport {
   readonly id: string
   readonly name: string
   readonly reportType: ExportReportType
+  /** Layout recipe of a shot-report doc; "image-led" when absent (pre-R3). */
+  readonly layout: ReportLayout
   readonly schemaVersion: number
   readonly updatedAt: Date | null
   readonly createdBy: string
@@ -77,11 +79,14 @@ export function mapReport(
   data: Record<string, unknown>,
 ): ExportReport {
   const ts = data.updatedAt as Timestamp | null | undefined
+  const config = data.config as { layout?: ReportLayout } | undefined
   return {
     id,
     name: (data.name as string) ?? "Untitled",
     // Missing reportType => a legacy block-canvas doc (no migration).
     reportType: (data.reportType as ExportReportType) ?? "block-canvas",
+    // Missing layout => image-led (the shipped recipe; pre-R3 docs render unchanged).
+    layout: config?.layout ?? "image-led",
     schemaVersion: (data.schemaVersion as number) ?? 1,
     updatedAt: ts?.toDate?.() ?? null,
     createdBy: (data.createdBy as string) ?? "",

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { deriveShotReportModel, normalizeGender } from "../reportModel"
+import { deriveShotReportModel, formatDateWindow, normalizeGender } from "../reportModel"
 import { DEFAULT_REPORT_CONFIG } from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
@@ -51,7 +51,31 @@ describe("normalizeGender", () => {
   })
 })
 
+describe("formatDateWindow", () => {
+  it("returns null for no dates", () => {
+    expect(formatDateWindow([])).toBeNull()
+    expect(formatDateWindow(undefined)).toBeNull()
+    expect(formatDateWindow(["nope"])).toBeNull()
+  })
+  it("formats a single day, a same-month range, cross-month, and cross-year (unsorted input)", () => {
+    expect(formatDateWindow(["2026-06-02"])).toBe("Jun 2, 2026")
+    expect(formatDateWindow(["2026-06-06", "2026-06-02", "2026-06-04"])).toBe("Jun 2–6, 2026")
+    expect(formatDateWindow(["2026-06-28", "2026-07-02"])).toBe("Jun 28 – Jul 2, 2026")
+    expect(formatDateWindow(["2026-01-02", "2025-12-30"])).toBe("Dec 30, 2025 – Jan 2, 2026")
+  })
+})
+
 describe("deriveShotReportModel", () => {
+  it("derives project.dateRange from shootDates (null when absent)", () => {
+    const withDates = deriveShotReportModel(
+      data({ project: { name: "P", clientId: "c", shootDates: ["2026-06-04", "2026-06-02"] } as ExportData["project"] }),
+      DEFAULT_REPORT_CONFIG,
+    )
+    expect(withDates.project.dateRange).toBe("Jun 2–4, 2026")
+    const noDates = deriveShotReportModel(data({}), DEFAULT_REPORT_CONFIG)
+    expect(noDates.project.dateRange).toBeNull()
+  })
+
   it("labels looks Primary/Alt and separates them (never merged)", () => {
     const model = deriveShotReportModel(
       data({

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -16,4 +16,11 @@ describe("ReportConfig persistence round-trip", () => {
     expect(hydrated.excludedShotIds).toEqual(["x"])
     expect(hydrated.looksMode).toBe("all")
   })
+
+  it("default-merges a pre-layout blob to layout 'image-led' (R3 forward-compat)", () => {
+    // A pre-R3 shot-report doc has no layout — it must hydrate to the shipped image-led layout.
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all"}')
+    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    expect(hydrated.layout).toBe("image-led")
+  })
 })

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -128,6 +128,33 @@ function shotNumberSortKey(n: string): [number, number, string] {
   return Number.isNaN(num) ? [1, 0, n] : [0, num, n]
 }
 
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
+/** Parse a "YYYY-MM-DD" date-only string into parts; null if malformed. (No Date() — avoids TZ shift.) */
+function parseDateOnly(s: string): { y: number; m: number; d: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s.trim())
+  if (!m) return null
+  const y = Number(m[1])
+  const mo = Number(m[2])
+  const d = Number(m[3])
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null
+  return { y, m: mo, d }
+}
+
+/** Format shoot dates into a display window: "Jun 2, 2026" / "Jun 2–6, 2026" / "Jun 28 – Jul 2, 2026" / cross-year. Null when none. */
+export function formatDateWindow(dates: readonly string[] | null | undefined): string | null {
+  const parsed = (dates ?? []).map(parseDateOnly).filter((p): p is NonNullable<typeof p> => p != null)
+  if (parsed.length === 0) return null
+  const sorted = [...parsed].sort((a, b) => a.y - b.y || a.m - b.m || a.d - b.d)
+  const lo = sorted[0]!
+  const hi = sorted[sorted.length - 1]!
+  const day = (p: typeof lo) => `${MONTHS[p.m - 1]} ${p.d}`
+  if (lo.y === hi.y && lo.m === hi.m && lo.d === hi.d) return `${day(lo)}, ${lo.y}`
+  if (lo.y === hi.y && lo.m === hi.m) return `${MONTHS[lo.m - 1]} ${lo.d}–${hi.d}, ${lo.y}`
+  if (lo.y === hi.y) return `${day(lo)} – ${day(hi)}, ${lo.y}`
+  return `${day(lo)}, ${lo.y} – ${day(hi)}, ${hi.y}`
+}
+
 const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]
 const GROUP_LABEL: Record<GenderKey, string> = {
   W: "Women",
@@ -184,6 +211,7 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
       name: data.project?.name ?? "Untitled project",
       client: data.project?.clientId ?? "",
       shotCount: shots.length,
+      dateRange: formatDateWindow(data.project?.shootDates),
     },
     groups,
   }

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -19,45 +19,22 @@ import {
   Image,
   StyleSheet,
 } from "@react-pdf/renderer"
-import { getPageDimensionsPt } from "../pageDimensions"
-import { mapFontFamilyToPdf } from "../pdf/fontMapping"
 import type {
+  ReportLayout,
   ReportModel,
   ReportGroup,
   ReportShot,
   ReportLook,
   ReportProduct,
 } from "./reportTypes"
+import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
+import { ProductionSheetPdfDocument } from "./reportPdfProductionSheet"
+import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
 
 // ---------------------------------------------------------------------------
-// Tokens (PDF-side mirror of the brand vars; built-in font families only)
+// Image-led layout — tokens shared via reportPdfShared. Red's one job: shot number.
 // ---------------------------------------------------------------------------
 
-const COLOR = {
-  surface: "#FFFFFF",
-  surfaceSubtle: "#F4F4F5",
-  text: "#18181B",
-  textSecondary: "#52525B",
-  textSubtle: "#5B5B60",
-  textDisabled: "#A1A1AA", // placeholder only
-  accent: "#EB1400", // Immediate Red — shot number only
-  rule: "#E4E4E7",
-  ruleStrong: "#D4D4D8",
-} as const
-
-const FONT = {
-  // Editorial serif on screen → Times here would read closer to Ivy Presto, but
-  // the codebase standard is Helvetica via mapFontFamilyToPdf; keep parity with
-  // the rest of the export PDFs and let the type differ from screen as expected.
-  display: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
-  displayRegular: mapFontFamilyToPdf(undefined), // Helvetica
-  body: mapFontFamilyToPdf(undefined), // Helvetica
-  bodyItalic: mapFontFamilyToPdf(undefined, false, true), // Helvetica-Oblique
-  ui: mapFontFamilyToPdf(undefined), // Helvetica
-  uiBold: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
-} as const
-
-const PAGE = getPageDimensionsPt("letter", "landscape") // 792 x 612 pt
 const PAD_X = 40
 const PAD_TOP = 36
 const PAD_BOTTOM = 34
@@ -395,21 +372,6 @@ const styles = StyleSheet.create({
   },
 })
 
-// Status dot colors — green/amber/gray reserved set (no red here).
-const STATUS: Record<
-  ReportShot["status"],
-  { readonly color: string; readonly label: string }
-> = {
-  complete: { color: "#16A34A", label: "Shot" },
-  in_progress: { color: "#2563EB", label: "In progress" },
-  todo: { color: COLOR.textDisabled, label: "To do" },
-  on_hold: { color: "#D97706", label: "On hold" },
-}
-
-function has(v: string | null | undefined): v is string {
-  return v != null && v.trim() !== ""
-}
-
 // ---------------------------------------------------------------------------
 // Pagination: two non-excluded plates per landscape sheet, never spanning a
 // gender group (a new group starts a fresh sheet, mirroring the north star).
@@ -643,6 +605,20 @@ export function ShotReportPdfDocument(props: {
 }
 
 // ---------------------------------------------------------------------------
+// Layout dispatch — one resolved model, the chosen recipe's Document.
+// ---------------------------------------------------------------------------
+
+function reportPdfDocument(
+  model: ReportModel,
+  imageMap: ReadonlyMap<string, string>,
+  layout: ReportLayout,
+): JSX.Element {
+  if (layout === "production-sheet") return <ProductionSheetPdfDocument model={model} imageMap={imageMap} />
+  if (layout === "balanced-rows") return <BalancedRowsPdfDocument model={model} imageMap={imageMap} />
+  return <ShotReportPdfDocument model={model} imageMap={imageMap} />
+}
+
+// ---------------------------------------------------------------------------
 // Generate + download — mirrors generateExportPdf (lazy import, toBlob, anchor).
 // ---------------------------------------------------------------------------
 
@@ -650,9 +626,10 @@ export async function generateShotReportPdf(
   model: ReportModel,
   imageMap: ReadonlyMap<string, string>,
   filename = "comprehensive-shot-report.pdf",
+  layout: ReportLayout = "image-led",
 ): Promise<void> {
   const { pdf } = await import("@react-pdf/renderer")
-  const element = <ShotReportPdfDocument model={model} imageMap={imageMap} />
+  const element = reportPdfDocument(model, imageMap, layout)
   const blob = await pdf(element).toBlob()
 
   const url = URL.createObjectURL(blob)

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -27,7 +27,7 @@ import type {
   ReportLook,
   ReportProduct,
 } from "./reportTypes"
-import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS_LEGACY, has } from "./reportPdfShared"
 import { ProductionSheetPdfDocument } from "./reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
 
@@ -494,7 +494,7 @@ function Plate({
   const primary = shot.looks[0]
   const heroCandidate = primary?.image ?? null
   const heroSrc = has(heroCandidate) ? imageMap.get(heroCandidate) : undefined
-  const status = STATUS[shot.status]
+  const status = STATUS_LEGACY[shot.status]
   const talent = shot.talent.filter((t) => has(t.name))
 
   // Width + keep-together are owned by the column wrapper in the Page; this is

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -1,0 +1,251 @@
+// Balanced-rows PDF (comp-c) — one full-width band per shot: native-aspect hero
+// on the LEFT, structured data panel on the RIGHT. Consumes the same ReportModel
+// + image sidecar as the other layouts. Red's ONE job here: the hero-product
+// marker (rail + "HERO" tag) inside each look.
+
+import type { JSX } from "react"
+import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
+import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
+import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage } from "./reportPdfShared"
+
+const PAD_X = 34
+const PAD_Y = 32
+const IMG_COL = 210
+const BAND_H = 150
+
+const GENDER_LABEL: Record<ReportShot["gender"], string> = { W: "Women", M: "Men", Mixed: "Mixed", "?": "Unresolved" }
+
+const s = StyleSheet.create({
+  page: { paddingTop: PAD_Y, paddingBottom: 32, paddingHorizontal: PAD_X, fontFamily: FONT.body, fontSize: 8, color: COLOR.text, backgroundColor: COLOR.surface },
+
+  // masthead (page 1)
+  mast: { flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between", borderBottomWidth: 1.5, borderBottomColor: COLOR.ruleStrong, paddingBottom: 10, marginBottom: 6 },
+  eyebrow: { fontFamily: FONT.uiBold, fontSize: 6.5, letterSpacing: 1, textTransform: "uppercase", color: COLOR.textSecondary },
+  title: { fontFamily: FONT.display, fontSize: 22, color: COLOR.text, marginTop: 5 },
+  proj: { fontFamily: FONT.ui, fontSize: 9, color: COLOR.textSecondary, marginTop: 6 },
+  facts: { flexDirection: "row" },
+  fact: { marginLeft: 22, alignItems: "flex-end" },
+  factK: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.textSubtle, marginBottom: 2 },
+  factV: { fontFamily: FONT.display, fontSize: 15, color: COLOR.text },
+  factVSmall: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary },
+
+  // group head
+  groupHead: { flexDirection: "row", alignItems: "baseline", borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, paddingTop: 12, paddingBottom: 6, marginBottom: 4 },
+  groupTitle: { fontFamily: FONT.display, fontSize: 16, color: COLOR.text },
+  groupCount: { fontFamily: FONT.uiBold, fontSize: 7, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.textSecondary, marginLeft: 12 },
+  groupNote: { fontFamily: FONT.ui, fontSize: 6, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle, marginLeft: "auto" },
+
+  // band
+  band: { flexDirection: "row", borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, paddingVertical: 10 },
+  bandZebra: { backgroundColor: COLOR.surfaceSubtle },
+  imgCol: { width: IMG_COL, height: BAND_H, alignItems: "center", justifyContent: "center", overflow: "hidden", marginRight: 18 },
+  img: { maxWidth: IMG_COL, maxHeight: BAND_H, objectFit: "contain" },
+  noImg: { width: IMG_COL, height: BAND_H, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center" },
+  noImgTxt: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSubtle, textTransform: "uppercase" },
+
+  panel: { flex: 1 },
+  panelHead: { flexDirection: "row", alignItems: "baseline", borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, paddingBottom: 8 },
+  shotNo: { fontFamily: FONT.uiBold, fontSize: 8, color: COLOR.textSubtle, marginRight: 10 },
+  headMain: { flex: 1 },
+  shotTitle: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text },
+  sub: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginTop: 5 },
+  colorway: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text, fontWeight: "bold", marginRight: 8 },
+  genderChip: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.4, textTransform: "uppercase", color: COLOR.textSecondary, borderWidth: 0.5, borderColor: COLOR.ruleStrong, borderRadius: 1, paddingHorizontal: 3, marginRight: 8 },
+  unresolved: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.4, textTransform: "uppercase", color: COLOR.accentInk, borderWidth: 0.5, borderColor: COLOR.accentInk, borderRadius: 1, paddingHorizontal: 3, marginRight: 8 },
+  talent: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary },
+  status: { flexDirection: "row", alignItems: "center", marginLeft: 10 },
+  statusDot: { width: 5, height: 5, borderRadius: 2.5, marginRight: 4 },
+  statusTxt: { fontFamily: FONT.uiBold, fontSize: 6, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.textSecondary },
+  note: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary, marginTop: 7, lineHeight: 1.4 },
+  noteK: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle },
+
+  looks: { marginTop: 8 },
+  look: { marginTop: 8 },
+  lookAlt: { marginLeft: 12, paddingLeft: 10, borderLeftWidth: 1, borderLeftColor: COLOR.ruleStrong },
+  lookLabel: { flexDirection: "row", alignItems: "center", marginBottom: 5 },
+  lookLabelTxt: { fontFamily: FONT.uiBold, fontSize: 6.5, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.textSecondary },
+  lkTag: { fontFamily: FONT.ui, fontSize: 5.5, color: COLOR.textSubtle, borderWidth: 0.5, borderColor: COLOR.rule, borderRadius: 1, paddingHorizontal: 3, marginLeft: 6 },
+
+  ph: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle },
+  prodHead: { flexDirection: "row", paddingBottom: 3, borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, marginBottom: 1 },
+  prod: { flexDirection: "row", alignItems: "baseline", paddingVertical: 3.5, borderBottomWidth: 0.5, borderBottomColor: COLOR.rule },
+  cMark: { width: 8 },
+  heroRail: { width: 3, height: 11, backgroundColor: COLOR.accent, borderRadius: 0.5 },
+  cFam: { flex: 1.9, paddingRight: 6 },
+  cStyle: { flex: 0.9, paddingRight: 6 },
+  cColour: { flex: 0.7, paddingRight: 6 },
+  cSize: { width: 52, paddingRight: 6 },
+  cQty: { width: 30, textAlign: "right" },
+  fam: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text },
+  heroTag: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.8, color: COLOR.accent },
+  style: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary },
+  colour: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary },
+  size: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.text },
+  qty: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary, textAlign: "right" },
+  muted: { fontFamily: FONT.bodyItalic, color: COLOR.textSubtle },
+
+  footer: { position: "absolute", bottom: 16, left: PAD_X, right: PAD_X, flexDirection: "row", justifyContent: "space-between", fontFamily: FONT.ui, fontSize: 6, color: COLOR.textDisabled, textTransform: "uppercase", letterSpacing: 0.5, borderTopWidth: 0.5, borderTopColor: COLOR.rule, paddingTop: 4 },
+})
+
+function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
+  const sizePending = p.sizeScope === "pending" || !has(p.size)
+  return (
+    <View style={s.prod} wrap={false}>
+      <View style={s.cMark}>{p.isHero ? <View style={s.heroRail} /> : null}</View>
+      <View style={s.cFam}>
+        <Text>
+          <Text style={s.fam}>{has(p.family) ? p.family : "Unnamed product"}</Text>
+          {p.isHero ? <Text style={s.heroTag}>{"  HERO"}</Text> : null}
+        </Text>
+      </View>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? p.style : "—"}</Text>
+      <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "—"}</Text>
+      <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizePending ? "Pending" : p.size}</Text>
+      <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>
+    </View>
+  )
+}
+
+function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
+  const n = look.products.length
+  return (
+    <View style={[s.look, ...(look.isAlt ? [s.lookAlt] : [])]}>
+      <View style={s.lookLabel}>
+        <Text style={s.lookLabelTxt}>{look.label}</Text>
+        <Text style={s.lkTag}>{n === 1 ? "1 piece" : `${n} pieces`}</Text>
+      </View>
+      <View style={s.prodHead}>
+        <View style={s.cMark} />
+        <Text style={[s.ph, s.cFam]}>Product family</Text>
+        <Text style={[s.ph, s.cStyle]}>Style #</Text>
+        <Text style={[s.ph, s.cColour]}>Colour</Text>
+        <Text style={[s.ph, s.cSize]}>Size</Text>
+        <Text style={[s.ph, s.cQty]}>Qty</Text>
+      </View>
+      {look.products.map((p, i) => (
+        <ProductRow key={i} p={p} />
+      ))}
+    </View>
+  )
+}
+
+function Band({ shot, imageMap, zebra }: { readonly shot: ReportShot; readonly imageMap: ReadonlyMap<string, string>; readonly zebra: boolean }): JSX.Element {
+  const cand = primaryLookImage(shot)
+  const src = has(cand) ? imageMap.get(cand) : undefined
+  const st = STATUS[shot.status]
+  const talent = shot.talent.map((t) => t.name).filter((n) => has(n))
+  return (
+    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]} wrap={false}>
+      <View style={s.imgCol}>
+        {src ? <Image src={src} style={s.img} /> : <View style={s.noImg}><Text style={s.noImgTxt}>No image yet</Text></View>}
+      </View>
+      <View style={s.panel}>
+        <View style={s.panelHead}>
+          <Text style={s.shotNo}>{shot.number}</Text>
+          <View style={s.headMain}>
+            <Text style={s.shotTitle}>{shot.title}</Text>
+            <View style={s.sub}>
+              {has(shot.colorway) ? <Text style={s.colorway}>{shot.colorway}</Text> : null}
+              {shot.gender === "?" ? (
+                <Text style={s.unresolved}>Gender ?</Text>
+              ) : (
+                <Text style={s.genderChip}>{GENDER_LABEL[shot.gender]}</Text>
+              )}
+              <Text style={s.talent}>{talent.length ? `Talent ${talent.join(" · ")}` : "Talent TBD"}</Text>
+            </View>
+          </View>
+          <View style={s.status}>
+            <View style={[s.statusDot, { backgroundColor: st.color }]} />
+            <Text style={s.statusTxt}>{st.label}</Text>
+          </View>
+        </View>
+        {has(shot.notes) ? (
+          <Text style={s.note}>
+            <Text style={s.noteK}>{"Note  "}</Text>
+            {shot.notes}
+          </Text>
+        ) : null}
+        <View style={s.looks}>
+          {shot.looks.map((lk) => (
+            <LookBlock key={lk.id} look={lk} />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+function GroupHead({ group }: { readonly group: ReportGroup }): JSX.Element {
+  return (
+    <View style={s.groupHead} wrap={false} minPresenceAhead={60}>
+      <Text style={s.groupTitle}>{group.label}</Text>
+      <Text style={s.groupCount}>{group.count === 1 ? "1 shot" : `${group.count} shots`}</Text>
+      <Text style={s.groupNote}>Grouped · sorted by shot no.</Text>
+    </View>
+  )
+}
+
+export function BalancedRowsPdfDocument(props: {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const { model, imageMap } = props
+  const all = model.groups.flatMap((g) => g.shots)
+  const withImg = all.filter((x) => x.hasImage).length
+  const total = model.project.shotCount
+  const projLine = has(model.project.client) ? `${model.project.name} · ${model.project.client}` : model.project.name
+  let z = 0
+
+  return (
+    <Document title="Comprehensive Shot Report" author={model.project.client || ""} producer="Shot Builder">
+      <Page size={{ width: PAGE.width, height: PAGE.height }} style={s.page} wrap>
+        <View style={s.mast}>
+          <View>
+            <Text style={s.eyebrow}>Production · Comprehensive shot report</Text>
+            <Text style={s.title}>Comprehensive Shot Report</Text>
+            <Text style={s.proj}>{projLine}</Text>
+          </View>
+          <View style={s.facts}>
+            <View style={s.fact}>
+              <Text style={s.factK}>Shots</Text>
+              <Text style={s.factV}>{total}</Text>
+            </View>
+            <View style={s.fact}>
+              <Text style={s.factK}>Captured</Text>
+              <Text style={s.factV}>
+                {withImg}
+                <Text style={s.factVSmall}> / {total} shot</Text>
+              </Text>
+            </View>
+            {model.project.dateRange ? (
+              <View style={s.fact}>
+                <Text style={s.factK}>Window</Text>
+                <Text style={[s.factV, { fontSize: 11 }]}>{model.project.dateRange}</Text>
+              </View>
+            ) : null}
+          </View>
+        </View>
+
+        {model.groups.map((group) => {
+          const printable = group.shots.filter((sh) => !sh.excluded)
+          if (printable.length === 0) return null
+          return (
+            <View key={group.key}>
+              <GroupHead group={{ ...group, count: printable.length }} />
+              {printable.map((shot) => {
+                const zebra = z % 2 === 1
+                z += 1
+                return <Band key={shot.id} shot={shot} imageMap={imageMap} zebra={zebra} />
+              })}
+            </View>
+          )
+        })}
+
+        <View style={s.footer} fixed>
+          <Text>Comprehensive Shot Report · {projLine}</Text>
+          <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
+        </View>
+      </Page>
+    </Document>
+  )
+}

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -123,7 +123,7 @@ function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
         <Text style={[s.ph, s.cQty]}>Qty</Text>
       </View>
       {look.products.map((p, i) => (
-        <ProductRow key={i} p={p} />
+        <ProductRow key={`${look.id}-p-${i}`} p={p} />
       ))}
     </View>
   )
@@ -190,9 +190,10 @@ export function BalancedRowsPdfDocument(props: {
   readonly imageMap: ReadonlyMap<string, string>
 }): JSX.Element {
   const { model, imageMap } = props
-  const all = model.groups.flatMap((g) => g.shots)
+  // Count only printable shots — excluded are omitted from the rendered bands.
+  const all = model.groups.flatMap((g) => g.shots).filter((x) => !x.excluded)
   const withImg = all.filter((x) => x.hasImage).length
-  const total = model.project.shotCount
+  const total = all.length
   const projLine = has(model.project.client) ? `${model.project.name} · ${model.project.client}` : model.project.name
   let z = 0
 

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -114,7 +114,7 @@ function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
         <Text style={s.lookCount}>{n === 1 ? "1 piece" : `${n} pieces`}</Text>
       </View>
       {look.products.map((p, i) => (
-        <ProductRow key={i} p={p} />
+        <ProductRow key={`${look.id}-p-${i}`} p={p} />
       ))}
     </View>
   )
@@ -191,7 +191,8 @@ export function ProductionSheetPdfDocument(props: {
   readonly imageMap: ReadonlyMap<string, string>
 }): JSX.Element {
   const { model, imageMap } = props
-  const all = model.groups.flatMap((g) => g.shots)
+  // Count only printable shots — the rows omit excluded, so the masthead must too.
+  const all = model.groups.flatMap((g) => g.shots).filter((x) => !x.excluded)
   const women = all.filter((x) => x.gender === "W").length
   const men = all.filter((x) => x.gender === "M").length
   const holds = all.filter((x) => x.status === "on_hold").length
@@ -215,7 +216,7 @@ export function ProductionSheetPdfDocument(props: {
             <Text style={s.sub}>{projLine}</Text>
           </View>
           <View style={s.metaRow}>
-            {cell(model.project.shotCount, "Shots")}
+            {cell(all.length, "Shots")}
             {women > 0 ? cell(women, "Women") : null}
             {men > 0 ? cell(men, "Men") : null}
             {holds > 0 ? cell(holds, "On Hold") : null}

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -1,0 +1,256 @@
+// Production-sheet PDF (comp-b) — dense landscape spec sheet. Consumes the same
+// ReportModel + image sidecar as the other layouts. Red's ONE job here: the
+// on-hold flag (left bar + "HOLD"); the hero product carries a neutral triangle.
+
+import type { JSX } from "react"
+import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
+import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
+import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage } from "./reportPdfShared"
+
+const PAD_X = 30
+const PAD_Y = 30
+
+const s = StyleSheet.create({
+  page: { paddingTop: PAD_Y, paddingBottom: 30, paddingHorizontal: PAD_X, fontFamily: FONT.body, fontSize: 8, color: COLOR.text, backgroundColor: COLOR.surface },
+
+  // masthead (page 1)
+  head: { flexDirection: "row", alignItems: "flex-end", justifyContent: "space-between", borderBottomWidth: 1.5, borderBottomColor: COLOR.text, paddingBottom: 8, marginBottom: 4 },
+  eyebrow: { fontFamily: FONT.uiBold, fontSize: 6.5, letterSpacing: 1, textTransform: "uppercase", color: COLOR.textSecondary },
+  title: { fontFamily: FONT.display, fontSize: 20, color: COLOR.text, marginTop: 4 },
+  sub: { fontFamily: FONT.ui, fontSize: 9, color: COLOR.textSecondary, marginTop: 3 },
+  metaRow: { flexDirection: "row" },
+  metaCell: { paddingHorizontal: 10, borderLeftWidth: 0.5, borderLeftColor: COLOR.rule, alignItems: "flex-end" },
+  metaNum: { fontFamily: FONT.display, fontSize: 15, color: COLOR.text },
+  metaLabel: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.textSubtle, marginTop: 1 },
+
+  legend: { flexDirection: "row", flexWrap: "wrap", marginTop: 6, marginBottom: 2 },
+  legendItem: { flexDirection: "row", alignItems: "center", marginRight: 16 },
+  legendTxt: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSecondary },
+  flagChip: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.accent, borderWidth: 0.5, borderColor: COLOR.accent, borderRadius: 1, paddingHorizontal: 2, marginRight: 4 },
+
+  // group band (dark)
+  groupBand: { flexDirection: "row", alignItems: "center", backgroundColor: COLOR.text, paddingVertical: 4, paddingHorizontal: 8, marginTop: 10 },
+  groupName: { fontFamily: FONT.uiBold, fontSize: 7.5, letterSpacing: 1.6, textTransform: "uppercase", color: COLOR.surface },
+  groupCount: { fontFamily: FONT.ui, fontSize: 6.5, letterSpacing: 0.8, textTransform: "uppercase", color: "#C9C9C9", marginLeft: "auto" },
+  // column ruler
+  ruler: { flexDirection: "row", borderBottomWidth: 0.5, borderBottomColor: COLOR.ruleStrong, backgroundColor: COLOR.surfaceSubtle, paddingVertical: 3 },
+  rulerSpine: { width: 26 },
+  rulerThumb: { width: 92, paddingLeft: 6, fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.textSubtle },
+  rulerProd: { flex: 1, flexDirection: "row", paddingLeft: 8 },
+
+  // shot row
+  row: { flexDirection: "row", borderBottomWidth: 0.5, borderBottomColor: COLOR.rule },
+  rowFlag: { borderLeftWidth: 3, borderLeftColor: COLOR.accent },
+  spine: { width: 26, borderRightWidth: 0.5, borderRightColor: COLOR.rule, alignItems: "center", paddingVertical: 8 },
+  statusDot: { width: 5, height: 5, borderRadius: 2.5, marginBottom: 4 },
+  holdTxt: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.accent },
+
+  thumbCol: { width: 92, borderRightWidth: 0.5, borderRightColor: COLOR.rule, padding: 6 },
+  thumbBox: { width: 80, height: 96, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center", overflow: "hidden" },
+  thumbImg: { maxWidth: 80, maxHeight: 96, objectFit: "contain" },
+  thumbNoImg: { fontFamily: FONT.ui, fontSize: 5.5, color: COLOR.textSubtle, textTransform: "uppercase" },
+  talent: { fontFamily: FONT.ui, fontSize: 5.5, color: COLOR.textSubtle, marginTop: 4 },
+  talentLabel: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textDisabled },
+
+  body: { flex: 1, paddingHorizontal: 8, paddingVertical: 7 },
+  ident: { flexDirection: "row", alignItems: "baseline", marginBottom: 2 },
+  num: { fontFamily: FONT.uiBold, fontSize: 8, color: COLOR.textSecondary, marginRight: 6 },
+  name: { fontFamily: FONT.display, fontSize: 11, color: COLOR.text, marginRight: 6 },
+  colorway: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary },
+  statusInline: { flexDirection: "row", alignItems: "center", marginLeft: "auto" },
+  statusInlineTxt: { fontFamily: FONT.uiBold, fontSize: 6, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.textSubtle, marginLeft: 4 },
+  unresolved: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.4, textTransform: "uppercase", color: COLOR.accentInk, borderWidth: 0.5, borderColor: COLOR.accentInk, borderRadius: 1, paddingHorizontal: 2, marginLeft: 5 },
+  note: { fontFamily: FONT.bodyItalic, fontSize: 6.5, color: COLOR.textSecondary, marginTop: 3, paddingLeft: 6, borderLeftWidth: 1, borderLeftColor: COLOR.ruleStrong, lineHeight: 1.4 },
+
+  look: { marginTop: 6, borderWidth: 0.5, borderColor: COLOR.rule },
+  lookAlt: { marginLeft: 14, borderStyle: "dashed", backgroundColor: COLOR.surfaceSubtle },
+  lookHead: { flexDirection: "row", alignItems: "center", backgroundColor: COLOR.surfaceSubtle, borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, paddingVertical: 2.5, paddingHorizontal: 7 },
+  lookTag: { fontFamily: FONT.uiBold, fontSize: 6, letterSpacing: 0.8, textTransform: "uppercase", color: COLOR.text },
+  lookCount: { fontFamily: FONT.ui, fontSize: 5.5, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.textDisabled, marginLeft: "auto" },
+
+  // product row
+  ph: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle },
+  prod: { flexDirection: "row", alignItems: "baseline", paddingVertical: 3, paddingHorizontal: 7, borderBottomWidth: 0.5, borderBottomColor: COLOR.rule },
+  prodHero: { backgroundColor: "#FBFAF7" },
+  cHero: { width: 12, alignItems: "center", justifyContent: "center" },
+  // neutral hero mark — a drawn dot (the ▲ glyph is absent from built-in Helvetica)
+  heroDot: { width: 5, height: 5, borderRadius: 2.5, backgroundColor: COLOR.text },
+  cFam: { flex: 1.7, paddingRight: 6 },
+  cStyle: { width: 64, paddingRight: 6 },
+  cColour: { flex: 1, paddingRight: 6 },
+  cSize: { width: 40, textAlign: "right", paddingRight: 4 },
+  cQty: { width: 24, textAlign: "right" },
+  fam: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text, lineHeight: 1.2 },
+  famHero: { fontFamily: FONT.uiBold },
+  style: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSecondary },
+  colour: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.text },
+  size: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.text },
+  qty: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSecondary },
+  muted: { fontFamily: FONT.bodyItalic, color: COLOR.textSubtle },
+
+  footer: { position: "absolute", bottom: 14, left: PAD_X, right: PAD_X, flexDirection: "row", justifyContent: "space-between", fontFamily: FONT.ui, fontSize: 6, color: COLOR.textDisabled, textTransform: "uppercase", letterSpacing: 0.5, borderTopWidth: 0.5, borderTopColor: COLOR.rule, paddingTop: 4 },
+})
+
+function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
+  const sizePending = p.sizeScope === "pending" || !has(p.size)
+  return (
+    <View style={[s.prod, ...(p.isHero ? [s.prodHero] : [])]} wrap={false}>
+      <View style={s.cHero}>{p.isHero ? <View style={s.heroDot} /> : null}</View>
+      <Text style={[s.fam, s.cFam, ...(p.isHero ? [s.famHero] : [])]}>{has(p.family) ? p.family : "Unnamed product"}</Text>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? p.style : "no style #"}</Text>
+      <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "Unspecified"}</Text>
+      <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizePending ? "Pending" : p.size}</Text>
+      <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>
+    </View>
+  )
+}
+
+function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
+  const n = look.products.length
+  return (
+    <View style={[s.look, ...(look.isAlt ? [s.lookAlt] : [])]} wrap={false}>
+      <View style={s.lookHead}>
+        <Text style={s.lookTag}>{look.label.toUpperCase()}</Text>
+        <Text style={s.lookCount}>{n === 1 ? "1 piece" : `${n} pieces`}</Text>
+      </View>
+      {look.products.map((p, i) => (
+        <ProductRow key={i} p={p} />
+      ))}
+    </View>
+  )
+}
+
+function Row({ shot, imageMap }: { readonly shot: ReportShot; readonly imageMap: ReadonlyMap<string, string> }): JSX.Element {
+  const flagged = shot.status === "on_hold"
+  const st = STATUS[shot.status]
+  const cand = primaryLookImage(shot)
+  const src = has(cand) ? imageMap.get(cand) : undefined
+  const talent = shot.talent.filter((t) => has(t.name))
+  return (
+    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]} wrap={false}>
+      <View style={s.spine}>
+        <View style={[s.statusDot, { backgroundColor: st.color }]} />
+        {flagged ? <Text style={s.holdTxt}>HOLD</Text> : null}
+      </View>
+      <View style={s.thumbCol}>
+        <View style={s.thumbBox}>
+          {src ? <Image src={src} style={s.thumbImg} /> : <Text style={s.thumbNoImg}>No ref</Text>}
+        </View>
+        <Text style={s.talent}>
+          <Text style={s.talentLabel}>Talent </Text>
+          {talent.length ? talent.map((t) => t.name).join(", ") : "Unassigned"}
+        </Text>
+      </View>
+      <View style={s.body}>
+        <View style={s.ident}>
+          <Text style={s.num}>{shot.number}</Text>
+          <Text style={s.name}>{shot.title}</Text>
+          {has(shot.colorway) ? <Text style={s.colorway}>{shot.colorway}</Text> : null}
+          <View style={s.statusInline}>
+            <View style={[s.statusDot, { backgroundColor: st.color, marginBottom: 0 }]} />
+            <Text style={s.statusInlineTxt}>{st.label}</Text>
+            {shot.gender === "?" ? <Text style={s.unresolved}>Gender ?</Text> : null}
+          </View>
+        </View>
+        {has(shot.notes) ? <Text style={s.note}>{shot.notes}</Text> : null}
+        {shot.looks.map((lk) => (
+          <LookBlock key={lk.id} look={lk} />
+        ))}
+      </View>
+    </View>
+  )
+}
+
+function GroupBand({ group }: { readonly group: ReportGroup }): JSX.Element {
+  return (
+    // minPresenceAhead pushes the band to the next page rather than stranding it
+    // above a page break, away from its first row.
+    <View wrap={false} minPresenceAhead={100}>
+      <View style={s.groupBand}>
+        <Text style={s.groupName}>{group.label}</Text>
+        <Text style={s.groupCount}>{group.count === 1 ? "1 shot" : `${group.count} shots`}</Text>
+      </View>
+      <View style={s.ruler}>
+        <View style={s.rulerSpine} />
+        <Text style={s.rulerThumb}>Shot / Reference</Text>
+        <View style={s.rulerProd}>
+          <View style={s.cHero} />
+          <Text style={[s.ph, s.cFam]}>Product family</Text>
+          <Text style={[s.ph, s.cStyle]}>Style #</Text>
+          <Text style={[s.ph, s.cColour]}>Colour</Text>
+          <Text style={[s.ph, s.cSize]}>Size</Text>
+          <Text style={[s.ph, s.cQty]}>Qty</Text>
+        </View>
+      </View>
+    </View>
+  )
+}
+
+export function ProductionSheetPdfDocument(props: {
+  readonly model: ReportModel
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const { model, imageMap } = props
+  const all = model.groups.flatMap((g) => g.shots)
+  const women = all.filter((x) => x.gender === "W").length
+  const men = all.filter((x) => x.gender === "M").length
+  const holds = all.filter((x) => x.status === "on_hold").length
+  const projLine = has(model.project.client) ? `${model.project.name} · ${model.project.client}` : model.project.name
+
+  const cell = (num: string | number, label: string) => (
+    <View style={s.metaCell} key={label}>
+      <Text style={s.metaNum}>{num}</Text>
+      <Text style={s.metaLabel}>{label}</Text>
+    </View>
+  )
+
+  return (
+    <Document title="Comprehensive Shot Report" author={model.project.client || ""} producer="Shot Builder">
+      <Page size={{ width: PAGE.width, height: PAGE.height }} style={s.page} wrap>
+        {/* masthead (page 1 only — flows once at start) */}
+        <View style={s.head}>
+          <View>
+            <Text style={s.eyebrow}>Production Pull Sheet · For Crew &amp; Warehouse</Text>
+            <Text style={s.title}>Comprehensive Shot Report</Text>
+            <Text style={s.sub}>{projLine}</Text>
+          </View>
+          <View style={s.metaRow}>
+            {cell(model.project.shotCount, "Shots")}
+            {women > 0 ? cell(women, "Women") : null}
+            {men > 0 ? cell(men, "Men") : null}
+            {holds > 0 ? cell(holds, "On Hold") : null}
+            {model.project.dateRange ? cell(model.project.dateRange, "Window") : null}
+          </View>
+        </View>
+        <View style={s.legend}>
+          <View style={s.legendItem}>
+            <View style={[s.heroDot, { marginRight: 5 }]} />
+            <Text style={s.legendTxt}>Hero product</Text>
+          </View>
+          <View style={s.legendItem}>
+            <Text style={s.flagChip}>Hold</Text>
+            <Text style={s.legendTxt}>Flagged — not cleared to shoot</Text>
+          </View>
+        </View>
+
+        {model.groups.map((group) => {
+          const printable = group.shots.filter((sh) => !sh.excluded)
+          if (printable.length === 0) return null
+          return (
+            <View key={group.key}>
+              <GroupBand group={{ ...group, count: printable.length }} />
+              {printable.map((shot) => (
+                <Row key={shot.id} shot={shot} imageMap={imageMap} />
+              ))}
+            </View>
+          )
+        })}
+
+        <View style={s.footer} fixed>
+          <Text>Comprehensive Shot Report · {projLine}</Text>
+          <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
+        </View>
+      </Page>
+    </Document>
+  )
+}

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -1,0 +1,54 @@
+// Shared @react-pdf tokens for the report layouts (image-led / production-sheet
+// / balanced-rows). One palette + font map + status set + page geometry so the
+// three PDF layouts can't drift. @react-pdf ships only Helvetica/Courier/Times
+// built-ins, so the editorial serif maps to Helvetica (matches the rest of the
+// export PDFs); the type intentionally differs from screen.
+
+import { getPageDimensionsPt } from "../pageDimensions"
+import { mapFontFamilyToPdf } from "../pdf/fontMapping"
+import type { ReportShot } from "./reportTypes"
+
+export const COLOR = {
+  surface: "#FFFFFF",
+  surfaceSubtle: "#F4F4F5",
+  text: "#18181B",
+  textSecondary: "#52525B",
+  textSubtle: "#5B5B60",
+  textDisabled: "#A1A1AA", // placeholder only
+  accent: "#EB1400", // Immediate Red — the ONE decisive job per layout
+  accentInk: "#B3261E", // muted red-ink (≈ DOM --sb-red-ink) for non-decisive marks (unresolved badge)
+  rule: "#E4E4E7",
+  ruleStrong: "#D4D4D8",
+} as const
+
+export const FONT = {
+  display: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
+  displayRegular: mapFontFamilyToPdf(undefined), // Helvetica
+  body: mapFontFamilyToPdf(undefined), // Helvetica
+  bodyItalic: mapFontFamilyToPdf(undefined, false, true), // Helvetica-Oblique
+  ui: mapFontFamilyToPdf(undefined), // Helvetica
+  uiBold: mapFontFamilyToPdf(undefined, true), // Helvetica-Bold
+} as const
+
+export const PAGE = getPageDimensionsPt("letter", "landscape") // 792 x 612 pt
+
+// Status dot colors — green/amber/blue/gray reserved set (no red here; red is
+// each layout's one job).
+export const STATUS: Record<
+  ReportShot["status"],
+  { readonly color: string; readonly label: string }
+> = {
+  complete: { color: "#16A34A", label: "Shot" },
+  in_progress: { color: "#2563EB", label: "In progress" },
+  todo: { color: COLOR.textDisabled, label: "To do" },
+  on_hold: { color: "#D97706", label: "On hold" },
+}
+
+export function has(v: string | null | undefined): v is string {
+  return v != null && v.trim() !== ""
+}
+
+/** The shot's primary image candidate (looks[0] — the canonical primary, as image-led uses). */
+export function primaryLookImage(shot: ReportShot): string | null {
+  return shot.looks[0]?.image ?? null
+}

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -6,6 +6,7 @@
 
 import { getPageDimensionsPt } from "../pageDimensions"
 import { mapFontFamilyToPdf } from "../pdf/fontMapping"
+import { getShotStatusLabel } from "@/shared/lib/statusMappings"
 import type { ReportShot } from "./reportTypes"
 
 export const COLOR = {
@@ -33,15 +34,15 @@ export const FONT = {
 export const PAGE = getPageDimensionsPt("letter", "landscape") // 792 x 612 pt
 
 // Status dot colors — green/amber/blue/gray reserved set (no red here; red is
-// each layout's one job).
+// each layout's one job). Labels come from statusMappings.ts (CLAUDE.md canonical).
 export const STATUS: Record<
   ReportShot["status"],
   { readonly color: string; readonly label: string }
 > = {
-  complete: { color: "#16A34A", label: "Shot" },
-  in_progress: { color: "#2563EB", label: "In progress" },
-  todo: { color: COLOR.textDisabled, label: "To do" },
-  on_hold: { color: "#D97706", label: "On hold" },
+  complete: { color: "#16A34A", label: getShotStatusLabel("complete") },
+  in_progress: { color: "#2563EB", label: getShotStatusLabel("in_progress") },
+  todo: { color: COLOR.textDisabled, label: getShotStatusLabel("todo") },
+  on_hold: { color: "#D97706", label: getShotStatusLabel("on_hold") },
 }
 
 export function has(v: string | null | undefined): v is string {

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -34,15 +34,34 @@ export const FONT = {
 export const PAGE = getPageDimensionsPt("letter", "landscape") // 792 x 612 pt
 
 // Status dot colors — green/amber/blue/gray reserved set (no red here; red is
-// each layout's one job). Labels come from statusMappings.ts (CLAUDE.md canonical).
+// each layout's one job).
+const STATUS_COLOR: Record<ReportShot["status"], string> = {
+  complete: "#16A34A",
+  in_progress: "#2563EB",
+  todo: COLOR.textDisabled,
+  on_hold: "#D97706",
+}
+
+// Canonical labels (statusMappings.ts) — used by the production-sheet + balanced-rows PDFs.
 export const STATUS: Record<
   ReportShot["status"],
   { readonly color: string; readonly label: string }
 > = {
-  complete: { color: "#16A34A", label: getShotStatusLabel("complete") },
-  in_progress: { color: "#2563EB", label: getShotStatusLabel("in_progress") },
-  todo: { color: COLOR.textDisabled, label: getShotStatusLabel("todo") },
-  on_hold: { color: "#D97706", label: getShotStatusLabel("on_hold") },
+  complete: { color: STATUS_COLOR.complete, label: getShotStatusLabel("complete") },
+  in_progress: { color: STATUS_COLOR.in_progress, label: getShotStatusLabel("in_progress") },
+  todo: { color: STATUS_COLOR.todo, label: getShotStatusLabel("todo") },
+  on_hold: { color: STATUS_COLOR.on_hold, label: getShotStatusLabel("on_hold") },
+}
+
+// Original image-led PDF labels — keeps the shipped report byte-identical.
+export const STATUS_LEGACY: Record<
+  ReportShot["status"],
+  { readonly color: string; readonly label: string }
+> = {
+  complete: { color: STATUS_COLOR.complete, label: "Shot" },
+  in_progress: { color: STATUS_COLOR.in_progress, label: "In progress" },
+  todo: { color: STATUS_COLOR.todo, label: "To do" },
+  on_hold: { color: STATUS_COLOR.on_hold, label: "On hold" },
 }
 
 export function has(v: string | null | undefined): v is string {

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -24,11 +24,9 @@ export const REPORT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout
   { value: "production-sheet", label: "On-set sheet" },
   { value: "balanced-rows", label: "All-rounder" },
 ]
-export const REPORT_LAYOUT_LABEL: Record<ReportLayout, string> = {
-  "image-led": "Image-led",
-  "production-sheet": "On-set sheet",
-  "balanced-rows": "All-rounder",
-}
+export const REPORT_LAYOUT_LABEL = Object.fromEntries(
+  REPORT_LAYOUT_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<ReportLayout, string>
 
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -9,6 +9,15 @@ export type ReportGroupBy = "gender" | "none"
 /** Which looks each shot shows: every look, or only the primary (alts hidden). */
 export type ReportLooksMode = "all" | "primary-only"
 
+/**
+ * Which layout recipe renders the (one) resolved model.
+ * - image-led: client-review deck (the shipped R1 layout, default).
+ * - production-sheet: dense on-set/warehouse spec sheet (comp-b).
+ * - balanced-rows: scannable one-band-per-shot all-rounder (comp-c).
+ * The recipes share the engine; only layout + which fields surface differ.
+ */
+export type ReportLayout = "image-led" | "production-sheet" | "balanced-rows"
+
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
@@ -16,12 +25,15 @@ export interface ReportConfig {
   readonly excludedShotIds: readonly string[]
   /** "primary-only" shows just each shot's primary look. Defaults to "all". */
   readonly looksMode?: ReportLooksMode
+  /** Layout recipe. Defaults to "image-led" so pre-R3 blobs render unchanged. */
+  readonly layout?: ReportLayout
 }
 
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   groupBy: "gender",
   excludedShotIds: [],
   looksMode: "all",
+  layout: "image-led",
 }
 
 /** Normalized gender bucket. "?" = unresolved (never silently dropped). */
@@ -81,6 +93,12 @@ export interface ReportGroup {
 }
 
 export interface ReportModel {
-  readonly project: { readonly name: string; readonly client: string; readonly shotCount: number }
+  readonly project: {
+    readonly name: string
+    readonly client: string
+    readonly shotCount: number
+    /** Shoot-date window (e.g. "Jun 2–6, 2026"), or null when no dates. Surfaced by production-sheet/balanced-rows mastheads. */
+    readonly dateRange: string | null
+  }
   readonly groups: readonly ReportGroup[]
 }

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -18,15 +18,19 @@ export type ReportLooksMode = "all" | "primary-only"
  */
 export type ReportLayout = "image-led" | "production-sheet" | "balanced-rows"
 
-/** Recipe option metadata — the single source for the picker + in-report switch + list chip. */
-export const REPORT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
-  { value: "image-led", label: "Image-led" },
-  { value: "production-sheet", label: "On-set sheet" },
-  { value: "balanced-rows", label: "All-rounder" },
-]
-export const REPORT_LAYOUT_LABEL = Object.fromEntries(
-  REPORT_LAYOUT_OPTIONS.map((o) => [o.value, o.label]),
-) as Record<ReportLayout, string>
+// Recipe display labels — the single source for the picker + in-report switch +
+// list chip. An exhaustive typed literal (TS flags a missing variant); the option
+// list derives from it so the strings aren't duplicated.
+export const REPORT_LAYOUT_LABEL: Record<ReportLayout, string> = {
+  "image-led": "Image-led",
+  "production-sheet": "On-set sheet",
+  "balanced-rows": "All-rounder",
+}
+export const REPORT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> =
+  (Object.keys(REPORT_LAYOUT_LABEL) as ReportLayout[]).map((value) => ({
+    value,
+    label: REPORT_LAYOUT_LABEL[value],
+  }))
 
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -18,6 +18,18 @@ export type ReportLooksMode = "all" | "primary-only"
  */
 export type ReportLayout = "image-led" | "production-sheet" | "balanced-rows"
 
+/** Recipe option metadata — the single source for the picker + in-report switch + list chip. */
+export const REPORT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout; readonly label: string }> = [
+  { value: "image-led", label: "Image-led" },
+  { value: "production-sheet", label: "On-set sheet" },
+  { value: "balanced-rows", label: "All-rounder" },
+]
+export const REPORT_LAYOUT_LABEL: Record<ReportLayout, string> = {
+  "image-led": "Image-led",
+  "production-sheet": "On-set sheet",
+  "balanced-rows": "All-rounder",
+}
+
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -170,4 +170,24 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureTalentLazy")).toBe(false)
     }
   })
+
+  it("defaults featureShotReportRecipes to false (R3 recipes dark on main; flag-off forces image-led)", () => {
+    expect(getFeatureFlags().featureShotReportRecipes).toBe(false)
+    expect(isFeatureEnabled("featureShotReportRecipes")).toBe(false)
+  })
+
+  it("VITE_SHOT_REPORT_RECIPES='1' or 'true' enables featureShotReportRecipes", () => {
+    vi.stubEnv("VITE_SHOT_REPORT_RECIPES", "1")
+    expect(isFeatureEnabled("featureShotReportRecipes")).toBe(true)
+
+    vi.stubEnv("VITE_SHOT_REPORT_RECIPES", "true")
+    expect(isFeatureEnabled("featureShotReportRecipes")).toBe(true)
+  })
+
+  it("any other VITE_SHOT_REPORT_RECIPES value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_SHOT_REPORT_RECIPES", value)
+      expect(isFeatureEnabled("featureShotReportRecipes")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -117,6 +117,16 @@ export interface FeatureFlags {
    * env-parse precedent). No URL/localStorage layer.
    */
   readonly featureShotReport: boolean
+  /**
+   * Export reimagine R3 — the two extra report recipes (production-sheet +
+   * balanced-rows) as layout variants of the live Shot Report. Gates the recipe
+   * picker (list), the in-report layout switch, and `config.layout` taking
+   * effect (flag-off forces "image-led", so prod is byte-identical to the live
+   * R1/R2 report). Default OFF; enabled via `VITE_SHOT_REPORT_RECIPES=1` (or
+   * `true`) at build/dev time (featureShotReport env-parse precedent). No
+   * URL/localStorage layer.
+   */
+  readonly featureShotReportRecipes: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -131,6 +141,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureCastingMatcherSurface: false,
   featureTalentLazy: false,
   featureShotReport: false,
+  featureShotReportRecipes: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -180,6 +191,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureShotReport:
       DEFAULT_FLAGS.featureShotReport ||
       parseEnvFlag(import.meta.env.VITE_SHOT_REPORT),
+    featureShotReportRecipes:
+      DEFAULT_FLAGS.featureShotReportRecipes ||
+      parseEnvFlag(import.meta.env.VITE_SHOT_REPORT_RECIPES),
   }
 }
 


### PR DESCRIPTION
## R3 — the other two report recipes (on-set sheet + all-rounder)

Adds the two remaining recipes from the reimagine comps as **layout variants of the one `deriveShotReportModel` engine** — not a second model, not a new `reportType`, not a new route, no migration. Builds on R1 (#486) + R2 (#487/#488), live in prod.

| | comp-b → "On-set sheet" (`production-sheet`) | comp-c → "All-rounder" (`balanced-rows`) |
|---|---|---|
| Unit | dense row `[status-spine │ thumb │ body]` | full-width band `[image │ panel]`, zebra |
| Red's ONE job | on-hold FLAG spine (red bar + "HOLD") | HERO product marker (red rail + "HERO") |

### Mechanism
- **`ReportConfig.layout`** enum, optional, defaults `"image-led"` → every pre-R3 saved report renders unchanged.
- **`ReportModel.project.dateRange`** derived purely from `Project.shootDates` (inert for image-led).
- `ReportView` (DOM) + `reportPdf` (landscape) branch on `layout`; recipe picked at create in the Shot Reports list + live-switchable in-report (persisted like `groupBy`/`looksMode`).
- Status + image resolution consolidated into `reportShared` / `reportPdfShared` so the three layouts can't drift.

### Why this is clobber-safe
Not a new doc-type — all three recipes stay `reportType: "shot-report"`; `layout` is an enum **inside** the already-persisted config blob, read only by new code, defaulting back-compat at every read site. Both legacy list filters (`ExportBuilderPage` → block-canvas, list → shot-report) stay correct. No migration.

### Own flag — `featureShotReportRecipes` (default OFF)
`featureShotReport` is already live, so the two new recipes ride their own flag and land dark. **Flag-off forces `image-led`** at every read site (render, PDF export, create) → prod byte-identical to the live R1/R2 report. Enable via `VITE_SHOT_REPORT_RECIPES=1`.

### Verification
- 7-lens adversarial review + verify; 5 confirmed findings fixed: PDF "Gender ?" badge → muted `accentInk` (one-red rule); production-sheet PDF hero `▲` → drawn dot (glyph absent from built-in Helvetica); PDF group bands `minPresenceAhead` (no stranding); `primaryLookImage` consolidated to canonical `looks[0]`; flag-off list row byte-identical.
- Gates: tsc baseline **0 new** (160/160) · vitest report/flags/map green · vite build green (`reportPdf` stays its own lazy chunk, @react-pdf isolated) · all 3 PDF layouts render to buffer.

### ⛔ HOLD — do not merge until the `:5174` eyeball
The two new layouts are unreviewed design. Ted reviews live on a free port with a throwaway project (never `Q2-26 No. 3`):
```
VITE_SHOT_REPORT=1 VITE_SHOT_REPORT_RECIPES=1 npm run dev -- --port 5174
```
Known limitation to confirm at eyeball: a single shot taller than a landscape page can clip in the row/band PDFs (`wrap=false`); realistic data (≤3 looks) is fine — pre-existing behavior the image-led layout shares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ejXd9M4gS6K1PqoAKS9Q8