### PR TITLE
feat(export): PR-B pre-flip bundle — report polish + Product Info hardening (flag-off)

### DIFF
--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -40,6 +40,10 @@ export default function ProductInfoReportPage() {
   // The image candidate set last resolved — re-derivations that don't change it
   // (an S/M/L toggle) skip the resolve so the loading overlay doesn't flash.
   const lastImageKeyRef = useRef<string | null>(null)
+  // False after unmount — gates async image setState so a navigate-away mid-resolve
+  // can't update a dead component. Unmount-scoped (NOT per-run), so a same-key
+  // re-run mid-resolve still lets the in-flight request clear the loading overlay.
+  const mountedRef = useRef(true)
 
   // Hydrate config from a saved product-info doc when ?reportId= is present, else
   // reset to defaults. Switching reports (or clearing reportId) also cancels any
@@ -88,13 +92,20 @@ export default function ProductInfoReportPage() {
     [reportId, saveReportConfig],
   )
 
-  // Cancel a pending config write if we unmount inside the debounce window.
-  useEffect(
-    () => () => {
+  // Cancel a pending config write + block async setState if we unmount. Reset to
+  // true on (re)mount — a remount (incl. StrictMode's mount→unmount→mount) must not
+  // leave it false, or the in-flight image resolve's setState is silently dropped
+  // while the keyed re-run skips re-resolving → empty imageMap (no product images).
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+      // Clear the resolved-image key too, so a remount re-resolves cleanly instead
+      // of relying on the prior in-flight resolve landing after remount.
+      lastImageKeyRef.current = null
       if (persistTimer.current) clearTimeout(persistTimer.current)
-    },
-    [],
-  )
+    }
+  }, [])
 
   const model = useMemo(() => deriveProductInfoModel(data, config), [data, config])
 
@@ -110,21 +121,20 @@ export default function ProductInfoReportPage() {
       setImagesLoading(false)
       return
     }
-    let cancelled = false
     setImagesLoading(true)
+    // Apply/clear only while this key is still the latest request, so a same-key
+    // re-run (groupBy/exclude toggle) mid-resolve can't strand imagesLoading at true.
     resolveReportImages(candidates)
       .then((resolved) => {
-        if (!cancelled) setImageMap(resolved)
+        if (mountedRef.current && lastImageKeyRef.current === key) {
+          setImageMap(resolved)
+          setImagesLoading(false)
+        }
       })
       .catch(() => {
-        /* per-image failures already drop out of resolveReportImages */
+        // per-image failures already drop out of resolveReportImages
+        if (mountedRef.current && lastImageKeyRef.current === key) setImagesLoading(false)
       })
