### PR TITLE
fix(ci): unblock trunk — pin websocket-driver ^0.7.5, drop dead callsheet flag

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -42,7 +42,6 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
-          VITE_FLAG_CALLSHEET_BUILDER:       1
           VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
           VITE_TALENT_ROSTER_IA:             1   # Talent redesign: Height+Waist toolbar filters
           VITE_TALENT_DETAIL_IA:             1   # Talent redesign: profile re-group (contact line, fit signals, creative assets)
@@ -85,7 +84,6 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
-          VITE_FLAG_CALLSHEET_BUILDER:       1
           VITE_REVIEW_SURFACE:               1   # 5f: client/warehouse Review surfaces ON in prod (default stays false elsewhere)
           VITE_TALENT_ROSTER_IA:             1   # Talent redesign: Height+Waist toolbar filters
           VITE_TALENT_DETAIL_IA:             1   # Talent redesign: profile re-group (contact line, fit signals, creative assets)

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,7 +36,6 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
-          VITE_FLAG_CALLSHEET_BUILDER:       1
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -61,7 +60,6 @@ jobs:
           VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
           VITE_FIREBASE_APP_ID:              ${{ secrets.VITE_FIREBASE_APP_ID }}
           VITE_FIREBASE_MEASUREMENT_ID:      ${{ secrets.VITE_FIREBASE_MEASUREMENT_ID }} # optional
-          VITE_FLAG_CALLSHEET_BUILDER:       1
         # Channel name uses PR number (stable across pushes)
         # Set expiration to 3 days (instead of default 7) to help with quota management
         # Pipe through tee so CLI output still appears in the GitHub log when the command fails.

--- a/package-lock.json
+++ b/package-lock.json
@@ -17392,9 +17392,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -99,5 +99,8 @@
     "typescript": "^5.9.3",
     "vite": "^7.1.9",
     "vitest": "^3.2.4"
+  },
+  "overrides": {
+    "websocket-driver": "^0.7.5"
   }
 }


### PR DESCRIPTION
## What & why — master plan S1 (UNBLOCK / Track 0)

Two Track-0 trunk-hygiene changes. No app code, no behavior change.

### 1. Fix the npm-audit red (the actual CI blocker)
`Security Audit` in `ci.yml` (`npm audit --production --audit-level=critical`) fails on every fresh run because of a **time-based** advisory. The prod chain

```
firebase@12.12.0 → @firebase/database@1.1.2 → faye-websocket@0.11.4 → websocket-driver@0.7.4
```

is now flagged **critical** (GHSA-mp7j-qc5w-4988, GHSA-xv26-6w52-cph6). main's last green CI run (Jul 2) and #497's checks (Jul 15 artifact) both **predate** these advisories — nothing regressed in code.

**Fix:** `overrides: { "websocket-driver": "^0.7.5" }`. 0.7.5 is the patched release; `faye-websocket@0.11.4` already declares `websocket-driver: >=0.5.1`, so the pin is in-range (not forced out of range).

- `npm audit --production --audit-level=critical` → **exit 0** (was 1); 0 production criticals
- Only prod-tree change: `websocket-driver 0.7.4 → 0.7.5` (lockfile diff is 3 lines)
- `npm run build` green locally

### 2. Remove dead `VITE_FLAG_CALLSHEET_BUILDER`
Referenced only by the retired `archive/legacy-src-2026-04/lib/flags.js`; the live app (`src-vnext`) never reads it. Removed from **both build blocks** of `deploy-live.yml` and `deploy-preview.yml`.

- Verified both `deploy-live.yml` flag blocks stay **byte-identical** (7 app flags each)
- ⚠️ This leaves `deploy-preview.yml` with **zero app flags** — tracked as the S4 preview-parity item in the master plan (previews no longer resemble prod for any flagged surface; decide mirroring vs deliberate PARK there).

## Gate
main CI green including `Security Audit` — this PR's `build` check is the proof.
