### PR TITLE
feat(export): Talent report (R4 PR2, flag-gated)

### DIFF
--- a/src-vnext/app/routes/breadcrumbs.ts
+++ b/src-vnext/app/routes/breadcrumbs.ts
@@ -127,6 +127,20 @@ export const breadcrumbsConfig: Record<string, BreadcrumbResolver> = {
     },
     { label: "Product Report" },
   ],
+  "/projects/:id/export/talent-reports": (ctx) => [
+    ...projectCrumbs(ctx),
+    { label: "Talent" },
+  ],
+  "/projects/:id/export/talent-report": (ctx) => [
+    ...projectCrumbs(ctx),
+    {
+      label: "Talent",
+      to: ctx.params["id"]
+        ? `/projects/${ctx.params["id"]}/export/talent-reports`
+        : undefined,
+    },
+    { label: "Talent Report" },
+  ],
   "/projects/:id/schedules/:scheduleId/onset": () => [],
 
   "/requests": () => [{ label: "Shot Requests" }],

--- a/src-vnext/app/routes/index.tsx
+++ b/src-vnext/app/routes/index.tsx
@@ -67,6 +67,12 @@ const ProductInfoReportPage = lazy(
 const ProductInfoReportListPage = lazy(
   () => import("@/features/export/components/report/ProductInfoReportListPage"),
 )
+const TalentReportPage = lazy(
+  () => import("@/features/export/components/report/TalentReportPage"),
+)
+const TalentReportListPage = lazy(
+  () => import("@/features/export/components/report/TalentReportListPage"),
+)
 const OnSetViewerPage = lazy(
   () => import("@/features/schedules/components/OnSetViewerPage"),
 )
@@ -324,6 +330,34 @@ export function AppRoutes() {
                   <ProjectScopeProvider>
                     <RequireDesktop label="Product info report">
                       <ProductInfoReportPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
+          {isFeatureEnabled("featureTalentReport") && (
+            <Route
+              path="projects/:id/export/talent-reports"
+              element={
+                <RouteBoundary featureName="Talent reports">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Talent reports">
+                      <TalentReportListPage />
+                    </RequireDesktop>
+                  </ProjectScopeProvider>
+                </RouteBoundary>
+              }
+            />
+          )}
+          {isFeatureEnabled("featureTalentReport") && (
+            <Route
+              path="projects/:id/export/talent-report"
+              element={
+                <RouteBoundary featureName="Talent report">
+                  <ProjectScopeProvider>
+                    <RequireDesktop label="Talent report">
+                      <TalentReportPage />
                     </RequireDesktop>
                   </ProjectScopeProvider>
                 </RouteBoundary>

--- a/src-vnext/features/export/components/report/TalentReportListPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportListPage.tsx
@@ -67,11 +67,14 @@ export default function TalentReportListPage() {
 
   const handleDelete = useCallback(
     async (reportId: string) => {
+      setBusy(true)
       try {
         await deleteReport(reportId)
         toast.success("Report deleted")
       } catch {
         toast.error("Couldn't delete the report")
+      } finally {
+        setBusy(false)
       }
     },
     [deleteReport],

--- a/src-vnext/features/export/components/report/TalentReportListPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportListPage.tsx
@@ -1,0 +1,171 @@
+import { useCallback, useMemo, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { toast } from "sonner"
+import { Plus, Trash2, Users } from "lucide-react"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { Button, buttonVariants } from "@/ui/button"
+import { Input } from "@/ui/input"
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/ui/alert-dialog"
+import { PageHeader } from "@/shared/components/PageHeader"
+import { EmptyState } from "@/shared/components/EmptyState"
+import { useExportReports } from "../../hooks/useExportReports"
+import { DEFAULT_TALENT_CONFIG } from "../../lib/report/talentTypes"
+
+// Saved talent reports for a project: create, open, and delete. Sits beside the
+// single report page; never touches the legacy block-canvas builder or the
+// shot-report / product-info lists. Flag-gated route. Mirrors
+// ProductInfoReportListPage.
+
+export default function TalentReportListPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const { clientId } = useAuth()
+  const navigate = useNavigate()
+  const { reports, loading, createTalentReport, deleteReport } = useExportReports(
+    clientId,
+    projectId,
+  )
+
+  const talentReports = useMemo(
+    () => reports.filter((r) => r.reportType === "talent"),
+    [reports],
+  )
+
+  const [newName, setNewName] = useState("")
+  const [busy, setBusy] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
+
+  const openReport = useCallback(
+    (reportId: string) =>
+      navigate(`/projects/${projectId}/export/talent-report?reportId=${reportId}`),
+    [navigate, projectId],
+  )
+
+  const handleCreate = useCallback(async () => {
+    setBusy(true)
+    try {
+      const id = await createTalentReport(
+        newName.trim() || "Untitled report",
+        DEFAULT_TALENT_CONFIG,
+      )
+      setNewName("")
+      openReport(id)
+    } catch {
+      toast.error("Couldn't create the report")
+    } finally {
+      setBusy(false)
+    }
+  }, [createTalentReport, newName, openReport])
+
+  const handleDelete = useCallback(
+    async (reportId: string) => {
+      try {
+        await deleteReport(reportId)
+        toast.success("Report deleted")
+      } catch {
+        toast.error("Couldn't delete the report")
+      }
+    },
+    [deleteReport],
+  )
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      <PageHeader title="Talent" />
+
+      <div className="mb-6 flex items-center gap-2">
+        <Input
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !busy) void handleCreate()
+          }}
+          placeholder="New report name…"
+          aria-label="New report name"
+          className="flex-1"
+        />
+        <Button onClick={() => void handleCreate()} disabled={busy}>
+          <Plus /> Create report
+        </Button>
+      </div>
+
+      {loading ? (
+        <p className="text-sm text-[var(--color-text-muted)]">Loading…</p>
+      ) : talentReports.length === 0 ? (
+        <EmptyState
+          icon={<Users className="h-8 w-8" />}
+          title="No talent reports yet"
+          description="Create a report above to lay out every talent in the project as a printable info sheet, then export it as a PDF."
+        />
+      ) : (
+        <ul className="divide-y divide-[var(--color-border)] rounded-md border border-[var(--color-border)]">
+          {talentReports.map((r) => (
+            <li key={r.id} className="flex items-center gap-2 p-3">
+              <button
+                type="button"
+                onClick={() => openReport(r.id)}
+                className="min-w-0 flex-1 text-left"
+              >
+                <span className="block truncate text-sm font-medium text-[var(--color-text)]">
+                  {r.name}
+                </span>
+                {r.updatedAt ? (
+                  <span className="block text-xs text-[var(--color-text-muted)]">
+                    Updated {r.updatedAt.toLocaleDateString()}
+                  </span>
+                ) : null}
+              </button>
+              <Button variant="outline" size="sm" onClick={() => openReport(r.id)}>
+                Open
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => setPendingDelete({ id: r.id, name: r.name })}
+                disabled={busy}
+                aria-label={`Delete ${r.name}`}
+              >
+                <Trash2 />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete this report?</AlertDialogTitle>
+            <AlertDialogDescription>
+              “{pendingDelete?.name}” will be permanently deleted. This can’t be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              className={buttonVariants({ variant: "destructive" })}
+              onClick={() => {
+                if (pendingDelete) void handleDelete(pendingDelete.id)
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/TalentReportListPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportListPage.tsx
@@ -67,14 +67,11 @@ export default function TalentReportListPage() {
 
   const handleDelete = useCallback(
     async (reportId: string) => {
-      setBusy(true)
       try {
         await deleteReport(reportId)
         toast.success("Report deleted")
       } catch {
         toast.error("Couldn't delete the report")
-      } finally {
-        setBusy(false)
       }
     },
     [deleteReport],

--- a/src-vnext/features/export/components/report/TalentReportPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportPage.tsx
@@ -41,6 +41,10 @@ export default function TalentReportPage() {
   // (a scope/group-by toggle that keeps the same headshots) skip the resolve so
   // the loading overlay doesn't flash.
   const lastImageKeyRef = useRef<string | null>(null)
+  // False after unmount — gates async image setState so a navigate-away mid-resolve
+  // can't update a dead component. Unmount-scoped (NOT per-run), so a same-key
+  // re-run mid-resolve still lets the in-flight request clear the loading overlay.
+  const mountedRef = useRef(true)
 
   // Hydrate config from a saved talent doc when ?reportId= is present, else reset
   // to defaults. Switching reports (or clearing reportId) also cancels any pending
@@ -64,7 +68,7 @@ export default function TalentReportPage() {
         hydratedReportIdRef.current = reportId
       })
       .catch(() => {
-        /* keep defaults on a transient load failure */
+        if (!cancelled) toast.error("Couldn't load the report — changes won't be saved")
       })
     return () => {
       cancelled = true
@@ -87,9 +91,10 @@ export default function TalentReportPage() {
     [reportId, saveReportConfig],
   )
 
-  // Cancel a pending config write if we unmount inside the debounce window.
+  // Cancel a pending config write + block async setState if we unmount.
   useEffect(
     () => () => {
+      mountedRef.current = false
       if (persistTimer.current) clearTimeout(persistTimer.current)
     },
     [],
@@ -114,14 +119,14 @@ export default function TalentReportPage() {
     // re-run (groupBy/exclude toggle) mid-resolve can't strand imagesLoading at true.
     resolveReportImages(candidates)
       .then((resolved) => {
-        if (lastImageKeyRef.current === key) {
+        if (mountedRef.current && lastImageKeyRef.current === key) {
           setImageMap(resolved)
           setImagesLoading(false)
         }
       })
       .catch(() => {
         // per-image failures already drop out of resolveReportImages
-        if (lastImageKeyRef.current === key) setImagesLoading(false)
+        if (mountedRef.current && lastImageKeyRef.current === key) setImagesLoading(false)
       })
   }, [model])
 

--- a/src-vnext/features/export/components/report/TalentReportPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportPage.tsx
@@ -109,21 +109,20 @@ export default function TalentReportPage() {
       setImagesLoading(false)
       return
     }
-    let cancelled = false
     setImagesLoading(true)
+    // Apply/clear only while this key is still the latest request, so a same-key
+    // re-run (groupBy/exclude toggle) mid-resolve can't strand imagesLoading at true.
     resolveReportImages(candidates)
       .then((resolved) => {
-        if (!cancelled) setImageMap(resolved)
+        if (lastImageKeyRef.current === key) {
+          setImageMap(resolved)
+          setImagesLoading(false)
+        }
       })
       .catch(() => {
-        /* per-image failures already drop out of resolveReportImages */
+        // per-image failures already drop out of resolveReportImages
+        if (lastImageKeyRef.current === key) setImagesLoading(false)
       })
-      .finally(() => {
-        if (!cancelled) setImagesLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
   }, [model])
 
   const handleExportPdf = useCallback(() => {

--- a/src-vnext/features/export/components/report/TalentReportPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportPage.tsx
@@ -1,0 +1,172 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useParams, useSearchParams } from "react-router-dom"
+import { toast } from "sonner"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { useExportData } from "../../hooks/useExportData"
+import { useExportReports } from "../../hooks/useExportReports"
+import {
+  collectTalentImageCandidates,
+  deriveTalentModel,
+} from "../../lib/report/talentModel"
+import { resolveReportImages } from "../../lib/report/reportImages"
+import {
+  DEFAULT_TALENT_CONFIG,
+  type TalentConfig,
+} from "../../lib/report/talentTypes"
+import { TalentReportView } from "./TalentReportView"
+
+// Integration layer: live export data -> resolved talent model -> image sidecar ->
+// TalentReportView. The model + imageMap feed both the screen render and the PDF,
+// so they can't drift. Mounted only behind the featureTalentReport flag (route
+// gate). Mirrors ProductInfoReportPage.
+
+export default function TalentReportPage() {
+  const data = useExportData()
+  const { id: projectId } = useParams<{ id: string }>()
+  const { clientId } = useAuth()
+  const [searchParams] = useSearchParams()
+  const reportId = searchParams.get("reportId")
+  const { loadReport, saveReportConfig } = useExportReports(clientId, projectId)
+
+  const [config, setConfig] = useState<TalentConfig>(DEFAULT_TALENT_CONFIG)
+  const [imageMap, setImageMap] = useState<ReadonlyMap<string, string>>(new Map())
+  const [imagesLoading, setImagesLoading] = useState(false)
+  const [exporting, setExporting] = useState(false)
+
+  const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // The reportId that has finished hydrating. Edits made while a report is still
+  // loading must not persist — they'd save the outgoing report's config onto it.
+  const hydratedReportIdRef = useRef<string | null>(null)
+  // The image candidate set last resolved — re-derivations that don't change it
+  // (a scope/group-by toggle that keeps the same headshots) skip the resolve so
+  // the loading overlay doesn't flash.
+  const lastImageKeyRef = useRef<string | null>(null)
+
+  // Hydrate config from a saved talent doc when ?reportId= is present, else reset
+  // to defaults. Switching reports (or clearing reportId) also cancels any pending
+  // write from the previous report. Default-merge so an older blob parses.
+  useEffect(() => {
+    if (persistTimer.current) clearTimeout(persistTimer.current)
+    hydratedReportIdRef.current = null
+    if (!reportId) {
+      setConfig(DEFAULT_TALENT_CONFIG)
+      return
+    }
+    let cancelled = false
+    void loadReport(reportId)
+      .then((full) => {
+        if (cancelled) return
+        if (!full) return // doc not found (deleted) — keep defaults, nothing to persist
+        // Cross-type guard: a pasted cross-type reportId must not clobber that doc's config.
+        if (full.reportType !== "talent") return
+        const loaded = full.config as TalentConfig | undefined
+        setConfig(loaded ? { ...DEFAULT_TALENT_CONFIG, ...loaded } : DEFAULT_TALENT_CONFIG)
+        hydratedReportIdRef.current = reportId
+      })
+      .catch(() => {
+        /* keep defaults on a transient load failure */
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [reportId, loadReport])
+
+  // User edits persist (debounced) only when editing a saved report that has
+  // hydrated. Hydration uses setConfig directly, so it never triggers a write-back.
+  const handleConfigChange = useCallback(
+    (next: TalentConfig) => {
+      setConfig(next)
+      if (!reportId || hydratedReportIdRef.current !== reportId) return
+      if (persistTimer.current) clearTimeout(persistTimer.current)
+      persistTimer.current = setTimeout(() => {
+        void saveReportConfig(reportId, next).catch(() => {
+          /* offline cache retries */
+        })
+      }, 800)
+    },
+    [reportId, saveReportConfig],
+  )
+
+  // Cancel a pending config write if we unmount inside the debounce window.
+  useEffect(
+    () => () => {
+      if (persistTimer.current) clearTimeout(persistTimer.current)
+    },
+    [],
+  )
+
+  const model = useMemo(() => deriveTalentModel(data, config), [data, config])
+
+  // Resolve every image candidate to a data URL once the model is known.
+  // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.
+  useEffect(() => {
+    const candidates = collectTalentImageCandidates(model)
+    const key = candidates.join("\n")
+    if (key === lastImageKeyRef.current) return // image set unchanged — no re-resolve
+    lastImageKeyRef.current = key
+    if (candidates.length === 0) {
+      setImageMap(new Map())
+      setImagesLoading(false)
+      return
+    }
+    let cancelled = false
+    setImagesLoading(true)
+    resolveReportImages(candidates)
+      .then((resolved) => {
+        if (!cancelled) setImageMap(resolved)
+      })
+      .catch(() => {
+        /* per-image failures already drop out of resolveReportImages */
+      })
+      .finally(() => {
+        if (!cancelled) setImagesLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [model])
+
+  const handleExportPdf = useCallback(() => {
+    setExporting(true)
+    // Lazy-import so @react-pdf (and its heavy deps) load only on export click,
+    // keeping them out of the report route's eager chunk.
+    void (async () => {
+      const { generateTalentPdf } = await import("../../lib/report/reportPdfTalent")
+      await generateTalentPdf(model, imageMap, `${model.project.name} — Talent.pdf`)
+    })()
+      .catch(() => toast.error("Couldn't export the PDF"))
+      .finally(() => {
+        setExporting(false)
+      })
+  }, [model, imageMap])
+
+  if (data.loading) {
+    return (
+      <div className="flex h-full items-center justify-center text-[var(--color-text-secondary)]">
+        Loading talent…
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-full">
+      {imagesLoading && (
+        <div
+          role="status"
+          className="absolute right-4 top-4 z-20 rounded bg-[var(--color-surface)] px-3 py-1 text-xs text-[var(--color-text-secondary)] ring-1 ring-[var(--color-border)]"
+        >
+          Loading images…
+        </div>
+      )}
+      <TalentReportView
+        model={model}
+        imageMap={imageMap}
+        config={config}
+        onConfigChange={handleConfigChange}
+        onExportPdf={handleExportPdf}
+        exporting={exporting}
+        imagesLoading={imagesLoading}
+      />
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -1,0 +1,495 @@
+// Talent report — DOM renderer (screen + paged print preview). A NEW report TYPE
+// (talent-centric, call-sheet-adjacent): one card per TalentRecord in the project,
+// grouped per config. Pure presentational + interaction callbacks; no data fetching.
+// Consumes the resolved TalentModel + an image *sidecar* map (candidate -> data URL).
+// Red does exactly one job here: the HOLD flag. Ported from comp-talent.html.
+
+import { useId, useMemo, useState } from "react"
+import type { JSX } from "react"
+import { Loader2 } from "lucide-react"
+import { resolveSrc, statusMeta } from "./reportShared"
+import { TALENT_STYLES } from "./talentStyles"
+import type {
+  TalentConfig,
+  TalentEntry,
+  TalentGroup,
+  TalentGroupBy,
+  TalentModel,
+  TalentScope,
+} from "../../lib/report/talentTypes"
+
+export interface TalentReportViewProps {
+  readonly model: TalentModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly config: TalentConfig
+  readonly onConfigChange: (next: TalentConfig) => void
+  readonly onExportPdf: () => void
+  readonly exporting?: boolean
+  readonly imagesLoading?: boolean
+}
+
+// Initials fallback — first letter of up to the first two name words.
+function initials(name: string): string {
+  return (name || "?")
+    .split(/\s+/)
+    .map((w) => w[0])
+    .filter(Boolean)
+    .slice(0, 2)
+    .join("")
+    .toUpperCase()
+}
+
+// ---------------------------------------------------------------------------
+// One talent card — headshot col (native-aspect or initials tile + shot count)
+// + info col: name, HOLD flag (the ONE red), gender badge + agency, contact,
+// measurements grid, "In shots" list with status dots + shot number + title + looks.
+// ---------------------------------------------------------------------------
+function TalentCard({
+  entry,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly entry: TalentEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (talentId: string) => void
+}): JSX.Element {
+  const src = resolveSrc(imageMap, entry.headshot)
+  const appears = entry.appears
+  const contact: ReadonlyArray<readonly [string, string | null]> = [
+    ["Email", entry.email],
+    ["Phone", entry.phone],
+    ["Web", entry.web],
+  ]
+  const shownContact = contact.filter(([, v]) => v && v.trim() !== "")
+
+  return (
+    <article className={"sb-tr-card" + (entry.excluded ? " sb-tr-excluded" : "")}>
+      <button
+        type="button"
+        className="sb-tr-exclude-toggle no-print"
+        aria-pressed={entry.excluded}
+        onClick={() => onToggleExclude(entry.id)}
+        title={entry.excluded ? "Restore this talent to the report" : "Exclude this talent from the report"}
+      >
+        {entry.excluded ? "Restore" : "Exclude"}
+      </button>
+
+      <div className="sb-tr-headshot">
+        <div className="sb-tr-headshot-frame">
+          {src ? (
+            <img src={src} alt={`${entry.name} — headshot`} loading="lazy" />
+          ) : (
+            <div className="sb-tr-headshot-initials">{initials(entry.name)}</div>
+          )}
+        </div>
+        <div className="sb-tr-appearances">
+          {appears.length} {appears.length === 1 ? "shot" : "shots"}
+        </div>
+      </div>
+
+      <div className="sb-tr-info">
+        <div className="sb-tr-name-row">
+          <span className="sb-tr-name">{entry.name}</span>
+          {entry.onHold ? <span className="sb-tr-hold-flag">Hold</span> : null}
+        </div>
+
+        {entry.genderLabel || entry.agency ? (
+          <div className="sb-tr-badges">
+            {entry.genderLabel ? <span className="sb-tr-badge-gender">{entry.genderLabel}</span> : null}
+            {entry.agency ? <span className="sb-tr-agency">{entry.agency}</span> : null}
+          </div>
+        ) : null}
+
+        {shownContact.length ? (
+          <div className="sb-tr-contact">
+            {shownContact.map(([k, v]) => (
+              <span className="sb-tr-c-item" key={k}>
+                <span className="sb-tr-c-k">{k}</span>
+                <span>{v}</span>
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {entry.measurements.length ? (
+          <div className="sb-tr-measures">
+            {entry.measurements.map((m) => (
+              <div className="sb-tr-measure" key={m.label}>
+                <span className="sb-tr-m-k">{m.label}</span>
+                <span className="sb-tr-m-v">{m.value}</span>
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="sb-tr-shots-k">In shots</div>
+        {appears.length ? (
+          <div className="sb-tr-shots-list">
+            {appears.map((a, i) => {
+              const st = statusMeta(a.status)
+              return (
+                <div className="sb-tr-shot-line" key={`${entry.id}-a-${i}`}>
+                  <span className="sb-tr-s-no">
+                    <span className={"sb-status-dot " + st.dotClass} title={st.label} aria-hidden="true" />
+                    <span>{a.number && a.number.trim() !== "" ? a.number : "—"}</span>
+                  </span>
+                  <span className="sb-tr-s-title">{a.title && a.title.trim() !== "" ? a.title : "Untitled shot"}</span>
+                  {a.looks.length ? <span className="sb-tr-s-looks">{a.looks.join(" · ")}</span> : null}
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <span className="sb-pending">Not yet slotted into a shot</span>
+        )}
+      </div>
+    </article>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Masthead band — Talent / Agencies / Holds / Window.
+// ---------------------------------------------------------------------------
+function Masthead({ model }: { readonly model: TalentModel }): JSX.Element {
+  const stats = useMemo(() => {
+    let holds = 0
+    const agencies = new Set<string>()
+    let total = 0
+    for (const g of model.groups) {
+      for (const e of g.items) {
+        if (e.excluded) continue
+        total += 1
+        if (e.onHold) holds += 1
+        if (e.agency) agencies.add(e.agency)
+      }
+    }
+    return { holds, agencies: agencies.size, total }
+  }, [model.groups])
+
+  const cells: ReadonlyArray<readonly [string, string | number]> = [
+    ["Talent", stats.total],
+    ["Agencies", stats.agencies],
+    ["Holds", stats.holds],
+    ["Window", model.project.dateRange ?? "—"],
+  ]
+
+  return (
+    <header className="sb-tr-masthead-band">
+      <div className="sb-tr-eyebrow-row">
+        <span className="sb-tr-eyebrow">
+          Talent{model.project.name ? ` · ${model.project.name}` : ""}
+        </span>
+        {model.project.client ? <span className="sb-tr-eyebrow sb-tr-lede">{model.project.client}</span> : null}
+      </div>
+      <h1 className="sb-tr-masthead-title">Talent</h1>
+      <div className="sb-tr-masthead-meta">
+        {cells.map(([k, v]) => (
+          <div className="sb-tr-meta-cell" key={k}>
+            <span className="sb-tr-meta-k">{k}</span>
+            <span className="sb-tr-meta-v">{String(v)}</span>
+          </div>
+        ))}
+      </div>
+    </header>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Fluid (screen) group section — header + count, responsive card grid.
+// ---------------------------------------------------------------------------
+function GroupSection({
+  group,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly group: TalentGroup
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (talentId: string) => void
+}): JSX.Element {
+  const shown = group.items.filter((e) => !e.excluded).length
+  return (
+    <section className="sb-tr-group" aria-label={group.label}>
+      <div className="sb-tr-group-head">
+        <span className="sb-tr-group-name">{group.label}</span>
+        <span className="sb-tr-group-count">{shown} talent</span>
+      </div>
+      <div className="sb-tr-grid">
+        {group.items.map((entry) => (
+          <TalentCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Paged (print preview) — US-Letter LANDSCAPE sheets. Explicit pagination packs
+// whole cards onto a fixed 2-column grid per sheet so a wide call-sheet card NEVER
+// straddles or clips a page break (mirrors the shipped report PagedView discipline
+// at DOM scope; the comp's CSS-only print clipping must NOT recur). Only PDF-bound
+// (non-excluded) entries are paginated.
+// ---------------------------------------------------------------------------
+const PRINT_COLS = 2
+const PRINT_ROWS = 3
+const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
+
+interface Sheet {
+  readonly groupLabel: string
+  readonly cont: boolean
+  readonly items: readonly TalentEntry[]
+}
+
+function buildSheets(model: TalentModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const printable = group.items.filter((e) => !e.excluded)
+    for (let i = 0; i < printable.length; i += CARDS_PER_SHEET) {
+      sheets.push({
+        groupLabel: group.label,
+        cont: i > 0,
+        items: printable.slice(i, i + CARDS_PER_SHEET),
+      })
+    }
+  }
+  return sheets
+}
+
+function PagedView({
+  model,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly model: TalentModel
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (talentId: string) => void
+}): JSX.Element {
+  const sheets = useMemo(() => buildSheets(model), [model])
+  const projLine = model.project.client
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+  const totalPages = sheets.length
+
+  return (
+    <div className="sb-tr-paged" style={{ ["--sb-tr-print-cols" as string]: PRINT_COLS }}>
+      {sheets.map((sheet, idx) => (
+        <section className="sb-tr-sheet" key={`tr-sheet-${idx}`}>
+          <div className="sb-tr-sheet-head">
+            <div>
+              <div className="sb-tr-sh-title">Talent Report</div>
+              <div className="sb-tr-sh-proj">{projLine}</div>
+            </div>
+            <div className="sb-tr-sh-group">
+              {sheet.groupLabel}
+              {sheet.cont ? " (cont.)" : ""}
+            </div>
+          </div>
+          <div className="sb-tr-sheet-body">
+            {sheet.items.map((entry) => (
+              <TalentCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+            ))}
+          </div>
+          <div className="sb-tr-sheet-foot">
+            <span>{projLine}</span>
+            <span>
+              Page {idx + 1} / {totalPages}
+            </span>
+          </div>
+        </section>
+      ))}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Control bar (never prints): scope (in-shots/project-attached), group-by
+// (none/gender/agency), Screen/Print, Export PDF. No image-size knob (headshots
+// are small).
+// ---------------------------------------------------------------------------
+function ControlBar({
+  scope,
+  onSetScope,
+  groupBy,
+  onSetGroupBy,
+  printMode,
+  onSetPrintMode,
+  onExportPdf,
+  exporting,
+  imagesLoading,
+}: {
+  readonly scope: TalentScope
+  readonly onSetScope: (v: TalentScope) => void
+  readonly groupBy: TalentGroupBy
+  readonly onSetGroupBy: (v: TalentGroupBy) => void
+  readonly printMode: boolean
+  readonly onSetPrintMode: (v: boolean) => void
+  readonly onExportPdf: () => void
+  readonly exporting: boolean
+  readonly imagesLoading: boolean
+}): JSX.Element {
+  const scopeLabelId = useId()
+  const groupLabelId = useId()
+  const viewLabelId = useId()
+
+  const scopeOpts: ReadonlyArray<readonly [TalentScope, string]> = [
+    ["in-shots", "In shots"],
+    ["project-attached", "Attached"],
+  ]
+  const groupOpts: ReadonlyArray<readonly [TalentGroupBy, string]> = [
+    ["none", "None"],
+    ["gender", "Gender"],
+    ["agency", "Agency"],
+  ]
+
+  return (
+    <div className="sb-tr-controlbar no-print" role="region" aria-label="Talent report controls">
+      <div className="sb-tr-control-group" role="group" aria-labelledby={scopeLabelId}>
+        <span id={scopeLabelId} className="sb-tr-control-label">
+          Scope
+        </span>
+        <div className="sb-tr-seg">
+          {scopeOpts.map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              className="sb-tr-seg-btn"
+              aria-pressed={scope === v}
+              onClick={() => onSetScope(v)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="sb-tr-control-group" role="group" aria-labelledby={groupLabelId}>
+        <span id={groupLabelId} className="sb-tr-control-label">
+          Group by
+        </span>
+        <div className="sb-tr-seg">
+          {groupOpts.map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              className="sb-tr-seg-btn"
+              aria-pressed={groupBy === v}
+              onClick={() => onSetGroupBy(v)}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="sb-tr-control-group" role="group" aria-labelledby={viewLabelId}>
+        <span id={viewLabelId} className="sb-tr-control-label">
+          View
+        </span>
+        <div className="sb-tr-seg">
+          <button
+            type="button"
+            className="sb-tr-seg-btn"
+            aria-pressed={!printMode}
+            onClick={() => onSetPrintMode(false)}
+          >
+            Screen
+          </button>
+          <button
+            type="button"
+            className="sb-tr-seg-btn"
+            aria-pressed={printMode}
+            onClick={() => onSetPrintMode(true)}
+          >
+            Print preview
+          </button>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        className="sb-tr-export-btn"
+        onClick={onExportPdf}
+        disabled={exporting || imagesLoading}
+        aria-busy={exporting}
+      >
+        {exporting ? (
+          <>
+            <Loader2 className="sb-tr-spin" size={15} aria-hidden="true" />
+            Exporting…
+          </>
+        ) : (
+          "Export PDF"
+        )}
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Root.
+// ---------------------------------------------------------------------------
+export function TalentReportView(props: TalentReportViewProps): JSX.Element {
+  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, imagesLoading = false } = props
+  const [printMode, setPrintMode] = useState(false)
+
+  const toggleExclude = (talentId: string): void => {
+    const set = new Set(config.excludedTalentIds)
+    if (set.has(talentId)) set.delete(talentId)
+    else set.add(talentId)
+    onConfigChange({ ...config, excludedTalentIds: [...set] })
+  }
+
+  const setScope = (talentScope: TalentScope): void => {
+    if (talentScope === config.talentScope) return
+    onConfigChange({ ...config, talentScope })
+  }
+
+  const setGroupBy = (groupBy: TalentGroupBy): void => {
+    if (groupBy === config.groupBy) return
+    onConfigChange({ ...config, groupBy })
+  }
+
+  const isEmpty = model.groups.length === 0 || model.project.talentCount === 0
+
+  return (
+    <div className={"sb-tr-root" + (printMode ? " sb-tr-print-mode" : "")}>
+      <style>{TALENT_STYLES}</style>
+
+      <ControlBar
+        scope={config.talentScope}
+        onSetScope={setScope}
+        groupBy={config.groupBy}
+        onSetGroupBy={setGroupBy}
+        printMode={printMode}
+        onSetPrintMode={setPrintMode}
+        onExportPdf={onExportPdf}
+        exporting={exporting}
+        imagesLoading={imagesLoading}
+      />
+
+      <main className="sb-tr-report">
+        <Masthead model={model} />
+
+        {isEmpty ? (
+          <p className="sb-tr-empty">No talent to report yet.</p>
+        ) : (
+          <>
+            {/* Fluid grouped grid (screen) */}
+            <div className="sb-tr-fluid">
+              {model.groups.map((group) => (
+                <GroupSection
+                  key={group.key}
+                  group={group}
+                  imageMap={imageMap}
+                  onToggleExclude={toggleExclude}
+                />
+              ))}
+            </div>
+
+            {/* Paged landscape preview (print mode + @media print) */}
+            <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -7,6 +7,7 @@
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
+import { initials } from "@/features/library/components/talentUtils"
 import { resolveSrc, statusMeta } from "./reportShared"
 import { TALENT_STYLES } from "./talentStyles"
 import type {
@@ -29,15 +30,6 @@ export interface TalentReportViewProps {
 }
 
 // Initials fallback — first letter of up to the first two name words.
-function initials(name: string): string {
-  return (name || "?")
-    .split(/\s+/)
-    .map((w) => w[0])
-    .filter(Boolean)
-    .slice(0, 2)
-    .join("")
-    .toUpperCase()
-}
 
 // ---------------------------------------------------------------------------
 // One talent card — headshot col (native-aspect or initials tile + shot count)
@@ -315,6 +307,7 @@ function ControlBar({
   onExportPdf,
   exporting,
   imagesLoading,
+  canExport,
 }: {
   readonly scope: TalentScope
   readonly onSetScope: (v: TalentScope) => void
@@ -325,6 +318,7 @@ function ControlBar({
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly imagesLoading: boolean
+  readonly canExport: boolean
 }): JSX.Element {
   const scopeLabelId = useId()
   const groupLabelId = useId()
@@ -408,7 +402,7 @@ function ControlBar({
         type="button"
         className="sb-tr-export-btn"
         onClick={onExportPdf}
-        disabled={exporting || imagesLoading}
+        disabled={exporting || imagesLoading || !canExport}
         aria-busy={exporting}
       >
         {exporting ? (
@@ -449,6 +443,8 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
   }
 
   const isEmpty = model.groups.length === 0 || model.project.talentCount === 0
+  // No non-excluded talent => the PDF would have zero pages (@react-pdf throws); gate Export.
+  const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
 
   return (
     <div className={"sb-tr-root" + (printMode ? " sb-tr-print-mode" : "")}>
@@ -464,6 +460,7 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
         onExportPdf={onExportPdf}
         exporting={exporting}
         imagesLoading={imagesLoading}
+        canExport={canExport}
       />
 
       <main className="sb-tr-report">

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -261,6 +261,14 @@ function PagedView({
     : model.project.name
   const totalPages = sheets.length
 
+  if (sheets.length === 0) {
+    return (
+      <div className="sb-tr-paged">
+        <p className="sb-tr-empty">All talent are excluded — nothing to print.</p>
+      </div>
+    )
+  }
+
   return (
     <div className="sb-tr-paged" style={{ ["--sb-tr-print-cols" as string]: PRINT_COLS }}>
       {sheets.map((sheet, idx) => (

--- a/src-vnext/features/export/components/report/talentStyles.ts
+++ b/src-vnext/features/export/components/report/talentStyles.ts
@@ -1,0 +1,316 @@
+// Scoped stylesheet for the Talent report DOM renderer (R4 PR2). All rules live
+// under `.sb-tr-root` with `sb-tr-`/`sb-`-prefixed classes so they never collide
+// with the app's Tailwind layer. Brand law (docs/DESIGN.md): editorial restraint,
+// ONE decisive red (the HOLD flag, nothing else), Ivy Presto for the editorial
+// moment, Neue Haas for body/labels/tabular, tiering by weight+size never faded
+// gray, no drop shadows. Fonts load app-wide via typekit gph3jzg. Ported faithfully
+// from comp-talent.html.
+
+export const TALENT_STYLES = `
+.sb-tr-root {
+  /* Type families (app loads typekit gph3jzg) */
+  --sb-font-display: "ivypresto-headline", Georgia, serif;
+  --sb-font-body: "neue-haas-grotesk-text", "Helvetica Neue", Arial, sans-serif;
+  --sb-font-ui: "neue-haas-grotesk-display", "Helvetica Neue", Arial, sans-serif;
+
+  /* Color — tinted neutrals toward the brand hue (OKLCH), never pure #000/#fff */
+  --sb-paper: oklch(0.994 0.001 30);
+  --sb-surface: oklch(0.985 0.002 30);
+  --sb-surface-sub: oklch(0.965 0.003 40);
+  --sb-ink: oklch(0.205 0.008 50);
+  --sb-ink-2: oklch(0.44 0.010 55);
+  --sb-ink-3: oklch(0.58 0.010 55);
+  --sb-ink-disabled: oklch(0.72 0.008 55);
+  --sb-rule: oklch(0.90 0.004 50);
+  --sb-rule-strong: oklch(0.83 0.005 50);
+  --sb-red: #EB1400;            /* Immediate Red — ONE job per surface (HOLD flag) */
+
+  /* Type scale (px) */
+  --sb-t-3xs: 9px; --sb-t-2xs: 10px; --sb-t-xs: 12px; --sb-t-sm: 13px;
+  --sb-t-base: 14px; --sb-t-lg: 16px; --sb-t-xl: 20px; --sb-t-2xl: 26px; --sb-t-3xl: 34px;
+
+  /* Card grid density — wide call-sheet card (headshot col + info col). */
+  --sb-card-min: 380px;
+  --sb-card-gap: clamp(20px, 2.2vw, 32px);
+
+  box-sizing: border-box;
+  font-family: var(--sb-font-body);
+  font-size: var(--sb-t-base);
+  line-height: 1.5;
+  color: var(--sb-ink);
+  background: var(--sb-surface-sub);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  min-height: 100%;
+}
+.sb-tr-root *, .sb-tr-root *::before, .sb-tr-root *::after { box-sizing: border-box; }
+
+/* shared atoms ---------------------------------------------------------- */
+.sb-tr-root .sb-tabular, .sb-tr-root .sb-tnum {
+  font-variant-numeric: tabular-nums; font-feature-settings: "tnum" 1;
+}
+.sb-tr-root .sb-pending { color: var(--sb-ink-disabled); font-style: italic; }
+.sb-tr-root .sb-status-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; flex: 0 0 auto; }
+.sb-tr-root .sb-status--complete { background: oklch(0.62 0.13 150); }   /* green = Shot */
+.sb-tr-root .sb-status--todo { background: var(--sb-ink-disabled); }     /* gray = To do */
+.sb-tr-root .sb-status--progress { background: oklch(0.62 0.13 240); }   /* blue = In progress */
+.sb-tr-root .sb-status--hold { background: oklch(0.74 0.14 75); }        /* amber = On hold */
+
+/* control bar (sticky, never prints) ------------------------------------ */
+.sb-tr-controlbar {
+  position: sticky; top: 0; z-index: 50;
+  display: flex; align-items: center; gap: clamp(16px, 2vw, 32px); flex-wrap: wrap;
+  padding: 10px clamp(24px, 5vw, 96px);
+  background: color-mix(in oklch, var(--sb-paper) 88%, transparent);
+  backdrop-filter: saturate(1.4) blur(8px);
+  border-bottom: 1px solid var(--sb-rule);
+}
+.sb-tr-control-group { display: inline-flex; align-items: center; gap: 9px; }
+.sb-tr-control-label {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-tr-seg {
+  display: inline-flex; align-items: stretch;
+  border: 1px solid var(--sb-rule-strong); border-radius: 999px; overflow: hidden;
+  background: var(--sb-paper);
+}
+.sb-tr-seg-btn {
+  appearance: none; border: 0; background: transparent; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 600;
+  letter-spacing: 0.04em; color: var(--sb-ink-2); padding: 7px 15px; line-height: 1;
+}
+.sb-tr-seg-btn + .sb-tr-seg-btn { border-left: 1px solid var(--sb-rule); }
+.sb-tr-seg-btn[aria-pressed="true"] { background: var(--sb-ink); color: var(--sb-paper); }
+.sb-tr-seg-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: -2px; }
+.sb-tr-export-btn {
+  margin-left: auto; appearance: none; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 8px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 700;
+  letter-spacing: 0.04em; color: var(--sb-paper); background: var(--sb-ink);
+  border: 1px solid var(--sb-ink); border-radius: 999px; padding: 9px 20px; line-height: 1;
+}
+.sb-tr-export-btn:hover:not(:disabled) { background: oklch(0.28 0.008 50); }
+.sb-tr-export-btn:disabled { cursor: default; opacity: 0.6; }
+.sb-tr-export-btn:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; }
+.sb-tr-spin { animation: sb-tr-spin 0.9s linear infinite; }
+@keyframes sb-tr-spin { to { transform: rotate(360deg); } }
+
+/* fluid report frame ---------------------------------------------------- */
+.sb-tr-report {
+  max-width: none; margin: 0;
+  padding: clamp(24px, 3vw, 40px) clamp(24px, 5vw, 96px) clamp(48px, 6vw, 120px);
+}
+.sb-tr-empty {
+  font-family: var(--sb-font-ui); color: var(--sb-ink-3); font-size: var(--sb-t-lg);
+  padding: 48px 0;
+}
+
+/* masthead -------------------------------------------------------------- */
+.sb-tr-masthead-band {
+  padding: clamp(40px, 5vw, 80px) 0 clamp(24px, 3vw, 40px);
+  border-bottom: 1px solid var(--sb-rule-strong); margin-bottom: clamp(32px, 4vw, 56px);
+}
+.sb-tr-eyebrow-row {
+  margin: 0 0 clamp(14px, 1.4vw, 20px);
+  display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap;
+}
+.sb-tr-eyebrow {
+  font-family: var(--sb-font-ui); font-weight: 600; font-size: var(--sb-t-2xs);
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-2);
+}
+.sb-tr-lede { color: var(--sb-ink-2); }
+.sb-tr-masthead-title {
+  font-family: var(--sb-font-display); font-weight: 700; letter-spacing: -0.01em;
+  font-size: clamp(38px, 5.6vw, 78px); line-height: 1.0; margin: 0; max-width: 18ch; color: var(--sb-ink);
+}
+.sb-tr-masthead-meta {
+  display: flex; flex-wrap: wrap; align-items: baseline;
+  gap: clamp(20px, 3vw, 52px); margin-top: clamp(22px, 2.4vw, 36px);
+}
+.sb-tr-meta-cell { display: flex; flex-direction: column; gap: 4px; }
+.sb-tr-meta-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-tr-meta-v {
+  font-family: var(--sb-font-display); font-size: var(--sb-t-2xl); line-height: 1;
+  color: var(--sb-ink); font-variant-numeric: tabular-nums;
+}
+
+/* group header ---------------------------------------------------------- */
+.sb-tr-group { margin-top: clamp(40px, 4.5vw, 72px); }
+.sb-tr-group:first-of-type { margin-top: 0; }
+.sb-tr-group-head {
+  display: flex; align-items: baseline; gap: 16px;
+  border-bottom: 1px solid var(--sb-rule); padding-bottom: 12px; margin-bottom: clamp(20px, 2.4vw, 32px);
+}
+.sb-tr-group-name {
+  font-family: var(--sb-font-display); font-weight: 600;
+  font-size: clamp(24px, 2.8vw, 38px); line-height: 1; color: var(--sb-ink);
+}
+.sb-tr-group-count {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-sm);
+  letter-spacing: 0.04em; color: var(--sb-ink-3);
+}
+
+/* talent grid ----------------------------------------------------------- */
+.sb-tr-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(var(--sb-card-min), 1fr));
+  gap: var(--sb-card-gap);
+}
+.sb-tr-card {
+  display: grid; grid-template-columns: 132px 1fr; gap: 18px;
+  break-inside: avoid; border: 1px solid var(--sb-rule); border-radius: 2px;
+  background: var(--sb-surface); padding: 16px; position: relative;
+}
+
+/* headshot column ------------------------------------------------------- */
+.sb-tr-headshot { width: 132px; }
+.sb-tr-headshot-frame {
+  width: 100%; background: var(--sb-surface-sub);
+  border: 1px solid var(--sb-rule); border-radius: 2px; overflow: hidden;
+}
+.sb-tr-headshot-frame img { display: block; width: 100%; height: auto; object-fit: contain; }
+.sb-tr-headshot-initials {
+  aspect-ratio: 4 / 5; display: flex; align-items: center; justify-content: center;
+  font-family: var(--sb-font-display); font-size: var(--sb-t-3xl); color: var(--sb-ink-3);
+}
+.sb-tr-appearances {
+  margin-top: 8px; font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs);
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-3); text-align: center;
+}
+
+/* info column ----------------------------------------------------------- */
+.sb-tr-info { min-width: 0; }
+.sb-tr-name-row { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; margin-bottom: 4px; }
+.sb-tr-name {
+  font-family: var(--sb-font-display); font-weight: 600; font-size: var(--sb-t-xl);
+  line-height: 1.08; letter-spacing: -0.005em; color: var(--sb-ink);
+}
+/* HOLD — the ONE red on this surface */
+.sb-tr-hold-flag {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-red);
+}
+.sb-tr-hold-flag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 1px; }
+
+.sb-tr-badges { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
+.sb-tr-badge-gender {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-2);
+  border: 1px solid var(--sb-rule-strong); border-radius: 2px; padding: 1px 6px;
+}
+.sb-tr-agency { font-family: var(--sb-font-ui); font-size: var(--sb-t-sm); color: var(--sb-ink-2); }
+
+.sb-tr-contact {
+  display: flex; flex-wrap: wrap; gap: 3px 12px; font-size: var(--sb-t-sm); color: var(--sb-ink);
+  margin-bottom: 12px; padding-bottom: 12px; border-bottom: 1px solid var(--sb-rule);
+}
+.sb-tr-c-item { display: inline-flex; align-items: baseline; gap: 5px; }
+.sb-tr-c-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+
+.sb-tr-measures {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px 14px; margin-bottom: 12px;
+}
+.sb-tr-measure { display: flex; flex-direction: column; gap: 1px; }
+.sb-tr-m-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-3);
+}
+.sb-tr-m-v { font-size: var(--sb-t-base); color: var(--sb-ink); font-variant-numeric: tabular-nums; }
+
+.sb-tr-shots-k {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-3); margin-bottom: 6px;
+}
+.sb-tr-shots-list { display: flex; flex-direction: column; gap: 4px; }
+.sb-tr-shot-line { display: flex; align-items: baseline; gap: 8px; font-size: var(--sb-t-sm); }
+.sb-tr-s-no {
+  flex: 0 0 auto; min-width: 22px; font-variant-numeric: tabular-nums; color: var(--sb-ink);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.sb-tr-s-title { color: var(--sb-ink-2); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.sb-tr-s-looks { flex: 0 0 auto; color: var(--sb-ink-3); font-size: var(--sb-t-xs); }
+
+/* per-card exclude toggle (screen only) */
+.sb-tr-exclude-toggle {
+  position: absolute; top: 8px; right: 8px; z-index: 3;
+  appearance: none; cursor: pointer;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2);
+  background: var(--sb-paper); border: 1px solid var(--sb-rule-strong); border-radius: 999px;
+  padding: 5px 11px; opacity: 0; transition: opacity 0.12s ease;
+}
+.sb-tr-card:hover .sb-tr-exclude-toggle,
+.sb-tr-card:focus-within .sb-tr-exclude-toggle { opacity: 1; }
+.sb-tr-exclude-toggle[aria-pressed="true"] { opacity: 1; color: var(--sb-ink); border-color: var(--sb-ink); }
+.sb-tr-exclude-toggle:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; opacity: 1; }
+
+/* excluded — visible but struck + dimmed (reversible) */
+.sb-tr-excluded { opacity: 0.42; }
+.sb-tr-excluded .sb-tr-name { text-decoration: line-through; text-decoration-thickness: 1px; }
+.sb-tr-excluded .sb-tr-exclude-toggle { opacity: 1; }
+
+/* paged (print preview) — hidden on screen until print-mode -------------- */
+.sb-tr-paged { display: none; }
+.sb-tr-sheet { display: none; }
+
+.sb-tr-print-mode { background: oklch(0.92 0.003 60); }
+.sb-tr-print-mode .sb-tr-fluid,
+.sb-tr-print-mode .sb-tr-masthead-band { display: none; }
+.sb-tr-print-mode .sb-tr-paged { display: block; }
+.sb-tr-print-mode .sb-tr-sheet {
+  display: grid; grid-template-rows: auto 1fr auto;
+  width: 11in; min-height: 8.5in;
+  margin: 0 auto 0.34in; padding: 0.5in 0.6in 0.4in;
+  background: var(--sb-paper); border: 1px solid var(--sb-rule);
+  box-sizing: border-box;
+}
+.sb-tr-sheet-head {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 18px;
+  padding-bottom: 9px; border-bottom: 1px solid var(--sb-rule-strong);
+}
+.sb-tr-sh-title { font-family: var(--sb-font-display); font-weight: 700; font-size: 15px; letter-spacing: -0.005em; color: var(--sb-ink); }
+.sb-tr-sh-proj { font-family: var(--sb-font-ui); font-size: 9px; color: var(--sb-ink-3); letter-spacing: 0.04em; }
+.sb-tr-sh-group {
+  font-family: var(--sb-font-ui); font-size: 9px; font-weight: 600;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--sb-ink-2); white-space: nowrap;
+}
+/* print card grid — 2-up landscape so a wide call-sheet card never straddles a break */
+.sb-tr-sheet-body {
+  display: grid; grid-template-columns: repeat(var(--sb-tr-print-cols, 2), 1fr);
+  gap: 0.3in 0.34in; align-items: start; min-height: 0;
+}
+.sb-tr-sheet-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  padding-top: 8px; border-top: 1px solid var(--sb-rule);
+  font-family: var(--sb-font-ui); font-size: 8px; color: var(--sb-ink-3);
+  letter-spacing: 0.06em; text-transform: uppercase;
+}
+.sb-tr-sheet .sb-tr-card { break-inside: avoid; page-break-inside: avoid; }
+.sb-tr-sheet .sb-tr-name { font-size: var(--sb-t-lg); }
+.sb-tr-sheet .sb-tr-headshot-frame img { max-height: 2in; width: auto; max-width: 100%; object-fit: contain; }
+
+@media print {
+  @page { size: letter landscape; margin: 0; }
+  .no-print { display: none !important; }
+  .sb-tr-root { background: #fff; }
+  .sb-tr-fluid, .sb-tr-masthead-band { display: none !important; }
+  .sb-tr-report { padding: 0; }
+  .sb-tr-paged { display: block !important; }
+  .sb-tr-sheet {
+    display: grid !important; grid-template-rows: auto 1fr auto;
+    width: 11in; min-height: 8.5in;
+    margin: 0; padding: 0.5in 0.6in 0.4in; border: 0; background: #fff;
+    break-after: page; page-break-after: always;
+  }
+  .sb-tr-sheet:last-child { break-after: auto; page-break-after: auto; }
+  .sb-tr-card { break-inside: avoid; page-break-inside: avoid; }
+}
+`

--- a/src-vnext/features/export/hooks/useExportReports.ts
+++ b/src-vnext/features/export/hooks/useExportReports.ts
@@ -23,11 +23,15 @@ import type {
 } from "../types/exportBuilder"
 import type { ReportConfig, ReportLayout } from "../lib/report/reportTypes"
 import type { ProductInfoConfig } from "../lib/report/productInfoTypes"
+import type { TalentConfig } from "../lib/report/talentTypes"
 
 // Discriminates a saved report doc from a legacy block-canvas doc. Absent on
 // disk for every pre-R2 doc -> defaulted to "block-canvas" at READ time, so no
-// existing doc is ever migrated. "product-info" added in R4 PR1.
-export type ExportReportType = "block-canvas" | "shot-report" | "product-info"
+// existing doc is ever migrated. "product-info" added in R4 PR1; "talent" in PR2.
+export type ExportReportType = "block-canvas" | "shot-report" | "product-info" | "talent"
+
+/** Union of every typed-report config blob (shot-report / product-info / talent). */
+export type ExportReportConfig = ReportConfig | ProductInfoConfig | TalentConfig
 
 export interface ExportReport {
   readonly id: string
@@ -45,8 +49,8 @@ export interface ExportReportFull extends ExportReport {
   readonly pages: readonly ExportPage[]
   readonly settings: PageSettings
   readonly customVariables: readonly CustomVariable[]
-  /** Present only on report docs (shot-report or product-info); narrow per page by reportType. */
-  readonly config?: ReportConfig | ProductInfoConfig
+  /** Present only on typed report docs (shot-report / product-info / talent); narrow per page by reportType. */
+  readonly config?: ExportReportConfig
 }
 
 interface SaveReportData {
@@ -76,10 +80,15 @@ export interface UseExportReportsReturn {
     name: string,
     config: ProductInfoConfig,
   ) => Promise<string>
+  /** Create a saved talent report doc whose config IS the recipe. */
+  readonly createTalentReport: (
+    name: string,
+    config: TalentConfig,
+  ) => Promise<string>
   /** Persist a report's config blob (partial merge; preserves the rest). Generic over config shape. */
   readonly saveReportConfig: (
     reportId: string,
-    config: ReportConfig | ProductInfoConfig,
+    config: ExportReportConfig,
   ) => Promise<void>
 }
 
@@ -159,7 +168,7 @@ export function useExportReports(
   )
 
   const saveReportConfig = useCallback(
-    async (reportId: string, config: ReportConfig | ProductInfoConfig) => {
+    async (reportId: string, config: ExportReportConfig) => {
       if (!clientId || !projectId) return
       const pathSegments = exportReportDocPath(clientId, projectId, reportId)
       const docRef = doc(db, pathSegments[0]!, ...pathSegments.slice(1))
@@ -205,7 +214,7 @@ export function useExportReports(
     async (
       reportType: ExportReportType,
       name: string,
-      config: ReportConfig | ProductInfoConfig,
+      config: ExportReportConfig,
     ): Promise<string> => {
       if (!clientId || !projectId) throw new Error("Missing clientId or projectId")
       // createdBy must equal auth.uid or the create rule rejects it.
@@ -242,6 +251,12 @@ export function useExportReports(
     [createTypedReport],
   )
 
+  const createTalentReport = useCallback(
+    (name: string, config: TalentConfig): Promise<string> =>
+      createTypedReport("talent", name, config),
+    [createTypedReport],
+  )
+
   const loadReport = useCallback(
     async (reportId: string): Promise<ExportReportFull | null> => {
       if (!clientId || !projectId) return null
@@ -273,7 +288,7 @@ export function useExportReports(
           fontFamily: "Inter",
         },
         customVariables: (data.customVariables as readonly CustomVariable[]) ?? [],
-        config: data.config as ReportConfig | ProductInfoConfig | undefined,
+        config: data.config as ExportReportConfig | undefined,
       }
     },
     [clientId, projectId],
@@ -326,6 +341,7 @@ export function useExportReports(
     importReport,
     createShotReport,
     createProductInfoReport,
+    createTalentReport,
     saveReportConfig,
   }
 }

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest"
+import { collectTalentImageCandidates, deriveTalentModel } from "../talentModel"
+import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
+import type { ExportData } from "../../../hooks/useExportData"
+import type { Shot, TalentRecord } from "@/shared/types"
+
+// Minimal factories — cast past required audit fields the model never reads.
+function tal(over: Partial<TalentRecord> & { id: string }): TalentRecord {
+  return { name: over.id, ...over } as unknown as TalentRecord
+}
+function shot(s: Partial<Shot> & { id: string }): Shot {
+  return {
+    title: "Shot",
+    status: "complete",
+    talent: [],
+    talentIds: [],
+    products: [],
+    looks: [],
+    sortOrder: 0,
+    ...s,
+  } as unknown as Shot
+}
+function data(over: Partial<ExportData>): ExportData {
+  return {
+    project: { id: "p1", name: "Q2-26 No. 3", clientId: "unbound-merino" } as ExportData["project"],
+    shots: [],
+    productFamilies: [],
+    pulls: [],
+    crew: [],
+    talent: [],
+    loading: false,
+    ...over,
+  }
+}
+function cfg(over: Partial<TalentConfig> = {}): TalentConfig {
+  return { ...DEFAULT_TALENT_CONFIG, ...over }
+}
+
+function flat(model: ReturnType<typeof deriveTalentModel>) {
+  return model.groups.flatMap((g) => g.items)
+}
+function find(model: ReturnType<typeof deriveTalentModel>, id: string) {
+  return flat(model).find((i) => i.id === id)
+}
+
+const ROSTER = [
+  tal({ id: "tA", name: "Ava Stone", gender: "female", agency: "Elite" }),
+  tal({ id: "tB", name: "Ben Cole", gender: "male", agency: "Next" }),
+]
+
+describe("deriveTalentModel — scope", () => {
+  it("in-shots: only talent slotted into non-deleted shots (not the flat library)", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", talentIds: ["tA"] }),
+          shot({ id: "gone", shotNumber: "02", deleted: true, talentIds: ["tB"] }),
+        ],
+      }),
+      cfg(),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("tA")
+    expect(ids).not.toContain("tB") // only in a DELETED shot
+    expect(model.project.talentCount).toBe(1)
+  })
+
+  it("in-shots: drops a soft-deleted talent even when still slotted into a live shot", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: [...ROSTER, tal({ id: "tDel", name: "Removed", deleted: true })],
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tDel"] })],
+      }),
+      cfg(),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("tA")
+    expect(ids).not.toContain("tDel")
+  })
+
+  it("project-attached: every non-deleted talent whose projectIds includes the project", () => {
+    const model = deriveTalentModel(
+      data({
+        project: { id: "p1", name: "P", clientId: "c" } as ExportData["project"],
+        talent: [
+          tal({ id: "tA", name: "Ava", projectIds: ["p1"] }),
+          tal({ id: "tB", name: "Ben", projectIds: ["other"] }),
+          tal({ id: "tC", name: "Cy", projectIds: ["p1"], deleted: true }),
+        ],
+        // No shots — proves project-attached does NOT depend on shot membership.
+        shots: [],
+      }),
+      cfg({ talentScope: "project-attached" }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toEqual(["tA"])
+    expect(ids).not.toContain("tB") // attached to a different project
+    expect(ids).not.toContain("tC") // soft-deleted, dropped in this scope too
+  })
+})
+
+describe("deriveTalentModel — appearances", () => {
+  it("one entry per shot the talent is in, sorted by shot number, with each shot's status", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({ id: "s10", shotNumber: "10", status: "todo", talentIds: ["tA"], looks: [{ id: "l", order: 0, products: [] }] }),
+          shot({ id: "s2", shotNumber: "2", status: "complete", talentIds: ["tA"], looks: [{ id: "l", order: 0, products: [] }] }),
+        ],
+      }),
+      cfg(),
+    )
+    const appears = find(model, "tA")?.appears ?? []
+    expect(appears.map((a) => `${a.number}:${a.status}`)).toEqual(["2:complete", "10:todo"])
+  })
+
+  it("a talent in two looks of one shot yields ONE appearance carrying both look labels", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({
+            id: "s1", shotNumber: "01", talentIds: ["tA"],
+            looks: [
+              { id: "l0", order: 0, products: [] },
+              { id: "l1", order: 1, label: "Alt A", products: [] },
+            ],
+          }),
+        ],
+      }),
+      cfg(),
+    )
+    const appears = find(model, "tA")?.appears ?? []
+    expect(appears.length).toBe(1) // one shot, not two looks
+    expect(appears[0]?.looks).toEqual(["Primary", "Alt A"]) // all the shot's looks, ordered
+    expect(appears[0]?.title).toBe("Shot")
+  })
+
+  it("dedupes repeated look labels within a shot", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({
+            id: "s1", shotNumber: "01", talentIds: ["tA"],
+            looks: [
+              { id: "l0", order: 0, label: "Primary", products: [] },
+              { id: "l1", order: 1, label: "Primary", products: [] },
+            ],
+          }),
+        ],
+      }),
+      cfg(),
+    )
+    expect(find(model, "tA")?.appears[0]?.looks).toEqual(["Primary"])
+  })
+
+  it("onHold is true iff ANY appearance is on_hold (the one red); false otherwise", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", status: "on_hold", talentIds: ["tA"] }),
+          shot({ id: "s2", shotNumber: "02", status: "complete", talentIds: ["tA", "tB"] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "tA")?.onHold).toBe(true) // s1 is on_hold
+    expect(find(model, "tB")?.onHold).toBe(false) // only in a complete shot
+  })
+})
+
+describe("deriveTalentModel — entry field resolution", () => {
+  it("name via buildDisplayName, gender label, agency/contact, notes; blank gender -> null label", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: [
+          tal({
+            id: "tA", name: "", firstName: "Ada", lastName: "Lin",
+            gender: "women", agency: "  Elite  ", email: " ada@x.co ", phone: "555", url: "ada.co", notes: " note ",
+          }),
+          tal({ id: "tB", name: "Blank", gender: "" }),
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tB"] })],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "tA")).toMatchObject({
+      name: "Ada Lin", // composed from first+last when name is blank
+      genderLabel: "Female",
+      agency: "Elite", // trimmed
+      email: "ada@x.co",
+      phone: "555",
+      web: "ada.co",
+      notes: "note",
+    })
+    // blank fields normalize to null, not ""
+    expect(find(model, "tB")).toMatchObject({ genderLabel: null, agency: null, email: null, phone: null, web: null })
+  })
+
+  it("headshot candidate follows headshotUrl -> imageUrl -> headshotPath order", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: [
+          tal({ id: "tU", name: "U", headshotUrl: "url.jpg", imageUrl: "img.jpg", headshotPath: "path.jpg" }),
+          tal({ id: "tI", name: "I", imageUrl: "img.jpg", headshotPath: "path.jpg" }),
+          tal({ id: "tP", name: "P", headshotPath: "path.jpg" }),
+          tal({ id: "tN", name: "N" }),
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tU", "tI", "tP", "tN"] })],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "tU")?.headshot).toBe("url.jpg")
+    expect(find(model, "tI")?.headshot).toBe("img.jpg")
+    expect(find(model, "tP")?.headshot).toBe("path.jpg")
+    expect(find(model, "tN")?.headshot).toBeNull()
+  })
+
+  it("measurements resolve as ordered, labeled fit specs for the gender", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: [tal({ id: "tA", name: "Ava", gender: "women", measurements: { waist: 25, height: 67 } })],
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA"] })],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    // women preferred order puts Height before Waist; height formats as ft'in"
+    expect(find(model, "tA")?.measurements).toEqual([
+      { label: "Height", value: `5'7"` },
+      { label: "Waist", value: `25"` },
+    ])
+  })
+
+  it("flags excluded talent from config.excludedTalentIds", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tB"] })],
+      }),
+      cfg({ groupBy: "none", excludedTalentIds: ["tB"] }),
+    )
+    expect(find(model, "tA")?.excluded).toBe(false)
+    expect(find(model, "tB")?.excluded).toBe(true)
+  })
+})
+
+describe("deriveTalentModel — grouping", () => {
+  const styled = () =>
+    data({
+      talent: [
+        tal({ id: "tF", name: "Zoe", gender: "female", agency: "Elite" }),
+        tal({ id: "tM", name: "Adam", gender: "male", agency: "Next" }),
+        tal({ id: "tNB", name: "Max", gender: "non-binary", agency: "Elite" }),
+        tal({ id: "tBlank", name: "Casey", gender: "", agency: "" }),
+      ],
+      shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tF", "tM", "tNB", "tBlank"] })],
+    })
+
+  it("group-by none: one flat 'All talent' group, alpha by display name", () => {
+    const model = deriveTalentModel(styled(), cfg({ groupBy: "none" }))
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.key).toBe("all")
+    expect(model.groups[0]?.label).toBe("All talent")
+    expect(model.groups[0]?.items.map((i) => i.name)).toEqual(["Adam", "Casey", "Max", "Zoe"])
+  })
+
+  it("group-by gender: lead order Female/Male/Non-binary, blank gender -> 'Unresolved' (never dropped, last)", () => {
+    const model = deriveTalentModel(styled(), cfg({ groupBy: "gender" }))
+    expect(model.groups.map((g) => g.label)).toEqual(["Female", "Male", "Non-binary", "Unresolved"])
+    expect(model.groups.find((g) => g.label === "Unresolved")?.items.map((i) => i.id)).toEqual(["tBlank"])
+    // items within a group are alpha by name
+    expect(model.groups[0]?.items.map((i) => i.name)).toEqual(["Zoe"])
+  })
+
+  it("group-by agency: alpha agencies, blank agency -> 'No agency' bucket (last); counts per group", () => {
+    const model = deriveTalentModel(styled(), cfg({ groupBy: "agency" }))
+    expect(model.groups.map((g) => g.label)).toEqual(["Elite", "Next", "No agency"])
+    const elite = model.groups.find((g) => g.label === "Elite")
+    expect(elite?.count).toBe(2)
+    expect(elite?.items.map((i) => i.name)).toEqual(["Max", "Zoe"]) // alpha within group
+    expect(model.groups.find((g) => g.label === "No agency")?.items.map((i) => i.id)).toEqual(["tBlank"])
+  })
+})
+
+describe("deriveTalentModel — project block & image candidates", () => {
+  it("dateRange + talentCount surface on the project block", () => {
+    const model = deriveTalentModel(
+      data({
+        project: { id: "p1", name: "P", clientId: "c", shootDates: ["2026-06-04", "2026-06-02"] } as ExportData["project"],
+        talent: ROSTER,
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tB"] })],
+      }),
+      cfg(),
+    )
+    expect(model.project.dateRange).toBe("Jun 2–4, 2026")
+    expect(model.project.talentCount).toBe(2)
+    expect(model.project.client).toBe("c")
+  })
+
+  it("collectTalentImageCandidates returns each unique headshot candidate once", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: [
+          tal({ id: "tA", name: "A", headshotUrl: "shared.jpg" }),
+          tal({ id: "tB", name: "B", headshotUrl: "shared.jpg" }),
+          tal({ id: "tC", name: "C", headshotUrl: "other.jpg" }),
+          tal({ id: "tD", name: "D" }), // no headshot
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tB", "tC", "tD"] })],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect([...collectTalentImageCandidates(model)].sort()).toEqual(["other.jpg", "shared.jpg"])
+  })
+})

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -174,13 +174,13 @@ describe("deriveTalentModel — appearances", () => {
 })
 
 describe("deriveTalentModel — entry field resolution", () => {
-  it("name via buildDisplayName, gender label, agency/contact, notes; blank gender -> null label", () => {
+  it("name via buildDisplayName, gender label, agency/contact; blank gender -> null label", () => {
     const model = deriveTalentModel(
       data({
         talent: [
           tal({
             id: "tA", name: "", firstName: "Ada", lastName: "Lin",
-            gender: "women", agency: "  Elite  ", email: " ada@x.co ", phone: "555", url: "ada.co", notes: " note ",
+            gender: "women", agency: "  Elite  ", email: " ada@x.co ", phone: "555", url: "ada.co",
           }),
           tal({ id: "tB", name: "Blank", gender: "" }),
         ],
@@ -195,7 +195,6 @@ describe("deriveTalentModel — entry field resolution", () => {
       email: "ada@x.co",
       phone: "555",
       web: "ada.co",
-      notes: "note",
     })
     // blank fields normalize to null, not ""
     expect(find(model, "tB")).toMatchObject({ genderLabel: null, agency: null, email: null, phone: null, web: null })

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -363,6 +363,20 @@ export function TalentPdfDocument(props: {
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
 
+  // Guarantee at least one page so a direct call with an all-excluded model can't
+  // hand @react-pdf a zero-page Document (which throws). The UI also disables Export.
+  if (sheets.length === 0) {
+    return (
+      <Document title="Talent Report" author={model.project.client || ""} producer="Shot Builder">
+        <Page size={{ width: PAGE.width, height: PAGE.height }} style={s.page}>
+          <Text style={{ fontFamily: FONT.body, fontSize: 11, color: COLOR.textSecondary }}>
+            No talent to report.
+          </Text>
+        </Page>
+      </Document>
+    )
+  }
+
   return (
     <Document title="Talent Report" author={model.project.client || ""} producer="Shot Builder">
       {sheets.map((sheet, i) => {

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -1,0 +1,439 @@
+// @react-pdf landscape renderer for the Talent report (R4 PR2).
+// Parity sibling of the DOM TalentReportView — both consume the same resolved
+// TalentModel + image sidecar so screen and PDF can't drift. A card per talent
+// (grouped none / gender / agency): a native-aspect headshot column + an info
+// column (name, gender badge + agency, contact, fit measurements, an "in shots"
+// list). Red (#EB1400) does exactly ONE job here: the HOLD flag (a talent with
+// any on-hold shot — "confirm before locking the call").
+//
+// PDF typography differs from screen by design: @react-pdf ships only the
+// Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — three
+// cards per landscape sheet, never spanning a group, each card wrap={false} so
+// a card NEVER straddles or clips a page break.
+
+import type { JSX } from "react"
+import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
+import type {
+  TalentAppearance,
+  TalentEntry,
+  TalentGroup,
+  TalentModel,
+} from "./talentTypes"
+import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
+
+const PAD_X = 36
+const PAD_TOP = 34
+const PAD_BOTTOM = 30
+const CARD_GAP = 22
+const CARDS_PER_SHEET = 3
+const CONTENT_WIDTH = PAGE.width - PAD_X * 2
+const CARD_WIDTH = (CONTENT_WIDTH - CARD_GAP * (CARDS_PER_SHEET - 1)) / CARDS_PER_SHEET
+// Headshot is width-only so its height follows the photo's native aspect; the
+// cap bounds an unusually tall portrait so the card body always fits the sheet.
+const HEADSHOT_MAX_HEIGHT = 168
+
+const s = StyleSheet.create({
+  page: {
+    paddingTop: PAD_TOP,
+    paddingBottom: PAD_BOTTOM,
+    paddingHorizontal: PAD_X,
+    fontFamily: FONT.body,
+    fontSize: 8,
+    color: COLOR.text,
+    backgroundColor: COLOR.surface,
+  },
+
+  // Running header
+  header: {
+    flexDirection: "row",
+    alignItems: "flex-end",
+    justifyContent: "space-between",
+    paddingBottom: 8,
+    marginBottom: 14,
+    borderBottomWidth: 1,
+    borderBottomColor: COLOR.ruleStrong,
+  },
+  headerTitle: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text, letterSpacing: -0.1 },
+  headerProject: { fontFamily: FONT.ui, fontSize: 8, color: COLOR.textSubtle, marginTop: 2 },
+  headerGroup: {
+    fontFamily: FONT.uiBold,
+    fontSize: 8,
+    color: COLOR.textSecondary,
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    textAlign: "right",
+  },
+
+  // Group band — starts each group's first sheet
+  groupBand: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    borderBottomWidth: 0.5,
+    borderBottomColor: COLOR.rule,
+    paddingBottom: 6,
+    marginBottom: 12,
+  },
+  groupName: { fontFamily: FONT.display, fontSize: 15, color: COLOR.text },
+  groupCount: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6.5,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.textSecondary,
+    marginLeft: 10,
+  },
+
+  // Card row + card
+  cards: { flexDirection: "row", gap: CARD_GAP },
+  card: {
+    width: CARD_WIDTH,
+    backgroundColor: COLOR.surface,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    padding: 12,
+  },
+
+  // Headshot column
+  headshot: { marginBottom: 10 },
+  headshotFrame: {
+    width: "100%",
+    backgroundColor: COLOR.surfaceSubtle,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    overflow: "hidden",
+  },
+  headshotImage: { width: "100%", maxHeight: HEADSHOT_MAX_HEIGHT, objectFit: "contain" },
+  initials: {
+    width: "100%",
+    height: 132,
+    backgroundColor: COLOR.surfaceSubtle,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  initialsText: { fontFamily: FONT.display, fontSize: 30, color: COLOR.textSubtle },
+  appearCount: {
+    fontFamily: FONT.ui,
+    fontSize: 6.5,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    textAlign: "center",
+    marginTop: 6,
+  },
+
+  // Info column
+  nameRow: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginBottom: 4 },
+  name: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text, lineHeight: 1.1, letterSpacing: -0.1 },
+
+  // HOLD — the ONE red on this surface (a drawn red square + label, not a glyph)
+  holdTag: { flexDirection: "row", alignItems: "center", marginLeft: 6 },
+  holdMark: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 1, marginRight: 3 },
+  holdLabel: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6.5,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.accent,
+  },
+
+  badges: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginBottom: 8 },
+  genderBadge: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSecondary,
+    borderWidth: 0.5,
+    borderColor: COLOR.ruleStrong,
+    borderRadius: 2,
+    paddingHorizontal: 4,
+    paddingVertical: 1,
+    marginRight: 6,
+  },
+  agency: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textSecondary },
+
+  contact: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    marginBottom: 10,
+    paddingBottom: 10,
+    borderBottomWidth: 0.5,
+    borderBottomColor: COLOR.rule,
+  },
+  contactItem: { flexDirection: "row", alignItems: "baseline", marginRight: 12, marginBottom: 2 },
+  contactKey: {
+    fontFamily: FONT.uiBold,
+    fontSize: 5.5,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    marginRight: 3,
+  },
+  contactValue: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text },
+
+  measures: { flexDirection: "row", flexWrap: "wrap", marginBottom: 10 },
+  measure: { width: "33%", marginBottom: 6 },
+  measureKey: {
+    fontFamily: FONT.uiBold,
+    fontSize: 5.5,
+    letterSpacing: 0.5,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    marginBottom: 1,
+  },
+  measureValue: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text },
+
+  shotsKey: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSubtle,
+    marginBottom: 5,
+  },
+  shotsList: { flexDirection: "column" },
+  shotLine: { flexDirection: "row", alignItems: "center", marginBottom: 3 },
+  statusDot: { width: 5, height: 5, borderRadius: 2.5, marginRight: 4 },
+  shotNum: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.text, minWidth: 16 },
+  shotTitle: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textSecondary, marginLeft: 4, flexShrink: 1 },
+  shotLooks: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSubtle, marginLeft: 4 },
+  shotsEmpty: { fontFamily: FONT.bodyItalic, fontSize: 7, color: COLOR.textSubtle },
+
+  footer: {
+    position: "absolute",
+    bottom: 14,
+    left: PAD_X,
+    right: PAD_X,
+    flexDirection: "row",
+    justifyContent: "space-between",
+    fontFamily: FONT.ui,
+    fontSize: 6,
+    color: COLOR.textDisabled,
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    borderTopWidth: 0.5,
+    borderTopColor: COLOR.rule,
+    paddingTop: 4,
+  },
+})
+
+// ---------------------------------------------------------------------------
+// Pagination: up to CARDS_PER_SHEET printable cards per landscape sheet, never
+// spanning a group (a new group starts a fresh sheet, mirroring the product-info
+// + shot-report PagedView discipline so a card never straddles or clips a break).
+// ---------------------------------------------------------------------------
+
+interface Sheet {
+  readonly group: TalentGroup
+  readonly groupItemCount: number
+  readonly fromIndex: number
+  readonly items: readonly TalentEntry[]
+}
+
+function paginate(model: TalentModel): readonly Sheet[] {
+  const sheets: Sheet[] = []
+  for (const group of model.groups) {
+    const visible = group.items.filter((i) => !i.excluded)
+    if (visible.length === 0) continue
+    for (let i = 0; i < visible.length; i += CARDS_PER_SHEET) {
+      sheets.push({
+        group,
+        groupItemCount: visible.length,
+        fromIndex: i + 1,
+        items: visible.slice(i, i + CARDS_PER_SHEET),
+      })
+    }
+  }
+  return sheets
+}
+
+function talentInitials(name: string): string {
+  return (
+    name
+      .split(/\s+/)
+      .map((w) => w[0])
+      .filter(Boolean)
+      .slice(0, 2)
+      .join("")
+      .toUpperCase() || "?"
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Pieces
+// ---------------------------------------------------------------------------
+
+function ShotLine({ a }: { readonly a: TalentAppearance }): JSX.Element {
+  const st = STATUS[a.status]
+  return (
+    <View style={s.shotLine}>
+      <View style={[s.statusDot, { backgroundColor: st.color }]} />
+      <Text style={s.shotNum}>{has(a.number) ? a.number : "—"}</Text>
+      <Text style={s.shotTitle}>{has(a.title) ? a.title : "Untitled shot"}</Text>
+      {a.looks.length ? <Text style={s.shotLooks}>{a.looks.join(" · ")}</Text> : null}
+    </View>
+  )
+}
+
+function ContactItem({ k, value }: { readonly k: string; readonly value: string }): JSX.Element {
+  return (
+    <View style={s.contactItem}>
+      <Text style={s.contactKey}>{k}</Text>
+      <Text style={s.contactValue}>{value}</Text>
+    </View>
+  )
+}
+
+function Card({
+  entry,
+  imageMap,
+}: {
+  readonly entry: TalentEntry
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const src = has(entry.headshot) ? imageMap.get(entry.headshot) : undefined
+  const n = entry.appears.length
+  const hasContact = has(entry.email) || has(entry.phone) || has(entry.web)
+  return (
+    <View style={s.card} wrap={false}>
+      <View style={s.headshot}>
+        <View style={s.headshotFrame}>
+          {src ? (
+            <Image src={src} style={s.headshotImage} />
+          ) : (
+            <View style={s.initials}>
+              <Text style={s.initialsText}>{talentInitials(entry.name)}</Text>
+            </View>
+          )}
+        </View>
+        <Text style={s.appearCount}>{`${n} ${n === 1 ? "shot" : "shots"}`}</Text>
+      </View>
+
+      <View style={s.nameRow}>
+        <Text style={s.name}>{has(entry.name) ? entry.name : "Unnamed talent"}</Text>
+        {entry.onHold ? (
+          <View style={s.holdTag}>
+            <View style={s.holdMark} />
+            <Text style={s.holdLabel}>Hold</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {entry.genderLabel || has(entry.agency) ? (
+        <View style={s.badges}>
+          {entry.genderLabel ? <Text style={s.genderBadge}>{entry.genderLabel}</Text> : null}
+          {has(entry.agency) ? <Text style={s.agency}>{entry.agency}</Text> : null}
+        </View>
+      ) : null}
+
+      {hasContact ? (
+        <View style={s.contact}>
+          {has(entry.email) ? <ContactItem k="Email" value={entry.email} /> : null}
+          {has(entry.phone) ? <ContactItem k="Phone" value={entry.phone} /> : null}
+          {has(entry.web) ? <ContactItem k="Web" value={entry.web} /> : null}
+        </View>
+      ) : null}
+
+      {entry.measurements.length > 0 ? (
+        <View style={s.measures}>
+          {entry.measurements.map((m, i) => (
+            <View key={i} style={s.measure}>
+              <Text style={s.measureKey}>{m.label}</Text>
+              <Text style={s.measureValue}>{m.value}</Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      <Text style={s.shotsKey}>In shots</Text>
+      {n > 0 ? (
+        <View style={s.shotsList}>
+          {entry.appears.map((a, i) => (
+            <ShotLine key={i} a={a} />
+          ))}
+        </View>
+      ) : (
+        <Text style={s.shotsEmpty}>Not yet slotted into a shot</Text>
+      )}
+    </View>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Document
+// ---------------------------------------------------------------------------
+
+export function TalentPdfDocument(props: {
+  readonly model: TalentModel
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const { model, imageMap } = props
+  const sheets = paginate(model)
+  const projectLine = has(model.project.client)
+    ? `${model.project.name} · ${model.project.client}`
+    : model.project.name
+
+  return (
+    <Document title="Talent Report" author={model.project.client || ""} producer="Shot Builder">
+      {sheets.map((sheet, i) => {
+        const firstOfGroup = sheet.fromIndex === 1
+        return (
+          <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={s.page} wrap>
+            {/* Running header — group label stays correct on any overflow page; the
+                per-sheet count lives in the group band + footer, never a stale fixed range. */}
+            <View style={s.header} fixed>
+              <View>
+                <Text style={s.headerTitle}>Talent</Text>
+                <Text style={s.headerProject}>{projectLine}</Text>
+              </View>
+              <Text style={s.headerGroup}>{sheet.group.label}</Text>
+            </View>
+
+            {firstOfGroup ? (
+              <View style={s.groupBand} minPresenceAhead={140}>
+                <Text style={s.groupName}>{sheet.group.label}</Text>
+                <Text style={s.groupCount}>
+                  {sheet.groupItemCount === 1 ? "1 talent" : `${sheet.groupItemCount} talent`}
+                </Text>
+              </View>
+            ) : null}
+
+            <View style={s.cards}>
+              {sheet.items.map((entry) => (
+                <Card key={entry.id} entry={entry} imageMap={imageMap} />
+              ))}
+            </View>
+
+            <View style={s.footer} fixed>
+              <Text>Talent · {projectLine}</Text>
+              <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
+            </View>
+          </Page>
+        )
+      })}
+    </Document>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Generate + download — mirrors generateProductInfoPdf (lazy import, toBlob, anchor).
+// ---------------------------------------------------------------------------
+
+export async function generateTalentPdf(
+  model: TalentModel,
+  imageMap: ReadonlyMap<string, string>,
+  filename = "talent-report.pdf",
+): Promise<void> {
+  const { pdf } = await import("@react-pdf/renderer")
+  const blob = await pdf(<TalentPdfDocument model={model} imageMap={imageMap} />).toBlob()
+
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement("a")
+  a.href = url
+  a.download = filename.endsWith(".pdf") ? filename : `${filename}.pdf`
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -20,6 +20,7 @@ import type {
   TalentGroup,
   TalentModel,
 } from "./talentTypes"
+import { initials } from "@/features/library/components/talentUtils"
 import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
 
 const PAD_X = 36
@@ -248,18 +249,6 @@ function paginate(model: TalentModel): readonly Sheet[] {
   return sheets
 }
 
-function talentInitials(name: string): string {
-  return (
-    name
-      .split(/\s+/)
-      .map((w) => w[0])
-      .filter(Boolean)
-      .slice(0, 2)
-      .join("")
-      .toUpperCase() || "?"
-  )
-}
-
 // ---------------------------------------------------------------------------
 // Pieces
 // ---------------------------------------------------------------------------
@@ -303,7 +292,7 @@ function Card({
             <Image src={src} style={s.headshotImage} />
           ) : (
             <View style={s.initials}>
-              <Text style={s.initialsText}>{talentInitials(entry.name)}</Text>
+              <Text style={s.initialsText}>{initials(entry.name)}</Text>
             </View>
           )}
         </View>

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -254,7 +254,7 @@ function paginate(model: TalentModel): readonly Sheet[] {
 // ---------------------------------------------------------------------------
 
 function ShotLine({ a }: { readonly a: TalentAppearance }): JSX.Element {
-  const st = STATUS[a.status]
+  const st = STATUS[a.status] ?? STATUS.todo // defensive: tolerate an out-of-enum status
   return (
     <View style={s.shotLine}>
       <View style={[s.statusDot, { backgroundColor: st.color }]} />

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -259,7 +259,7 @@ function ShotLine({ a }: { readonly a: TalentAppearance }): JSX.Element {
     <View style={s.shotLine}>
       <View style={[s.statusDot, { backgroundColor: st.color }]} />
       <Text style={s.shotNum}>{has(a.number) ? a.number : "—"}</Text>
-      <Text style={s.shotTitle}>{has(a.title) ? a.title : "Untitled shot"}</Text>
+      <Text style={s.shotTitle}>{a.title}</Text>
       {a.looks.length ? <Text style={s.shotLooks}>{a.looks.join(" · ")}</Text> : null}
     </View>
   )

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -1,0 +1,199 @@
+import type { Shot, TalentRecord } from "@/shared/types"
+import { buildDisplayName } from "@/features/library/components/talentUtils"
+import {
+  genderDisplayLabel,
+  formatLabeledMeasurements,
+} from "@/features/library/lib/measurementOptions"
+import type { ExportData } from "../../hooks/useExportData"
+import { formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder } from "./reportModel"
+import type {
+  TalentAppearance,
+  TalentConfig,
+  TalentEntry,
+  TalentGroup,
+  TalentMeasurement,
+  TalentModel,
+} from "./talentTypes"
+
+// Pure derivation: ExportData + TalentConfig -> TalentModel. No async, no image
+// bytes (headshot is a path/URL candidate resolved later). The single source both
+// the DOM (TalentReportView) and PDF renderers consume.
+
+const NO_AGENCY = "No agency"
+const UNRESOLVED = "Unresolved"
+
+// Stable lead order for gender buckets; any label outside this list sorts alpha
+// after these, and the blank-gender "Unresolved" bucket is always pinned last.
+const GENDER_ORDER: readonly string[] = ["Female", "Male", "Non-binary", "Other"]
+
+// Build the per-talent appearance list: ONE entry per non-deleted shot the talent
+// is slotted into (shot.talentIds includes the id). Looks have no talentIds, so a
+// talent inherits ALL of that shot's look labels (deduped, look-order preserved).
+function buildAppearances(
+  talentId: string,
+  shots: readonly Shot[],
+): readonly TalentAppearance[] {
+  const out: TalentAppearance[] = []
+  for (const shot of shots) {
+    if (shot.deleted) continue
+    if (!(shot.talentIds ?? []).includes(talentId)) continue
+    const looks = sortLooksByOrder(shot.looks ?? [])
+    const labels: string[] = []
+    looks.forEach((look, i) => {
+      const label = lookLabel(look.label, i)
+      if (!labels.includes(label)) labels.push(label)
+    })
+    out.push({
+      number: shot.shotNumber ?? "",
+      title: shot.title || "Untitled shot",
+      looks: labels,
+      status: shot.status,
+    })
+  }
+  return out.sort((a, b) => {
+    const [ak, an, as] = shotNumberSortKey(a.number)
+    const [bk, bn, bs] = shotNumberSortKey(b.number)
+    return ak - bk || an - bn || as.localeCompare(bs)
+  })
+}
+
+function toEntry(
+  t: TalentRecord,
+  shots: readonly Shot[],
+  excluded: ReadonlySet<string>,
+): TalentEntry {
+  const appears = buildAppearances(t.id, shots)
+  const label = genderDisplayLabel(t.gender)
+  const measurements = formatLabeledMeasurements(
+    t.measurements,
+    t.gender,
+    "labeled",
+  ) as readonly TalentMeasurement[]
+  return {
+    id: t.id,
+    name: buildDisplayName(t),
+    gender: t.gender ?? null,
+    genderLabel: label === "" ? null : label,
+    agency: t.agency?.trim() ? t.agency.trim() : null,
+    email: t.email?.trim() ? t.email.trim() : null,
+    phone: t.phone?.trim() ? t.phone.trim() : null,
+    web: t.url?.trim() ? t.url.trim() : null,
+    headshot: t.headshotUrl ?? t.imageUrl ?? t.headshotPath ?? null,
+    measurements,
+    notes: t.notes?.trim() ? t.notes.trim() : null,
+    onHold: appears.some((a) => a.status === "on_hold"),
+    excluded: excluded.has(t.id),
+    appears,
+  }
+}
+
+// in-shots: talent slotted into any non-deleted shot, resolved against the library
+// (drop soft-deleted records). Order is stabilized by the later alpha sort.
+function inShotsTalent(data: ExportData): readonly TalentRecord[] {
+  const byId = new Map(data.talent.map((t) => [t.id, t]))
+  const ids = new Set<string>()
+  for (const shot of data.shots) {
+    if (shot.deleted) continue
+    for (const id of shot.talentIds ?? []) ids.add(id)
+  }
+  return [...ids]
+    .map((id) => byId.get(id))
+    .filter((t): t is TalentRecord => t != null && t.deleted !== true)
+}
+
+// project-attached: every non-deleted talent whose projectIds includes this project.
+function projectAttachedTalent(data: ExportData): readonly TalentRecord[] {
+  const projectId = data.project?.id
+  return data.talent.filter(
+    (t) => t.deleted !== true && !!projectId && (t.projectIds ?? []).includes(projectId),
+  )
+}
+
+function groupEntries(
+  items: readonly TalentEntry[],
+  groupBy: TalentConfig["groupBy"],
+): readonly TalentGroup[] {
+  if (groupBy === "none") {
+    return [{ key: "all", label: "All talent", count: items.length, items }]
+  }
+  if (groupBy === "gender") {
+    const byLabel = new Map<string, TalentEntry[]>()
+    for (const item of items) {
+      const key = item.genderLabel ?? UNRESOLVED
+      const bucket = byLabel.get(key)
+      if (bucket) bucket.push(item)
+      else byLabel.set(key, [item])
+    }
+    return [...byLabel.keys()]
+      .sort(genderBucketSort)
+      .map((key): TalentGroup => {
+        const inGroup = byLabel.get(key) ?? []
+        return { key, label: key, count: inGroup.length, items: inGroup }
+      })
+  }
+  // agency
+  const byAgency = new Map<string, TalentEntry[]>()
+  for (const item of items) {
+    const key = item.agency ?? NO_AGENCY
+    const bucket = byAgency.get(key)
+    if (bucket) bucket.push(item)
+    else byAgency.set(key, [item])
+  }
+  return [...byAgency.keys()]
+    .sort(agencyBucketSort)
+    .map((key): TalentGroup => {
+      const inGroup = byAgency.get(key) ?? []
+      return { key, label: key, count: inGroup.length, items: inGroup }
+    })
+}
+
+// Lead-ordered gender buckets, then unknown labels alpha, Unresolved always last.
+function genderBucketSort(a: string, b: string): number {
+  if (a === UNRESOLVED) return b === UNRESOLVED ? 0 : 1
+  if (b === UNRESOLVED) return -1
+  const ai = GENDER_ORDER.indexOf(a)
+  const bi = GENDER_ORDER.indexOf(b)
+  if (ai !== -1 && bi !== -1) return ai - bi
+  if (ai !== -1) return -1
+  if (bi !== -1) return 1
+  return a.localeCompare(b)
+}
+
+// Agencies alpha; the catch-all "No agency" bucket always last.
+function agencyBucketSort(a: string, b: string): number {
+  if (a === NO_AGENCY) return b === NO_AGENCY ? 0 : 1
+  if (b === NO_AGENCY) return -1
+  return a.localeCompare(b)
+}
+
+/** Derive the resolved talent model from live export data + config. */
+export function deriveTalentModel(data: ExportData, config: TalentConfig): TalentModel {
+  const excluded = new Set(config.excludedTalentIds)
+  const records =
+    config.talentScope === "project-attached"
+      ? projectAttachedTalent(data)
+      : inShotsTalent(data)
+
+  const items = records
+    .map((t) => toEntry(t, data.shots, excluded))
+    .sort((a, b) => a.name.localeCompare(b.name))
+
+  return {
+    project: {
+      name: data.project?.name ?? "Untitled project",
+      client: data.project?.clientId ?? "",
+      dateRange: formatDateWindow(data.project?.shootDates),
+      talentCount: items.length,
+    },
+    groups: groupEntries(items, config.groupBy),
+  }
+}
+
+/** Collect every unique headshot candidate referenced by the talent model. */
+export function collectTalentImageCandidates(model: TalentModel): readonly string[] {
+  const set = new Set<string>()
+  for (const group of model.groups) {
+    for (const item of group.items) if (item.headshot) set.add(item.headshot)
+  }
+  return [...set]
+}

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -80,7 +80,6 @@ function toEntry(
     web: t.url?.trim() ? t.url.trim() : null,
     headshot: t.headshotUrl ?? t.imageUrl ?? t.headshotPath ?? null,
     measurements,
-    notes: t.notes?.trim() ? t.notes.trim() : null,
     onHold: appears.some((a) => a.status === "on_hold"),
     excluded: excluded.has(t.id),
     appears,

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -1,0 +1,83 @@
+// Resolved, presentation-free model for the Talent report (R4 PR2).
+// A NEW report TYPE (talent-centric, call-sheet-adjacent), applying the shipped
+// product-info pattern. One card/section per TalentRecord in the project; the DOM
+// (TalentReportView) and the @react-pdf renderer (reportPdfTalent) both consume
+// this one pure model, so screen and PDF can't drift. The headshot field is a
+// *candidate* (a Storage path or URL) resolved to a data URL once via reportImages —
+// the model stays pure.
+
+import type { ReportShotStatus } from "./reportTypes"
+
+/** How talent are grouped on the report. */
+export type TalentGroupBy = "none" | "gender" | "agency"
+
+/** Which talent surface: those slotted into shots, or every project-attached talent. */
+export type TalentScope = "in-shots" | "project-attached"
+
+/** Persisted config — serializable; optional fields default-merge from older blobs. NO imageSize (headshots are small). */
+export interface TalentConfig {
+  readonly groupBy: TalentGroupBy
+  readonly talentScope: TalentScope
+  /** Talent excluded by the user — struck on screen, omitted from the PDF. */
+  readonly excludedTalentIds: readonly string[]
+}
+
+export const DEFAULT_TALENT_CONFIG: TalentConfig = {
+  groupBy: "none",
+  talentScope: "in-shots",
+  excludedTalentIds: [],
+}
+
+/** One shot a talent appears in: its number/title, the look labels there, and that shot's status. */
+export interface TalentAppearance {
+  readonly number: string
+  readonly title: string
+  readonly looks: readonly string[]
+  readonly status: ReportShotStatus
+}
+
+/** A single talent's labeled fit measurement (e.g. { label: "Height", value: "5'10\"" }). */
+export interface TalentMeasurement {
+  readonly label: string
+  readonly value: string
+}
+
+export interface TalentEntry {
+  readonly id: string
+  /** Display name (buildDisplayName). */
+  readonly name: string
+  /** Raw stored gender, or null. */
+  readonly gender: string | null
+  /** Canonical talent gender label (genderDisplayLabel), or null when blank. */
+  readonly genderLabel: string | null
+  readonly agency: string | null
+  readonly email: string | null
+  readonly phone: string | null
+  readonly web: string | null
+  /** Headshot image candidate (path/URL) or null. */
+  readonly headshot: string | null
+  readonly measurements: readonly TalentMeasurement[]
+  readonly notes: string | null
+  /** True when any appearance is on_hold — the ONE red on this surface. */
+  readonly onHold: boolean
+  readonly excluded: boolean
+  readonly appears: readonly TalentAppearance[]
+}
+
+export interface TalentGroup {
+  readonly key: string
+  readonly label: string
+  readonly count: number
+  readonly items: readonly TalentEntry[]
+}
+
+export interface TalentModel {
+  readonly project: {
+    readonly name: string
+    readonly client: string
+    /** Shoot-date window (e.g. "Jun 2–6, 2026"), or null when no dates. */
+    readonly dateRange: string | null
+    readonly talentCount: number
+  }
+  readonly groups: readonly TalentGroup[]
+}

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -57,7 +57,6 @@ export interface TalentEntry {
   /** Headshot image candidate (path/URL) or null. */
   readonly headshot: string | null
   readonly measurements: readonly TalentMeasurement[]
-  readonly notes: string | null
   /** True when any appearance is on_hold — the ONE red on this surface. */
   readonly onHold: boolean
   readonly excluded: boolean

--- a/src-vnext/shared/components/AppShell.tsx
+++ b/src-vnext/shared/components/AppShell.tsx
@@ -15,6 +15,7 @@ import {
   getMobileNavConfig,
   withProductInfoReportsNav,
   withShotReportsNav,
+  withTalentReportsNav,
 } from "./sidebar/nav-config"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useSidebarState } from "./sidebar/useSidebarState"
@@ -69,10 +70,15 @@ export function AppShell() {
       ? withShotReportsNav(baseDesktopConfig, projectId)
       : baseDesktopConfig
   // featureProductInfoReport adds a project-scoped Product Info nav item after it.
-  const desktopConfig =
+  const withProductInfo =
     isFeatureEnabled("featureProductInfoReport") && projectId
       ? withProductInfoReportsNav(withShotReports, projectId)
       : withShotReports
+  // featureTalentReport adds a project-scoped Talent nav item after Product Info.
+  const desktopConfig =
+    isFeatureEnabled("featureTalentReport") && projectId
+      ? withTalentReportsNav(withProductInfo, projectId)
+      : withProductInfo
   const mobileConfig = getMobileNavConfig(projectId, role)
 
   return (

--- a/src-vnext/shared/components/sidebar/nav-config.test.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.test.ts
@@ -4,6 +4,7 @@ import {
   getMobileNavConfig,
   withProductInfoReportsNav,
   withShotReportsNav,
+  withTalentReportsNav,
   type NavConfig,
 } from "./nav-config"
 
@@ -285,5 +286,66 @@ describe("withProductInfoReportsNav", () => {
     withProductInfoReportsNav(base, "p1")
     expect(base.entries.length).toBe(beforeLen)
     expect(base.entries.some((e) => e.type === "item" && e.item.label === "Product Info")).toBe(false)
+  })
+})
+
+describe("withTalentReportsNav", () => {
+  const itemLabels = (config: NavConfig) =>
+    config.entries
+      .filter((e) => e.type === "item")
+      .map((e) => (e as { type: "item"; item: { label: string } }).item.label)
+
+  it("inserts a Talent item right after Product Info when present", () => {
+    const withProduct = withProductInfoReportsNav(
+      withShotReportsNav(buildNavConfig("p1"), "p1"),
+      "p1",
+    )
+    const labels = itemLabels(withTalentReportsNav(withProduct, "p1"))
+    const productIdx = labels.indexOf("Product Info")
+    expect(productIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[productIdx + 1]).toBe("Talent")
+  })
+
+  it("inserts a Talent item right after Shot Reports when Product Info absent", () => {
+    const withShots = withShotReportsNav(buildNavConfig("p1"), "p1")
+    const labels = itemLabels(withTalentReportsNav(withShots, "p1"))
+    const shotIdx = labels.indexOf("Shot Reports")
+    expect(shotIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[shotIdx + 1]).toBe("Talent")
+  })
+
+  it("inserts a Talent item right after Export when reports absent", () => {
+    const labels = itemLabels(withTalentReportsNav(buildNavConfig("p1"), "p1"))
+    const exportIdx = labels.indexOf("Export")
+    expect(exportIdx).toBeGreaterThanOrEqual(0)
+    expect(labels[exportIdx + 1]).toBe("Talent")
+  })
+
+  it("points the item at the project-scoped talent-reports route", () => {
+    const next = withTalentReportsNav(buildNavConfig("p1"), "p1")
+    const item = next.entries.find((e) => e.type === "item" && e.item.label === "Talent")
+    expect(item && item.type === "item" ? item.item.to : null).toBe(
+      "/projects/p1/export/talent-reports",
+    )
+  })
+
+  it("appends Talent when no Export entry exists (fallback)", () => {
+    const stub: NavConfig = {
+      variant: "project",
+      entries: [{ type: "item", item: { label: "Shots", to: "/projects/p1/shots", iconName: "camera" } }],
+    }
+    const next = withTalentReportsNav(stub, "p1")
+    const last = next.entries[next.entries.length - 1]
+    expect(last && last.type === "item" ? last.item.label : null).toBe("Talent")
+  })
+
+  it("does not mutate the input config", () => {
+    const base = buildNavConfig("p1")
+    const beforeLen = base.entries.length
+    withTalentReportsNav(base, "p1")
+    expect(base.entries.length).toBe(beforeLen)
+    expect(
+      base.entries.some((e) => e.type === "item" && e.item.label === "Talent"),
+    ).toBe(false)
   })
 })

--- a/src-vnext/shared/components/sidebar/nav-config.test.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.test.ts
@@ -303,7 +303,7 @@ describe("withTalentReportsNav", () => {
     const labels = itemLabels(withTalentReportsNav(withProduct, "p1"))
     const productIdx = labels.indexOf("Product Info")
     expect(productIdx).toBeGreaterThanOrEqual(0)
-    expect(labels[productIdx + 1]).toBe("Talent")
+    expect(labels[productIdx + 1]).toBe("Talent Reports")
   })
 
   it("inserts a Talent item right after Shot Reports when Product Info absent", () => {
@@ -311,19 +311,19 @@ describe("withTalentReportsNav", () => {
     const labels = itemLabels(withTalentReportsNav(withShots, "p1"))
     const shotIdx = labels.indexOf("Shot Reports")
     expect(shotIdx).toBeGreaterThanOrEqual(0)
-    expect(labels[shotIdx + 1]).toBe("Talent")
+    expect(labels[shotIdx + 1]).toBe("Talent Reports")
   })
 
   it("inserts a Talent item right after Export when reports absent", () => {
     const labels = itemLabels(withTalentReportsNav(buildNavConfig("p1"), "p1"))
     const exportIdx = labels.indexOf("Export")
     expect(exportIdx).toBeGreaterThanOrEqual(0)
-    expect(labels[exportIdx + 1]).toBe("Talent")
+    expect(labels[exportIdx + 1]).toBe("Talent Reports")
   })
 
   it("points the item at the project-scoped talent-reports route", () => {
     const next = withTalentReportsNav(buildNavConfig("p1"), "p1")
-    const item = next.entries.find((e) => e.type === "item" && e.item.label === "Talent")
+    const item = next.entries.find((e) => e.type === "item" && e.item.label === "Talent Reports")
     expect(item && item.type === "item" ? item.item.to : null).toBe(
       "/projects/p1/export/talent-reports",
     )
@@ -336,7 +336,7 @@ describe("withTalentReportsNav", () => {
     }
     const next = withTalentReportsNav(stub, "p1")
     const last = next.entries[next.entries.length - 1]
-    expect(last && last.type === "item" ? last.item.label : null).toBe("Talent")
+    expect(last && last.type === "item" ? last.item.label : null).toBe("Talent Reports")
   })
 
   it("does not mutate the input config", () => {

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -208,6 +208,42 @@ export function withShotReportsNav(config: NavConfig, projectId: string): NavCon
 }
 
 /**
+ * Insert a project-scoped "Talent" item after Product Info (or Shot Reports, or
+ * Export, or appended). Pure — the featureTalentReport check stays at the AppShell
+ * call site so buildNavConfig stays flag-free and its unit tests are unaffected.
+ */
+export function withTalentReportsNav(config: NavConfig, projectId: string): NavConfig {
+  const item: NavEntry = {
+    type: "item",
+    item: {
+      label: "Talent",
+      to: `/projects/${projectId}/export/talent-reports`,
+      iconName: "users",
+      desktopOnly: true,
+    },
+  }
+  const productInfoTo = `/projects/${projectId}/export/product-reports`
+  const shotReportsTo = `/projects/${projectId}/export/reports`
+  const exportTo = `/projects/${projectId}/export`
+  // Anchor after Product Info if present, else Shot Reports, else Export. Single
+  // scan each, in priority order.
+  const productInfoIdx = config.entries.findIndex((e) => e.type === "item" && e.item.to === productInfoTo)
+  const priorIdx =
+    productInfoIdx !== -1
+      ? productInfoIdx
+      : config.entries.findIndex((e) => e.type === "item" && e.item.to === shotReportsTo)
+  const idx =
+    priorIdx !== -1
+      ? priorIdx
+      : config.entries.findIndex((e) => e.type === "item" && e.item.to === exportTo)
+  const entries =
+    idx === -1
+      ? [...config.entries, item]
+      : [...config.entries.slice(0, idx + 1), item, ...config.entries.slice(idx + 1)]
+  return { ...config, entries }
+}
+
+/**
  * Insert a project-scoped "Product Info" item after Shot Reports (or Export, or
  * appended). Pure — the featureProductInfoReport check stays at the AppShell call
  * site so buildNavConfig stays flag-free and its unit tests are unaffected.

--- a/src-vnext/shared/components/sidebar/nav-config.ts
+++ b/src-vnext/shared/components/sidebar/nav-config.ts
@@ -216,7 +216,7 @@ export function withTalentReportsNav(config: NavConfig, projectId: string): NavC
   const item: NavEntry = {
     type: "item",
     item: {
-      label: "Talent",
+      label: "Talent Reports",
       to: `/projects/${projectId}/export/talent-reports`,
       iconName: "users",
       desktopOnly: true,

--- a/src-vnext/shared/lib/__tests__/flags.test.ts
+++ b/src-vnext/shared/lib/__tests__/flags.test.ts
@@ -213,4 +213,27 @@ describe("feature flags", () => {
       expect(isFeatureEnabled("featureProductInfoReport")).toBe(false)
     }
   })
+
+  it("defaults featureTalentReport to false (R4 PR2 Talent report dark on main)", () => {
+    expect(getFeatureFlags().featureTalentReport).toBe(false)
+    expect(isFeatureEnabled("featureTalentReport")).toBe(false)
+  })
+
+  it("VITE_TALENT_REPORT='1' or 'true' enables featureTalentReport", () => {
+    vi.stubEnv("VITE_TALENT_REPORT", "1")
+    expect(isFeatureEnabled("featureTalentReport")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_REPORT", "true")
+    expect(isFeatureEnabled("featureTalentReport")).toBe(true)
+
+    vi.stubEnv("VITE_TALENT_REPORT", "TRUE")
+    expect(isFeatureEnabled("featureTalentReport")).toBe(true)
+  })
+
+  it("any other VITE_TALENT_REPORT value stays off (no URL/localStorage override layer)", () => {
+    for (const value of ["0", "false", "", "yes", "on"]) {
+      vi.stubEnv("VITE_TALENT_REPORT", value)
+      expect(isFeatureEnabled("featureTalentReport")).toBe(false)
+    }
+  })
 })

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -137,6 +137,16 @@ export interface FeatureFlags {
    * URL/localStorage layer.
    */
   readonly featureProductInfoReport: boolean
+  /**
+   * Export reimagine R4 PR2 — the Talent report (a new talent-centric,
+   * call-sheet-adjacent report TYPE applying the product-info pattern). Gates its
+   * two routes (projects/:id/export/talent-reports + .../export/talent-report) +
+   * the nav item. Default OFF; the flag-off path is byte-identical to trunk
+   * (routes don't register, no nav item). Enabled via `VITE_TALENT_REPORT=1` (or
+   * `true`) at build/dev time (featureProductInfoReport env-parse precedent). No
+   * URL/localStorage layer.
+   */
+  readonly featureTalentReport: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -153,6 +163,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureShotReport: false,
   featureShotReportRecipes: false,
   featureProductInfoReport: false,
+  featureTalentReport: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -208,6 +219,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureProductInfoReport:
       DEFAULT_FLAGS.featureProductInfoReport ||
       parseEnvFlag(import.meta.env.VITE_PRODUCT_INFO_REPORT),
+    featureTalentReport:
+      DEFAULT_FLAGS.featureTalentReport ||
+      parseEnvFlag(import.meta.env.VITE_TALENT_REPORT),
   }
 }
 


### PR DESCRIPTION
## R4 PR2 — Talent report (the call-sheet-adjacent crew deliverable)

The second R4 report type. A **talent-centric** report — one card per `TalentRecord` in the project — applying the same pattern as the just-merged Product Info report (one pure model → DOM + @react-pdf adapters → parity), as its own `reportType`. Behind **`featureTalentReport`** (default OFF, env `VITE_TALENT_REPORT`); **flag-off is byte-identical** to trunk.

### What's in it
- **`talentModel.ts`** — `deriveTalentModel(data, config)`: **in-shots** scope (union of `shot.talentIds` over non-deleted shots, resolved against `data.talent`) or **project-attached** (`talent.projectIds` includes the project); **soft-deleted talent dropped in both scopes**. Per talent: `buildDisplayName`, `genderDisplayLabel`, agency, contact (email/phone/web), labeled measurements (`formatLabeledMeasurements`), headshot candidate, and `appears` = **one entry per shot** (looks accrued; count = distinct shots). `onHold` (any on-hold appearance) is the one decisive red.
- **`TalentReportView.tsx`** (DOM, **one red = the HOLD flag**) + **`reportPdfTalent.tsx`** (landscape @react-pdf, lazy; DOM ↔ PDF share the model). Initials-tile fallback for no headshot.
- **List + report pages**, flag-gated routes (`export/talent-reports`, `export/talent-report`) + breadcrumbs + nav. Config `groupBy: none|gender|agency`, `talentScope: in-shots|project-attached`.
- **Persistence**: widen `ExportReportType` (+`talent`) via `createTalentReport` over the shared `createTypedReport`. **No `firestore.rules` change.** Clobber-safe (the list filters `reportType === "talent"`).

### Inherits every PR1 fix
Built from the merged Product Info files as the template, so it carries the hardened patterns by construction (a dedicated verify lens confirmed this): cross-type `reportId` guard (`!full` + `reportType`), Export disabled while images load, image-key skip-reresolve, shared `resolveSrc`, export-error toast, no stale PDF header, per-shot appearance shape, soft-delete filter.

### Verification
- Staged writer→adversarial-verify workflow (5 lenses incl. a PR1-regression check): **all PASS, 0 actionable findings** (2 cosmetic cleanups already applied — a dead pluralization ternary, a misleading nav var name).
- Gates: **tsc baseline 160/160 · vitest 391/8-skip** (16 new `talentModel` tests, +3 flags, breadcrumbs/nav) **· lint · vite build** (`@react-pdf` lazy chunk).

**Flag stays OFF.** The `:5174` eyeball (both reports, flags on, throwaway project) is the gate before any prod flag flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011YRgXcNvEuGVF7jwftCmB4