-      .finally(() => {
-        if (!cancelled) setImagesLoading(false)
-      })
-    return () => {
-      cancelled = true
-    }
   }, [model])
 
   const handleExportPdf = useCallback(() => {

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -308,6 +308,7 @@ function ControlBar({
   onExportPdf,
   exporting,
   imagesLoading,
+  canExport,
 }: {
   readonly scope: ProductInfoScope
   readonly onSetScope: (v: ProductInfoScope) => void
@@ -320,6 +321,7 @@ function ControlBar({
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly imagesLoading: boolean
+  readonly canExport: boolean
 }): JSX.Element {
   const scopeLabelId = useId()
   const groupLabelId = useId()
@@ -428,7 +430,7 @@ function ControlBar({
         type="button"
         className="sb-pir-export-btn"
         onClick={onExportPdf}
-        disabled={exporting || imagesLoading}
+        disabled={exporting || imagesLoading || !canExport}
         aria-busy={exporting}
       >
         {exporting ? (
@@ -450,6 +452,9 @@ function ControlBar({
 export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.Element {
   const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, imagesLoading = false } = props
   const [printMode, setPrintMode] = useState(false)
+
+  // No non-excluded product => the PDF would have zero pages (@react-pdf throws); gate Export.
+  const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
 
   const toggleExclude = (familyId: string): void => {
     const set = new Set(config.excludedFamilyIds)
@@ -491,6 +496,7 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
         onExportPdf={onExportPdf}
         exporting={exporting}
         imagesLoading={imagesLoading}
+        canExport={canExport}
       />
 
       <main className="sb-pir-report">

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -2,7 +2,7 @@
 // (talent-centric, call-sheet-adjacent): one card per TalentRecord in the project,
 // grouped per config. Pure presentational + interaction callbacks; no data fetching.
 // Consumes the resolved TalentModel + an image *sidecar* map (candidate -> data URL).
-// Red does exactly one job here: the HOLD flag. Ported from comp-talent.html.
+// No red on this surface — status uses neutral/amber dots only. Ported from comp-talent.html.
 
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
@@ -33,7 +33,7 @@ export interface TalentReportViewProps {
 
 // ---------------------------------------------------------------------------
 // One talent card — headshot col (native-aspect or initials tile + shot count)
-// + info col: name, HOLD flag (the ONE red), gender badge + agency, contact,
+// + info col: name, gender badge + agency, contact,
 // measurements grid, "In shots" list with status dots + shot number + title + looks.
 // ---------------------------------------------------------------------------
 function TalentCard({
@@ -82,7 +82,6 @@ function TalentCard({
       <div className="sb-tr-info">
         <div className="sb-tr-name-row">
           <span className="sb-tr-name">{entry.name}</span>
-          {entry.onHold ? <span className="sb-tr-hold-flag">Hold</span> : null}
         </div>
 
         {entry.genderLabel || entry.agency ? (
@@ -140,28 +139,25 @@ function TalentCard({
 }
 
 // ---------------------------------------------------------------------------
-// Masthead band — Talent / Agencies / Holds / Window.
+// Masthead band — Talent / Agencies / Window.
 // ---------------------------------------------------------------------------
 function Masthead({ model }: { readonly model: TalentModel }): JSX.Element {
   const stats = useMemo(() => {
-    let holds = 0
     const agencies = new Set<string>()
     let total = 0
     for (const g of model.groups) {
       for (const e of g.items) {
         if (e.excluded) continue
         total += 1
-        if (e.onHold) holds += 1
         if (e.agency) agencies.add(e.agency)
       }
     }
-    return { holds, agencies: agencies.size, total }
+    return { agencies: agencies.size, total }
   }, [model.groups])
 
   const cells: ReadonlyArray<readonly [string, string | number]> = [
     ["Talent", stats.total],
     ["Agencies", stats.agencies],
-    ["Holds", stats.holds],
     ["Window", model.project.dateRange ?? "—"],
   ]
 

--- a/src-vnext/features/export/components/report/productInfoStyles.ts
+++ b/src-vnext/features/export/components/report/productInfoStyles.ts
@@ -202,7 +202,7 @@ export const PRODUCT_INFO_STYLES = `
   font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
   letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-red);
 }
-.sb-pir-hero-tag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 1px; }
+.sb-pir-hero-tag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 50%; }
 
 .sb-pir-row { display: flex; gap: 8px; align-items: baseline; margin-bottom: 7px; font-size: var(--sb-t-sm); }
 .sb-pir-row .sb-pir-k {

--- a/src-vnext/features/export/components/report/talentStyles.ts
+++ b/src-vnext/features/export/components/report/talentStyles.ts
@@ -1,9 +1,9 @@
 // Scoped stylesheet for the Talent report DOM renderer (R4 PR2). All rules live
 // under `.sb-tr-root` with `sb-tr-`/`sb-`-prefixed classes so they never collide
 // with the app's Tailwind layer. Brand law (docs/DESIGN.md): editorial restraint,
-// ONE decisive red (the HOLD flag, nothing else), Ivy Presto for the editorial
-// moment, Neue Haas for body/labels/tabular, tiering by weight+size never faded
-// gray, no drop shadows. Fonts load app-wide via typekit gph3jzg. Ported faithfully
+// no decorative red on this surface (status uses neutral/amber dots), Ivy Presto for
+// the editorial moment, Neue Haas for body/labels/tabular, tiering by weight+size
+// never faded gray, no drop shadows. Fonts load app-wide via typekit gph3jzg. Ported faithfully
 // from comp-talent.html.
 
 export const TALENT_STYLES = `
@@ -23,7 +23,6 @@ export const TALENT_STYLES = `
   --sb-ink-disabled: oklch(0.72 0.008 55);
   --sb-rule: oklch(0.90 0.004 50);
   --sb-rule-strong: oklch(0.83 0.005 50);
-  --sb-red: #EB1400;            /* Immediate Red — ONE job per surface (HOLD flag) */
 
   /* Type scale (px) */
   --sb-t-3xs: 9px; --sb-t-2xs: 10px; --sb-t-xs: 12px; --sb-t-sm: 13px;
@@ -189,13 +188,6 @@ export const TALENT_STYLES = `
   font-family: var(--sb-font-display); font-weight: 600; font-size: var(--sb-t-xl);
   line-height: 1.08; letter-spacing: -0.005em; color: var(--sb-ink);
 }
-/* HOLD — the ONE red on this surface */
-.sb-tr-hold-flag {
-  display: inline-flex; align-items: center; gap: 4px;
-  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
-  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-red);
-}
-.sb-tr-hold-flag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 1px; }
 
 .sb-tr-badges { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 10px; }
 .sb-tr-badge-gender {

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -265,7 +265,7 @@ describe("deriveProductInfoModel — entry fields & images", () => {
     expect(find(model, "fX")).toMatchObject({ gender: "?", genderLabel: null, excluded: false })
   })
 
-  it("picks the image candidate by assignment thumbs, then family thumbnail, then header", () => {
+  it("picks the image COLOURWAY-FIRST (skuImageUrl, then familyImageUrl), then family thumbnail, then header", () => {
     const model = deriveProductInfoModel(
       data({
         productFamilies: [
@@ -275,17 +275,85 @@ describe("deriveProductInfoModel — entry fields & images", () => {
         ],
         shots: [
           shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
-            { familyId: "fA", thumbUrl: "asn/A.jpg" }, // assignment wins
-            { familyId: "fB" }, // no assignment image, no thumbnail -> header
+            // thumbUrl is IGNORED; skuImageUrl is the colourway-first winner
+            { familyId: "fA", thumbUrl: "asn/A-thumb.jpg", skuImageUrl: "asn/A-sku.jpg", familyImageUrl: "asn/A-fam.jpg" },
+            { familyId: "fB" }, // no assignment image, no family thumbnail -> family header
             { familyId: "fC" }, // no assignment image -> family thumbnail
           ] }] }),
         ],
       }),
       cfg({ groupBy: "none" }),
     )
-    expect(find(model, "fA")?.image).toBe("asn/A.jpg")
+    expect(find(model, "fA")?.image).toBe("asn/A-sku.jpg") // skuImageUrl beats thumbUrl + familyImageUrl
     expect(find(model, "fB")?.image).toBe("fam/B-head.jpg")
     expect(find(model, "fC")?.image).toBe("fam/C-thumb.jpg")
+  })
+
+  it("falls back skuImageUrl -> familyImageUrl on the assignment when no sku image", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [fam({ id: "fA", styleName: "A", thumbnailImagePath: "fam/A-thumb.jpg" })],
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fA", thumbUrl: "asn/A-thumb.jpg", familyImageUrl: "asn/A-fam.jpg" }, // no skuImageUrl
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fA")?.image).toBe("asn/A-fam.jpg") // familyImageUrl, NOT thumbUrl, NOT family thumbnail
+  })
+
+  it("chooses the HERO assignment's colourway image deterministically, overriding an earlier non-hero one", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [fam({ id: "fA", styleName: "A" })],
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fA", colourName: "Black", skuImageUrl: "asn/black.jpg" }, // first, non-hero
+            { familyId: "fA", colourName: "Navy", skuImageUrl: "asn/navy.jpg", isHero: true }, // hero wins
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fA")?.image).toBe("asn/navy.jpg") // hero colourway beats the earlier non-hero one
+  })
+
+  it("is deterministic: the first hero wins regardless of which look it sits in (sorted look order)", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [fam({ id: "fA", styleName: "A" })],
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [
+            // out-of-order: order:1 listed first, but sortLooksByOrder runs the order:0 look first
+            { id: "l1", order: 1, heroProductId: "fA", products: [{ familyId: "fA", skuImageUrl: "asn/alt-hero.jpg" }] },
+            { id: "l0", order: 0, products: [{ familyId: "fA", skuImageUrl: "asn/primary-nonhero.jpg" }] },
+          ] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    // The Alt look's heroProductId-matched assignment is the only hero -> it wins,
+    // even though the order:0 (Primary) non-hero assignment is walked first.
+    expect(find(model, "fA")?.image).toBe("asn/alt-hero.jpg")
+  })
+
+  it("a hero with no resolvable image does not block a sibling assignment that has one", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: [fam({ id: "fA", styleName: "A" })], // no family thumbnail/header
+        shots: [
+          shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+            { familyId: "fA", isHero: true }, // hero but NO image, family has no fallback
+            { familyId: "fA", skuImageUrl: "asn/sibling.jpg" }, // non-hero sibling carries one
+          ] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none" }),
+    )
+    expect(find(model, "fA")?.image).toBe("asn/sibling.jpg") // hero-no-image must not lock out the sibling
+    expect(find(model, "fA")?.isHero).toBe(true) // still a hero family (the hero mark stays)
   })
 
   it("collectProductInfoImageCandidates returns each unique resolved candidate once", () => {

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { deriveShotReportModel, formatDateWindow, normalizeGender, sizeLabel } from "../reportModel"
+import { deriveShotReportModel, formatDateWindow, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
 import { DEFAULT_REPORT_CONFIG } from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
@@ -381,5 +381,34 @@ describe("sizeLabel", () => {
   })
   it("pending scope stays 'Pending' even with a stale non-empty size", () => {
     expect(sizeLabel("pending", "M")).toEqual({ text: "Pending", pending: true })
+  })
+})
+
+describe("titleCaseSlug", () => {
+  it("title-cases a hyphenated client slug", () => {
+    expect(titleCaseSlug("unbound-merino")).toBe("Unbound Merino")
+  })
+  it("treats underscores as word separators", () => {
+    expect(titleCaseSlug("acme_widgets_co")).toBe("Acme Widgets Co")
+  })
+  it("handles mixed hyphen + underscore separators", () => {
+    expect(titleCaseSlug("big-brand_inc")).toBe("Big Brand Inc")
+  })
+  it("normalizes an already-spaced name", () => {
+    expect(titleCaseSlug("Acme Co")).toBe("Acme Co")
+  })
+  it("lowercases the tail of each word (simple title-case)", () => {
+    expect(titleCaseSlug("ACME-LLC")).toBe("Acme Llc")
+  })
+  it("collapses runs of separators and trims edges", () => {
+    expect(titleCaseSlug("--foo__bar--")).toBe("Foo Bar")
+  })
+  it("returns empty string for empty / nullish input", () => {
+    expect(titleCaseSlug("")).toBe("")
+    expect(titleCaseSlug(undefined)).toBe("")
+    expect(titleCaseSlug(null)).toBe("")
+  })
+  it("capitalizes a single-char slug", () => {
+    expect(titleCaseSlug("c")).toBe("C")
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -156,21 +156,6 @@ describe("deriveTalentModel — appearances", () => {
     )
     expect(find(model, "tA")?.appears[0]?.looks).toEqual(["Primary"])
   })
-
-  it("onHold is true iff ANY appearance is on_hold (the one red); false otherwise", () => {
-    const model = deriveTalentModel(
-      data({
-        talent: ROSTER,
-        shots: [
-          shot({ id: "s1", shotNumber: "01", status: "on_hold", talentIds: ["tA"] }),
-          shot({ id: "s2", shotNumber: "02", status: "complete", talentIds: ["tA", "tB"] }),
-        ],
-      }),
-      cfg({ groupBy: "none" }),
-    )
-    expect(find(model, "tA")?.onHold).toBe(true) // s1 is on_hold
-    expect(find(model, "tB")?.onHold).toBe(false) // only in a complete shot
-  })
 })
 
 describe("deriveTalentModel — entry field resolution", () => {
@@ -297,7 +282,7 @@ describe("deriveTalentModel — project block & image candidates", () => {
     )
     expect(model.project.dateRange).toBe("Jun 2–4, 2026")
     expect(model.project.talentCount).toBe(2)
-    expect(model.project.client).toBe("c")
+    expect(model.project.client).toBe("C")
   })
 
   it("collectTalentImageCandidates returns each unique headshot candidate once", () => {

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -92,7 +92,7 @@ function walkInUse(
   // an image wins outright and locks the slot; until that happens the first
   // assignment carrying any image holds the slot and a later hero-with-image
   // upgrades it. Sorted look order + array order make "first" deterministic.
-  const imageIsHero = new Map<string, boolean>()
+  const imageIsHero = new Set<string>()
   for (const shot of shots) {
     if (shot.deleted) continue
     const looks = sortLooksByOrder(shot.looks ?? [])
@@ -110,14 +110,14 @@ function walkInUse(
         if (!byFamily.has(id)) byFamily.set(id, agg)
         const isHeroAssignment =
           p.isHero === true || (heroId != null && matchesHeroProductId(p, heroId))
-        if (!imageIsHero.get(id)) {
+        if (!imageIsHero.has(id)) {
           const candidate = pickColourwayFirstImage(p, familyById.get(id))
           if (isHeroAssignment) {
             // Lock to the hero only when it actually carries an image — a hero with
             // no resolvable image must not block a later sibling that has one.
             if (candidate != null) {
               agg.image = candidate
-              imageIsHero.set(id, true)
+              imageIsHero.add(id)
             }
           } else if (agg.image == null && candidate != null) {
             agg.image = candidate

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -1,4 +1,4 @@
-import type { ProductFamily, Shot } from "@/shared/types"
+import type { ProductAssignment, ProductFamily, Shot } from "@/shared/types"
 import { matchesHeroProductId } from "@/features/shots/lib/lookHeroes"
 import type { ExportData } from "../../hooks/useExportData"
 import {
@@ -6,10 +6,10 @@ import {
   GROUP_ORDER,
   lookLabel,
   normalizeGender,
-  pickProductImage,
   shotNumberSortKey,
   sortLooksByOrder,
   formatDateWindow,
+  titleCaseSlug,
 } from "./reportModel"
 import type { GenderKey, ReportShotStatus } from "./reportTypes"
 import type {
@@ -61,10 +61,38 @@ function pushUnique(list: string[], value: string | null | undefined): void {
   if (v && !list.includes(v)) list.push(v)
 }
 
+// Deterministic, COLOURWAY-FIRST image candidate for a Product Info card. Unlike
+// the shot-report pickProductImage (which prefers the denormalized, ambiguous
+// `thumbUrl`), this prefers the colourway-resolved sku image, then the family
+// image carried on the assignment, then the family's own thumbnail/header. This
+// only makes the PICKER deterministic — it does NOT correct wrong colourway data
+// (a separate future data-quality job).
+function pickColourwayFirstImage(
+  p: ProductAssignment,
+  family: ProductFamily | undefined,
+): string | null {
+  return (
+    p.skuImageUrl ??
+    p.familyImageUrl ??
+    family?.thumbnailImagePath ??
+    family?.headerImagePath ??
+    null
+  )
+}
+
 // Walk every non-deleted shot's sorted looks and styled products, accumulating
 // the rich (assignment-side) fields per family. Returns the agg map keyed by id.
-function walkInUse(shots: readonly Shot[]): Map<string, FamilyAgg> {
+function walkInUse(
+  shots: readonly Shot[],
+  familyById: ReadonlyMap<string, ProductFamily>,
+): Map<string, FamilyAgg> {
   const byFamily = new Map<string, FamilyAgg>()
+  // Per family, whether the currently-held image came from a HERO assignment.
+  // Colourway-first + hero-first deterministically: the first hero assignment WITH
+  // an image wins outright and locks the slot; until that happens the first
+  // assignment carrying any image holds the slot and a later hero-with-image
+  // upgrades it. Sorted look order + array order make "first" deterministic.
+  const imageIsHero = new Map<string, boolean>()
   for (const shot of shots) {
     if (shot.deleted) continue
     const looks = sortLooksByOrder(shot.looks ?? [])
@@ -80,8 +108,22 @@ function walkInUse(shots: readonly Shot[]): Map<string, FamilyAgg> {
         if (!id) continue
         const agg = byFamily.get(id) ?? emptyAgg(id)
         if (!byFamily.has(id)) byFamily.set(id, agg)
-        if (agg.image == null) agg.image = pickProductImage(p, undefined)
-        if (p.isHero === true || (heroId != null && matchesHeroProductId(p, heroId))) agg.isHero = true
+        const isHeroAssignment =
+          p.isHero === true || (heroId != null && matchesHeroProductId(p, heroId))
+        if (!imageIsHero.get(id)) {
+          const candidate = pickColourwayFirstImage(p, familyById.get(id))
+          if (isHeroAssignment) {
+            // Lock to the hero only when it actually carries an image — a hero with
+            // no resolvable image must not block a later sibling that has one.
+            if (candidate != null) {
+              agg.image = candidate
+              imageIsHero.set(id, true)
+            }
+          } else if (agg.image == null && candidate != null) {
+            agg.image = candidate
+          }
+        }
+        if (isHeroAssignment) agg.isHero = true
         if (p.sizeScope === "pending") agg.sizePending = true
         pushUnique(agg.colours, p.colourName ?? p.skuName ?? null)
         if (p.sizeScope !== "pending") pushUnique(agg.sizes, p.size ?? null)
@@ -172,7 +214,7 @@ export function deriveProductInfoModel(
 ): ProductInfoModel {
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
   const excluded = new Set(config.excludedFamilyIds)
-  const aggByFamily = walkInUse(data.shots)
+  const aggByFamily = walkInUse(data.shots, familyById)
 
   // in-use: families styled into non-deleted shots, resolved against the library.
   // library: every non-deleted family (appears still derived from the same walk).
@@ -190,7 +232,7 @@ export function deriveProductInfoModel(
   return {
     project: {
       name: data.project?.name ?? "Untitled project",
-      client: data.project?.clientId ?? "",
+      client: titleCaseSlug(data.project?.clientId),
       dateRange: formatDateWindow(data.project?.shootDates),
       familyCount: items.length,
     },

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -7,6 +7,7 @@ import type {
   TalentRecord,
 } from "@/shared/types"
 import type { ExportData } from "../../hooks/useExportData"
+import { humanizeLabel } from "@/shared/lib/textUtils"
 import {
   type GenderKey,
   type ReportConfig,
@@ -186,19 +187,9 @@ export function formatDateWindow(dates: readonly string[] | null | undefined): s
   return `${day(lo)}, ${lo.y} – ${day(hi)}, ${hi.y}`
 }
 
-/**
- * Title-case an auth-org client slug for display: "unbound-merino" / "unbound_merino" -> "Unbound Merino".
- * Splits on hyphens, underscores, and whitespace; collapses separator runs; capitalizes each word's
- * first letter and lowercases the rest. Empty / nullish input returns "". Simple title-case — acronyms
- * are not preserved ("acme-llc" -> "Acme Llc"), which is acceptable here.
- */
+/** Title-case a client slug via the shared humanizer (lowercases the tail first, so acronyms degrade). */
 export function titleCaseSlug(slug: string | null | undefined): string {
-  if (!slug) return ""
-  return slug
-    .split(/[-_\s]+/)
-    .filter((w) => w.length > 0)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
-    .join(" ")
+  return slug ? humanizeLabel(slug.toLowerCase()) : ""
 }
 
 export const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -186,6 +186,21 @@ export function formatDateWindow(dates: readonly string[] | null | undefined): s
   return `${day(lo)}, ${lo.y} – ${day(hi)}, ${hi.y}`
 }
 
+/**
+ * Title-case an auth-org client slug for display: "unbound-merino" / "unbound_merino" -> "Unbound Merino".
+ * Splits on hyphens, underscores, and whitespace; collapses separator runs; capitalizes each word's
+ * first letter and lowercases the rest. Empty / nullish input returns "". Simple title-case — acronyms
+ * are not preserved ("acme-llc" -> "Acme Llc"), which is acceptable here.
+ */
+export function titleCaseSlug(slug: string | null | undefined): string {
+  if (!slug) return ""
+  return slug
+    .split(/[-_\s]+/)
+    .filter((w) => w.length > 0)
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase())
+    .join(" ")
+}
+
 export const GROUP_ORDER: readonly GenderKey[] = ["W", "M", "Mixed", "?"]
 export const GROUP_LABEL: Record<GenderKey, string> = {
   W: "Women",
@@ -241,7 +256,7 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
   return {
     project: {
       name: data.project?.name ?? "Untitled project",
-      client: data.project?.clientId ?? "",
+      client: titleCaseSlug(data.project?.clientId),
       shotCount: shots.length,
       dateRange: formatDateWindow(data.project?.shootDates),
     },

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -103,7 +103,9 @@ const s = StyleSheet.create({
   image: { width: CARD_WIDTH, maxHeight: IMAGE_MAX_HEIGHT, objectFit: "contain" },
   noImage: {
     width: CARD_WIDTH,
-    height: 150,
+    // Match the image cap so a missing-image card is no taller than an imaged one
+    // (else the denser 4×3 grid overflows on incomplete libraries).
+    height: IMAGE_MAX_HEIGHT,
     backgroundColor: COLOR.surfaceSubtle,
     alignItems: "center",
     justifyContent: "center",

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -7,8 +7,8 @@
 //
 // PDF typography differs from screen by design: @react-pdf ships only the
 // Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
-// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — three
-// cards per landscape sheet, never spanning a group, each card wrap={false} so
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — 12
+// cards (4×3) per landscape sheet, never spanning a group, each card wrap={false} so
 // a card NEVER straddles or clips a page break.
 
 import type { JSX } from "react"
@@ -24,13 +24,20 @@ import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
 const PAD_X = 36
 const PAD_TOP = 34
 const PAD_BOTTOM = 30
-const CARD_GAP = 22
-const CARDS_PER_SHEET = 3
+const COL_GAP = 22
+const ROW_GAP = 18
+const PRINT_COLS = 4
+const PRINT_ROWS = 3
+const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
-const CARD_WIDTH = (CONTENT_WIDTH - CARD_GAP * (CARDS_PER_SHEET - 1)) / CARDS_PER_SHEET
+// Card width derives from the COLUMN count (not cards-per-sheet): a 4-up card is
+// (content - 3 col gaps) / 4. Matches the on-screen PagedView's 4-col grid.
+const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // Image is width-only so its height follows the photo's native aspect; the cap
-// bounds an unusually tall portrait so the card body always fits the sheet.
-const IMAGE_MAX_HEIGHT = 232
+// bounds an unusually tall portrait so the card body always fits the sheet. At
+// 4×3 (12/page) three card rows stack on one landscape sheet, so the cap is far
+// tighter than the old 3-up (1 row) value of 232. EYEBALL-GATE this number.
+const IMAGE_MAX_HEIGHT = 96
 
 const s = StyleSheet.create({
   page: {
@@ -83,8 +90,8 @@ const s = StyleSheet.create({
     marginLeft: 10,
   },
 
-  // Card row + card
-  cards: { flexDirection: "row", gap: CARD_GAP },
+  // Card grid + card
+  cards: { flexDirection: "row", flexWrap: "wrap", columnGap: COL_GAP, rowGap: ROW_GAP },
   card: { width: CARD_WIDTH },
   frame: {
     width: CARD_WIDTH,
@@ -115,9 +122,9 @@ const s = StyleSheet.create({
   identText: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textSecondary },
   identSep: { fontFamily: FONT.ui, fontSize: 7.5, color: COLOR.textDisabled, marginHorizontal: 4 },
 
-  // HERO — the ONE red on this surface (a drawn red square + label, not a glyph)
+  // HERO — the ONE red on this surface (a drawn red dot + label, not a glyph)
   heroTag: { flexDirection: "row", alignItems: "center", marginLeft: 4 },
-  heroMark: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 1, marginRight: 3 },
+  heroMark: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 3, marginRight: 3 },
   heroLabel: {
     fontFamily: FONT.uiBold,
     fontSize: 6.5,
@@ -328,6 +335,20 @@ export function ProductInfoPdfDocument(props: {
   const projectLine = has(model.project.client)
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
+
+  // Guarantee at least one page so a direct call with an all-excluded model can't
+  // hand @react-pdf a zero-page Document (which throws). The UI also disables Export.
+  if (sheets.length === 0) {
+    return (
+      <Document title="Product Info Report" author={model.project.client || ""} producer="Shot Builder">
+        <Page size={{ width: PAGE.width, height: PAGE.height }} style={s.page}>
+          <Text style={{ fontFamily: FONT.body, fontSize: 11, color: COLOR.textSecondary }}>
+            No products to report.
+          </Text>
+        </Page>
+      </Document>
+    )
+  }
 
   return (
     <Document title="Product Info Report" author={model.project.client || ""} producer="Shot Builder">

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -68,6 +68,29 @@ export function has(v: string | null | undefined): v is string {
   return v != null && v.trim() !== ""
 }
 
+const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%", "#", ",", ";"])
+/** Inject U+200B break opportunities so @react-pdf (which ignores overflow-wrap) can wrap a long URL/token. */
+export function breakLongToken(value: string, chunk = 14): string {
+  let out = ""
+  let run = 0
+  for (const ch of value) {
+    out += ch
+    if (ch === " " || ch === "\n" || ch === "\t") {
+      run = 0
+      continue
+    }
+    run += 1
+    if (BREAKABLE.has(ch)) {
+      out += "​"
+      run = 0
+    } else if (run >= chunk) {
+      out += "​"
+      run = 0
+    }
+  }
+  return out
+}
+
 /** The shot's primary image candidate (looks[0] — the canonical primary, as image-led uses). */
 export function primaryLookImage(shot: ReportShot): string | null {
   return shot.looks[0]?.image ?? null

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -114,7 +114,9 @@ const s = StyleSheet.create({
   headshotImage: { width: "100%", maxHeight: HEADSHOT_MAX_HEIGHT, objectFit: "contain" },
   initials: {
     width: "100%",
-    height: 132,
+    // Match the headshot cap so a no-headshot card is no taller than one with a
+    // photo (else the denser 2×3 grid overflows).
+    height: HEADSHOT_MAX_HEIGHT,
     backgroundColor: COLOR.surfaceSubtle,
     alignItems: "center",
     justifyContent: "center",

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -3,13 +3,13 @@
 // TalentModel + image sidecar so screen and PDF can't drift. A card per talent
 // (grouped none / gender / agency): a native-aspect headshot column + an info
 // column (name, gender badge + agency, contact, fit measurements, an "in shots"
-// list). Red (#EB1400) does exactly ONE job here: the HOLD flag (a talent with
-// any on-hold shot — "confirm before locking the call").
+// list). No accent red on this surface — per-shot status uses the neutral/amber
+// STATUS dot only.
 //
 // PDF typography differs from screen by design: @react-pdf ships only the
 // Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
-// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — three
-// cards per landscape sheet, never spanning a group, each card wrap={false} so
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — six
+// cards (2×3) per landscape sheet, never spanning a group, each card wrap={false} so
 // a card NEVER straddles or clips a page break.
 
 import type { JSX } from "react"
@@ -26,13 +26,20 @@ import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
 const PAD_X = 36
 const PAD_TOP = 34
 const PAD_BOTTOM = 30
-const CARD_GAP = 22
-const CARDS_PER_SHEET = 3
+const COL_GAP = 22
+const ROW_GAP = 18
+const PRINT_COLS = 2
+const PRINT_ROWS = 3
+const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
-const CARD_WIDTH = (CONTENT_WIDTH - CARD_GAP * (CARDS_PER_SHEET - 1)) / CARDS_PER_SHEET
+// Card width derives from the COLUMN count (not cards-per-sheet): a 2-up card is
+// (content - 1 col gap) / 2. Matches the on-screen PagedView's 2-col grid.
+const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // Headshot is width-only so its height follows the photo's native aspect; the
 // cap bounds an unusually tall portrait so the card body always fits the sheet.
-const HEADSHOT_MAX_HEIGHT = 168
+// At 2×3 (6/page) three card rows stack on one landscape sheet, so the cap is
+// tighter than the old 3-up (1 row) value of 168. EYEBALL-GATE this number.
+const HEADSHOT_MAX_HEIGHT = 120
 
 const s = StyleSheet.create({
   page: {
@@ -85,8 +92,8 @@ const s = StyleSheet.create({
     marginLeft: 10,
   },
 
-  // Card row + card
-  cards: { flexDirection: "row", gap: CARD_GAP },
+  // Card grid + card
+  cards: { flexDirection: "row", flexWrap: "wrap", columnGap: COL_GAP, rowGap: ROW_GAP },
   card: {
     width: CARD_WIDTH,
     backgroundColor: COLOR.surface,
@@ -126,17 +133,6 @@ const s = StyleSheet.create({
   // Info column
   nameRow: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginBottom: 4 },
   name: { fontFamily: FONT.display, fontSize: 13, color: COLOR.text, lineHeight: 1.1, letterSpacing: -0.1 },
-
-  // HOLD — the ONE red on this surface (a drawn red square + label, not a glyph)
-  holdTag: { flexDirection: "row", alignItems: "center", marginLeft: 6 },
-  holdMark: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 1, marginRight: 3 },
-  holdLabel: {
-    fontFamily: FONT.uiBold,
-    fontSize: 6.5,
-    letterSpacing: 0.8,
-    textTransform: "uppercase",
-    color: COLOR.accent,
-  },
 
   badges: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginBottom: 8 },
   genderBadge: {
@@ -265,11 +261,38 @@ function ShotLine({ a }: { readonly a: TalentAppearance }): JSX.Element {
   )
 }
 
+// @react-pdf breaks lines only on existing whitespace/hyphens, never mid-token,
+// so a long unbroken URL (an agency portfolio link) overflows the card. CSS
+// overflow-wrap is honored by the DOM view but @react-pdf ignores it. Insert
+// zero-width-space (U+200B) break opportunities after common URL delimiters, and
+// as a safety net every `chunk` chars inside any still-unbroken run.
+const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%", "#", ",", ";"])
+function breakLongToken(value: string, chunk = 14): string {
+  let out = ""
+  let run = 0
+  for (const ch of value) {
+    out += ch
+    if (ch === " " || ch === "\n" || ch === "\t") {
+      run = 0
+      continue
+    }
+    run += 1
+    if (BREAKABLE.has(ch)) {
+      out += "​"
+      run = 0
+    } else if (run >= chunk) {
+      out += "​"
+      run = 0
+    }
+  }
+  return out
+}
+
 function ContactItem({ k, value }: { readonly k: string; readonly value: string }): JSX.Element {
   return (
     <View style={s.contactItem}>
       <Text style={s.contactKey}>{k}</Text>
-      <Text style={s.contactValue}>{value}</Text>
+      <Text style={s.contactValue}>{breakLongToken(value)}</Text>
     </View>
   )
 }
@@ -301,12 +324,6 @@ function Card({
 
       <View style={s.nameRow}>
         <Text style={s.name}>{has(entry.name) ? entry.name : "Unnamed talent"}</Text>
-        {entry.onHold ? (
-          <View style={s.holdTag}>
-            <View style={s.holdMark} />
-            <Text style={s.holdLabel}>Hold</Text>
-          </View>
-        ) : null}
       </View>
 
       {entry.genderLabel || has(entry.agency) ? (

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -21,7 +21,7 @@ import type {
   TalentModel,
 } from "./talentTypes"
 import { initials } from "@/features/library/components/talentUtils"
-import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS, has, breakLongToken } from "./reportPdfShared"
 
 const PAD_X = 36
 const PAD_TOP = 34
@@ -261,33 +261,6 @@ function ShotLine({ a }: { readonly a: TalentAppearance }): JSX.Element {
       {a.looks.length ? <Text style={s.shotLooks}>{a.looks.join(" · ")}</Text> : null}
     </View>
   )
-}
-
-// @react-pdf breaks lines only on existing whitespace/hyphens, never mid-token,
-// so a long unbroken URL (an agency portfolio link) overflows the card. CSS
-// overflow-wrap is honored by the DOM view but @react-pdf ignores it. Insert
-// zero-width-space (U+200B) break opportunities after common URL delimiters, and
-// as a safety net every `chunk` chars inside any still-unbroken run.
-const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%", "#", ",", ";"])
-function breakLongToken(value: string, chunk = 14): string {
-  let out = ""
-  let run = 0
-  for (const ch of value) {
-    out += ch
-    if (ch === " " || ch === "\n" || ch === "\t") {
-      run = 0
-      continue
-    }
-    run += 1
-    if (BREAKABLE.has(ch)) {
-      out += "​"
-      run = 0
-    } else if (run >= chunk) {
-      out += "​"
-      run = 0
-    }
-  }
-  return out
 }
 
 function ContactItem({ k, value }: { readonly k: string; readonly value: string }): JSX.Element {

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -5,7 +5,7 @@ import {
   formatLabeledMeasurements,
 } from "@/features/library/lib/measurementOptions"
 import type { ExportData } from "../../hooks/useExportData"
-import { formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder } from "./reportModel"
+import { formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder, titleCaseSlug } from "./reportModel"
 import type {
   TalentAppearance,
   TalentConfig,
@@ -80,7 +80,6 @@ function toEntry(
     web: t.url?.trim() ? t.url.trim() : null,
     headshot: t.headshotUrl ?? t.imageUrl ?? t.headshotPath ?? null,
     measurements,
-    onHold: appears.some((a) => a.status === "on_hold"),
     excluded: excluded.has(t.id),
     appears,
   }
@@ -180,7 +179,7 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
   return {
     project: {
       name: data.project?.name ?? "Untitled project",
-      client: data.project?.clientId ?? "",
+      client: titleCaseSlug(data.project?.clientId),
       dateRange: formatDateWindow(data.project?.shootDates),
       talentCount: items.length,
     },

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -57,8 +57,6 @@ export interface TalentEntry {
   /** Headshot image candidate (path/URL) or null. */
   readonly headshot: string | null
   readonly measurements: readonly TalentMeasurement[]
-  /** True when any appearance is on_hold — the ONE red on this surface. */
-  readonly onHold: boolean
   readonly excluded: boolean
   readonly appears: readonly TalentAppearance[]
 }


### PR DESCRIPTION
Pre-flip **dark bundle** for the Product Info + Talent reports. All behind the existing flags (`featureProductInfoReport` / `featureTalentReport` / `featureShotReportRecipes`) — **prod byte-identical** until Ted flips them. Implements his ratified R4 `:5174` eyeball decisions plus the Product Info hardening parity that PR-A applied to the Talent report.

## Changes
- **D3 — remove the Talent HOLD flag entirely.** Confusing, and it rendered as a square red period (brand violation). Deletes `onHold` in lockstep across `talentTypes` → `talentModel` → `TalentReportView` (badge + masthead "Holds" stat) → `talentStyles` → `reportPdfTalent` → test, and cleans the now-orphaned `--sb-red` token. The **per-shot amber `on_hold` status dot** and the **Production Sheet's own HOLD flag** are different concepts and are untouched. Talent surface is now red-free.
- **#4 — Product Info image is colourway-first + deterministic.** New `pickColourwayFirstImage` (`skuImageUrl` → `familyImageUrl` → family thumbnail/header), hero-first. Stops preferring the ambiguous denormalized `thumbUrl`. A hero with no resolvable image no longer locks out a sibling that has one. The shot-report `pickProductImage` path is unchanged. *(Note: the product page's colourway data is sometimes wrong — that's a separate future data-quality job; this PR only makes the picker deterministic.)*
- **Brand — round dot.** Product Info hero mark square → round (DOM `border-radius:50%`, PDF `borderRadius:3` on a 6×6). The LIVE shot-report hero **bar** is left as-is.
- **D1 — title-case the client slug.** One shared `titleCaseSlug` at all 3 model boundaries (`unbound-merino` → `Unbound Merino`). Reaches the live shot report's client line too (approved).
- **D2 — align PDFs to the on-screen grid.** Product Info 4×3 (12/page), Talent 2×3 (6/page) wrapping grids. Image caps tightened (`IMAGE_MAX_HEIGHT` 232→96, `HEADSHOT_MAX_HEIGHT` 168→120). **⚠️ EYEBALL-GATED** — see below.
- **Hardening — Product Info.** Zero-page Export guard + `canExport` gate, and ports its image effect to the **StrictMode-safe `mountedRef` + latest-key** pattern (the bug that blanked Talent headshots in PR-A; Product Info had the same one).
- **Talent PDF URL wrap.** `breakLongToken` inserts U+200B so long portfolio URLs wrap (PR-A's `overflow-wrap` fix was DOM-only; @react-pdf ignores CSS overflow).

## Verification
- **Gates:** tsc baseline 160/160 (0 new) · 68 report unit tests · vite build · eslint — all green.
- **Built via** a ground-truth audit workflow (7 agents) → implement → **adversarial-verify workflow (5 skeptics)**. The skeptics found one colourway hero-lock edge (a hero with no image could regress a sibling's image) — **fixed + pinned with a regression test**. D3 lockstep, the StrictMode port (byte-identical to the canonical Talent page), round-dot, D1, and U+200B were all independently confirmed.

## ⚠️ Eyeball gate (the one thing static analysis can't confirm)
The D2 PDF density needs a real export on a **dense** project (most products/talent; a family with many colourways in many shots; a lead in 12+ shots):
- **Good:** a full 4×3 / 2×3 grid stacks on one landscape sheet, no card clipping a page break.
- **Watch for:** rows 2–3 pushed onto sparse continuation pages (a dense card taller than ~⅓ page) → lower the image cap (try 80) or accept sparse pages; and for a 12+ shot lead, confirm the in-shots list doesn't clip the card bottom (pre-existing `wrap={false}` behavior, *improved* by the cap reduction here).

After the eyeball, the prod flag flips are Ted's call (`VITE_PRODUCT_INFO_REPORT` / `VITE_TALENT_REPORT` / `VITE_SHOT_REPORT_RECIPES` in `deploy-live.yml` both build blocks) → then R5 retires the block canvas.

> NB: the `preview` CI check fails on a broken firebase-login preview-channel auth (infra, not code) — ignore for merge; affects all PRs.