### PR TITLE
feat(export): Product Info report (R4 PR1, flag-gated)

### DIFF
--- a/src-vnext/app/routes/breadcrumbs.ts
+++ b/src-vnext/app/routes/breadcrumbs.ts
@@ -113,6 +113,20 @@ export const breadcrumbsConfig: Record<string, BreadcrumbResolver> = {
     },
     { label: "Shot Report" },
   ],
+  "/projects/:id/export/product-reports": (ctx) => [
+    ...projectCrumbs(ctx),
+    { label: "Product Info" },
+  ],
+  "/projects/:id/export/product-report": (ctx) => [
+    ...projectCrumbs(ctx),
+    {
+      label: "Product Info",
+      to: ctx.params["id"]
+        ? `/projects/${ctx.params["id"]}/export/product-reports`
+        : undefined,
+    },
+    { label: "Product Report" },
+  ],
   "/projects/:id/schedules/:scheduleId/onset": () => [],
 
   "/requests": () => [{ label: "Shot Requests" }],

--- a/src-vnext/app/routes/index.tsx
+++ b/src-vnext/app/routes/index.tsx
@@ -61,6 +61,12 @@ const ShotReportPage = lazy(
 const ShotReportListPage = lazy(
   () => import("@/features/export/components/report/ShotReportListPage"),
 )
+const ProductInfoReportPage = lazy(
+  () => import("@/features/export/components/report/ProductInfoReportPage"),
+)
+const ProductInfoReportListPage = lazy(
+  () => import("@/features/export/components/report/ProductInfoReportListPage"),
+)
 const OnSetViewerPage = lazy(
   () => import("@/features/schedules/components/OnSetViewerPage"),
 )
@@ -290,6 +296,34 @@ export function AppRoutes() {
                   <ProjectScopeProvider>
                     <RequireDesktop label="Shot report">
                       <ShotReportPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
+          {isFeatureEnabled("featureProductInfoReport") && (
+            <Route
+              path="projects/:id/export/product-reports"
+              element={
+                <RouteBoundary featureName="Product info reports">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Product info reports">
+                      <ProductInfoReportListPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
+          {isFeatureEnabled("featureProductInfoReport") && (
+            <Route
+              path="projects/:id/export/product-report"
+              element={
+                <RouteBoundary featureName="Product info report">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Product info report">
+                      <ProductInfoReportPage />
                     </RequireDesktop>
                   </ProjectScopeProvider>
                 </RouteBoundary>

--- a/src-vnext/features/export/components/report/ProductInfoReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportListPage.tsx
@@ -1,13 +1,10 @@
 import { useCallback, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
-import { Copy, FileText, Plus, Trash2 } from "lucide-react"
+import { Package, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
-import { isFeatureEnabled } from "@/shared/lib/flags"
-import { badgeVariants } from "@/ui/badge"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/ui/select"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -21,50 +18,43 @@ import {
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
-import {
-  DEFAULT_REPORT_CONFIG,
-  REPORT_LAYOUT_LABEL,
-  REPORT_LAYOUT_OPTIONS,
-  type ReportConfig,
-  type ReportLayout,
-} from "../../lib/report/reportTypes"
+import { DEFAULT_PRODUCT_INFO_CONFIG } from "../../lib/report/productInfoTypes"
 
-// Saved shot reports for a project: create (optionally cloning an existing
-// report's config as a recipe), open, and delete. Sits beside the single report
-// page; never touches the legacy block-canvas builder. Flag-gated route.
+// Saved product-info reports for a project: create, open, and delete. Sits beside
+// the single report page; never touches the legacy block-canvas builder or the
+// shot-report list. Flag-gated route. Mirrors ShotReportListPage.
 
-export default function ShotReportListPage() {
+export default function ProductInfoReportListPage() {
   const { id: projectId } = useParams<{ id: string }>()
   const { clientId } = useAuth()
   const navigate = useNavigate()
-  const { reports, loading, createShotReport, loadReport, deleteReport } =
-    useExportReports(clientId, projectId)
+  const { reports, loading, createProductInfoReport, deleteReport } = useExportReports(
+    clientId,
+    projectId,
+  )
 
-  const shotReports = useMemo(
-    () => reports.filter((r) => r.reportType === "shot-report"),
+  const productReports = useMemo(
+    () => reports.filter((r) => r.reportType === "product-info"),
     [reports],
   )
 
-  const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
   const [newName, setNewName] = useState("")
-  const [recipe, setRecipe] = useState<ReportLayout>("image-led")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
 
   const openReport = useCallback(
-    (reportId: string) => navigate(`/projects/${projectId}/export/report?reportId=${reportId}`),
+    (reportId: string) =>
+      navigate(`/projects/${projectId}/export/product-report?reportId=${reportId}`),
     [navigate, projectId],
   )
 
   const handleCreate = useCallback(async () => {
     setBusy(true)
     try {
-      // Recipes flag-off => always image-led, so the create config can't smuggle
-      // an unreviewed layout into prod.
-      const config = recipesEnabled
-        ? { ...DEFAULT_REPORT_CONFIG, layout: recipe }
-        : DEFAULT_REPORT_CONFIG
-      const id = await createShotReport(newName.trim() || "Untitled report", config)
+      const id = await createProductInfoReport(
+        newName.trim() || "Untitled report",
+        DEFAULT_PRODUCT_INFO_CONFIG,
+      )
       setNewName("")
       openReport(id)
     } catch {
@@ -72,25 +62,7 @@ export default function ShotReportListPage() {
     } finally {
       setBusy(false)
     }
-  }, [createShotReport, newName, openReport, recipe, recipesEnabled])
-
-  const handleDuplicate = useCallback(
-    async (sourceId: string, sourceName: string) => {
-      setBusy(true)
-      try {
-        const full = await loadReport(sourceId)
-        // This list only handles shot-report docs; config narrows to ReportConfig.
-        const sourceConfig = (full?.config as ReportConfig | undefined) ?? DEFAULT_REPORT_CONFIG
-        const id = await createShotReport(`${sourceName} (copy)`, sourceConfig)
-        openReport(id)
-      } catch {
-        toast.error("Couldn't duplicate the report")
-      } finally {
-        setBusy(false)
-      }
-    },
-    [createShotReport, loadReport, openReport],
-  )
+  }, [createProductInfoReport, newName, openReport])
 
   const handleDelete = useCallback(
     async (reportId: string) => {
@@ -106,7 +78,7 @@ export default function ShotReportListPage() {
 
   return (
     <div className="mx-auto w-full max-w-3xl">
-      <PageHeader title="Shot Reports" />
+      <PageHeader title="Product Info" />
 
       <div className="mb-6 flex items-center gap-2">
         <Input
@@ -119,20 +91,6 @@ export default function ShotReportListPage() {
           aria-label="New report name"
           className="flex-1"
         />
-        {recipesEnabled && (
-          <Select value={recipe} onValueChange={(v) => setRecipe(v as ReportLayout)}>
-            <SelectTrigger className="w-40" aria-label="Report recipe">
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent>
-              {REPORT_LAYOUT_OPTIONS.map((opt) => (
-                <SelectItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
         <Button onClick={() => void handleCreate()} disabled={busy}>
           <Plus /> Create report
         </Button>
@@ -140,15 +98,15 @@ export default function ShotReportListPage() {
 
       {loading ? (
         <p className="text-sm text-[var(--color-text-muted)]">Loading…</p>
-      ) : shotReports.length === 0 ? (
+      ) : productReports.length === 0 ? (
         <EmptyState
-          icon={<FileText className="h-8 w-8" />}
-          title="No shot reports yet"
-          description="Create a report above to lay your shots out as an image-led deck, then export it as a PDF."
+          icon={<Package className="h-8 w-8" />}
+          title="No product info reports yet"
+          description="Create a report above to lay out every product in use as a printable info sheet, then export it as a PDF."
         />
       ) : (
         <ul className="divide-y divide-[var(--color-border)] rounded-md border border-[var(--color-border)]">
-          {shotReports.map((r) => (
+          {productReports.map((r) => (
             <li key={r.id} className="flex items-center gap-2 p-3">
               <button
                 type="button"
@@ -158,28 +116,14 @@ export default function ShotReportListPage() {
                 <span className="block truncate text-sm font-medium text-[var(--color-text)]">
                   {r.name}
                 </span>
-                {(recipesEnabled || r.updatedAt) && (
+                {r.updatedAt ? (
                   <span className="block text-xs text-[var(--color-text-muted)]">
-                    {recipesEnabled && (
-                      <span className={`${badgeVariants({ variant: "secondary" })} mr-2`}>
-                        {REPORT_LAYOUT_LABEL[r.layout]}
-                      </span>
-                    )}
-                    {r.updatedAt ? `Updated ${r.updatedAt.toLocaleDateString()}` : null}
+                    Updated {r.updatedAt.toLocaleDateString()}
                   </span>
-                )}
+                ) : null}
               </button>
               <Button variant="outline" size="sm" onClick={() => openReport(r.id)}>
                 Open
-              </Button>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => void handleDuplicate(r.id, r.name)}
-                disabled={busy}
-                title="New report from this one's settings"
-              >
-                <Copy /> Recipe
               </Button>
               <Button
                 variant="ghost"

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -1,22 +1,25 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
 import { useAuth } from "@/app/providers/AuthProvider"
-import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
-import { deriveShotReportModel } from "../../lib/report/reportModel"
 import {
-  collectReportImageCandidates,
-  resolveReportImages,
-} from "../../lib/report/reportImages"
-import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../../lib/report/reportTypes"
-import { ReportView } from "./ReportView"
+  collectProductInfoImageCandidates,
+  deriveProductInfoModel,
+} from "../../lib/report/productInfoModel"
+import { resolveReportImages } from "../../lib/report/reportImages"
+import {
+  DEFAULT_PRODUCT_INFO_CONFIG,
+  type ProductInfoConfig,
+} from "../../lib/report/productInfoTypes"
+import { ProductInfoReportView } from "./ProductInfoReportView"
 
-// Integration layer: live export data -> resolved model -> image sidecar ->
-// ReportView. The model + imageMap feed both the screen render and the PDF, so
-// they can't drift. Mounted only behind the featureShotReport flag (route gate).
+// Integration layer: live export data -> resolved product-info model -> image
+// sidecar -> ProductInfoReportView. The model + imageMap feed both the screen
+// render and the PDF, so they can't drift. Mounted only behind the
+// featureProductInfoReport flag (route gate). Mirrors ShotReportPage.
 
-export default function ShotReportPage() {
+export default function ProductInfoReportPage() {
   const data = useExportData()
   const { id: projectId } = useParams<{ id: string }>()
   const { clientId } = useAuth()
@@ -24,7 +27,7 @@ export default function ShotReportPage() {
   const reportId = searchParams.get("reportId")
   const { loadReport, saveReportConfig } = useExportReports(clientId, projectId)
 
-  const [config, setConfig] = useState<ReportConfig>(DEFAULT_REPORT_CONFIG)
+  const [config, setConfig] = useState<ProductInfoConfig>(DEFAULT_PRODUCT_INFO_CONFIG)
   const [imageMap, setImageMap] = useState<ReadonlyMap<string, string>>(new Map())
   const [imagesLoading, setImagesLoading] = useState(false)
   const [exporting, setExporting] = useState(false)
@@ -34,23 +37,25 @@ export default function ShotReportPage() {
   // loading must not persist — they'd save the outgoing report's config onto it.
   const hydratedReportIdRef = useRef<string | null>(null)
 
-  // Hydrate config from a saved shot-report doc when ?reportId= is present, else
+  // Hydrate config from a saved product-info doc when ?reportId= is present, else
   // reset to defaults. Switching reports (or clearing reportId) also cancels any
   // pending write from the previous report. Default-merge so an older blob parses.
   useEffect(() => {
     if (persistTimer.current) clearTimeout(persistTimer.current)
     hydratedReportIdRef.current = null
     if (!reportId) {
-      setConfig(DEFAULT_REPORT_CONFIG)
+      setConfig(DEFAULT_PRODUCT_INFO_CONFIG)
       return
     }
     let cancelled = false
     void loadReport(reportId)
       .then((full) => {
         if (cancelled) return
-        // This page only loads shot-report docs; config narrows to ReportConfig.
-        const loaded = full?.config as ReportConfig | undefined
-        setConfig(loaded ? { ...DEFAULT_REPORT_CONFIG, ...loaded } : DEFAULT_REPORT_CONFIG)
+        // This page only loads product-info docs; config narrows to ProductInfoConfig.
+        const loaded = full?.config as ProductInfoConfig | undefined
+        setConfig(
+          loaded ? { ...DEFAULT_PRODUCT_INFO_CONFIG, ...loaded } : DEFAULT_PRODUCT_INFO_CONFIG,
+        )
         hydratedReportIdRef.current = reportId
       })
       .catch(() => {
@@ -64,13 +69,13 @@ export default function ShotReportPage() {
   // User edits persist (debounced) only when editing a saved report that has
   // hydrated. Hydration uses setConfig directly, so it never triggers a write-back.
   const handleConfigChange = useCallback(
-    (next: ReportConfig) => {
+    (next: ProductInfoConfig) => {
       setConfig(next)
       if (!reportId || hydratedReportIdRef.current !== reportId) return
       if (persistTimer.current) clearTimeout(persistTimer.current)
       persistTimer.current = setTimeout(() => {
         void saveReportConfig(reportId, next).catch(() => {
-          /* offline cache retries; save status surfaced in the report UI (PR-B) */
+          /* offline cache retries */
         })
       }, 800)
     },
@@ -85,13 +90,13 @@ export default function ShotReportPage() {
     [],
   )
 
-  const model = useMemo(() => deriveShotReportModel(data, config), [data, config])
+  const model = useMemo(() => deriveProductInfoModel(data, config), [data, config])
 
   // Resolve every image candidate to a data URL once the model is known.
   // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.
   useEffect(() => {
     let cancelled = false
-    const candidates = collectReportImageCandidates(model)
+    const candidates = collectProductInfoImageCandidates(model)
     if (candidates.length === 0) {
       setImageMap(new Map())
       return
@@ -117,27 +122,21 @@ export default function ShotReportPage() {
     // Lazy-import so @react-pdf (and its heavy deps) load only on export click,
     // keeping them out of the report route's eager chunk.
     void (async () => {
-      const { generateShotReportPdf } = await import("../../lib/report/reportPdf")
-      // Recipes ride their own flag; flag-off forces image-led so the PDF matches
-      // the on-screen layout (which ReportView also forces to image-led).
-      const layout = isFeatureEnabled("featureShotReportRecipes")
-        ? (config.layout ?? "image-led")
-        : "image-led"
-      await generateShotReportPdf(
+      const { generateProductInfoPdf } = await import("../../lib/report/reportPdfProductInfo")
+      await generateProductInfoPdf(
         model,
         imageMap,
-        `${model.project.name} — Shot Report.pdf`,
-        layout,
+        `${model.project.name} — Product Info.pdf`,
       )
     })().finally(() => {
       setExporting(false)
     })
-  }, [model, imageMap, config.layout])
+  }, [model, imageMap])
 
   if (data.loading) {
     return (
       <div className="flex h-full items-center justify-center text-[var(--color-text-secondary)]">
-        Loading shots…
+        Loading products…
       </div>
     )
   }
@@ -152,7 +151,7 @@ export default function ShotReportPage() {
           Loading images…
         </div>
       )}
-      <ReportView
+      <ProductInfoReportView
         model={model}
         imageMap={imageMap}
         config={config}

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -37,6 +37,9 @@ export default function ProductInfoReportPage() {
   // The reportId that has finished hydrating. Edits made while a report is still
   // loading must not persist — they'd save the outgoing report's config onto it.
   const hydratedReportIdRef = useRef<string | null>(null)
+  // The image candidate set last resolved — re-derivations that don't change it
+  // (an S/M/L toggle) skip the resolve so the loading overlay doesn't flash.
+  const lastImageKeyRef = useRef<string | null>(null)
 
   // Hydrate config from a saved product-info doc when ?reportId= is present, else
   // reset to defaults. Switching reports (or clearing reportId) also cancels any
@@ -52,7 +55,9 @@ export default function ProductInfoReportPage() {
     void loadReport(reportId)
       .then((full) => {
         if (cancelled) return
-        // This page only loads product-info docs; config narrows to ProductInfoConfig.
+        // Cross-type guard: never hydrate or arm write-back from a non-product-info
+        // doc — a pasted cross-type reportId must not clobber that doc's config.
+        if (full?.reportType !== "product-info") return
         const loaded = full?.config as ProductInfoConfig | undefined
         setConfig(
           loaded ? { ...DEFAULT_PRODUCT_INFO_CONFIG, ...loaded } : DEFAULT_PRODUCT_INFO_CONFIG,
@@ -96,12 +101,16 @@ export default function ProductInfoReportPage() {
   // Resolve every image candidate to a data URL once the model is known.
   // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.
   useEffect(() => {
-    let cancelled = false
     const candidates = collectProductInfoImageCandidates(model)
+    const key = candidates.join("\n")
+    if (key === lastImageKeyRef.current) return // image set unchanged (e.g. S/M/L) — no re-resolve
+    lastImageKeyRef.current = key
     if (candidates.length === 0) {
       setImageMap(new Map())
+      setImagesLoading(false)
       return
     }
+    let cancelled = false
     setImagesLoading(true)
     resolveReportImages(candidates)
       .then((resolved) => {

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -55,10 +55,10 @@ export default function ProductInfoReportPage() {
     void loadReport(reportId)
       .then((full) => {
         if (cancelled) return
-        // Cross-type guard: never hydrate or arm write-back from a non-product-info
-        // doc — a pasted cross-type reportId must not clobber that doc's config.
-        if (full?.reportType !== "product-info") return
-        const loaded = full?.config as ProductInfoConfig | undefined
+        if (!full) return // doc not found (deleted) — keep defaults, nothing to persist
+        // Cross-type guard: a pasted cross-type reportId must not clobber that doc's config.
+        if (full.reportType !== "product-info") return
+        const loaded = full.config as ProductInfoConfig | undefined
         setConfig(
           loaded ? { ...DEFAULT_PRODUCT_INFO_CONFIG, ...loaded } : DEFAULT_PRODUCT_INFO_CONFIG,
         )
@@ -170,6 +170,7 @@ export default function ProductInfoReportPage() {
         onConfigChange={handleConfigChange}
         onExportPdf={handleExportPdf}
         exporting={exporting}
+        imagesLoading={imagesLoading}
       />
     </div>
   )

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
+import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
@@ -128,9 +129,11 @@ export default function ProductInfoReportPage() {
         imageMap,
         `${model.project.name} — Product Info.pdf`,
       )
-    })().finally(() => {
-      setExporting(false)
-    })
+    })()
+      .catch(() => toast.error("Couldn't export the PDF"))
+      .finally(() => {
+        setExporting(false)
+      })
   }, [model, imageMap])
 
   if (data.loading) {

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -7,7 +7,7 @@
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
-import { statusMeta } from "./reportShared"
+import { resolveSrc, statusMeta } from "./reportShared"
 import { PRODUCT_INFO_STYLES } from "./productInfoStyles"
 import type {
   ProductInfoConfig,
@@ -28,10 +28,6 @@ export interface ProductInfoReportViewProps {
   readonly exporting?: boolean
 }
 
-function resolveSrc(imageMap: ReadonlyMap<string, string>, candidate: string | null): string | null {
-  if (!candidate) return null
-  return imageMap.get(candidate) ?? null
-}
 
 // ---------------------------------------------------------------------------
 // One product card — image (native aspect), name, style#·gender·HERO, colours,

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -1,0 +1,522 @@
+// Product Info report — DOM renderer (screen + paged print preview). A NEW report
+// TYPE (product-centric): one card per ProductFamily in use, grouped per config.
+// Pure presentational + interaction callbacks; no data fetching. Consumes the
+// resolved ProductInfoModel + an image *sidecar* map (candidate -> data URL). Red
+// does exactly one job here: the HERO mark. Ported from comp-product-info.html.
+
+import { useId, useMemo, useState } from "react"
+import type { JSX } from "react"
+import { Loader2 } from "lucide-react"
+import { statusMeta } from "./reportShared"
+import { PRODUCT_INFO_STYLES } from "./productInfoStyles"
+import type {
+  ProductInfoConfig,
+  ProductInfoEntry,
+  ProductInfoGroup,
+  ProductInfoGroupBy,
+  ProductInfoImageSize,
+  ProductInfoModel,
+  ProductInfoScope,
+} from "../../lib/report/productInfoTypes"
+
+export interface ProductInfoReportViewProps {
+  readonly model: ProductInfoModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly config: ProductInfoConfig
+  readonly onConfigChange: (next: ProductInfoConfig) => void
+  readonly onExportPdf: () => void
+  readonly exporting?: boolean
+}
+
+function resolveSrc(imageMap: ReadonlyMap<string, string>, candidate: string | null): string | null {
+  if (!candidate) return null
+  return imageMap.get(candidate) ?? null
+}
+
+// ---------------------------------------------------------------------------
+// One product card — image (native aspect), name, style#·gender·HERO, colours,
+// sizes / "Size pending", "Appears in N shots" with status dots + look labels.
+// ---------------------------------------------------------------------------
+function ProductCard({
+  entry,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (familyId: string) => void
+}): JSX.Element {
+  const src = resolveSrc(imageMap, entry.image)
+  const appears = entry.appears
+  const styleNo = entry.styleNumber && entry.styleNumber.trim() !== "" ? entry.styleNumber : null
+
+  return (
+    <article className={"sb-pir-card" + (entry.excluded ? " sb-pir-excluded" : "")}>
+      <button
+        type="button"
+        className="sb-pir-exclude-toggle no-print"
+        aria-pressed={entry.excluded}
+        onClick={() => onToggleExclude(entry.id)}
+        title={entry.excluded ? "Restore this product to the report" : "Exclude this product from the report"}
+      >
+        {entry.excluded ? "Restore" : "Exclude"}
+      </button>
+
+      <div className="sb-pir-card-frame">
+        {src ? (
+          <img src={src} alt={`${entry.styleName} — product image`} loading="lazy" />
+        ) : (
+          <div className="sb-pir-noimg">No product image</div>
+        )}
+      </div>
+
+      <div className="sb-pir-card-body">
+        <h3 className="sb-pir-card-name">{entry.styleName}</h3>
+
+        <div className="sb-pir-card-ident">
+          {styleNo ? <span className="sb-pir-style-no">{styleNo}</span> : null}
+          {styleNo && entry.genderLabel ? <span className="sb-pir-dot-sep">·</span> : null}
+          {entry.genderLabel ? <span>{entry.genderLabel}</span> : null}
+          {entry.isHero ? (
+            <>
+              {styleNo || entry.genderLabel ? <span className="sb-pir-dot-sep">·</span> : null}
+              <span className="sb-pir-hero-tag">Hero</span>
+            </>
+          ) : null}
+        </div>
+
+        <div className="sb-pir-row">
+          <span className="sb-pir-k">Colours</span>
+          {entry.colours.length ? (
+            <div className="sb-pir-chips">
+              {entry.colours.map((c) => (
+                <span className="sb-pir-chip" key={c}>
+                  {c}
+                </span>
+              ))}
+            </div>
+          ) : (
+            <span className="sb-pir-v sb-pending">TBD</span>
+          )}
+        </div>
+
+        <div className="sb-pir-row">
+          <span className="sb-pir-k">Sizes</span>
+          {entry.sizes.length ? (
+            <span className="sb-pir-v sb-tabular">{entry.sizes.join(" · ")}</span>
+          ) : entry.sizePending ? (
+            <span className="sb-pir-v sb-pending">Size pending</span>
+          ) : (
+            <span className="sb-pir-v sb-pending">—</span>
+          )}
+        </div>
+
+        <div className="sb-pir-appears">
+          <span className="sb-pir-k">
+            Appears in {appears.length} {appears.length === 1 ? "shot" : "shots"}
+          </span>
+          {appears.length ? (
+            <div className="sb-pir-appears-list">
+              {appears.map((a, i) => {
+                const st = statusMeta(a.status)
+                return (
+                  <span className="sb-pir-appears-item" key={`${entry.id}-a-${i}`}>
+                    <span className={"sb-status-dot " + st.dotClass} title={st.label} aria-hidden="true" />
+                    <span>{a.number && a.number.trim() !== "" ? a.number : "—"}</span>
+                    <span className="sb-pir-look">{a.look}</span>
+                  </span>
+                )
+              })}
+            </div>
+          ) : (
+            <span className="sb-pir-v sb-pending">Not yet styled into a shot</span>
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Masthead band — Products / Women / Men / Heroes / Window.
+// ---------------------------------------------------------------------------
+function Masthead({ model }: { readonly model: ProductInfoModel }): JSX.Element {
+  const stats = useMemo(() => {
+    let women = 0
+    let men = 0
+    let heroes = 0
+    for (const g of model.groups) {
+      for (const e of g.items) {
+        if (e.excluded) continue
+        if (e.gender === "W") women += 1
+        else if (e.gender === "M") men += 1
+        if (e.isHero) heroes += 1
+      }
+    }
+    const total = model.groups.reduce((acc, g) => acc + g.items.filter((e) => !e.excluded).length, 0)
+    return { women, men, heroes, total }
+  }, [model.groups])
+
+  const cells: ReadonlyArray<readonly [string, string | number]> = [
+    ["Products", stats.total],
+    ["Women", stats.women],
+    ["Men", stats.men],
+    ["Heroes", stats.heroes],
+    ["Window", model.project.dateRange ?? "—"],
+  ]
+
+  return (
+    <header className="sb-pir-masthead-band">
+      <div className="sb-pir-eyebrow-row">
+        <span className="sb-pir-eyebrow">
+          Product Info{model.project.name ? ` · ${model.project.name}` : ""}
+        </span>
+        {model.project.client ? <span className="sb-pir-eyebrow sb-pir-lede">{model.project.client}</span> : null}
+      </div>
+      <h1 className="sb-pir-masthead-title">Product Info</h1>
+      <div className="sb-pir-masthead-meta">
+        {cells.map(([k, v]) => (
+          <div className="sb-pir-meta-cell" key={k}>
+            <span className="sb-pir-meta-k">{k}</span>
+            <span className="sb-pir-meta-v">{String(v)}</span>
+          </div>
+        ))}
+      </div>
+    </header>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Fluid (screen) group section — header + count, responsive card grid.
+// ---------------------------------------------------------------------------
+function GroupSection({
+  group,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly group: ProductInfoGroup
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (familyId: string) => void
+}): JSX.Element {
+  const shown = group.items.filter((e) => !e.excluded).length
+  return (
+    <section className="sb-pir-group" aria-label={group.label}>
+      <div className="sb-pir-group-head">
+        <span className="sb-pir-group-name">{group.label}</span>
+        <span className="sb-pir-group-count">
+          {shown} {shown === 1 ? "product" : "products"}
+        </span>
+      </div>
+      <div className="sb-pir-grid">
+        {group.items.map((entry) => (
+          <ProductCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Paged (print preview) — US-Letter LANDSCAPE sheets. Explicit pagination packs
+// whole cards onto a fixed N-column grid per sheet so a card NEVER straddles or
+// clips a page break (mirrors the shipped report PagedView discipline at DOM
+// scope; the comp's CSS-only print clipping must NOT recur). Only PDF-bound
+// (non-excluded) entries are paginated.
+// ---------------------------------------------------------------------------
+const PRINT_COLS = 4
+const PRINT_ROWS = 3
+const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
+
+interface Sheet {
+  readonly groupLabel: string
+  readonly cont: boolean
+  readonly items: readonly ProductInfoEntry[]
+}
+
+function buildSheets(model: ProductInfoModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const printable = group.items.filter((e) => !e.excluded)
+    for (let i = 0; i < printable.length; i += CARDS_PER_SHEET) {
+      sheets.push({
+        groupLabel: group.label,
+        cont: i > 0,
+        items: printable.slice(i, i + CARDS_PER_SHEET),
+      })
+    }
+  }
+  return sheets
+}
+
+function PagedView({
+  model,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly model: ProductInfoModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (familyId: string) => void
+}): JSX.Element {
+  const sheets = useMemo(() => buildSheets(model), [model])
+  const projLine = model.project.client
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+  const totalPages = sheets.length
+
+  return (
+    <div className="sb-pir-paged" style={{ ["--sb-pir-print-cols" as string]: PRINT_COLS }}>
+      {sheets.map((sheet, idx) => (
+        <section className="sb-pir-sheet" key={`pir-sheet-${idx}`}>
+          <div className="sb-pir-sheet-head">
+            <div>
+              <div className="sb-pir-sh-title">Product Info Report</div>
+              <div className="sb-pir-sh-proj">{projLine}</div>
+            </div>
+            <div className="sb-pir-sh-group">
+              {sheet.groupLabel}
+              {sheet.cont ? " (cont.)" : ""}
+            </div>
+          </div>
+          <div className="sb-pir-sheet-body">
+            {sheet.items.map((entry) => (
+              <ProductCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+            ))}
+          </div>
+          <div className="sb-pir-sheet-foot">
+            <span>{projLine}</span>
+            <span>
+              Page {idx + 1} / {totalPages}
+            </span>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Control bar (never prints): scope (in-use/library), group-by (gender/
+// product-type/none), image size (S/M/L — column density only), Screen/Print,
+// Export PDF.
+// ---------------------------------------------------------------------------
+function ControlBar({
+  scope,
+  onSetScope,
+  groupBy,
+  onSetGroupBy,
+  imageSize,
+  onSetImageSize,
+  printMode,
+  onSetPrintMode,
+  onExportPdf,
+  exporting,
+}: {
+  readonly scope: ProductInfoScope
+  readonly onSetScope: (v: ProductInfoScope) => void
+  readonly groupBy: ProductInfoGroupBy
+  readonly onSetGroupBy: (v: ProductInfoGroupBy) => void
+  readonly imageSize: ProductInfoImageSize
+  readonly onSetImageSize: (v: ProductInfoImageSize) => void
+  readonly printMode: boolean
+  readonly onSetPrintMode: (v: boolean) => void
+  readonly onExportPdf: () => void
+  readonly exporting: boolean
+}): JSX.Element {
+  const scopeLabelId = useId()
+  const groupLabelId = useId()
+  const sizeLabelId = useId()
+  const viewLabelId = useId()
+
+  const scopeOpts: ReadonlyArray<readonly [ProductInfoScope, string]> = [
+    ["in-use", "In use"],
+    ["library", "Library"],
+  ]
+  const groupOpts: ReadonlyArray<readonly [ProductInfoGroupBy, string]> = [
+    ["gender", "Gender"],
+    ["product-type", "Type"],
+    ["none", "None"],
+  ]
+  const sizeOpts: ReadonlyArray<readonly [ProductInfoImageSize, string]> = [
+    ["s", "S"],
+    ["m", "M"],
+    ["l", "L"],
+  ]
+
+  return (
+    <div className="sb-pir-controlbar no-print" role="region" aria-label="Product info report controls">
+      <div className="sb-pir-control-group" role="group" aria-labelledby={scopeLabelId}>
+        <span id={scopeLabelId} className="sb-pir-control-label">
+          Scope
+        </span>
+        <div className="sb-pir-seg">
+          {scopeOpts.map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              className="sb-pir-seg-btn"
+              aria-pressed={scope === v}
+              onClick={() => onSetScope(v)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="sb-pir-control-group" role="group" aria-labelledby={groupLabelId}>
+        <span id={groupLabelId} className="sb-pir-control-label">
+          Group by
+        </span>
+        <div className="sb-pir-seg">
+          {groupOpts.map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              className="sb-pir-seg-btn"
+              aria-pressed={groupBy === v}
+              onClick={() => onSetGroupBy(v)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="sb-pir-control-group" role="group" aria-labelledby={sizeLabelId}>
+        <span id={sizeLabelId} className="sb-pir-control-label">
+          Image size
+        </span>
+        <div className="sb-pir-seg">
+          {sizeOpts.map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              className="sb-pir-seg-btn"
+              aria-pressed={imageSize === v}
+              onClick={() => onSetImageSize(v)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="sb-pir-control-group" role="group" aria-labelledby={viewLabelId}>
+        <span id={viewLabelId} className="sb-pir-control-label">
+          View
+        </span>
+        <div className="sb-pir-seg">
+          <button
+            type="button"
+            className="sb-pir-seg-btn"
+            aria-pressed={!printMode}
+            onClick={() => onSetPrintMode(false)}
+          >
+            Screen
+          </button>
+          <button
+            type="button"
+            className="sb-pir-seg-btn"
+            aria-pressed={printMode}
+            onClick={() => onSetPrintMode(true)}
+          >
+            Print preview
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="sb-pir-export-btn"
+        onClick={onExportPdf}
+        disabled={exporting}
+        aria-busy={exporting}
+      >
+        {exporting ? (
+          <>
+            <Loader2 className="sb-pir-spin" size={15} aria-hidden="true" />
+            Exporting…
+          </>
+        ) : (
+          "Export PDF"
+        )}
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root.
+// ---------------------------------------------------------------------------
+export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.Element {
+  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false } = props
+  const [printMode, setPrintMode] = useState(false)
+
+  const toggleExclude = (familyId: string): void => {
+    const set = new Set(config.excludedFamilyIds)
+    if (set.has(familyId)) set.delete(familyId)
+    else set.add(familyId)
+    onConfigChange({ ...config, excludedFamilyIds: [...set] })
+  }
+
+  const setScope = (productScope: ProductInfoScope): void => {
+    if (productScope === config.productScope) return
+    onConfigChange({ ...config, productScope })
+  }
+
+  const setGroupBy = (groupBy: ProductInfoGroupBy): void => {
+    if (groupBy === config.groupBy) return
+    onConfigChange({ ...config, groupBy })
+  }
+
+  const setImageSize = (imageSize: ProductInfoImageSize): void => {
+    if (imageSize === config.imageSize) return
+    onConfigChange({ ...config, imageSize })
+  }
+
+  const isEmpty = model.groups.length === 0 || model.project.familyCount === 0
+
+  return (
+    <div className={"sb-pir-root" + (printMode ? " sb-pir-print-mode" : "")} data-size={config.imageSize}>
+      <style>{PRODUCT_INFO_STYLES}</style>
+
+      <ControlBar
+        scope={config.productScope}
+        onSetScope={setScope}
+        groupBy={config.groupBy}
+        onSetGroupBy={setGroupBy}
+        imageSize={config.imageSize}
+        onSetImageSize={setImageSize}
+        printMode={printMode}
+        onSetPrintMode={setPrintMode}
+        onExportPdf={onExportPdf}
+        exporting={exporting}
+      />
+
+      <main className="sb-pir-report">
+        <Masthead model={model} />
+
+        {isEmpty ? (
+          <p className="sb-pir-empty">No products to report yet.</p>
+        ) : (
+          <>
+            {/* Fluid grouped grid (screen) */}
+            <div className="sb-pir-fluid">
+              {model.groups.map((group) => (
+                <GroupSection
+                  key={group.key}
+                  group={group}
+                  imageMap={imageMap}
+                  onToggleExclude={toggleExclude}
+                />
+              ))}
+            </div>
+
+            {/* Paged landscape preview (print mode + @media print) */}
+            <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -26,6 +26,7 @@ export interface ProductInfoReportViewProps {
   readonly onConfigChange: (next: ProductInfoConfig) => void
   readonly onExportPdf: () => void
   readonly exporting?: boolean
+  readonly imagesLoading?: boolean
 }
 
 
@@ -306,6 +307,7 @@ function ControlBar({
   onSetPrintMode,
   onExportPdf,
   exporting,
+  imagesLoading,
 }: {
   readonly scope: ProductInfoScope
   readonly onSetScope: (v: ProductInfoScope) => void
@@ -317,6 +319,7 @@ function ControlBar({
   readonly onSetPrintMode: (v: boolean) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
+  readonly imagesLoading: boolean
 }): JSX.Element {
   const scopeLabelId = useId()
   const groupLabelId = useId()
@@ -425,7 +428,7 @@ function ControlBar({
         type="button"
         className="sb-pir-export-btn"
         onClick={onExportPdf}
-        disabled={exporting}
+        disabled={exporting || imagesLoading}
         aria-busy={exporting}
       >
         {exporting ? (
@@ -445,7 +448,7 @@ function ControlBar({
 // Root.
 // ---------------------------------------------------------------------------
 export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.Element {
-  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false } = props
+  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, imagesLoading = false } = props
   const [printMode, setPrintMode] = useState(false)
 
   const toggleExclude = (familyId: string): void => {
@@ -487,6 +490,7 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
         onSetPrintMode={setPrintMode}
         onExportPdf={onExportPdf}
         exporting={exporting}
+        imagesLoading={imagesLoading}
       />
 
       <main className="sb-pir-report">

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -123,7 +123,7 @@ function ProductCard({
                   <span className="sb-pir-appears-item" key={`${entry.id}-a-${i}`}>
                     <span className={"sb-status-dot " + st.dotClass} title={st.label} aria-hidden="true" />
                     <span>{a.number && a.number.trim() !== "" ? a.number : "—"}</span>
-                    <span className="sb-pir-look">{a.look}</span>
+                    {a.looks.length ? <span className="sb-pir-look">{a.looks.join(", ")}</span> : null}
                   </span>
                 )
               })}

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -48,10 +48,10 @@ export default function ShotReportPage() {
     void loadReport(reportId)
       .then((full) => {
         if (cancelled) return
-        // Cross-type guard: never hydrate or arm write-back from a non-shot-report
-        // doc — a pasted cross-type reportId must not clobber that doc's config.
-        if (full?.reportType !== "shot-report") return
-        const loaded = full?.config as ReportConfig | undefined
+        if (!full) return // doc not found (deleted) — keep defaults, nothing to persist
+        // Cross-type guard: a pasted cross-type reportId must not clobber that doc's config.
+        if (full.reportType !== "shot-report") return
+        const loaded = full.config as ReportConfig | undefined
         setConfig(loaded ? { ...DEFAULT_REPORT_CONFIG, ...loaded } : DEFAULT_REPORT_CONFIG)
         hydratedReportIdRef.current = reportId
       })

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -48,7 +48,9 @@ export default function ShotReportPage() {
     void loadReport(reportId)
       .then((full) => {
         if (cancelled) return
-        // This page only loads shot-report docs; config narrows to ReportConfig.
+        // Cross-type guard: never hydrate or arm write-back from a non-shot-report
+        // doc — a pasted cross-type reportId must not clobber that doc's config.
+        if (full?.reportType !== "shot-report") return
         const loaded = full?.config as ReportConfig | undefined
         setConfig(loaded ? { ...DEFAULT_REPORT_CONFIG, ...loaded } : DEFAULT_REPORT_CONFIG)
         hydratedReportIdRef.current = reportId

--- a/src-vnext/features/export/components/report/productInfoStyles.ts
+++ b/src-vnext/features/export/components/report/productInfoStyles.ts
@@ -1,0 +1,306 @@
+// Scoped stylesheet for the Product Info report DOM renderer (R4 PR1). All rules
+// live under `.sb-pir-root` with `sb-pir-`/`sb-`-prefixed classes so they never
+// collide with the app's Tailwind layer. Brand law (docs/DESIGN.md): editorial
+// restraint, ONE decisive red (the HERO mark, nothing else), Ivy Presto for the
+// editorial moment, Neue Haas for body/labels/tabular, tiering by weight+size
+// never faded gray, no drop shadows. Fonts load app-wide via typekit gph3jzg.
+// Ported faithfully from comp-product-info.html.
+
+export const PRODUCT_INFO_STYLES = `
+.sb-pir-root {
+  /* Type families (app loads typekit gph3jzg) */
+  --sb-font-display: "ivypresto-headline", Georgia, serif;
+  --sb-font-body: "neue-haas-grotesk-text", "Helvetica Neue", Arial, sans-serif;
+  --sb-font-ui: "neue-haas-grotesk-display", "Helvetica Neue", Arial, sans-serif;
+
+  /* Color — tinted neutrals toward the brand hue (OKLCH), never pure #000/#fff */
+  --sb-paper: oklch(0.994 0.001 30);
+  --sb-surface: oklch(0.985 0.002 30);
+  --sb-surface-sub: oklch(0.965 0.003 40);
+  --sb-ink: oklch(0.205 0.008 50);
+  --sb-ink-2: oklch(0.44 0.010 55);
+  --sb-ink-3: oklch(0.58 0.010 55);
+  --sb-ink-disabled: oklch(0.72 0.008 55);
+  --sb-rule: oklch(0.90 0.004 50);
+  --sb-rule-strong: oklch(0.83 0.005 50);
+  --sb-red: #EB1400;            /* Immediate Red — ONE job per surface (HERO mark) */
+
+  /* Type scale (px) */
+  --sb-t-3xs: 9px; --sb-t-2xs: 10px; --sb-t-xs: 12px; --sb-t-sm: 13px;
+  --sb-t-base: 14px; --sb-t-lg: 16px; --sb-t-xl: 20px; --sb-t-2xl: 26px;
+
+  /* Card grid density — driven by the S/M/L image-size toggle (column count
+     only; images fill the card width natively, never letterboxed). */
+  --sb-card-min: 232px;
+  --sb-card-gap: clamp(20px, 2.2vw, 36px);
+
+  box-sizing: border-box;
+  font-family: var(--sb-font-body);
+  font-size: var(--sb-t-base);
+  line-height: 1.5;
+  color: var(--sb-ink);
+  background: var(--sb-surface-sub);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: 100%;
+}
+.sb-pir-root *, .sb-pir-root *::before, .sb-pir-root *::after { box-sizing: border-box; }
+
+/* S / M / L image-size — pure column density (no max-height letterbox) */
+.sb-pir-root[data-size="s"] { --sb-card-min: 184px; }
+.sb-pir-root[data-size="m"] { --sb-card-min: 232px; }
+.sb-pir-root[data-size="l"] { --sb-card-min: 300px; }
+
+/* shared atoms ---------------------------------------------------------- */
+.sb-pir-root .sb-tabular, .sb-pir-root .sb-tnum {
+  font-variant-numeric: tabular-nums; font-feature-settings: "tnum" 1;
+}
+.sb-pir-root .sb-img-native { display: block; width: 100%; height: auto; object-fit: contain; }
+.sb-pir-root .sb-pending { color: var(--sb-ink-disabled); font-style: italic; }
+.sb-pir-root .sb-status-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.sb-pir-root .sb-status--complete { background: oklch(0.62 0.13 150); }   /* green = Shot */
+.sb-pir-root .sb-status--todo { background: var(--sb-ink-disabled); }     /* gray = To do */
+.sb-pir-root .sb-status--progress { background: oklch(0.62 0.13 240); }   /* blue = In progress */
+.sb-pir-root .sb-status--hold { background: oklch(0.74 0.14 75); }        /* amber = On hold */
+
+.sb-pir-noimg {
+  display: flex; align-items: center; justify-content: center;
+  background: repeating-linear-gradient(135deg, var(--sb-surface) 0 10px, var(--sb-surface-sub) 10px 20px);
+  color: var(--sb-ink-3);
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs);
+  letter-spacing: 0.08em; text-transform: uppercase;
+  border: 1px solid var(--sb-rule);
+  width: 100%; aspect-ratio: 4 / 5;
+}
+
+/* control bar (sticky, never prints) ------------------------------------ */
+.sb-pir-controlbar {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; gap: clamp(16px, 2vw, 32px); flex-wrap: wrap;
+  padding: 10px clamp(24px, 5vw, 96px);
+  background: color-mix(in oklch, var(--sb-paper) 88%, transparent);
+  backdrop-filter: saturate(1.4) blur(8px);
+  border-bottom: 1px solid var(--sb-rule);
+}
+.sb-pir-control-group { display: inline-flex; align-items: center; gap: 9px; }
+.sb-pir-control-label {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-pir-seg {
+  display: inline-flex; align-items: stretch;
+  border: 1px solid var(--sb-rule-strong); border-radius: 999px; overflow: hidden;
+  background: var(--sb-paper);
+}
+.sb-pir-seg-btn {
+  appearance: none; border: 0; background: transparent; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 600;
+  letter-spacing: 0.04em; color: var(--sb-ink-2); padding: 7px 15px; line-height: 1;
+}
+.sb-pir-seg-btn + .sb-pir-seg-btn { border-left: 1px solid var(--sb-rule); }
+.sb-pir-seg-btn[aria-pressed="true"] { background: var(--sb-ink); color: var(--sb-paper); }
+.sb-pir-seg-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: -2px; }
+.sb-pir-export-btn {
+  margin-left: auto; appearance: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 700;
+  letter-spacing: 0.04em; color: var(--sb-paper); background: var(--sb-ink);
+  border: 1px solid var(--sb-ink); border-radius: 999px; padding: 9px 20px; line-height: 1;
+}
+.sb-pir-export-btn:hover:not(:disabled) { background: oklch(0.28 0.008 50); }
+.sb-pir-export-btn:disabled { cursor: default; opacity: 0.6; }
+.sb-pir-export-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; }
+.sb-pir-spin { animation: sb-pir-spin 0.9s linear infinite; }
+@keyframes sb-pir-spin { to { transform: rotate(360deg); } }
+
+/* fluid report frame ---------------------------------------------------- */
+.sb-pir-report {
+  max-width: none; margin: 0;
+  padding: clamp(24px, 3vw, 40px) clamp(24px, 5vw, 96px) clamp(48px, 6vw, 120px);
+}
+.sb-pir-empty {
+  font-family: var(--sb-font-ui); color: var(--sb-ink-3); font-size: var(--sb-t-lg);
+  padding: 48px 0;
+}
+
+/* masthead -------------------------------------------------------------- */
+.sb-pir-masthead-band {
+  padding: clamp(40px, 5vw, 80px) 0 clamp(24px, 3vw, 40px);
+  border-bottom: 1px solid var(--sb-rule-strong); margin-bottom: clamp(32px, 4vw, 64px);
+}
+.sb-pir-eyebrow-row {
+  margin: 0 0 clamp(14px, 1.4vw, 20px);
+  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+}
+.sb-pir-eyebrow {
+  font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-2xs);
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-2);
+}
+.sb-pir-lede { color: var(--sb-ink-3); }
+.sb-pir-masthead-title {
+  font-family: var(--sb-font-display); font-weight: 700; letter-spacing: -0.01em;
+  font-size: clamp(38px, 5.6vw, 78px); line-height: 1.0; margin: 0; max-width: 18ch; color: var(--sb-ink);
+}
+.sb-pir-masthead-meta {
+  display: flex; flex-wrap: wrap; align-items: baseline;
+  gap: clamp(20px, 3vw, 52px); margin-top: clamp(22px, 2.4vw, 36px);
+}
+.sb-pir-meta-cell { display: flex; flex-direction: column; gap: 4px; }
+.sb-pir-meta-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-pir-meta-v {
+  font-family: var(--sb-font-display); font-size: var(--sb-t-2xl); line-height: 1;
+  color: var(--sb-ink); font-variant-numeric: tabular-nums;
+}
+
+/* group header ---------------------------------------------------------- */
+.sb-pir-group { margin-top: clamp(40px, 4.5vw, 72px); }
+.sb-pir-group:first-of-type { margin-top: 0; }
+.sb-pir-group-head {
+  display: flex; align-items: baseline; gap: 16px;
+  border-bottom: 1px solid var(--sb-rule); padding-bottom: 12px; margin-bottom: clamp(20px, 2.4vw, 32px);
+}
+.sb-pir-group-name {
+  font-family: var(--sb-font-display); font-weight: 600;
+  font-size: clamp(24px, 2.8vw, 38px); line-height: 1; color: var(--sb-ink);
+}
+.sb-pir-group-count {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-sm);
+  letter-spacing: 0.04em; color: var(--sb-ink-3);
+}
+
+/* product grid ---------------------------------------------------------- */
+.sb-pir-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--sb-card-min), 1fr));
+  gap: var(--sb-card-gap);
+}
+.sb-pir-card { display: flex; flex-direction: column; break-inside: avoid; position: relative; }
+.sb-pir-card-frame {
+  position: relative; width: 100%; background: var(--sb-surface);
+  border: 1px solid var(--sb-rule); border-radius: 2px; overflow: hidden;
+}
+.sb-pir-card-frame img { display: block; width: 100%; height: auto; }
+
+.sb-pir-card-body { padding: 14px 2px 0; }
+.sb-pir-card-name {
+  font-family: var(--sb-font-display); font-weight: 600; font-size: var(--sb-t-lg);
+  line-height: 1.14; letter-spacing: -0.005em; color: var(--sb-ink); margin: 0 0 6px;
+}
+.sb-pir-card-ident {
+  display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2); margin-bottom: 10px;
+}
+.sb-pir-style-no { font-variant-numeric: tabular-nums; letter-spacing: 0.02em; }
+.sb-pir-dot-sep { color: var(--sb-ink-disabled); }
+
+/* HERO — the ONE red on this surface */
+.sb-pir-hero-tag {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-red);
+}
+.sb-pir-hero-tag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 1px; }
+
+.sb-pir-row { display: flex; gap: 8px; align-items: baseline; margin-bottom: 7px; font-size: var(--sb-t-sm); }
+.sb-pir-row .sb-pir-k {
+  flex: 0 0 auto; font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); min-width: 58px;
+}
+.sb-pir-row .sb-pir-v { color: var(--sb-ink); }
+.sb-pir-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+.sb-pir-chip {
+  font-size: var(--sb-t-xs); padding: 2px 8px; border: 1px solid var(--sb-rule-strong);
+  border-radius: 999px; color: var(--sb-ink-2); white-space: nowrap;
+}
+
+.sb-pir-appears { margin-top: 4px; padding-top: 10px; border-top: 1px solid var(--sb-rule); }
+.sb-pir-appears .sb-pir-k {
+  display: block; font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); margin-bottom: 5px;
+}
+.sb-pir-appears-list { display: flex; flex-wrap: wrap; gap: 4px 10px; }
+.sb-pir-appears-item {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-size: var(--sb-t-sm); color: var(--sb-ink); font-variant-numeric: tabular-nums;
+}
+.sb-pir-appears-item .sb-pir-look { color: var(--sb-ink-3); font-size: var(--sb-t-xs); }
+
+/* per-card exclude toggle (screen only) */
+.sb-pir-exclude-toggle {
+  position: absolute; top: 8px; right: 8px; z-index: 3;
+  appearance: none; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2);
+  background: var(--sb-paper); border: 1px solid var(--sb-rule-strong); border-radius: 999px;
+  padding: 5px 11px; opacity: 0; transition: opacity 0.12s ease;
+}
+.sb-pir-card:hover .sb-pir-exclude-toggle,
+.sb-pir-card:focus-within .sb-pir-exclude-toggle { opacity: 1; }
+.sb-pir-exclude-toggle[aria-pressed="true"] { opacity: 1; color: var(--sb-ink); border-color: var(--sb-ink); }
+.sb-pir-exclude-toggle:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; opacity: 1; }
+
+/* excluded — visible but struck + dimmed (reversible) */
+.sb-pir-excluded { opacity: 0.42; }
+.sb-pir-excluded .sb-pir-card-name { text-decoration: line-through; text-decoration-thickness: 1px; }
+.sb-pir-excluded .sb-pir-exclude-toggle { opacity: 1; }
+
+/* paged (print preview) — hidden on screen until print-mode -------------- */
+.sb-pir-paged { display: none; }
+.sb-pir-sheet { display: none; }
+
+.sb-pir-print-mode { background: oklch(0.92 0.003 60); }
+.sb-pir-print-mode .sb-pir-fluid,
+.sb-pir-print-mode .sb-pir-masthead-band { display: none; }
+.sb-pir-print-mode .sb-pir-paged { display: block; }
+.sb-pir-print-mode .sb-pir-sheet {
+  display: grid; grid-template-rows: auto 1fr auto;
+  width: 11in; min-height: 8.5in;
+  margin: 0 auto 0.34in; padding: 0.5in 0.6in 0.4in;
+  background: var(--sb-paper); border: 1px solid var(--sb-rule);
+  box-sizing: border-box;
+}
+.sb-pir-sheet-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 18px;
+  padding-bottom: 9px; border-bottom: 1px solid var(--sb-rule-strong);
+}
+.sb-pir-sh-title { font-family: var(--sb-font-display); font-weight: 700; font-size: 15px; letter-spacing: -0.005em; color: var(--sb-ink); }
+.sb-pir-sh-proj { font-family: var(--sb-font-ui); font-size: 9px; color: var(--sb-ink-3); letter-spacing: 0.04em; }
+.sb-pir-sh-group {
+  font-family: var(--sb-font-ui); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink-2); white-space: nowrap;
+}
+/* print card grid — denser fixed column count so a card never straddles a break */
+.sb-pir-sheet-body {
+  display: grid; grid-template-columns: repeat(var(--sb-pir-print-cols, 4), 1fr);
+  gap: 0.3in 0.34in; align-items: start; min-height: 0;
+}
+.sb-pir-sheet-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 8px; border-top: 1px solid var(--sb-rule);
+  font-family: var(--sb-font-ui); font-size: 8px; color: var(--sb-ink-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-pir-sheet .sb-pir-card { break-inside: avoid; page-break-inside: avoid; }
+.sb-pir-sheet .sb-pir-card-name { font-size: var(--sb-t-sm); }
+.sb-pir-sheet .sb-pir-card-frame img { max-height: 2.3in; width: auto; max-width: 100%; object-fit: contain; }
+
+@media print {
+  @page { size: letter landscape; margin: 0; }
+  .no-print { display: none !important; }
+  .sb-pir-root { background: #fff; }
+  .sb-pir-fluid, .sb-pir-masthead-band { display: none !important; }
+  .sb-pir-report { padding: 0; }
+  .sb-pir-paged { display: block !important; }
+  .sb-pir-sheet {
+    display: grid !important; grid-template-rows: auto 1fr auto;
+    width: 11in; min-height: 8.5in;
+    margin: 0; padding: 0.5in 0.6in 0.4in; border: 0; background: #fff;
+    break-after: page; page-break-after: always;
+  }
+  .sb-pir-sheet:last-child { break-after: auto; page-break-after: auto; }
+  .sb-pir-card { break-inside: avoid; page-break-inside: avoid; }
+}
+`

--- a/src-vnext/features/export/hooks/useExportReports.ts
+++ b/src-vnext/features/export/hooks/useExportReports.ts
@@ -22,11 +22,12 @@ import type {
   CustomVariable,
 } from "../types/exportBuilder"
 import type { ReportConfig, ReportLayout } from "../lib/report/reportTypes"
+import type { ProductInfoConfig } from "../lib/report/productInfoTypes"
 
-// Discriminates a saved shot-report doc from a legacy block-canvas doc. Absent
-// on disk for every pre-R2 doc -> defaulted to "block-canvas" at READ time, so
-// no existing doc is ever migrated.
-export type ExportReportType = "block-canvas" | "shot-report"
+// Discriminates a saved report doc from a legacy block-canvas doc. Absent on
+// disk for every pre-R2 doc -> defaulted to "block-canvas" at READ time, so no
+// existing doc is ever migrated. "product-info" added in R4 PR1.
+export type ExportReportType = "block-canvas" | "shot-report" | "product-info"
 
 export interface ExportReport {
   readonly id: string
@@ -44,8 +45,8 @@ export interface ExportReportFull extends ExportReport {
   readonly pages: readonly ExportPage[]
   readonly settings: PageSettings
   readonly customVariables: readonly CustomVariable[]
-  /** Present only on shot-report docs. */
-  readonly config?: ReportConfig
+  /** Present only on report docs (shot-report or product-info); narrow per page by reportType. */
+  readonly config?: ReportConfig | ProductInfoConfig
 }
 
 interface SaveReportData {
@@ -70,8 +71,16 @@ export interface UseExportReportsReturn {
   ) => Promise<string>
   /** Create a saved shot-report doc whose config IS the recipe. */
   readonly createShotReport: (name: string, config: ReportConfig) => Promise<string>
-  /** Persist a shot-report's config blob (partial merge; preserves the rest). */
-  readonly saveReportConfig: (reportId: string, config: ReportConfig) => Promise<void>
+  /** Create a saved product-info report doc whose config IS the recipe. */
+  readonly createProductInfoReport: (
+    name: string,
+    config: ProductInfoConfig,
+  ) => Promise<string>
+  /** Persist a report's config blob (partial merge; preserves the rest). Generic over config shape. */
+  readonly saveReportConfig: (
+    reportId: string,
+    config: ReportConfig | ProductInfoConfig,
+  ) => Promise<void>
 }
 
 export function mapReport(
@@ -150,7 +159,7 @@ export function useExportReports(
   )
 
   const saveReportConfig = useCallback(
-    async (reportId: string, config: ReportConfig) => {
+    async (reportId: string, config: ReportConfig | ProductInfoConfig) => {
       if (!clientId || !projectId) return
       const pathSegments = exportReportDocPath(clientId, projectId, reportId)
       const docRef = doc(db, pathSegments[0]!, ...pathSegments.slice(1))
@@ -190,19 +199,23 @@ export function useExportReports(
     [clientId, projectId, user?.uid],
   )
 
-  const createShotReport = useCallback(
-    async (name: string, config: ReportConfig): Promise<string> => {
+  // Shared create path for every typed report (config-driven, not block-canvas).
+  // pages:[] keeps the doc inert if it ever reaches the legacy block loader.
+  const createTypedReport = useCallback(
+    async (
+      reportType: ExportReportType,
+      name: string,
+      config: ReportConfig | ProductInfoConfig,
+    ): Promise<string> => {
       if (!clientId || !projectId) throw new Error("Missing clientId or projectId")
       // createdBy must equal auth.uid or the create rule rejects it.
       if (!user?.uid) throw new Error("Not authenticated")
       const pathSegments = exportReportsPath(clientId, projectId)
       const collRef = collection(db, pathSegments[0]!, ...pathSegments.slice(1))
       const newDocRef = doc(collRef)
-      // Shot-report docs render from config, not block-canvas pages/settings;
-      // pages:[] keeps the doc inert if it ever reaches the legacy block loader.
       await setDoc(newDocRef, {
         name,
-        reportType: "shot-report",
+        reportType,
         schemaVersion: 2,
         config,
         pages: [],
@@ -215,6 +228,18 @@ export function useExportReports(
       return newDocRef.id
     },
     [clientId, projectId, user?.uid],
+  )
+
+  const createShotReport = useCallback(
+    (name: string, config: ReportConfig): Promise<string> =>
+      createTypedReport("shot-report", name, config),
+    [createTypedReport],
+  )
+
+  const createProductInfoReport = useCallback(
+    (name: string, config: ProductInfoConfig): Promise<string> =>
+      createTypedReport("product-info", name, config),
+    [createTypedReport],
   )
 
   const loadReport = useCallback(
@@ -248,7 +273,7 @@ export function useExportReports(
           fontFamily: "Inter",
         },
         customVariables: (data.customVariables as readonly CustomVariable[]) ?? [],
-        config: data.config as ReportConfig | undefined,
+        config: data.config as ReportConfig | ProductInfoConfig | undefined,
       }
     },
     [clientId, projectId],
@@ -300,6 +325,7 @@ export function useExportReports(
     loadReport,
     importReport,
     createShotReport,
+    createProductInfoReport,
     saveReportConfig,
   }
 }

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -1,0 +1,290 @@
+import { describe, it, expect } from "vitest"
+import {
+  collectProductInfoImageCandidates,
+  deriveProductInfoModel,
+} from "../productInfoModel"
+import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
+import type { ExportData } from "../../../hooks/useExportData"
+import type { ProductFamily, Shot } from "@/shared/types"
+
+// Minimal factories — cast past required audit fields the model never reads.
+function fam(over: Partial<ProductFamily> & { id: string }): ProductFamily {
+  return { styleName: over.id, clientId: "c", ...over } as unknown as ProductFamily
+}
+function shot(s: Partial<Shot> & { id: string }): Shot {
+  return {
+    title: "Shot",
+    status: "complete",
+    talent: [],
+    products: [],
+    sortOrder: 0,
+    ...s,
+  } as unknown as Shot
+}
+function data(over: Partial<ExportData>): ExportData {
+  return {
+    project: { name: "Q2-26 No. 3", clientId: "unbound-merino" } as ExportData["project"],
+    shots: [],
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+    ...over,
+  }
+}
+
+function cfg(over: Partial<ProductInfoConfig> = {}): ProductInfoConfig {
+  return { ...DEFAULT_PRODUCT_INFO_CONFIG, ...over }
+}
+
+const FAMILIES = [
+  fam({ id: "fM", styleName: "Merino Crew", styleNumber: "M-TP-LS-1399", gender: "men", productType: "Tops" }),
+  fam({ id: "fW", styleName: "Wool Pant", styleNumber: "W-BT-PN-1048", gender: "women", productType: "Bottoms" }),
+]
+
+function flat(model: ReturnType<typeof deriveProductInfoModel>) {
+  return model.groups.flatMap((g) => g.items)
+}
+function find(model: ReturnType<typeof deriveProductInfoModel>, id: string) {
+  return flat(model).find((i) => i.id === id)
+}
+
+describe("deriveProductInfoModel — in-use scope", () => {
+  it("includes only families styled into non-deleted shots' looks (not the flat library)", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+          shot({ id: "gone", shotNumber: "02", deleted: true, looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        ],
+      }),
+      cfg(),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("fM")
+    expect(ids).not.toContain("fW") // only styled into a DELETED shot
+    expect(model.project.familyCount).toBe(1)
+  })
+
+  it("aggregates colours and sizes as a de-duped union across every styling assignment", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({
+            id: "s1", shotNumber: "01",
+            looks: [
+              { id: "l0", order: 0, products: [{ familyId: "fM", colourName: "Black", size: "M", sizeScope: "single" }] },
+              { id: "l1", order: 1, products: [{ familyId: "fM", colourName: "Black", size: "L", sizeScope: "single" }] },
+            ],
+          }),
+          shot({
+            id: "s2", shotNumber: "02",
+            looks: [{ id: "l", order: 0, products: [{ familyId: "fM", skuName: "Navy", size: "M", sizeScope: "single" }] }],
+          }),
+        ],
+      }),
+      cfg(),
+    )
+    const e = find(model, "fM")
+    expect(e?.colours).toEqual(["Black", "Navy"]) // colourName, then skuName fallback; deduped
+    expect(e?.sizes).toEqual(["M", "L"]) // M appears twice -> once
+  })
+
+  it("flags sizePending when any assignment is sizeScope 'pending', and excludes that size from the union", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({
+            id: "s1", shotNumber: "01",
+            looks: [{ id: "l", order: 0, products: [
+              { familyId: "fM", colourName: "Black", size: "M", sizeScope: "single" },
+              { familyId: "fM", colourName: "Black", size: "?", sizeScope: "pending" },
+            ] }],
+          }),
+        ],
+      }),
+      cfg(),
+    )
+    const e = find(model, "fM")
+    expect(e?.sizePending).toBe(true)
+    expect(e?.sizes).toEqual(["M"]) // the pending entry's size is not unioned
+  })
+
+  it("isHero is true from an assignment isHero flag OR the look's heroProductId", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, heroProductId: "fW", products: [{ familyId: "fW" }] }] }),
+          shot({ id: "s2", shotNumber: "02", looks: [{ id: "l", order: 0, products: [{ familyId: "fM", isHero: true }] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fW")?.isHero).toBe(true) // via heroProductId
+    expect(find(model, "fM")?.isHero).toBe(true) // via assignment flag
+  })
+
+  it("does NOT mark hero when heroProductId points at a different family", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, heroProductId: "fM", products: [{ familyId: "fW" }] }] }),
+        ],
+      }),
+      cfg(),
+    )
+    expect(find(model, "fW")?.isHero).toBe(false)
+  })
+
+  it("builds appears[] with the shot number, look label, and status — sorted by shot number", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s10", shotNumber: "10", status: "todo", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+          shot({ id: "s2", shotNumber: "2", status: "complete", looks: [
+            { id: "l0", order: 0, products: [{ familyId: "fM" }] },
+            { id: "l1", order: 1, label: "Alt A", products: [{ familyId: "fM" }] },
+          ] }),
+        ],
+      }),
+      cfg(),
+    )
+    const appears = find(model, "fM")?.appears ?? []
+    // shot 2 (both looks) before shot 10; look labels are Primary/Alt A
+    expect(appears.map((a) => `${a.number}:${a.look}:${a.status}`)).toEqual([
+      "2:Primary:complete",
+      "2:Alt A:complete",
+      "10:Primary:todo",
+    ])
+  })
+})
+
+describe("deriveProductInfoModel — library scope", () => {
+  it("includes every non-deleted family even when never styled, and still derives appears", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [
+          ...FAMILIES,
+          fam({ id: "fGone", styleName: "Retired", gender: "men", deleted: true }),
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] })],
+      }),
+      cfg({ productScope: "library" }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("fW") // unused but in the library
+    expect(ids).not.toContain("fGone") // soft-deleted family dropped
+    expect(find(model, "fM")?.appears.length).toBe(1)
+    expect(find(model, "fW")?.appears.length).toBe(0) // unused -> no appearances
+  })
+})
+
+describe("deriveProductInfoModel — grouping", () => {
+  const styled = () =>
+    data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({ id: "sM", shotNumber: "02", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+        shot({ id: "sW", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+      ],
+    })
+
+  it("group-by gender orders Women then Men and reuses the shared GROUP_LABEL", () => {
+    const model = deriveProductInfoModel(styled(), cfg({ groupBy: "gender" }))
+    expect(model.groups.map((g) => g.key)).toEqual(["W", "M"])
+    expect(model.groups.map((g) => g.label)).toEqual(["Women", "Men"])
+    expect(model.groups[0]?.items.map((i) => i.id)).toEqual(["fW"])
+  })
+
+  it("group-by product-type buckets by family.productType, alpha-ordered", () => {
+    const model = deriveProductInfoModel(styled(), cfg({ groupBy: "product-type" }))
+    expect(model.groups.map((g) => g.key)).toEqual(["Bottoms", "Tops"])
+    expect(model.groups[0]?.items.map((i) => i.id)).toEqual(["fW"]) // Bottoms
+  })
+
+  it("group-by none yields one flat alpha group by styleName", () => {
+    const model = deriveProductInfoModel(styled(), cfg({ groupBy: "none" }))
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.key).toBe("all")
+    expect(model.groups[0]?.items.map((i) => i.styleName)).toEqual(["Merino Crew", "Wool Pant"])
+  })
+})
+
+describe("deriveProductInfoModel — entry fields & images", () => {
+  it("resolves styleNumber from styleNumbers[0] then styleNumber, gender label, and excluded flag", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [
+          fam({ id: "fM", styleName: "Crew", styleNumbers: ["PREF-1"], styleNumber: "OLD-1", gender: "men" }),
+          fam({ id: "fX", styleName: "Mystery", gender: "alien" }),
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }, { familyId: "fX" }] }] })],
+      }),
+      cfg({ groupBy: "none", excludedFamilyIds: ["fM"] }),
+    )
+    expect(find(model, "fM")).toMatchObject({ styleNumber: "PREF-1", genderLabel: "Men", excluded: true })
+    expect(find(model, "fX")).toMatchObject({ gender: "?", genderLabel: null, excluded: false })
+  })
+
+  it("picks the image candidate by assignment thumbs, then family thumbnail, then header", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [
+          fam({ id: "fA", styleName: "A", thumbnailImagePath: "fam/A-thumb.jpg", headerImagePath: "fam/A-head.jpg" }),
+          fam({ id: "fB", styleName: "B", headerImagePath: "fam/B-head.jpg" }),
+          fam({ id: "fC", styleName: "C", thumbnailImagePath: "fam/C-thumb.jpg" }),
+        ],
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fA", thumbUrl: "asn/A.jpg" }, // assignment wins
+            { familyId: "fB" }, // no assignment image, no thumbnail -> header
+            { familyId: "fC" }, // no assignment image -> family thumbnail
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fA")?.image).toBe("asn/A.jpg")
+    expect(find(model, "fB")?.image).toBe("fam/B-head.jpg")
+    expect(find(model, "fC")?.image).toBe("fam/C-thumb.jpg")
+  })
+
+  it("collectProductInfoImageCandidates returns each unique resolved candidate once", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [
+          fam({ id: "fA", styleName: "A", thumbnailImagePath: "shared.jpg" }),
+          fam({ id: "fB", styleName: "B", thumbnailImagePath: "shared.jpg" }),
+          fam({ id: "fC", styleName: "C" }), // no image
+        ],
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fA" }, { familyId: "fB" }, { familyId: "fC" },
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(collectProductInfoImageCandidates(model)).toEqual(["shared.jpg"])
+  })
+
+  it("dateRange + familyCount surface on the project masthead block", () => {
+    const model = deriveProductInfoModel(
+      data({
+        project: { name: "P", clientId: "c", shootDates: ["2026-06-04", "2026-06-02"] } as ExportData["project"],
+        productFamilies: FAMILIES,
+        shots: [shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }, { familyId: "fW" }] }] })],
+      }),
+      cfg(),
+    )
+    expect(model.project.dateRange).toBe("Jun 2–4, 2026")
+    expect(model.project.familyCount).toBe(2)
+  })
+})

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -142,7 +142,7 @@ describe("deriveProductInfoModel — in-use scope", () => {
     expect(find(model, "fW")?.isHero).toBe(false)
   })
 
-  it("builds appears[] with the shot number, look label, and status — sorted by shot number", () => {
+  it("builds appears[] as one entry per shot (looks accrued), sorted by shot number", () => {
     const model = deriveProductInfoModel(
       data({
         productFamilies: FAMILIES,
@@ -157,12 +157,44 @@ describe("deriveProductInfoModel — in-use scope", () => {
       cfg(),
     )
     const appears = find(model, "fM")?.appears ?? []
-    // shot 2 (both looks) before shot 10; look labels are Primary/Alt A
-    expect(appears.map((a) => `${a.number}:${a.look}:${a.status}`)).toEqual([
-      "2:Primary:complete",
-      "2:Alt A:complete",
+    // shot 2 (one entry, both look labels) before shot 10 — NOT three rows
+    expect(appears.map((a) => `${a.number}:${a.looks.join("+")}:${a.status}`)).toEqual([
+      "2:Primary+Alt A:complete",
       "10:Primary:todo",
     ])
+  })
+
+  it("counts one appearance per shot for multiple same-family SKUs in one look", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", status: "complete", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fM", colourName: "Black" },
+            { familyId: "fM", colourName: "White" },
+          ] }] }),
+        ],
+      }),
+      cfg(),
+    )
+    const appears = find(model, "fM")?.appears ?? []
+    expect(appears.length).toBe(1) // one shot, not two
+    expect(appears[0]?.looks).toEqual(["Primary"]) // one look, deduped
+  })
+
+  it("flags isHero when the look heroProductId points at a SKU id, not the family id", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, heroProductId: "sku-1", products: [
+            { familyId: "fM", skuId: "sku-1" },
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fM")?.isHero).toBe(true)
   })
 })
 

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -1,4 +1,5 @@
 import type { ProductFamily, Shot } from "@/shared/types"
+import { matchesHeroProductId } from "@/features/shots/lib/lookHeroes"
 import type { ExportData } from "../../hooks/useExportData"
 import {
   GROUP_LABEL,
@@ -10,7 +11,7 @@ import {
   sortLooksByOrder,
   formatDateWindow,
 } from "./reportModel"
-import type { GenderKey } from "./reportTypes"
+import type { GenderKey, ReportShotStatus } from "./reportTypes"
 import type {
   ProductInfoAppearance,
   ProductInfoConfig,
@@ -25,6 +26,14 @@ import type {
 
 // Per-family aggregate accumulated during the inverse walk over non-deleted
 // shots -> looks -> products. Mutated only inside the derivation (never an input).
+// Mutable appearance accumulator: one per (shot, family); looks accrue as the
+// family is found across the shot's looks. Frozen into ProductInfoAppearance at build.
+interface AppearanceAcc {
+  readonly number: string
+  readonly looks: string[]
+  readonly status: ReportShotStatus
+}
+
 interface FamilyAgg {
   readonly familyId: string
   image: string | null
@@ -32,7 +41,7 @@ interface FamilyAgg {
   sizePending: boolean
   readonly colours: string[]
   readonly sizes: string[]
-  readonly appears: ProductInfoAppearance[]
+  readonly appears: AppearanceAcc[]
 }
 
 function emptyAgg(familyId: string): FamilyAgg {
@@ -59,6 +68,10 @@ function walkInUse(shots: readonly Shot[]): Map<string, FamilyAgg> {
   for (const shot of shots) {
     if (shot.deleted) continue
     const looks = sortLooksByOrder(shot.looks ?? [])
+    // One appearance per (shot, family); the looks the family is styled into this
+    // shot accrue onto it, so two SKUs in one look (or one family across Primary +
+    // Alt) count as a single shot, not several.
+    const appearanceByFamily = new Map<string, AppearanceAcc>()
     looks.forEach((look, index) => {
       const label = lookLabel(look.label, index)
       const heroId = look.heroProductId
@@ -68,15 +81,17 @@ function walkInUse(shots: readonly Shot[]): Map<string, FamilyAgg> {
         const agg = byFamily.get(id) ?? emptyAgg(id)
         if (!byFamily.has(id)) byFamily.set(id, agg)
         if (agg.image == null) agg.image = pickProductImage(p, undefined)
-        if (p.isHero === true || (heroId != null && heroId === id)) agg.isHero = true
+        if (p.isHero === true || (heroId != null && matchesHeroProductId(p, heroId))) agg.isHero = true
         if (p.sizeScope === "pending") agg.sizePending = true
         pushUnique(agg.colours, p.colourName ?? p.skuName ?? null)
         if (p.sizeScope !== "pending") pushUnique(agg.sizes, p.size ?? null)
-        agg.appears.push({
-          number: shot.shotNumber ?? "",
-          look: label,
-          status: shot.status,
-        })
+        let appearance = appearanceByFamily.get(id)
+        if (!appearance) {
+          appearance = { number: shot.shotNumber ?? "", looks: [], status: shot.status }
+          appearanceByFamily.set(id, appearance)
+          agg.appears.push(appearance)
+        }
+        pushUnique(appearance.looks, label)
       }
     })
   }

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -145,19 +145,14 @@ function groupEntries(
     return [{ key: "all", label: "All products", count: items.length, items }]
   }
   if (groupBy === "product-type") {
-    const order: string[] = []
     const byType = new Map<string, ProductInfoEntry[]>()
     for (const item of items) {
       const key = item.productType ?? "Unspecified"
       const bucket = byType.get(key)
       if (bucket) bucket.push(item)
-      else {
-        byType.set(key, [item])
-        order.push(key)
-      }
+      else byType.set(key, [item])
     }
-    return order
-      .slice()
+    return [...byType.keys()]
       .sort((a, b) => a.localeCompare(b))
       .map((key): ProductInfoGroup => {
         const inGroup = byType.get(key) ?? []

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -186,7 +186,7 @@ export function deriveProductInfoModel(
       ? data.productFamilies.filter((f) => f.deleted !== true)
       : [...aggByFamily.keys()]
           .map((id) => familyById.get(id))
-          .filter((f): f is ProductFamily => f != null)
+          .filter((f): f is ProductFamily => f != null && f.deleted !== true)
 
   const items = families
     .map((family) => toEntry(family, aggByFamily.get(family.id), excluded))

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -1,0 +1,200 @@
+import type { ProductFamily, Shot } from "@/shared/types"
+import type { ExportData } from "../../hooks/useExportData"
+import {
+  GROUP_LABEL,
+  GROUP_ORDER,
+  lookLabel,
+  normalizeGender,
+  pickProductImage,
+  shotNumberSortKey,
+  sortLooksByOrder,
+  formatDateWindow,
+} from "./reportModel"
+import type { GenderKey } from "./reportTypes"
+import type {
+  ProductInfoAppearance,
+  ProductInfoConfig,
+  ProductInfoEntry,
+  ProductInfoGroup,
+  ProductInfoModel,
+} from "./productInfoTypes"
+
+// Pure derivation: ExportData + ProductInfoConfig -> ProductInfoModel. No async,
+// no image bytes (image fields are path/URL candidates resolved later). The
+// single source both the DOM (ProductInfoReportView) and PDF renderers consume.
+
+// Per-family aggregate accumulated during the inverse walk over non-deleted
+// shots -> looks -> products. Mutated only inside the derivation (never an input).
+interface FamilyAgg {
+  readonly familyId: string
+  image: string | null
+  isHero: boolean
+  sizePending: boolean
+  readonly colours: string[]
+  readonly sizes: string[]
+  readonly appears: ProductInfoAppearance[]
+}
+
+function emptyAgg(familyId: string): FamilyAgg {
+  return {
+    familyId,
+    image: null,
+    isHero: false,
+    sizePending: false,
+    colours: [],
+    sizes: [],
+    appears: [],
+  }
+}
+
+function pushUnique(list: string[], value: string | null | undefined): void {
+  const v = value?.trim()
+  if (v && !list.includes(v)) list.push(v)
+}
+
+// Walk every non-deleted shot's sorted looks and styled products, accumulating
+// the rich (assignment-side) fields per family. Returns the agg map keyed by id.
+function walkInUse(shots: readonly Shot[]): Map<string, FamilyAgg> {
+  const byFamily = new Map<string, FamilyAgg>()
+  for (const shot of shots) {
+    if (shot.deleted) continue
+    const looks = sortLooksByOrder(shot.looks ?? [])
+    looks.forEach((look, index) => {
+      const label = lookLabel(look.label, index)
+      const heroId = look.heroProductId
+      for (const p of look.products) {
+        const id = p.familyId
+        if (!id) continue
+        const agg = byFamily.get(id) ?? emptyAgg(id)
+        if (!byFamily.has(id)) byFamily.set(id, agg)
+        if (agg.image == null) agg.image = pickProductImage(p, undefined)
+        if (p.isHero === true || (heroId != null && heroId === id)) agg.isHero = true
+        if (p.sizeScope === "pending") agg.sizePending = true
+        pushUnique(agg.colours, p.colourName ?? p.skuName ?? null)
+        if (p.sizeScope !== "pending") pushUnique(agg.sizes, p.size ?? null)
+        agg.appears.push({
+          number: shot.shotNumber ?? "",
+          look: label,
+          status: shot.status,
+        })
+      }
+    })
+  }
+  return byFamily
+}
+
+// Sort by shot number only; insertion order (look order within a shot) is
+// preserved by the stable sort, so a shot's looks stay Primary-then-Alt.
+function sortAppears(
+  appears: readonly ProductInfoAppearance[],
+): readonly ProductInfoAppearance[] {
+  return [...appears].sort((a, b) => {
+    const [ak, an, as] = shotNumberSortKey(a.number)
+    const [bk, bn, bs] = shotNumberSortKey(b.number)
+    return ak - bk || an - bn || as.localeCompare(bs)
+  })
+}
+
+// Build a resolved entry from a family + (possibly absent) accumulated agg. The
+// image falls back to family thumbnail/header when no styled assignment carried one.
+function toEntry(
+  family: ProductFamily,
+  agg: FamilyAgg | undefined,
+  excluded: ReadonlySet<string>,
+): ProductInfoEntry {
+  const gender = (normalizeGender(family.gender) ?? "?") as GenderKey
+  const image =
+    agg?.image ?? family.thumbnailImagePath ?? family.headerImagePath ?? null
+  return {
+    id: family.id,
+    styleName: family.styleName,
+    styleNumber: family.styleNumbers?.[0] ?? family.styleNumber ?? null,
+    gender,
+    genderLabel: gender === "?" ? null : GROUP_LABEL[gender],
+    productType: family.productType ?? family.productSubcategory ?? null,
+    image,
+    colours: agg?.colours ?? [],
+    sizes: agg?.sizes ?? [],
+    sizePending: agg?.sizePending ?? false,
+    isHero: agg?.isHero ?? false,
+    excluded: excluded.has(family.id),
+    appears: sortAppears(agg?.appears ?? []),
+  }
+}
+
+function groupEntries(
+  items: readonly ProductInfoEntry[],
+  groupBy: ProductInfoConfig["groupBy"],
+): readonly ProductInfoGroup[] {
+  if (groupBy === "none") {
+    return [{ key: "all", label: "All products", count: items.length, items }]
+  }
+  if (groupBy === "product-type") {
+    const order: string[] = []
+    const byType = new Map<string, ProductInfoEntry[]>()
+    for (const item of items) {
+      const key = item.productType ?? "Unspecified"
+      const bucket = byType.get(key)
+      if (bucket) bucket.push(item)
+      else {
+        byType.set(key, [item])
+        order.push(key)
+      }
+    }
+    return order
+      .slice()
+      .sort((a, b) => a.localeCompare(b))
+      .map((key): ProductInfoGroup => {
+        const inGroup = byType.get(key) ?? []
+        return { key, label: key, count: inGroup.length, items: inGroup }
+      })
+  }
+  return GROUP_ORDER.map((key): ProductInfoGroup => {
+    const inGroup = items.filter((i) => i.gender === key)
+    return { key, label: GROUP_LABEL[key], count: inGroup.length, items: inGroup }
+  }).filter((g) => g.count > 0)
+}
+
+/** Derive the resolved product-info model from live export data + config. */
+export function deriveProductInfoModel(
+  data: ExportData,
+  config: ProductInfoConfig,
+): ProductInfoModel {
+  const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
+  const excluded = new Set(config.excludedFamilyIds)
+  const aggByFamily = walkInUse(data.shots)
+
+  // in-use: families styled into non-deleted shots, resolved against the library.
+  // library: every non-deleted family (appears still derived from the same walk).
+  const families: ProductFamily[] =
+    config.productScope === "library"
+      ? data.productFamilies.filter((f) => f.deleted !== true)
+      : [...aggByFamily.keys()]
+          .map((id) => familyById.get(id))
+          .filter((f): f is ProductFamily => f != null)
+
+  const items = families
+    .map((family) => toEntry(family, aggByFamily.get(family.id), excluded))
+    .sort((a, b) => a.styleName.localeCompare(b.styleName))
+
+  return {
+    project: {
+      name: data.project?.name ?? "Untitled project",
+      client: data.project?.clientId ?? "",
+      dateRange: formatDateWindow(data.project?.shootDates),
+      familyCount: items.length,
+    },
+    groups: groupEntries(items, config.groupBy),
+  }
+}
+
+/** Collect every unique image candidate referenced by the product-info model. */
+export function collectProductInfoImageCandidates(
+  model: ProductInfoModel,
+): readonly string[] {
+  const set = new Set<string>()
+  for (const group of model.groups) {
+    for (const item of group.items) if (item.image) set.add(item.image)
+  }
+  return [...set]
+}

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -1,0 +1,78 @@
+// Resolved, presentation-free model for the Product Info report (R4 PR1).
+// A NEW report TYPE (product-centric), applying the shipped shot-report pattern.
+// One card/section per ProductFamily; the DOM (ProductInfoReportView) and the
+// @react-pdf renderer (reportPdfProductInfo) both consume this one pure model,
+// so screen and PDF can't drift. Image fields are *candidates* (a Storage path
+// or URL) resolved to data URLs once via reportImages — the model stays pure.
+
+import type { GenderKey } from "./reportTypes"
+
+/** How families are grouped on the report. */
+export type ProductInfoGroupBy = "gender" | "product-type" | "none"
+
+/** Which families surface: those styled into shots, or the whole library. */
+export type ProductInfoScope = "in-use" | "library"
+
+/** Image / column density. S/M/L is a display knob only (no letterbox). */
+export type ProductInfoImageSize = "s" | "m" | "l"
+
+/** Persisted config — serializable; optional fields default-merge from older blobs. */
+export interface ProductInfoConfig {
+  readonly groupBy: ProductInfoGroupBy
+  readonly productScope: ProductInfoScope
+  readonly imageSize: ProductInfoImageSize
+  /** Families excluded by the user — struck on screen, omitted from the PDF. */
+  readonly excludedFamilyIds: readonly string[]
+}
+
+export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
+  groupBy: "gender",
+  productScope: "in-use",
+  imageSize: "m",
+  excludedFamilyIds: [],
+}
+
+/** One appearance of a family: a shot + look it's styled into, with that shot's status. */
+export interface ProductInfoAppearance {
+  readonly number: string
+  readonly look: string
+  readonly status: import("./reportTypes").ReportShotStatus
+}
+
+export interface ProductInfoEntry {
+  /** Family id. */
+  readonly id: string
+  readonly styleName: string
+  readonly styleNumber: string | null
+  /** Raw-normalized gender used for group-by. */
+  readonly gender: GenderKey
+  /** Display label for the family's gender, or null when unresolved. */
+  readonly genderLabel: string | null
+  readonly productType: string | null
+  /** Image candidate (path/URL) or null. */
+  readonly image: string | null
+  readonly colours: readonly string[]
+  readonly sizes: readonly string[]
+  readonly sizePending: boolean
+  readonly isHero: boolean
+  readonly excluded: boolean
+  readonly appears: readonly ProductInfoAppearance[]
+}
+
+export interface ProductInfoGroup {
+  readonly key: string
+  readonly label: string
+  readonly count: number
+  readonly items: readonly ProductInfoEntry[]
+}
+
+export interface ProductInfoModel {
+  readonly project: {
+    readonly name: string
+    readonly client: string
+    /** Shoot-date window (e.g. "Jun 2–6, 2026"), or null when no dates. */
+    readonly dateRange: string | null
+    readonly familyCount: number
+  }
+  readonly groups: readonly ProductInfoGroup[]
+}

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -32,10 +32,10 @@ export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
   excludedFamilyIds: [],
 }
 
-/** One appearance of a family: a shot + look it's styled into, with that shot's status. */
+/** One shot a family is styled into: its number, the look labels it appears in there, and that shot's status. */
 export interface ProductInfoAppearance {
   readonly number: string
-  readonly look: string
+  readonly looks: readonly string[]
   readonly status: import("./reportTypes").ReportShotStatus
 }
 

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -38,7 +38,8 @@ function pickLookDisplayImage(look: ShotLook): string | null {
   return chosen?.downloadURL ?? chosen?.path ?? null
 }
 
-function pickProductImage(
+/** Best image candidate for a styled product: assignment thumbs, then family thumbnail. */
+export function pickProductImage(
   p: ProductAssignment,
   family: ProductFamily | undefined,
 ): string | null {
@@ -70,15 +71,24 @@ function resolveProducts(
   })
 }
 
-/** Label looks: explicit label, else Primary for the first by order, else "Alt N". */
+/** Look label rule: explicit label, else Primary for the first by order, else "Alt N". */
+export function lookLabel(rawLabel: string | null | undefined, index: number): string {
+  const trimmed = rawLabel?.trim()
+  return trimmed && trimmed.length > 0 ? trimmed : index === 0 ? "Primary" : `Alt ${index}`
+}
+
+/** Sort a shot's looks by order (shared by the shot + product-info derivations). */
+export function sortLooksByOrder(looks: readonly ShotLook[]): readonly ShotLook[] {
+  return [...looks].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+}
+
 function resolveLooks(
   shot: Shot,
   familyById: ReadonlyMap<string, ProductFamily>,
 ): readonly ReportLook[] {
-  const looks = [...(shot.looks ?? [])].sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+  const looks = sortLooksByOrder(shot.looks ?? [])
   return looks.map((look, i): ReportLook => {
-    const rawLabel = look.label?.trim()
-    const label = rawLabel && rawLabel.length > 0 ? rawLabel : i === 0 ? "Primary" : `Alt ${i}`
+    const label = lookLabel(look.label, i)
     const isAlt = i > 0 || /^alt/i.test(label)
     return {
       id: look.id,
@@ -123,7 +133,8 @@ function resolveTalent(
   })
 }
 
-function shotNumberSortKey(n: string): [number, number, string] {
+/** Sort key for shot numbers: numerics first (ascending), then non-numerics alpha. */
+export function shotNumberSortKey(n: string): [number, number, string] {
   const num = Number.parseInt(n, 10)
   return Number.isNaN(num) ? [1, 0, n] : [0, num, n]
 }
@@ -155,8 +166,8 @@ export function formatDateWindow(dates: readonly string[] | null | undefined): s
   return `${day(lo)}, ${lo.y} – ${day(hi)}, ${hi.y}`
 }
 
-const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]
-const GROUP_LABEL: Record<GenderKey, string> = {
+export const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]
+export const GROUP_LABEL: Record<GenderKey, string> = {
   W: "Women",
   M: "Men",
   Mixed: "Mixed",

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -1,0 +1,395 @@
+// @react-pdf landscape renderer for the Product Info report (R4 PR1).
+// Parity sibling of the DOM ProductInfoReportView — both consume the same
+// resolved ProductInfoModel + image sidecar so screen and PDF can't drift. A
+// card per in-use product family, grouped (gender / product-type / none),
+// native-aspect product image, identity + colours + sizes + an "appears in"
+// shot list. Red (#EB1400) does exactly ONE job here: the hero product mark.
+//
+// PDF typography differs from screen by design: @react-pdf ships only the
+// Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — three
+// cards per landscape sheet, never spanning a group, each card wrap={false} so
+// a card NEVER straddles or clips a page break.
+
+import type { JSX } from "react"
+import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
+import type {
+  ProductInfoAppearance,
+  ProductInfoEntry,
+  ProductInfoGroup,
+  ProductInfoModel,
+} from "./productInfoTypes"
+import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
+
+const PAD_X = 36
+const PAD_TOP = 34
+const PAD_BOTTOM = 30
+const CARD_GAP = 22
+const CARDS_PER_SHEET = 3
+const CONTENT_WIDTH = PAGE.width - PAD_X * 2
+const CARD_WIDTH = (CONTENT_WIDTH - CARD_GAP * (CARDS_PER_SHEET - 1)) / CARDS_PER_SHEET
+// Image is width-only so its height follows the photo's native aspect; the cap
+// bounds an unusually tall portrait so the card body always fits the sheet.
+const IMAGE_MAX_HEIGHT = 232
+
+const s = StyleSheet.create({
+  page: {
+    paddingTop: PAD_TOP,
+    paddingBottom: PAD_BOTTOM,
+    paddingHorizontal: PAD_X,
+    fontFamily: FONT.body,
+    fontSize: 8,
+    color: COLOR.text,
+    backgroundColor: COLOR.surface,
+  },
+
+  // Running header
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    paddingBottom: 8,
+    marginBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: COLOR.ruleStrong,
+  },
+  headerTitle: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text, letterSpacing: -0.1 },
+  headerProject: { fontFamily: FONT.ui, fontSize: 8, color: COLOR.textSubtle, marginTop: 2 },
+  headerGroup: {
+    fontFamily: FONT.uiBold,
+    fontSize: 8,
+    color: COLOR.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    textAlign: "right",
+  },
+
+  // Group band — starts each group's first sheet
+  groupBand: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    borderBottomWidth: 0.5,
+    borderBottomColor: COLOR.rule,
+    paddingBottom: 6,
+    marginBottom: 12,
+  },
+  groupName: { fontFamily: FONT.display, fontSize: 15, color: COLOR.text },
+  groupCount: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6.5,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.textSecondary,
+    marginLeft: 10,
+  },
+
+  // Card row + card
+  cards: { flexDirection: "row", gap: CARD_GAP },
+  card: { width: CARD_WIDTH },
+  frame: {
+    width: CARD_WIDTH,
+    backgroundColor: COLOR.surface,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    overflow: "hidden",
+  },
+  image: { width: CARD_WIDTH, maxHeight: IMAGE_MAX_HEIGHT, objectFit: "contain" },
+  noImage: {
+    width: CARD_WIDTH,
+    height: 150,
+    backgroundColor: COLOR.surfaceSubtle,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  noImageText: {
+    fontFamily: FONT.ui,
+    fontSize: 6.5,
+    color: COLOR.textSubtle,
+    textTransform: "uppercase",
+    letterSpacing: 0.6,
+  },
+
+  body: { paddingTop: 10 },
+  name: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text, lineHeight: 1.12, letterSpacing: -0.1 },
+  ident: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginTop: 4 },
+  identText: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textSecondary },
+  identSep: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textDisabled, marginHorizontal: 4 },
+
+  // HERO — the ONE red on this surface (a drawn red square + label, not a glyph)
+  heroTag: { flexDirection: "row", alignItems: "center", marginLeft: 4 },
+  heroMark: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 1, marginRight: 3 },
+  heroLabel: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6.5,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.accent,
+  },
+
+  row: { flexDirection: "row", alignItems: "baseline", marginTop: 8 },
+  rowKey: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    width: 42,
+    paddingTop: 1,
+  },
+  rowValue: { flex: 1 },
+  chips: { flexDirection: "row", flexWrap: "wrap" },
+  chip: {
+    fontFamily: FONT.ui,
+    fontSize: 6.5,
+    color: COLOR.textSecondary,
+    borderWidth: 0.5,
+    borderColor: COLOR.ruleStrong,
+    borderRadius: 6,
+    paddingHorizontal: 5,
+    paddingVertical: 1.5,
+    marginRight: 4,
+    marginBottom: 4,
+  },
+  sizes: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text },
+  pending: { fontFamily: FONT.bodyItalic, fontSize: 7.5, color: COLOR.textSubtle },
+
+  appears: { marginTop: 10, paddingTop: 8, borderTopWidth: 0.5, borderTopColor: COLOR.rule },
+  appearsKey: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    marginBottom: 5,
+  },
+  appearsList: { flexDirection: "row", flexWrap: "wrap" },
+  appearItem: { flexDirection: "row", alignItems: "center", marginRight: 10, marginBottom: 4 },
+  statusDot: { width: 5, height: 5, borderRadius: 2.5, marginRight: 4 },
+  appearNum: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text },
+  appearLook: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSubtle, marginLeft: 3 },
+  appearEmpty: { fontFamily: FONT.bodyItalic, fontSize: 7, color: COLOR.textSubtle },
+
+  footer: {
+    position: "absolute",
+    bottom: 14,
+    left: PAD_X,
+    right: PAD_X,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    fontFamily: FONT.ui,
+    fontSize: 6,
+    color: COLOR.textDisabled,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    borderTopWidth: 0.5,
+    borderTopColor: COLOR.rule,
+    paddingTop: 4,
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Pagination: up to CARDS_PER_SHEET printable cards per landscape sheet, never
+// spanning a group (a new group starts a fresh sheet, mirroring the shot-report
+// PagedView discipline so a card never straddles or clips a page break).
+// ---------------------------------------------------------------------------
+
+interface Sheet {
+  readonly group: ProductInfoGroup
+  readonly groupItemCount: number
+  readonly fromIndex: number
+  readonly items: readonly ProductInfoEntry[]
+}
+
+function paginate(model: ProductInfoModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const visible = group.items.filter((i) => !i.excluded)
+    if (visible.length === 0) continue
+    for (let i = 0; i < visible.length; i += CARDS_PER_SHEET) {
+      sheets.push({
+        group,
+        groupItemCount: visible.length,
+        fromIndex: i + 1,
+        items: visible.slice(i, i + CARDS_PER_SHEET),
+      })
+    }
+  }
+  return sheets
+}
+
+// ---------------------------------------------------------------------------
+// Pieces
+// ---------------------------------------------------------------------------
+
+function AppearRow({ a }: { readonly a: ProductInfoAppearance }): JSX.Element {
+  const st = STATUS[a.status]
+  return (
+    <View style={s.appearItem}>
+      <View style={[s.statusDot, { backgroundColor: st.color }]} />
+      <Text style={s.appearNum}>{has(a.number) ? a.number : "—"}</Text>
+      {has(a.look) ? <Text style={s.appearLook}>{a.look}</Text> : null}
+    </View>
+  )
+}
+
+function Card({
+  entry,
+  imageMap,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const src = has(entry.image) ? imageMap.get(entry.image) : undefined
+  const n = entry.appears.length
+  return (
+    <View style={s.card} wrap={false}>
+      <View style={s.frame}>
+        {src ? (
+          <Image src={src} style={s.image} />
+        ) : (
+          <View style={s.noImage}>
+            <Text style={s.noImageText}>No product image</Text>
+          </View>
+        )}
+      </View>
+
+      <View style={s.body}>
+        <Text style={s.name}>{has(entry.styleName) ? entry.styleName : "Unnamed product"}</Text>
+
+        <View style={s.ident}>
+          {has(entry.styleNumber) ? <Text style={s.identText}>{entry.styleNumber}</Text> : null}
+          {has(entry.styleNumber) && entry.genderLabel ? <Text style={s.identSep}>·</Text> : null}
+          {entry.genderLabel ? <Text style={s.identText}>{entry.genderLabel}</Text> : null}
+          {entry.isHero ? (
+            <View style={s.heroTag}>
+              <View style={s.heroMark} />
+              <Text style={s.heroLabel}>Hero</Text>
+            </View>
+          ) : null}
+        </View>
+
+        <View style={s.row}>
+          <Text style={s.rowKey}>Colours</Text>
+          <View style={s.rowValue}>
+            {entry.colours.length > 0 ? (
+              <View style={s.chips}>
+                {entry.colours.map((c, i) => (
+                  <Text key={i} style={s.chip}>
+                    {c}
+                  </Text>
+                ))}
+              </View>
+            ) : (
+              <Text style={s.pending}>TBD</Text>
+            )}
+          </View>
+        </View>
+
+        <View style={s.row}>
+          <Text style={s.rowKey}>Sizes</Text>
+          <View style={s.rowValue}>
+            {entry.sizes.length > 0 ? (
+              <Text style={s.sizes}>{entry.sizes.join(" · ")}</Text>
+            ) : entry.sizePending ? (
+              <Text style={s.pending}>Size pending</Text>
+            ) : (
+              <Text style={s.pending}>—</Text>
+            )}
+          </View>
+        </View>
+
+        <View style={s.appears}>
+          <Text style={s.appearsKey}>{`Appears in ${n} ${n === 1 ? "shot" : "shots"}`}</Text>
+          {n > 0 ? (
+            <View style={s.appearsList}>
+              {entry.appears.map((a, i) => (
+                <AppearRow key={i} a={a} />
+              ))}
+            </View>
+          ) : (
+            <Text style={s.appearEmpty}>Not yet styled into a shot</Text>
+          )}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+export function ProductInfoPdfDocument(props: {
+  readonly model: ProductInfoModel
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const { model, imageMap } = props
+  const sheets = paginate(model)
+  const projectLine = has(model.project.client)
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+
+  return (
+    <Document title="Product Info Report" author={model.project.client || ""} producer="Shot Builder">
+      {sheets.map((sheet, i) => {
+        const toIndex = sheet.fromIndex + sheet.items.length - 1
+        const firstOfGroup = sheet.fromIndex === 1
+        return (
+          <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={s.page} wrap>
+            <View style={s.header} fixed>
+              <View>
+                <Text style={s.headerTitle}>Product Info</Text>
+                <Text style={s.headerProject}>{projectLine}</Text>
+              </View>
+              <Text style={s.headerGroup}>
+                {`${sheet.group.label} · ${sheet.fromIndex}–${toIndex} of ${sheet.groupItemCount}`}
+              </Text>
+            </View>
+
+            {firstOfGroup ? (
+              <View style={s.groupBand} minPresenceAhead={140}>
+                <Text style={s.groupName}>{sheet.group.label}</Text>
+                <Text style={s.groupCount}>
+                  {sheet.groupItemCount === 1 ? "1 product" : `${sheet.groupItemCount} products`}
+                </Text>
+              </View>
+            ) : null}
+
+            <View style={s.cards}>
+              {sheet.items.map((entry) => (
+                <Card key={entry.id} entry={entry} imageMap={imageMap} />
+              ))}
+            </View>
+
+            <View style={s.footer} fixed>
+              <Text>Product Info · {projectLine}</Text>
+              <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
+            </View>
+          </Page>
+        )
+      })}
+    </Document>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Generate + download — mirrors generateShotReportPdf (lazy import, toBlob, anchor).
+// ---------------------------------------------------------------------------
+
+export async function generateProductInfoPdf(
+  model: ProductInfoModel,
+  imageMap: ReadonlyMap<string, string>,
+  filename = "product-info-report.pdf",
+): Promise<void> {
+  const { pdf } = await import("@react-pdf/renderer")
+  const blob = await pdf(<ProductInfoPdfDocument model={model} imageMap={imageMap} />).toBlob()
+
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename.endsWith(".pdf") ? filename : `${filename}.pdf`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -227,7 +227,7 @@ function AppearRow({ a }: { readonly a: ProductInfoAppearance }): JSX.Element {
     <View style={s.appearItem}>
       <View style={[s.statusDot, { backgroundColor: st.color }]} />
       <Text style={s.appearNum}>{has(a.number) ? a.number : "—"}</Text>
-      {has(a.look) ? <Text style={s.appearLook}>{a.look}</Text> : null}
+      {a.looks.length ? <Text style={s.appearLook}>{a.looks.join(", ")}</Text> : null}
     </View>
   )
 }
@@ -332,18 +332,17 @@ export function ProductInfoPdfDocument(props: {
   return (
     <Document title="Product Info Report" author={model.project.client || ""} producer="Shot Builder">
       {sheets.map((sheet, i) => {
-        const toIndex = sheet.fromIndex + sheet.items.length - 1
         const firstOfGroup = sheet.fromIndex === 1
         return (
           <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={s.page} wrap>
+            {/* Running header — group label stays correct on any overflow page; the
+                per-sheet count lives in the group band + footer, never a stale fixed range. */}
             <View style={s.header} fixed>
               <View>
                 <Text style={s.headerTitle}>Product Info</Text>
                 <Text style={s.headerProject}>{projectLine}</Text>
               </View>
-              <Text style={s.headerGroup}>
-                {`${sheet.group.label} · ${sheet.fromIndex}–${toIndex} of ${sheet.groupItemCount}`}
-              </Text>
+              <Text style={s.headerGroup}>{sheet.group.label}</Text>
             </View>
 
             {firstOfGroup ? (

--- a/src-vnext/features/shots/lib/lookHeroes.ts
+++ b/src-vnext/features/shots/lib/lookHeroes.ts
@@ -14,8 +14,8 @@ export function assignmentHeroId(p: ProductAssignment): string {
   return p.skuId ?? p.colourId ?? p.familyId
 }
 
-/** True when `p` is the product the legacy heroProductId referenced. */
-function matchesHeroProductId(p: ProductAssignment, heroId: string): boolean {
+/** True when `p` is the product the legacy heroProductId referenced (sku/colour/family). */
+export function matchesHeroProductId(p: ProductAssignment, heroId: string): boolean {
   return p.skuId === heroId || p.colourId === heroId || p.familyId === heroId
 }
 

--- a/src-vnext/shared/components/AppShell.tsx
+++ b/src-vnext/shared/components/AppShell.tsx
@@ -10,7 +10,12 @@ import { useAuth } from "@/app/providers/AuthProvider"
 import { useProject } from "@/features/projects/hooks/useProject"
 import { useSubmittedRequestCount } from "@/features/requests/hooks/useSubmittedRequestCount"
 import { ROLE } from "@/shared/lib/rbac"
-import { buildNavConfig, getMobileNavConfig, withShotReportsNav } from "./sidebar/nav-config"
+import {
+  buildNavConfig,
+  getMobileNavConfig,
+  withProductInfoReportsNav,
+  withShotReportsNav,
+} from "./sidebar/nav-config"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useSidebarState } from "./sidebar/useSidebarState"
 import { DesktopSidebar } from "./sidebar/DesktopSidebar"
@@ -59,10 +64,15 @@ export function AppShell() {
   const baseDesktopConfig = buildNavConfig(projectId, role)
   // featureShotReport adds a project-scoped Shot Reports nav item; flag check
   // lives here so nav-config stays pure (and the report route is desktop-only).
-  const desktopConfig =
+  const withShotReports =
     isFeatureEnabled("featureShotReport") && projectId
       ? withShotReportsNav(baseDesktopConfig, projectId)
       : baseDesktopConfig
+  // featureProductInfoReport adds a project-scoped Product Info nav item after it.
+  const desktopConfig =
+    isFeatureEnabled("featureProductInfoReport") && projectId
+      ? withProductInfoReportsNav(withShotReports, projectId)
+      : withShotReports
   const mobileConfig = getMobileNavConfig(projectId, role)
 
   return (

--- a/src-vnext/shared/components/sidebar/nav-config.test.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest"
-import { buildNavConfig, getMobileNavConfig, withShotReportsNav, type NavConfig } from "./nav-config"
+import {
+  buildNavConfig,
+  getMobileNavConfig,
+  withProductInfoReportsNav,
+  withShotReportsNav,
+  type NavConfig,
+} from "./nav-config"
 
 describe("buildNavConfig", () => {
   it("returns org variant when no projectId", () => {
@@ -231,5 +237,53 @@ describe("withShotReportsNav", () => {
     withShotReportsNav(base, "p1")
     expect(base.entries.length).toBe(beforeLen)
     expect(base.entries.some((e) => e.type === "item" && e.item.label === "Shot Reports")).toBe(false)
+  })
+})
+
+describe("withProductInfoReportsNav", () => {
+  const itemLabels = (config: NavConfig) =>
+    config.entries
+      .filter((e) => e.type === "item")
+      .map((e) => (e as { type: "item"; item: { label: string } }).item.label)
+
+  it("inserts a Product Info item right after Shot Reports when present", () => {
+    const withShots = withShotReportsNav(buildNavConfig("p1"), "p1")
+    const labels = itemLabels(withProductInfoReportsNav(withShots, "p1"))
+    const shotIdx = labels.indexOf("Shot Reports")
+    expect(shotIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[shotIdx + 1]).toBe("Product Info")
+  })
+
+  it("inserts a Product Info item right after Export when Shot Reports absent", () => {
+    const labels = itemLabels(withProductInfoReportsNav(buildNavConfig("p1"), "p1"))
+    const exportIdx = labels.indexOf("Export")
+    expect(exportIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[exportIdx + 1]).toBe("Product Info")
+  })
+
+  it("points the item at the project-scoped product-reports route", () => {
+    const next = withProductInfoReportsNav(buildNavConfig("p1"), "p1")
+    const item = next.entries.find((e) => e.type === "item" && e.item.label === "Product Info")
+    expect(item && item.type === "item" ? item.item.to : null).toBe(
+      "/projects/p1/export/product-reports",
+    )
+  })
+
+  it("appends Product Info when no Export entry exists (fallback)", () => {
+    const stub: NavConfig = {
+      variant: "project",
+      entries: [{ type: "item", item: { label: "Shots", to: "/projects/p1/shots", iconName: "camera" } }],
+    }
+    const next = withProductInfoReportsNav(stub, "p1")
+    const last = next.entries[next.entries.length - 1]
+    expect(last && last.type === "item" ? last.item.label : null).toBe("Product Info")
+  })
+
+  it("does not mutate the input config", () => {
+    const base = buildNavConfig("p1")
+    const beforeLen = base.entries.length
+    withProductInfoReportsNav(base, "p1")
+    expect(base.entries.length).toBe(beforeLen)
+    expect(base.entries.some((e) => e.type === "item" && e.item.label === "Product Info")).toBe(false)
   })
 })

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -224,11 +224,12 @@ export function withProductInfoReportsNav(config: NavConfig, projectId: string):
   }
   const shotReportsTo = `/projects/${projectId}/export/reports`
   const exportTo = `/projects/${projectId}/export`
-  const anchor =
-    config.entries.findIndex((e) => e.type === "item" && e.item.to === shotReportsTo) !== -1
-      ? shotReportsTo
-      : exportTo
-  const idx = config.entries.findIndex((e) => e.type === "item" && e.item.to === anchor)
+  // Anchor after Shot Reports if present, else after Export. Single scan each.
+  const shotReportsIdx = config.entries.findIndex((e) => e.type === "item" && e.item.to === shotReportsTo)
+  const idx =
+    shotReportsIdx !== -1
+      ? shotReportsIdx
+      : config.entries.findIndex((e) => e.type === "item" && e.item.to === exportTo)
   const entries =
     idx === -1
       ? [...config.entries, item]

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -206,3 +206,32 @@ export function withShotReportsNav(config: NavConfig, projectId: string): NavCon
       : [...config.entries.slice(0, idx + 1), item, ...config.entries.slice(idx + 1)]
   return { ...config, entries }
 }
+
+/**
+ * Insert a project-scoped "Product Info" item after Shot Reports (or Export, or
+ * appended). Pure — the featureProductInfoReport check stays at the AppShell call
+ * site so buildNavConfig stays flag-free and its unit tests are unaffected.
+ */
+export function withProductInfoReportsNav(config: NavConfig, projectId: string): NavConfig {
+  const item: NavEntry = {
+    type: "item",
+    item: {
+      label: "Product Info",
+      to: `/projects/${projectId}/export/product-reports`,
+      iconName: "package",
+      desktopOnly: true,
+    },
+  }
+  const shotReportsTo = `/projects/${projectId}/export/reports`
+  const exportTo = `/projects/${projectId}/export`
+  const anchor =
+    config.entries.findIndex((e) => e.type === "item" && e.item.to === shotReportsTo) !== -1
+      ? shotReportsTo
+      : exportTo
+  const idx = config.entries.findIndex((e) => e.type === "item" && e.item.to === anchor)
+  const entries =
+    idx === -1
+      ? [...config.entries, item]
+      : [...config.entries.slice(0, idx + 1), item, ...config.entries.slice(idx + 1)]
+  return { ...config, entries }
+}

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -190,4 +190,27 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureShotReportRecipes")).toBe(false)
     }
   })
+
+  it("defaults featureProductInfoReport to false (R4 PR1 Product Info report dark on main)", () => {
+    expect(getFeatureFlags().featureProductInfoReport).toBe(false)
+    expect(isFeatureEnabled("featureProductInfoReport")).toBe(false)
+  })
+
+  it("VITE_PRODUCT_INFO_REPORT='1' or 'true' enables featureProductInfoReport", () => {
+    vi.stubEnv("VITE_PRODUCT_INFO_REPORT", "1")
+    expect(isFeatureEnabled("featureProductInfoReport")).toBe(true)
+
+    vi.stubEnv("VITE_PRODUCT_INFO_REPORT", "true")
+    expect(isFeatureEnabled("featureProductInfoReport")).toBe(true)
+
+    vi.stubEnv("VITE_PRODUCT_INFO_REPORT", "TRUE")
+    expect(isFeatureEnabled("featureProductInfoReport")).toBe(true)
+  })
+
+  it("any other VITE_PRODUCT_INFO_REPORT value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_PRODUCT_INFO_REPORT", value)
+      expect(isFeatureEnabled("featureProductInfoReport")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -127,6 +127,16 @@ export interface FeatureFlags {
    * URL/localStorage layer.
    */
   readonly featureShotReportRecipes: boolean
+  /**
+   * Export reimagine R4 PR1 — the Product Info report (a new product-centric
+   * report TYPE applying the shot-report pattern). Gates its two routes
+   * (projects/:id/export/product-reports + .../export/product-report) + the nav
+   * item. Default OFF; the flag-off path is byte-identical to trunk (routes
+   * don't register, no nav item). Enabled via `VITE_PRODUCT_INFO_REPORT=1` (or
+   * `true`) at build/dev time (featureShotReport env-parse precedent). No
+   * URL/localStorage layer.
+   */
+  readonly featureProductInfoReport: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -142,6 +152,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureTalentLazy: false,
   featureShotReport: false,
   featureShotReportRecipes: false,
+  featureProductInfoReport: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -194,6 +205,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureShotReportRecipes:
       DEFAULT_FLAGS.featureShotReportRecipes ||
       parseEnvFlag(import.meta.env.VITE_SHOT_REPORT_RECIPES),
+    featureProductInfoReport:
+      DEFAULT_FLAGS.featureProductInfoReport ||
+      parseEnvFlag(import.meta.env.VITE_PRODUCT_INFO_REPORT),
   }
 }
 


### PR DESCRIPTION
## R4 PR1 — Product Info report (the product-centric crew deliverable)

First of the two new R4 report types. A **product-centric** report — one card/section per product family in the project — applying the shipped shot-report **pattern** (one pure model → DOM + @react-pdf adapters → parity), **not** a new `ReportLayout` variant of the shot model. Behind **`featureProductInfoReport`** (default OFF, env `VITE_PRODUCT_INFO_REPORT`); **flag-off is byte-identical** to trunk.

### What's in it
- **`productInfoModel.ts`** — `deriveProductInfoModel(data, config)` (the inverse of `deriveShotReportModel`: walk non-deleted shots → looks → products → in-use families). Per family: colours/sizes used, `sizePending`, `isHero`, and `appears` (sorted shot numbers + look labels + status). Scope `in-use | library`, group-by `gender | product-type | none`, S/M/L image size. Reuses (not duplicates) `reportModel` helpers (now named exports) + the model-agnostic `resolveReportImages`.
- **`ProductInfoReportView.tsx`** (DOM, **one red = the hero mark**) + **`reportPdfProductInfo.tsx`** (landscape @react-pdf, lazy-imported on export; DOM ↔ PDF share the model). Explicit per-card pagination so a card never straddles/clips a page break.
- **List + report pages**, flag-gated routes (`export/product-reports`, `export/product-report`) + breadcrumbs + nav injection.
- **Persistence**: widen `ExportReportType` (+`product-info`) via a shared `createTypedReport`; reuse `saveReportConfig`. **No `firestore.rules` change** (rules validate nothing on `reportType`/`config`).

### Clobber-safety (scout-verified, decisive)
The new `reportType` is **safe by construction**: the only list-all consumer (`useExportReports` snapshot) never auto-acts, and every auto-acting surface filters by exact-match include (`ExportBuilderPage` → `block-canvas`, `ShotReportListPage` → `shot-report`), so a `product-info` doc is auto-excluded and can't be auto-selected/clobbered. The new list page filters `=== "product-info"` with explicit user actions only.

### Verification
- Built via a staged writer→adversarial-verify workflow (5 lenses: flag-off byte-identical, model-correctness, one-red+parity, clobber-persistence, wiring). **0 actionable findings**; 2 minors fixed (DOM print-preview clip-robustness, removed an unused `--sb-red-ink` token), rest accepted with rationale.
- Gates: **tsc baseline 160/160 · vitest 100/100** (incl. 14 new `productInfoModel` tests, +3 flags, breadcrumbs/nav coverage) **· lint · vite build** (`@react-pdf` stays in its own lazy chunk).

### Notes
- Two shipped shot-report files got a 1-line `as ReportConfig` narrowing each (forced by widening `config` to a union) — pure type narrowing, runtime-identical.
- `sizes` deliberately omits pending-scoped sizes (the comp surfaces "Size pending" as a distinct state); the `gender` group reuses the shared `GROUP_ORDER` (its `Mixed` bucket is filtered out — products only normalize to W/M/?).

**Flag stays OFF.** Eyeball gate is on `:5174` (with PR2/Talent) before any prod flag flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YRgXcNvEuGVF7jwftCmB4
