### PR TITLE
feat(shots): Sets Phase 1 — additive schema (Set location + Shot mediaType)

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -954,6 +954,17 @@ service cloud.firestore {
               request.resource.data.sceneNumber >= 1 &&
               request.resource.data.sceneNumber <= 9999
             )
+          ) &&
+          // Sets: the Set's location (a Location doc id) + denormalized name.
+          (
+            !('locationId' in request.resource.data) ||
+            request.resource.data.locationId == null ||
+            (request.resource.data.locationId is string && request.resource.data.locationId.size() <= 200)
+          ) &&
+          (
+            !('locationName' in request.resource.data) ||
+            request.resource.data.locationName == null ||
+            (request.resource.data.locationName is string && request.resource.data.locationName.size() <= 500)
           );
         allow delete: if clientMatches(clientId) &&
           (isAdmin() || producerCanAccessProject(clientId, projectId) ||

--- a/src-vnext/features/shots/lib/__tests__/assignShotsInheritLocation.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/assignShotsInheritLocation.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Sets initiative — Phase 1, location inheritance (D3). When shots are assigned
+// to a Set (Lane) that HAS a location, each shot adopts the Set's
+// locationId/locationName. Inheritance must fire ONLY when laneId is non-null
+// AND a real locationId is supplied — never on ungroup, never on a location-less
+// Set — so a shot's own (possibly-overridden) location is never silently wiped.
+//
+// Mirrors the Firestore-write mocking pattern in backfillShotDates.test.ts.
+
+vi.mock("@/shared/lib/firebase", () => ({ db: { __db: true } }))
+
+const mockUpdate = vi.fn()
+const mockCommit = vi.fn(async () => undefined)
+
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => ({ __coll: true })),
+  doc: vi.fn((...args: unknown[]) => ({ __doc: args })),
+  setDoc: vi.fn(async () => undefined),
+  updateDoc: vi.fn(async () => undefined),
+  deleteDoc: vi.fn(async () => undefined),
+  serverTimestamp: vi.fn(() => ({ __serverTs: true })),
+  writeBatch: vi.fn(() => ({ update: mockUpdate, commit: mockCommit })),
+}))
+
+vi.mock("@/shared/lib/paths", () => ({
+  lanesPath: () => ["clients", "c1", "projects", "p1", "lanes"],
+  laneDocPath: () => ["clients", "c1", "projects", "p1", "lanes", "lane-1"],
+  shotsPath: () => ["clients", "c1", "shots"],
+}))
+
+async function assign(
+  params: Parameters<
+    typeof import("../laneActions")["assignShotsToLane"]
+  >[0],
+): Promise<number> {
+  const { assignShotsToLane } = await import("../laneActions")
+  return assignShotsToLane(params)
+}
+
+function payloads(): Record<string, unknown>[] {
+  return mockUpdate.mock.calls.map((c) => c?.[1] as Record<string, unknown>)
+}
+
+function firstPayload(): Record<string, unknown> {
+  const p = mockUpdate.mock.calls[0]?.[1] as Record<string, unknown> | undefined
+  if (!p) throw new Error("expected a batch.update call, got none")
+  return p
+}
+
+describe("assignShotsToLane — Sets location inheritance", () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it("copies the Set's location onto every shot when assigning to a located Set", async () => {
+    const n = await assign({
+      shotIds: ["s1", "s2"],
+      laneId: "lane-1",
+      projectId: "p1",
+      clientId: "c1",
+      inheritLocation: { locationId: "loc-b", locationName: "Studio B" },
+    })
+    expect(n).toBe(2)
+    expect(mockUpdate).toHaveBeenCalledTimes(2)
+    for (const p of payloads()) {
+      expect(p.laneId).toBe("lane-1")
+      expect(p.locationId).toBe("loc-b")
+      expect(p.locationName).toBe("Studio B")
+      expect((p.updatedAt as { __serverTs?: boolean }).__serverTs).toBe(true)
+    }
+  })
+
+  it("does NOT touch location when the Set has no location (no inheritLocation)", async () => {
+    await assign({ shotIds: ["s1"], laneId: "lane-1", projectId: "p1", clientId: "c1" })
+    const p = firstPayload()
+    expect(p.laneId).toBe("lane-1")
+    expect("locationId" in p).toBe(false)
+    expect("locationName" in p).toBe(false)
+  })
+
+  it("does NOT inherit when ungrouping (laneId=null), even if a location is passed", async () => {
+    await assign({
+      shotIds: ["s1"],
+      laneId: null,
+      projectId: "p1",
+      clientId: "c1",
+      inheritLocation: { locationId: "loc-b", locationName: "Studio B" },
+    })
+    const p = firstPayload()
+    expect(p.laneId).toBeNull()
+    expect("locationId" in p).toBe(false)
+    expect("locationName" in p).toBe(false)
+  })
+
+  it("does NOT inherit when inheritLocation carries an empty locationId", async () => {
+    await assign({
+      shotIds: ["s1"],
+      laneId: "lane-1",
+      projectId: "p1",
+      clientId: "c1",
+      inheritLocation: { locationId: "", locationName: "x" },
+    })
+    const p = firstPayload()
+    expect("locationId" in p).toBe(false)
+  })
+
+  it("denormalizes a missing locationName to null (Firestore-safe, not undefined)", async () => {
+    await assign({
+      shotIds: ["s1"],
+      laneId: "lane-1",
+      projectId: "p1",
+      clientId: "c1",
+      inheritLocation: { locationId: "loc-b" },
+    })
+    const p = firstPayload()
+    expect(p.locationId).toBe("loc-b")
+    expect(p.locationName).toBeNull()
+  })
+})

