### PR TITLE
fix(export): height-aware 2-up pagination for image-led shot report PDF

### DIFF
--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -23,6 +23,7 @@ import type {
 } from "../../lib/report/reportTypes"
 import { REPORT_LAYOUT_OPTIONS } from "../../lib/report/reportTypes"
 import { hasAnyIncludedShot, sizeLabel } from "../../lib/report/reportModel"
+import { packShotSheets } from "../../lib/report/reportPdfHeights"
 import { REPORT_STYLES } from "./reportStyles"
 import { resolveSrc, statusMetaLegacy } from "./reportShared"
 import { ProductionSheetReport } from "./ProductionSheetReport"
@@ -354,21 +355,17 @@ interface Sheet {
   readonly shots: readonly ReportShot[]
 }
 
+// Mirror the PDF's height-aware pagination (reportPdfHeights.packShotSheets) so the
+// on-screen print preview and the downloaded PDF agree shot-for-shot (WYSIWYG): a
+// too-tall shot solos in both, rather than pairing here but soloing in the PDF.
 function buildSheets(model: ReportModel): readonly Sheet[] {
-  const sheets: Sheet[] = []
-  for (const group of model.groups) {
-    const printable = group.shots.filter((s) => !s.excluded)
-    for (let i = 0; i < printable.length; i += 2) {
-      sheets.push({
-        groupLabel: group.label,
-        rangeFrom: i + 1,
-        rangeTo: Math.min(i + 2, printable.length),
-        groupTotal: printable.length,
-        shots: printable.slice(i, i + 2),
-      })
-    }
-  }
-  return sheets
+  return packShotSheets(model).map((s) => ({
+    groupLabel: s.group.label,
+    rangeFrom: s.firstPosition,
+    rangeTo: s.lastPosition,
+    groupTotal: s.groupShotCount,
+    shots: [...s.leftColumn, ...s.rightColumn],
+  }))
 }
 
 function PagedView({
@@ -395,7 +392,7 @@ function PagedView({
               <div className="sb-sh-proj">{projLine}</div>
             </div>
             <div className="sb-sh-group">
-              {sheet.groupLabel} · {sheet.rangeFrom}
+              {sheet.groupLabel} · Shots {sheet.rangeFrom}
               {sheet.rangeTo > sheet.rangeFrom ? `–${sheet.rangeTo}` : ""} of {sheet.groupTotal}
             </div>
           </div>

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
@@ -33,7 +33,7 @@ function look(over: Partial<ReportLook> = {}): ReportLook {
     id: "look",
     label: "Primary",
     isAlt: false,
-    image: null,
+    image: "ref", // present figure by default (estimator keys off looks[0].image)
     hasReference: false,
     products: [product()],
     ...over,
@@ -94,9 +94,9 @@ describe("estimateWrappedLines", () => {
 })
 
 describe("estimatePlateHeight", () => {
-  it("is larger with an image than without (image dominates)", () => {
-    expect(estimatePlateHeight(shot("a", { hasImage: true }))).toBeGreaterThan(
-      estimatePlateHeight(shot("a", { hasImage: false })),
+  it("is larger with a figure than without (image dominates; keyed off the look image)", () => {
+    expect(estimatePlateHeight(shot("a", { looks: [look({ image: "ref" })] }))).toBeGreaterThan(
+      estimatePlateHeight(shot("a", { looks: [look({ image: null })] })),
     )
   })
   it("grows with more products, notes, and alt looks", () => {

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect } from "vitest"
+import {
+  estimatePlateHeight,
+  estimateWrappedLines,
+  packShotSheets,
+  COL_MAX,
+} from "../reportPdfHeights"
+import type {
+  ReportModel,
+  ReportGroup,
+  ReportShot,
+  ReportLook,
+  ReportProduct,
+} from "../reportTypes"
+
+// --- Minimal factories (only the fields the packer/estimator read) ---
+function product(over: Partial<ReportProduct> = {}): ReportProduct {
+  return {
+    family: "Family",
+    style: null,
+    colour: null,
+    size: null,
+    sizeScope: null,
+    qty: 1,
+    gender: "W",
+    isHero: false,
+    img: null,
+    ...over,
+  }
+}
+function look(over: Partial<ReportLook> = {}): ReportLook {
+  return {
+    id: "look",
+    label: "Primary",
+    isAlt: false,
+    image: null,
+    hasReference: false,
+    products: [product()],
+    ...over,
+  }
+}
+function shot(id: string, over: Partial<ReportShot> = {}): ReportShot {
+  return {
+    id,
+    number: id,
+    title: "A shot",
+    colorway: null,
+    status: "todo",
+    gender: "W",
+    notes: null,
+    talent: [],
+    looks: [look()],
+    excluded: false,
+    hasImage: true,
+    ...over,
+  }
+}
+function group(label: string, shots: ReportShot[], over: Partial<ReportGroup> = {}): ReportGroup {
+  return { key: "W", label, count: shots.length, shots, ...over }
+}
+function model(groups: ReportGroup[]): ReportModel {
+  return { project: { name: "P", client: "C", shotCount: 0, dateRange: null }, groups }
+}
+
+/** A deliberately huge shot whose estimate exceeds a single column. */
+function hugeShot(id: string): ReportShot {
+  const products = Array.from({ length: 30 }, (_, i) => product({ family: `Fam ${i}` }))
+  return shot(id, {
+    title: "A very long shot title that wraps across several lines on the plate",
+    colorway: "Some colourway",
+    notes: "A long note ".repeat(20),
+    looks: [look({ products }), look({ id: "alt", isAlt: true, label: "Alt A", products })],
+    hasImage: true,
+  })
+}
+
+// Safe indexed access (repo uses noUncheckedIndexedAccess).
+function at<T>(arr: readonly T[], i: number): T {
+  const v = arr[i]
+  if (v === undefined) throw new Error(`index ${i} out of range (len ${arr.length})`)
+  return v
+}
+
+// Walk every sheet's plates in render order (left column top-down, then right).
+function placedInOrder(sheets: ReturnType<typeof packShotSheets>): ReportShot[] {
+  return sheets.flatMap((s) => [...s.leftColumn, ...s.rightColumn])
+}
+
+describe("estimateWrappedLines", () => {
+  it("returns at least 1 line for any non-empty text, clamped to maxLines", () => {
+    expect(estimateWrappedLines("hi", 300, 14, 3)).toBe(1)
+    expect(estimateWrappedLines("x".repeat(1000), 300, 14, 3)).toBe(3)
+  })
+})
+
+describe("estimatePlateHeight", () => {
+  it("is larger with an image than without (image dominates)", () => {
+    expect(estimatePlateHeight(shot("a", { hasImage: true }))).toBeGreaterThan(
+      estimatePlateHeight(shot("a", { hasImage: false })),
+    )
+  })
+  it("grows with more products, notes, and alt looks", () => {
+    const base = estimatePlateHeight(shot("a"))
+    const more = estimatePlateHeight(
+      shot("a", { looks: [look({ products: [product(), product(), product()] })] }),
+    )
+    expect(more).toBeGreaterThan(base)
+    expect(estimatePlateHeight(shot("a", { notes: "lots of notes ".repeat(10) }))).toBeGreaterThan(base)
+    expect(
+      estimatePlateHeight(shot("a", { looks: [look(), look({ id: "alt", isAlt: true })] })),
+    ).toBeGreaterThan(base)
+  })
+})
+
+describe("packShotSheets — structural invariants", () => {
+  const m = model([
+    group("Women", [shot("1"), shot("2"), shot("3"), shot("4"), shot("5")]),
+    group("Men", [shot("6"), shot("7"), shot("8")], { key: "M" }),
+  ])
+  const sheets = packShotSheets(m)
+
+  it("places every non-excluded shot exactly once, in original order", () => {
+    const placed = placedInOrder(sheets).map((s) => s.id)
+    expect(placed).toEqual(["1", "2", "3", "4", "5", "6", "7", "8"])
+  })
+
+  it("never emits a sheet with zero shots", () => {
+    for (const s of sheets) {
+      expect(s.leftColumn.length + s.rightColumn.length).toBeGreaterThan(0)
+    }
+  })
+
+  it("keeps every plate on a normal sheet within one page, at most two per sheet", () => {
+    for (const s of sheets) {
+      if (s.oversized) continue
+      expect(s.leftColumn).toHaveLength(1)
+      expect(s.rightColumn.length).toBeLessThanOrEqual(1)
+      for (const shot of [...s.leftColumn, ...s.rightColumn]) {
+        expect(estimatePlateHeight(shot)).toBeLessThanOrEqual(COL_MAX)
+      }
+    }
+  })
+
+  it("never spans a gender group within one sheet", () => {
+    for (const s of sheets) {
+      const ids = [...s.leftColumn, ...s.rightColumn].map((x) => x.id)
+      const groupIds = s.group.shots.map((x) => x.id)
+      for (const id of ids) expect(groupIds).toContain(id)
+    }
+  })
+
+  it("derives the header range from the shots actually placed (contiguous, complete)", () => {
+    const labels = [...new Set(sheets.map((s) => s.group.label))]
+    for (const label of labels) {
+      const arr = sheets.filter((s) => s.group.label === label)
+      let expectedFirst = 1
+      for (const s of arr) {
+        const placedCount = s.leftColumn.length + s.rightColumn.length
+        expect(s.firstPosition).toBe(expectedFirst)
+        expect(s.lastPosition - s.firstPosition + 1).toBe(placedCount)
+        expectedFirst = s.lastPosition + 1
+      }
+      const last = at(arr, arr.length - 1)
+      expect(last.lastPosition).toBe(last.groupShotCount)
+    }
+  })
+})
+
+describe("packShotSheets — behaviour", () => {
+  it("packs normal image shots two-up (one per column)", () => {
+    const sheets = packShotSheets(model([group("Women", [shot("1"), shot("2"), shot("3"), shot("4")])]))
+    expect(sheets).toHaveLength(2)
+    for (const s of sheets) {
+      expect(s.leftColumn).toHaveLength(1)
+      expect(s.rightColumn).toHaveLength(1)
+    }
+  })
+
+  it("gives an over-tall shot its own oversized page (empty right column)", () => {
+    const sheets = packShotSheets(model([group("Women", [hugeShot("big")])]))
+    expect(sheets).toHaveLength(1)
+    const s = at(sheets, 0)
+    expect(s.oversized).toBe(true)
+    expect(s.leftColumn).toHaveLength(1)
+    expect(s.rightColumn).toHaveLength(0)
+    expect(estimatePlateHeight(at(s.leftColumn, 0))).toBeGreaterThan(COL_MAX)
+  })
+
+  it("never pairs an oversized shot — it sits alone between its neighbours, in order", () => {
+    const sheets = packShotSheets(model([group("Women", [shot("1"), hugeShot("2"), shot("3")])]))
+    expect(placedInOrder(sheets).map((s) => s.id)).toEqual(["1", "2", "3"])
+    const oversized = sheets.filter((s) => s.oversized)
+    expect(oversized).toHaveLength(1)
+    expect(at(oversized, 0).leftColumn.map((s) => s.id)).toEqual(["2"])
+    expect(sheets.some((s) => s.rightColumn.some((x) => x.id === "2"))).toBe(false)
+  })
+
+  it("drops excluded shots and skips an all-excluded group entirely", () => {
+    const sheets = packShotSheets(
+      model([
+        group("Women", [shot("1"), shot("2", { excluded: true }), shot("3")]),
+        group("Men", [shot("4", { excluded: true })], { key: "M" }),
+      ]),
+    )
+    const placed = placedInOrder(sheets).map((s) => s.id)
+    expect(placed).toEqual(["1", "3"])
+    expect(sheets.every((s) => s.group.label !== "Men")).toBe(true)
+    expect(at(sheets, 0).groupShotCount).toBe(2) // visible count, not raw group size
+  })
+
+  it("orphans the trailing shot of an odd group on its own (final) half-page", () => {
+    const sheets = packShotSheets(model([group("Women", [shot("1"), shot("2"), shot("3")])]))
+    expect(sheets).toHaveLength(2)
+    const last = at(sheets, 1)
+    expect(last.leftColumn).toHaveLength(1)
+    expect(last.rightColumn).toHaveLength(0)
+    expect(last.firstPosition).toBe(3)
+    expect(last.lastPosition).toBe(3)
+  })
+})

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -28,7 +28,14 @@ import type {
 } from "./reportTypes"
 import { COLOR, FONT, PAGE, STATUS_LEGACY, has } from "./reportPdfShared"
 import { hasAnyIncludedShot, sizeLabel } from "./reportModel"
-import { packShotSheets } from "./reportPdfHeights"
+import {
+  packShotSheets,
+  PAD_X,
+  COLUMN_GAP,
+  PLATE_WIDTH,
+  HERO_MAX_HEIGHT,
+  NO_IMAGE_HEIGHT,
+} from "./reportPdfHeights"
 import { ProductionSheetPdfDocument } from "./reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
 
@@ -36,17 +43,13 @@ import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
 // Image-led layout — tokens shared via reportPdfShared. Red's one job: shot number.
 // ---------------------------------------------------------------------------
 
-const PAD_X = 40
+// Page padding (image-led only). The layout geometry shared with the height
+// estimator — PAD_X, COLUMN_GAP, PLATE_WIDTH, HERO_MAX_HEIGHT, NO_IMAGE_HEIGHT — is
+// imported from reportPdfHeights (single source) so the renderer and estimator
+// can't drift. Each plate's image is width-only so its height is the photo's native
+// aspect (never cropped); only an unusually tall portrait is bounded by HERO_MAX_HEIGHT.
 const PAD_TOP = 36
 const PAD_BOTTOM = 34
-const COLUMN_GAP = 36
-// Two plates fill the content width; each plate's image is width-only so its
-// height is the photo's native aspect (never cropped/squashed).
-const CONTENT_WIDTH = PAGE.width - PAD_X * 2
-const PLATE_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
-// Cap the hero so the caption always fits the sheet — width still drives aspect
-// up to the cap; only an unusually tall portrait is bounded by maxHeight.
-const HERO_MAX_HEIGHT = 300
 
 const styles = StyleSheet.create({
   page: {
@@ -146,7 +149,7 @@ const styles = StyleSheet.create({
   // No-image frame
   noImage: {
     width: PLATE_WIDTH,
-    height: 230,
+    height: NO_IMAGE_HEIGHT,
     backgroundColor: COLOR.surfaceSubtle,
     borderWidth: 0.5,
     borderColor: COLOR.rule,
@@ -526,10 +529,12 @@ function Plate({
   )
 }
 
-/** One packed column. Each plate is kept intact (wrap=false) — the packer has
- *  already guaranteed it fits the page (or, for a too-tall shot, packed it alone so
- *  it never strands a partner). An empty column (a solo too-tall shot, or a group's
- *  trailing orphan) renders an empty half — honest, not a stranded page. */
+/** One packed column. The column itself is wrap=false (defensive): the packer has
+ *  guaranteed its plate fits the page, but if an estimate ever underflows, the whole
+ *  column moves to the next page (one honest half-empty page) rather than splitting
+ *  to leave a blank column with an orphaned plate. The inner plate is wrap=false too.
+ *  An empty column (a solo too-tall shot, or a group's trailing orphan) renders an
+ *  empty half — honest, not a stranded page. */
 function Column({
   shots,
   imageMap,
@@ -538,7 +543,7 @@ function Column({
   readonly imageMap: ReadonlyMap<string, string>
 }) {
   return (
-    <View style={styles.column}>
+    <View style={styles.column} wrap={false}>
       {shots.map((shot) => (
         <View key={shot.id} style={styles.plate} wrap={false}>
           <Plate shot={shot} imageMap={imageMap} />

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -582,7 +582,9 @@ export function ShotReportPdfDocument(props: {
               <Text style={styles.headerProject}>{projectLine}</Text>
             </View>
             <Text style={styles.headerGroup}>
-              {`${sheet.group.label} · Shots ${sheet.firstPosition}–${sheet.lastPosition} of ${sheet.groupShotCount}`}
+              {`${sheet.group.label} · Shots ${sheet.firstPosition}${
+                sheet.lastPosition > sheet.firstPosition ? `–${sheet.lastPosition}` : ""
+              } of ${sheet.groupShotCount}`}
             </Text>
           </View>
 

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -22,13 +22,13 @@ import {
 import type {
   ReportLayout,
   ReportModel,
-  ReportGroup,
   ReportShot,
   ReportLook,
   ReportProduct,
 } from "./reportTypes"
 import { COLOR, FONT, PAGE, STATUS_LEGACY, has } from "./reportPdfShared"
 import { hasAnyIncludedShot, sizeLabel } from "./reportModel"
+import { packShotSheets } from "./reportPdfHeights"
 import { ProductionSheetPdfDocument } from "./reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
 
@@ -112,6 +112,9 @@ const styles = StyleSheet.create({
   body: {
     flexDirection: "row",
     gap: COLUMN_GAP,
+  },
+  column: {
+    width: PLATE_WIDTH,
   },
   plate: {
     width: PLATE_WIDTH,
@@ -374,34 +377,11 @@ const styles = StyleSheet.create({
 })
 
 // ---------------------------------------------------------------------------
-// Pagination: two non-excluded plates per landscape sheet, never spanning a
-// gender group (a new group starts a fresh sheet, mirroring the north star).
+// Pagination is height-aware (reportPdfHeights.packShotSheets): plates are packed
+// into two columns that each fit the page, never spanning a gender group — so no
+// blank/half/stranded pages, and the running-header range tracks the shots
+// actually placed on each page.
 // ---------------------------------------------------------------------------
-
-interface Sheet {
-  readonly group: ReportGroup
-  readonly groupShotCount: number
-  /** 1-based index of the first shot on this sheet within its group. */
-  readonly fromIndex: number
-  readonly shots: readonly ReportShot[]
-}
-
-function paginate(model: ReportModel): readonly Sheet[] {
-  const sheets: Sheet[] = []
-  for (const group of model.groups) {
-    const visible = group.shots.filter((s) => !s.excluded)
-    if (visible.length === 0) continue
-    for (let i = 0; i < visible.length; i += 2) {
-      sheets.push({
-        group,
-        groupShotCount: visible.length,
-        fromIndex: i + 1,
-        shots: visible.slice(i, i + 2),
-      })
-    }
-  }
-  return sheets
-}
 
 // ---------------------------------------------------------------------------
 // Pieces
@@ -546,6 +526,28 @@ function Plate({
   )
 }
 
+/** One packed column. Each plate is kept intact (wrap=false) — the packer has
+ *  already guaranteed it fits the page (or, for a too-tall shot, packed it alone so
+ *  it never strands a partner). An empty column (a solo too-tall shot, or a group's
+ *  trailing orphan) renders an empty half — honest, not a stranded page. */
+function Column({
+  shots,
+  imageMap,
+}: {
+  readonly shots: readonly ReportShot[]
+  readonly imageMap: ReadonlyMap<string, string>
+}) {
+  return (
+    <View style={styles.column}>
+      {shots.map((shot) => (
+        <View key={shot.id} style={styles.plate} wrap={false}>
+          <Plate shot={shot} imageMap={imageMap} />
+        </View>
+      ))}
+    </View>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Document
 // ---------------------------------------------------------------------------
@@ -555,7 +557,7 @@ export function ShotReportPdfDocument(props: {
   readonly imageMap: ReadonlyMap<string, string>
 }): JSX.Element {
   const { model, imageMap } = props
-  const sheets = paginate(model)
+  const sheets = packShotSheets(model)
   const projectLine = has(model.project.client)
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
@@ -566,40 +568,33 @@ export function ShotReportPdfDocument(props: {
       author={model.project.client || ""}
       producer="Shot Builder"
     >
-      {sheets.map((sheet, i) => {
-        const toIndex = sheet.fromIndex + sheet.shots.length - 1
-        return (
-          <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={styles.page} wrap>
-            {/* Running header */}
-            <View style={styles.header} fixed>
-              <View>
-                <Text style={styles.headerTitle}>Comprehensive Shot Report</Text>
-                <Text style={styles.headerProject}>{projectLine}</Text>
-              </View>
-              <Text style={styles.headerGroup}>
-                {`${sheet.group.label} · ${sheet.fromIndex}–${toIndex} of ${sheet.groupShotCount}`}
-              </Text>
+      {sheets.map((sheet, i) => (
+        <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={styles.page} wrap>
+          {/* Running header — range tracks the shots actually placed on this page */}
+          <View style={styles.header} fixed>
+            <View>
+              <Text style={styles.headerTitle}>Comprehensive Shot Report</Text>
+              <Text style={styles.headerProject}>{projectLine}</Text>
             </View>
+            <Text style={styles.headerGroup}>
+              {`${sheet.group.label} · Shots ${sheet.firstPosition}–${sheet.lastPosition} of ${sheet.groupShotCount}`}
+            </Text>
+          </View>
 
-            {/* Two plates, each in its own column — wrap=false keeps a plate intact */}
-            <View style={styles.body}>
-              {sheet.shots.map((shot) => (
-                <View key={shot.id} style={styles.plate} wrap={false}>
-                  <Plate shot={shot} imageMap={imageMap} />
-                </View>
-              ))}
-            </View>
+          {/* Two height-packed columns. A too-tall shot is packed alone (empty right
+              column) so it never strands a partner or blanks a mid-document page. */}
+          <View style={styles.body}>
+            <Column shots={sheet.leftColumn} imageMap={imageMap} />
+            <Column shots={sheet.rightColumn} imageMap={imageMap} />
+          </View>
 
-            {/* Footer with page number */}
-            <View style={styles.footer} fixed>
-              <Text>{projectLine}</Text>
-              <Text
-                render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`}
-              />
-            </View>
-          </Page>
-        )
-      })}
+          {/* Footer with page number */}
+          <View style={styles.footer} fixed>
+            <Text>{projectLine}</Text>
+            <Text render={({ pageNumber, totalPages }) => `Page ${pageNumber} of ${totalPages}`} />
+          </View>
+        </Page>
+      ))}
     </Document>
   )
 }

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -574,7 +574,14 @@ export function ShotReportPdfDocument(props: {
       producer="Shot Builder"
     >
       {sheets.map((sheet, i) => (
-        <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={styles.page} wrap>
+        // wrap is a per-sheet decision. NORMAL sheets keep wrap so an under-estimated
+        // column moves whole to a continuation (an honest half-empty page — Column is
+        // wrap=false) rather than clipping. An OVERSIZED sheet's lone column is taller
+        // than the page and cannot wrap, so wrap would emit a trailing BLANK
+        // continuation page (header/footer only) — reintroducing the blank-page defect
+        // packShotSheets exists to kill. Disabling wrap on oversized sheets clips the
+        // too-tall tail on its single page instead (the accepted known limitation).
+        <Page key={i} size={{ width: PAGE.width, height: PAGE.height }} style={styles.page} wrap={!sheet.oversized}>
           {/* Running header — range tracks the shots actually placed on this page */}
           <View style={styles.header} fixed>
             <View>

--- a/src-vnext/features/export/lib/report/reportPdfHeights.ts
+++ b/src-vnext/features/export/lib/report/reportPdfHeights.ts
@@ -52,9 +52,14 @@ export const NO_IMAGE_HEIGHT = 230
  * carries a +5% safety, so the fit boundary on the estimate scale is ~493×1.05 ≈
  * 518; 515 sits just under it. Result: a 1-image + ≤3-product shot (estimate ~486–
  * 501) packs 2-up; only a genuinely too-tall shot (4+ products plus notes, or an
- * alt look — estimate ≳537) gets a solo splittable page. Tune here if the :5174
- * eyeball shows under/over-packing — lower if any normal page overflows, raise if
- * too many shots solo.
+ * alt look — estimate ≳537) gets a solo page (its tail clips — see PackedSheet).
+ *
+ * This is intentionally a CALIBRATED CONSTANT, not a geometry formula. A formula
+ * (page − padding − header ≈ 470–490) over-solos, because estimatePlateHeight
+ * already carries the +5% safety — the empirical fit boundary on the estimate scale
+ * is higher (~518). Re-verify with a render if the page geometry changes; tune here
+ * if the :5174 eyeball shows under/over-packing (lower if any normal page overflows,
+ * raise if too many shots solo).
  */
 export const COL_MAX = 515
 
@@ -109,13 +114,13 @@ export function estimatePlateHeight(shot: ReportShot): number {
 
   // Caption header
   h += CAPTION_PAD
-  h += TITLE_LINE * estimateWrappedLines(shot.title ?? "", PLATE_WIDTH, 14, 3)
+  h += TITLE_LINE * estimateWrappedLines(shot.title, PLATE_WIDTH, 14, 3)
   if (has(shot.colorway)) h += COLORWAY_H
   // Status chip + talent row; talent names can wrap past the status chip's ~70pt.
   const talentText = shot.talent.map((t) => t.name).filter((nm) => has(nm)).join(" · ")
   h += SUBROW_H + (talentText ? (estimateWrappedLines(talentText, PLATE_WIDTH - 70, 7.5, 3) - 1) * NOTE_LINE : 0)
   if (has(shot.notes)) {
-    h += NOTE_BASE + NOTE_LINE * estimateWrappedLines(shot.notes ?? "", PLATE_WIDTH - 8, 7.5, 4)
+    h += NOTE_BASE + NOTE_LINE * estimateWrappedLines(shot.notes, PLATE_WIDTH - 8, 7.5, 4)
   }
 
   // Looks (already filtered by looksMode in the model)
@@ -172,8 +177,9 @@ export function packShotSheets(model: ReportModel): readonly PackedSheet[] {
       if (!first) break // unreachable (i in bounds); satisfies noUncheckedIndexedAccess
       const firstPosition = i + 1
 
-      // A shot taller than one page gets its own page, allowed to split (no partner).
-      if ((heights[i] ?? 0) > COL_MAX) {
+      // A shot taller than one page gets its own page, packed alone (no partner; its
+      // tail may clip). `?? Infinity` keeps an unknown height on the SAFE solo path.
+      if ((heights[i] ?? Infinity) > COL_MAX) {
         sheets.push({
           group,
           groupShotCount,
@@ -193,7 +199,7 @@ export function packShotSheets(model: ReportModel): readonly PackedSheet[] {
       i += 1
       let rightColumn: readonly ReportShot[] = []
       const second = visible[i]
-      if (second && (heights[i] ?? 0) <= COL_MAX) {
+      if (second && (heights[i] ?? Infinity) <= COL_MAX) {
         rightColumn = [second]
         i += 1
       }

--- a/src-vnext/features/export/lib/report/reportPdfHeights.ts
+++ b/src-vnext/features/export/lib/report/reportPdfHeights.ts
@@ -1,0 +1,206 @@
+// Height-aware pagination for the image-led Comprehensive Shot Report PDF.
+//
+// WHY: @react-pdf cannot measure-then-reflow, so the old paginate() blindly
+// sliced two shots per page (`visible.slice(i, i+2)`) and laid them as two
+// side-by-side wrap={false} plates inside one <Page wrap>. When a plate exceeded
+// the page height (tall image + alt looks + notes + multi-product table) it
+// bumped to a continuation page, leaving its partner stranded — producing blank
+// pages, ~half-empty "stranded" pages, and a running header whose range no longer
+// tracked the shots actually placed.
+//
+// FIX: estimate each plate's height from the resolved model, then GREEDILY PACK
+// two columns — fill the left column top-to-bottom until the next plate would
+// overflow the column, then the right column the same way, then start a new page.
+// A plate is placed only where its (conservative) estimate fits, so a column's
+// real height never exceeds the page — no mid-document blank/half pages. A plate
+// whose estimate alone exceeds the column height gets its own page (it is
+// inherently un-fittable; @react-pdf's wrap is the safety net). The running-header
+// range is derived from the shots ACTUALLY placed on each page.
+//
+// The estimate is intentionally CONSERVATIVE on the dominant term (the hero image
+// is capped at HERO_MAX_HEIGHT by `maxHeight`, so estimating it at the cap can
+// only over-estimate, never under), which biases toward "column fits" over
+// "column overflows". Constants mirror the styles in reportPdf.tsx; they are
+// tuned for ~2 plates/page (one per column) for normal shots, a solo page for an
+// unusually tall shot. COL_MAX / SAFETY are the knobs to tune at the :5174 eyeball.
+
+import type { ReportModel, ReportGroup, ReportShot } from "./reportTypes"
+import { PAGE, has } from "./reportPdfShared"
+
+// --- Geometry (mirrors reportPdf.tsx; both derive from PAGE so they can't drift) ---
+const PAD_X = 40
+const COLUMN_GAP = 36
+const CONTENT_WIDTH = PAGE.width - PAD_X * 2
+/** Width of one of the two plate columns (a plate's text wraps within this). */
+export const PLATE_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
+
+const HERO_MAX_HEIGHT = 300 // image figure cap (reportPdf.tsx heroImage.maxHeight)
+const NO_IMAGE_HEIGHT = 230 // "Awaiting capture" frame (reportPdf.tsx noImage.height)
+
+/**
+ * Estimate-scale threshold (pt): a plate estimated within this packs 2-up (one per
+ * column); a plate estimated taller is inherently un-fittable and gets its own page,
+ * packed alone so it never strands a partner (its tail may clip — see PackedSheet).
+ *
+ * EMPIRICALLY CALIBRATED against a real @react-pdf render of landscape Letter
+ * (792×612): the true usable column is ~493pt actual (page height minus ~36/34
+ * padding, the ~49pt in-flow fixed header, and the footer). estimatePlateHeight
+ * carries a +5% safety, so the fit boundary on the estimate scale is ~493×1.05 ≈
+ * 518; 515 sits just under it. Result: a 1-image + ≤3-product shot (estimate ~486–
+ * 501) packs 2-up; only a genuinely too-tall shot (4+ products plus notes, or an
+ * alt look — estimate ≳537) gets a solo splittable page. Tune here if the :5174
+ * eyeball shows under/over-packing — lower if any normal page overflows, raise if
+ * too many shots solo.
+ */
+export const COL_MAX = 515
+
+/** Global safety multiplier on every estimate (covers proportional-font wrap slack). */
+const SAFETY = 1.05
+
+// --- Per-section estimate constants (mirror reportPdf.tsx styles) ---
+const FIGURE_PAD = 13 // figure borderTop(1) + paddingTop(12)
+const CAPTION_PAD = 12 // caption paddingTop
+const TITLE_LINE = 16 // shotTitle fontSize 14 * lineHeight 1.1, rounded up
+const COLORWAY_H = 13 // colorway fontSize 9 + marginTop 2 + slack
+const SUBROW_H = 25 // status chip + talent row (marginTop 8 + paddingTop 7 + content)
+const NOTE_BASE = 8 // note marginTop
+const NOTE_LINE = 11 // note fontSize 7.5 * lineHeight 1.4, rounded up
+const LOOKS_TOP = 12 // looks container marginTop
+const LOOK_TOP = 10 // each look marginTop
+const LOOK_HEAD = 14 // look header row (marginBottom 6 + label)
+const ALT_FIGURE = 134 // alt thumb (maxHeight 110 + marginBottom 8) + lookAlt padding
+const COLHEAD_H = 17 // product column header (paddingBottom 5 + marginBottom 5 + label)
+const PRODUCT_ROW = 15 // one product row (marginBottom 5 + content; slack for occasional wrap)
+
+/**
+ * Conservative wrapped-line count for a text run at a given width. Uses a slightly
+ * WIDE average glyph width so it errs toward MORE lines (Helvetica is proportional;
+ * over-counting lines keeps the estimate safe). Clamped to [1, maxLines].
+ */
+export function estimateWrappedLines(
+  text: string,
+  widthPt: number,
+  fontSizePt: number,
+  maxLines: number,
+): number {
+  const avgGlyph = fontSizePt * 0.55
+  const perLine = Math.max(1, Math.floor(widthPt / avgGlyph))
+  const lines = Math.ceil(text.length / perLine)
+  return Math.min(Math.max(1, lines), maxLines)
+}
+
+/**
+ * Estimate the rendered height (pt) of one image-led plate from the resolved shot.
+ * Conservative: hero image estimated at its cap; text wrap over-counted. Returns a
+ * value comparable against COL_MAX for packing.
+ */
+export function estimatePlateHeight(shot: ReportShot): number {
+  let h = 0
+
+  // Figure (image at cap, or the no-image frame)
+  h += FIGURE_PAD + (shot.hasImage ? HERO_MAX_HEIGHT : NO_IMAGE_HEIGHT)
+
+  // Caption header
+  h += CAPTION_PAD
+  h += TITLE_LINE * estimateWrappedLines(shot.title ?? "", PLATE_WIDTH, 14, 3)
+  if (has(shot.colorway)) h += COLORWAY_H
+  // Status chip + talent row; talent names can wrap past the status chip's ~70pt.
+  const talentText = shot.talent.map((t) => t.name).filter((nm) => has(nm)).join(" · ")
+  h += SUBROW_H + (talentText ? (estimateWrappedLines(talentText, PLATE_WIDTH - 70, 7.5, 3) - 1) * NOTE_LINE : 0)
+  if (has(shot.notes)) {
+    h += NOTE_BASE + NOTE_LINE * estimateWrappedLines(shot.notes ?? "", PLATE_WIDTH - 8, 7.5, 4)
+  }
+
+  // Looks (already filtered by looksMode in the model)
+  h += LOOKS_TOP
+  for (const look of shot.looks) {
+    h += LOOK_TOP + LOOK_HEAD
+    if (look.isAlt) h += ALT_FIGURE
+    h += COLHEAD_H
+    h += PRODUCT_ROW * Math.max(1, look.products.length)
+  }
+
+  return Math.ceil(h * SAFETY)
+}
+
+/**
+ * A packed landscape sheet. A normal sheet holds up to two plates (one per column,
+ * each ≤ COL_MAX). An `oversized` sheet holds a single shot too tall for one page,
+ * packed ALONE (empty right column) so it never strands a partner or blanks a
+ * mid-document page. (Such a shot still exceeds one page and its tail is clipped by
+ * @react-pdf; reshaping heavy plates — smaller hero / flowing looks — to truly fit
+ * is a follow-up, not this pagination pass.) `firstPosition`/`lastPosition` are the
+ * 1-based positions (within the group's visible shots) of the first/last shot placed
+ * — the source for the running-header range. A sheet never spans a gender group.
+ */
+export interface PackedSheet {
+  readonly group: ReportGroup
+  readonly groupShotCount: number
+  readonly firstPosition: number
+  readonly lastPosition: number
+  readonly leftColumn: readonly ReportShot[]
+  readonly rightColumn: readonly ReportShot[]
+  readonly oversized: boolean
+}
+
+/**
+ * Pack the model's shots into landscape sheets. Image-led plates are tall (a hero
+ * image plus its caption/looks), so two never fit stacked in one column — each
+ * column holds exactly one plate, two per page. A shot taller than one page
+ * (COL_MAX) gets its own sheet, packed alone, never paired. Pure and deterministic:
+ * excluded shots are dropped, empty groups produce no sheet, a sheet never spans a
+ * gender group, and every non-excluded shot is placed exactly once in order.
+ */
+export function packShotSheets(model: ReportModel): readonly PackedSheet[] {
+  const sheets: PackedSheet[] = []
+  for (const group of model.groups) {
+    const visible = group.shots.filter((s) => !s.excluded)
+    if (visible.length === 0) continue
+    const heights = visible.map(estimatePlateHeight)
+    const groupShotCount = visible.length
+
+    let i = 0
+    while (i < visible.length) {
+      const first = visible[i]
+      if (!first) break // unreachable (i in bounds); satisfies noUncheckedIndexedAccess
+      const firstPosition = i + 1
+
+      // A shot taller than one page gets its own page, allowed to split (no partner).
+      if ((heights[i] ?? 0) > COL_MAX) {
+        sheets.push({
+          group,
+          groupShotCount,
+          firstPosition,
+          lastPosition: firstPosition,
+          leftColumn: [first],
+          rightColumn: [],
+          oversized: true,
+        })
+        i += 1
+        continue
+      }
+
+      // Normal: this shot in the left column; the next FITTING shot (if any) in the
+      // right. An oversized next shot is left for its own sheet, never paired here.
+      const leftColumn: readonly ReportShot[] = [first]
+      i += 1
+      let rightColumn: readonly ReportShot[] = []
+      const second = visible[i]
+      if (second && (heights[i] ?? 0) <= COL_MAX) {
+        rightColumn = [second]
+        i += 1
+      }
+
+      sheets.push({
+        group,
+        groupShotCount,
+        firstPosition,
+        lastPosition: i, // i now points past the last placed shot → its 1-based position
+        leftColumn,
+        rightColumn,
+        oversized: false,
+      })
+    }
+  }
+  return sheets
+}

--- a/src-vnext/features/export/lib/report/reportPdfHeights.ts
+++ b/src-vnext/features/export/lib/report/reportPdfHeights.ts
@@ -25,17 +25,21 @@
 // unusually tall shot. COL_MAX / SAFETY are the knobs to tune at the :5174 eyeball.
 
 import type { ReportModel, ReportGroup, ReportShot } from "./reportTypes"
-import { PAGE, has } from "./reportPdfShared"
+import { PAGE, has, primaryLookImage } from "./reportPdfShared"
 
-// --- Geometry (mirrors reportPdf.tsx; both derive from PAGE so they can't drift) ---
-const PAD_X = 40
-const COLUMN_GAP = 36
+// --- Geometry: the SINGLE SOURCE for the image-led page layout. reportPdf.tsx
+// imports these so the estimator and the renderer can't drift — a drift (e.g.
+// bumping HERO_MAX_HEIGHT in only one file) would make the estimate stale and
+// re-open the blank/stranded-page path this module exists to close. ---
+export const PAD_X = 40
+export const COLUMN_GAP = 36
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
 /** Width of one of the two plate columns (a plate's text wraps within this). */
 export const PLATE_WIDTH = (CONTENT_WIDTH - COLUMN_GAP) / 2
-
-const HERO_MAX_HEIGHT = 300 // image figure cap (reportPdf.tsx heroImage.maxHeight)
-const NO_IMAGE_HEIGHT = 230 // "Awaiting capture" frame (reportPdf.tsx noImage.height)
+/** Hero image figure cap — the figure's max height (reportPdf.tsx heroImage.maxHeight). */
+export const HERO_MAX_HEIGHT = 300
+/** "Awaiting capture" no-image frame height (reportPdf.tsx noImage.height). */
+export const NO_IMAGE_HEIGHT = 230
 
 /**
  * Estimate-scale threshold (pt): a plate estimated within this packs 2-up (one per
@@ -97,8 +101,11 @@ export function estimateWrappedLines(
 export function estimatePlateHeight(shot: ReportShot): number {
   let h = 0
 
-  // Figure (image at cap, or the no-image frame)
-  h += FIGURE_PAD + (shot.hasImage ? HERO_MAX_HEIGHT : NO_IMAGE_HEIGHT)
+  // Figure: the plate shows the hero (capped at HERO_MAX_HEIGHT) iff the primary look
+  // has an image candidate — INCLUDING a product-image fallback. Key off the same
+  // signal the renderer uses (looks[0].image via primaryLookImage), NOT shot.hasImage,
+  // which is false for a fallback and would under-estimate a plate that does show a hero.
+  h += FIGURE_PAD + (has(primaryLookImage(shot)) ? HERO_MAX_HEIGHT : NO_IMAGE_HEIGHT)
 
   // Caption header
   h += CAPTION_PAD


### PR DESCRIPTION
## What & why

The image-led Comprehensive Shot Report PDF (LIVE in prod, `featureShotReport` ON) had structurally broken pagination: `reportPdf.tsx`'s `paginate()` blind-sliced 2 shots/page into side-by-side `wrap={false}` plates inside one `<Page wrap>`. A plate taller than the page bumped to a continuation, stranding its partner → **blank pages, ~half-empty "stranded" pages, and a running header whose range didn't track the shots placed** (documented in the 2026-06-24 render audit).

This is **Phase 1** of the export design-system + layout initiative: **pagination only — no paint/red/hero changes** (those are later phases).

## The fix

New pure module `reportPdfHeights.ts`:
- **`estimatePlateHeight(shot)`** — conservative height estimate (hero image at its 300pt cap = the true max, so it only ever over-estimates; title/notes/talent wrapping counted).
- **`packShotSheets(model)`** — clean height-aware **2-up** (one plate per column, two per page); a shot **too tall for one page is packed alone** so it can never strand a partner; the header range is derived from the shots **actually placed**.
- **`COL_MAX`** empirically calibrated against a real @react-pdf render (plates ≤ ~486pt fit; ≥ ~537pt overflow).

`reportPdf.tsx` swaps `paginate()` → `packShotSheets()`, adds a `Column`, and prints **"Shots X–Y of N"** (header) vs **"Page n of N"** (footer).

## Verification
- ✅ 13 new invariant tests + 73 existing export-report tests (**86 total**) pass
- ✅ tsc baseline **160/160** (no new errors) · lint clean · build succeeds
- ✅ Senior code-review: **no CRITICAL/HIGH**; paint scope confirmed untouched
- ✅ Headless @react-pdf renders: clean 2-up, **zero stranding** (caught + fixed an over-engineered stacking packer and a `COL_MAX` miscalibration during the build)

## Known limitation (deferred to the design-system phase)
A genuinely too-tall shot (an alt-look shot whose content exceeds a full page) is soloed — no stranded partner, no blank pages — but its **tail clips**. Pre-existing, now isolated to that one shot. Reshaping heavy plates to truly fit (smaller hero / flowing looks) is design-system work, not this pagination pass.

## Before merge — :5174 eyeball gate
`featureShotReport` is **ON in prod**, so this reaches users on merge. Eyeball first: `VITE_SHOT_REPORT=1 npm run dev` on a throwaway project (**never Q2-26 No. 3**), Export the image-led report, confirm no blank/half pages + correct "Shots X–Y of N" headers + clean 2-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YQZa1rD8ZahBRTXznZw3nV