--- a/src-vnext/features/shots/lib/__tests__/mapLane.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/mapLane.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest"
+import { mapLane } from "../mapLane"
+
+// Sets initiative — Phase 1. A "Scene" (Lane) is surfaced as a "Set" and now
+// carries the location it is built at; shots inherit it on assign. These tests
+// pin the new location fields plus prove legacy lanes (no fields) still map.
+
+describe("mapLane — Sets location fields", () => {
+  it("maps locationId and denormalized locationName when present", () => {
+    const lane = mapLane("lane-1", {
+      name: "Room Service",
+      projectId: "p1",
+      clientId: "c1",
+      sortOrder: 2,
+      locationId: "loc-b",
+      locationName: "Studio B",
+    })
+    expect(lane.locationId).toBe("loc-b")
+    expect(lane.locationName).toBe("Studio B")
+  })
+
+  it("collapses null location fields to undefined", () => {
+    const lane = mapLane("lane-1", {
+      name: "X",
+      projectId: "p1",
+      clientId: "c1",
+      sortOrder: 0,
+      locationId: null,
+      locationName: null,
+    })
+    expect(lane.locationId).toBeUndefined()
+    expect(lane.locationName).toBeUndefined()
+  })
+
+  it("leaves location undefined for legacy lanes lacking the fields (back-compat)", () => {
+    const lane = mapLane("lane-1", {
+      name: "Legacy",
+      projectId: "p1",
+      clientId: "c1",
+      sortOrder: 0,
+    })
+    expect(lane.locationId).toBeUndefined()
+    expect(lane.locationName).toBeUndefined()
+    // Sanity: pre-existing mapping still works.
+    expect(lane.name).toBe("Legacy")
+    expect(lane.sceneNumber).toBe(1) // sortOrder + 1 fallback
+  })
+})

--- a/src-vnext/features/shots/lib/__tests__/mapShotMediaType.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/mapShotMediaType.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest"
+import { mapShot } from "../mapShot"
+
+// Sets initiative — Phase 1. `mediaType` is a first-class, defensive enum:
+// only "photo"/"video" survive the read; anything else (legacy garbage, wrong
+// type, absent) maps to undefined so no read site ever sees an invalid value.
+
+const BASE = { title: "A", projectId: "p1", clientId: "c1" }
+
+describe("mapShot — mediaType (Sets)", () => {
+  it("maps 'photo'", () => {
+    expect(mapShot("s1", { ...BASE, mediaType: "photo" }).mediaType).toBe("photo")
+  })
+
+  it("maps 'video'", () => {
+    expect(mapShot("s1", { ...BASE, mediaType: "video" }).mediaType).toBe("video")
+  })
+
+  it("rejects unknown string values -> undefined", () => {
+    expect(mapShot("s1", { ...BASE, mediaType: "audio" }).mediaType).toBeUndefined()
+    expect(mapShot("s1", { ...BASE, mediaType: "PHOTO" }).mediaType).toBeUndefined()
+  })
+
+  it("rejects non-string values -> undefined", () => {
+    expect(mapShot("s1", { ...BASE, mediaType: 3 }).mediaType).toBeUndefined()
+    expect(mapShot("s1", { ...BASE, mediaType: null }).mediaType).toBeUndefined()
+    expect(mapShot("s1", { ...BASE, mediaType: true }).mediaType).toBeUndefined()
+  })
+
+  it("absent -> undefined (legacy shots)", () => {
+    expect(mapShot("s1", { ...BASE }).mediaType).toBeUndefined()
+  })
+})

--- a/src-vnext/features/shots/lib/laneActions.ts
+++ b/src-vnext/features/shots/lib/laneActions.ts
@@ -26,6 +26,9 @@ export type LanePatch = {
   readonly direction?: string | null
   readonly notes?: string | null
   readonly sceneNumber?: number | null
+  // Sets: the Set's location. `locationName` is denormalized for label render.
+  readonly locationId?: string | null
+  readonly locationName?: string | null
 }
 
 export async function createLane(params: {
@@ -35,6 +38,9 @@ export async function createLane(params: {
   readonly sortOrder: number
   readonly color?: string
   readonly sceneNumber?: number
+  // Sets: optional location the Set is built at (shots inherit it on assign).
+  readonly locationId?: string | null
+  readonly locationName?: string | null
   readonly existingLanes?: ReadonlyArray<Lane>
   readonly user: User | null
 }): Promise<string> {
@@ -56,6 +62,8 @@ export async function createLane(params: {
     sceneNumber: resolvedSceneNumber,
     direction: null,
     notes: null,
+    locationId: params.locationId ?? null,
+    locationName: params.locationName ?? null,
     createdAt: serverTimestamp(),
     updatedAt: serverTimestamp(),
     createdBy: user?.uid ?? "",
@@ -92,12 +100,27 @@ export async function assignShotsToLane(params: {
   readonly laneId: string | null
   readonly projectId: string
   readonly clientId: string
+  /**
+   * Sets — location inheritance (D3). When assigning shots to a Set (Lane) that
+   * HAS a location, pass it here and each shot adopts the Set's
+   * `locationId`/`locationName`. Inheritance fires ONLY when `laneId` is
+   * non-null AND a real `locationId` is provided — so ungrouping
+   * (`laneId: null`), or assigning to a Set with no location, never touches a
+   * shot's own location (which may be a per-shot override).
+   */
+  readonly inheritLocation?: {
+    readonly locationId: string
+    readonly locationName?: string | null
+  } | null
 }): Promise<number> {
-  const { shotIds, laneId, clientId } = params
+  const { shotIds, laneId, clientId, inheritLocation } = params
   if (shotIds.length === 0) return 0
   if (shotIds.length > MAX_BULK_OPS) {
     throw new Error(`Cannot assign more than ${MAX_BULK_OPS} shots to a scene at once.`)
   }
+
+  const shouldInherit =
+    laneId !== null && inheritLocation != null && !!inheritLocation.locationId
 
   let updated = 0
 
@@ -107,10 +130,15 @@ export async function assignShotsToLane(params: {
 
     for (const shotId of chunk) {
       const ref = doc(db, ...shotsPath(clientId), shotId)
-      batch.update(ref, {
+      const update: Record<string, unknown> = {
         laneId: laneId,
         updatedAt: serverTimestamp(),
-      })
+      }
+      if (shouldInherit) {
+        update["locationId"] = inheritLocation.locationId
+        update["locationName"] = inheritLocation.locationName ?? null
+      }
+      batch.update(ref, update)
     }
 
     await batch.commit()

--- a/src-vnext/features/shots/lib/mapLane.ts
+++ b/src-vnext/features/shots/lib/mapLane.ts
@@ -28,6 +28,9 @@ export function mapLane(id: string, data: Record<string, unknown>): Lane {
     sceneNumber,
     direction: (data["direction"] as string | null) ?? undefined,
     notes: (data["notes"] as string | null) ?? undefined,
+    // Sets: a Set (Lane) is built at one location; shots inherit it on assign.
+    locationId: (data["locationId"] as string | null) ?? undefined,
+    locationName: (data["locationName"] as string | null) ?? undefined,
     createdAt: data["createdAt"] as Timestamp,
     updatedAt: data["updatedAt"] as Timestamp,
     createdBy: (data["createdBy"] as string) ?? "",

--- a/src-vnext/features/shots/lib/mapShot.ts
+++ b/src-vnext/features/shots/lib/mapShot.ts
@@ -383,6 +383,11 @@ export function mapShot(id: string, data: Record<string, unknown>): Shot {
     locationId: data["locationId"] as string | undefined,
     locationName: data["locationName"] as string | undefined,
     laneId: data["laneId"] as string | undefined,
+    // Sets: first-class photo/video. Defensive — anything else maps to undefined.
+    mediaType:
+      data["mediaType"] === "photo" || data["mediaType"] === "video"
+        ? (data["mediaType"] as Shot["mediaType"])
+        : undefined,
     sortOrder: (data["sortOrder"] as number) ?? 0,
     shotNumber: data["shotNumber"] as string | undefined,
     notes: data["notes"] as string | undefined,

--- a/src-vnext/shared/types/index.ts
+++ b/src-vnext/shared/types/index.ts
@@ -34,6 +34,13 @@ export interface Project {
 
 export type ShotFirestoreStatus = "todo" | "in_progress" | "complete" | "on_hold"
 
+/**
+ * Deliverable media type for a shot (Sets initiative). The brief slices
+ * deliverables by set × media; this promotes the former "media" tag pair
+ * (Photo/Video) to a first-class, filterable/schedulable field.
+ */
+export type ShotMediaType = "photo" | "video"
+
 export type SizeScope = "all" | "single" | "pending"
 
 export interface ProductAssignment {
@@ -124,6 +131,15 @@ export interface Lane {
   readonly sceneNumber?: number
   readonly direction?: string
   readonly notes?: string
+  /**
+   * The Set's location (Sets initiative). A "Scene" (Lane) is surfaced as a
+   * "Set" in the UI; a Set is built at one location, and its shots inherit
+   * this location when assigned (see `assignShotsToLane`). `locationName` is
+   * denormalized to mirror the `Shot.locationId`/`locationName` pair so labels
+   * render without a lookup.
+   */
+  readonly locationId?: string
+  readonly locationName?: string
   readonly createdAt: Timestamp
   readonly updatedAt: Timestamp
   readonly createdBy: string
@@ -144,6 +160,11 @@ export interface Shot {
   readonly locationId?: string
   readonly locationName?: string
   readonly laneId?: string
+  /**
+   * Deliverable media type (Sets initiative). Photo vs video, sliced the way
+   * the brief organizes deliverables per set. Absent = unspecified.
+   */
+  readonly mediaType?: ShotMediaType
   readonly sortOrder: number
   readonly shotNumber?: string
   readonly notes?: string


### PR DESCRIPTION
## Sets initiative — Phase 1: additive schema (foundation)

First phase of the **Sets** initiative. A "Scene" (Firestore `Lane`) is being reframed as a **"Set"** — a designed environment that groups shots, sits at one location, and whose deliverables split by media type (photo/video). This is the model that lets you schedule a shoot day when multiple sets run simultaneously.

**This PR is schema + write layer ONLY.** Nothing reads or renders the new fields yet, so production is **behavior/render byte-identical** (pure-additive). No UI, no feature flag needed. It's the safe foundation Phases 2–5 build on.

> Model locked with Ted 2026-07-15. Design SoR (Dropbox): `Projects/Shot Builder/outputs/2026-07-15-sets-data-model/sets-media-scheduling-design-options.md` (worked example + full phased plan).

### Decisions baked in
- **Set = the existing project-scoped Scene, extended.** Internal `Lane`/`shot.laneId` unchanged (no field migration — same trick as the Phase-1 "Track→Unit" UI-string-only rename). UI rename to "Set" comes in Phase 2.
- **Location lives on the Set; shots inherit it on assign** (per-shot override preserved).
- **`mediaType` is first-class photo/video** (previously only a free-form "media" tag).

### Changes
| File | What |
|---|---|
| `shared/types/index.ts` | `ShotMediaType`; `Lane.locationId?` + denormalized `Lane.locationName?`; `Shot.mediaType?` |
| `mapLane.ts` / `mapShot.ts` | Read the new fields defensively (null→undefined; `mediaType` accepts only exact `"photo"`/`"video"`) |
| `laneActions.ts` | `LanePatch` + `createLane` carry the Set location; **`assignShotsToLane` gains optional `inheritLocation`** → copies the Set's location onto shots, but **only** when `laneId` is non-null AND a real `locationId` is given. Ungroup / location-less Set never touch a shot's own location. Firestore-safe (`?? null`). |
| `firestore.rules` | Validate `locationId`/`locationName` in the `/lanes` block (mirrors the `direction`/`notes` validators). |

### Test plan
- **13 new unit tests, all green** — `mapLane.test.ts` (3), `mapShotMediaType.test.ts` (5), `assignShotsInheritLocation.test.ts` (5, mocks Firestore writes like `backfillShotDates.test.ts`). Covers inherit-on-located-Set, no-touch on ungroup / location-less Set, empty-`locationId` exclusion, `null` denorm, and legacy back-compat.
- **tsc baseline 160/160** (0 new type errors) · **eslint clean** · adversarial **code-review: CLEAN** (no CRITICAL/HIGH — confirmed all existing `assignShotsToLane` callers get the identical `{laneId, updatedAt}` payload, and the rules clause is enforced, not wildcard-bypassed).

### Notes for the reviewer / merge
- ⚠️ **The `firestore.rules` change needs a `firestore:rules` deploy to take effect.** Writes already succeed without it (the existing rule never rejected unknown fields) — the clause only *adds* validation. Non-blocking, but worth deploying with (or before) Phase 2.
- **Phase-2 threading (not in this PR, captured in the SoR):** when Phase 2 starts *writing* `mediaType`, add it to `buildShotClonePayload` and `VERSIONED_SHOT_FIELDS` or clone/version-history will silently drop it.

### Out of scope (later phases)
Set editor + rename, `mediaType` pickers/columns/filters (P2); scheduler "add whole Set to a Unit" + faceted picker + real media badge (P3); "clone Set from past shoot" (P4); report/call-sheet grouping by Set × media (P5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LH2AUXGzvTanEjgSfCqx4L
