### PR TITLE
feat(export): report-config Phase A — rename + hide-by-status (flagged)

### DIFF
--- a/src-vnext/features/export/__tests__/exportReports.rules.test.ts
+++ b/src-vnext/features/export/__tests__/exportReports.rules.test.ts
@@ -133,6 +133,16 @@ describeOrSkip("firestore.rules — exportReports (shot-report docs)", () => {
     const db = authed("prod-b", CLIENT_A, "producer")
     await assertFails(updateDoc(reportRef(db, REPORT_OWNED), { createdBy: "prod-b" }))
   })
+
+  it("[9] producer UPDATE of name (rename) succeeds, preserving createdBy (renameReport path)", async () => {
+    const db = authed("prod-a", CLIENT_A, "producer")
+    await assertSucceeds(
+      updateDoc(reportRef(db, REPORT_OWNED), {
+        name: "Renamed",
+        updatedBy: "prod-a",
+      }),
+    )
+  })
 })
 
 // Visible skip notice so developers know why zero rules tests ran locally.

--- a/src-vnext/features/export/components/report/ProductInfoReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportListPage.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
-import { Package, Plus, Trash2 } from "lucide-react"
+import { Package, Pencil, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
 import {
@@ -15,6 +16,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
@@ -28,19 +36,20 @@ export default function ProductInfoReportListPage() {
   const { id: projectId } = useParams<{ id: string }>()
   const { clientId } = useAuth()
   const navigate = useNavigate()
-  const { reports, loading, createProductInfoReport, deleteReport } = useExportReports(
-    clientId,
-    projectId,
-  )
+  const { reports, loading, createProductInfoReport, deleteReport, renameReport } =
+    useExportReports(clientId, projectId)
 
   const productReports = useMemo(
     () => reports.filter((r) => r.reportType === "product-info"),
     [reports],
   )
 
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
   const [newName, setNewName] = useState("")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
+  const [pendingRename, setPendingRename] = useState<{ id: string; name: string } | null>(null)
+  const [renameDraft, setRenameDraft] = useState("")
 
   const openReport = useCallback(
     (reportId: string) =>
@@ -75,6 +84,24 @@ export default function ProductInfoReportListPage() {
     },
     [deleteReport],
   )
+
+  const openRename = useCallback((id: string, name: string) => {
+    setPendingRename({ id, name })
+    setRenameDraft(name)
+  }, [])
+
+  const handleRename = useCallback(async () => {
+    if (!pendingRename) return
+    const name = renameDraft.trim()
+    setPendingRename(null)
+    if (!name || name === pendingRename.name) return
+    try {
+      await renameReport(pendingRename.id, name)
+      toast.success("Report renamed")
+    } catch {
+      toast.error("Couldn't rename the report")
+    }
+  }, [pendingRename, renameDraft, renameReport])
 
   return (
     <div className="mx-auto w-full max-w-3xl">
@@ -125,6 +152,17 @@ export default function ProductInfoReportListPage() {
               <Button variant="outline" size="sm" onClick={() => openReport(r.id)}>
                 Open
               </Button>
+              {reportConfigEnabled && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => openRename(r.id, r.name)}
+                  disabled={busy}
+                  aria-label={`Rename ${r.name}`}
+                >
+                  <Pencil />
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="icon"
@@ -165,6 +203,39 @@ export default function ProductInfoReportListPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {reportConfigEnabled && (
+        <Dialog
+          open={pendingRename !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingRename(null)
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Rename report</DialogTitle>
+            </DialogHeader>
+            <Input
+              value={renameDraft}
+              onChange={(e) => setRenameDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && renameDraft.trim()) void handleRename()
+              }}
+              placeholder="Report name…"
+              aria-label="Report name"
+              autoFocus
+            />
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setPendingRename(null)}>
+                Cancel
+              </Button>
+              <Button disabled={!renameDraft.trim()} onClick={() => void handleRename()}>
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   )
 }

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
 import {
@@ -107,7 +108,17 @@ export default function ProductInfoReportPage() {
     }
   }, [])
 
-  const model = useMemo(() => deriveProductInfoModel(data, config), [data, config])
+  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
+  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
+  // byte-identical. Build-time flag → not a memo dep.
+  const model = useMemo(
+    () =>
+      deriveProductInfoModel(
+        data,
+        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+      ),
+    [data, config],
+  )
 
   // Resolve every image candidate to a data URL once the model is known.
   // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -7,6 +7,7 @@
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { resolveSrc, statusMeta } from "./reportShared"
 import { PRODUCT_INFO_STYLES } from "./productInfoStyles"
 import type {
@@ -18,6 +19,8 @@ import type {
   ProductInfoModel,
   ProductInfoScope,
 } from "../../lib/report/productInfoTypes"
+import type { ReportShotStatus } from "../../lib/report/reportTypes"
+import { REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
 
 export interface ProductInfoReportViewProps {
   readonly model: ProductInfoModel
@@ -305,6 +308,9 @@ function ControlBar({
   onSetImageSize,
   printMode,
   onSetPrintMode,
+  showStatusFilter,
+  hiddenStatuses,
+  onToggleStatus,
   onExportPdf,
   exporting,
   imagesLoading,
@@ -318,6 +324,9 @@ function ControlBar({
   readonly onSetImageSize: (v: ProductInfoImageSize) => void
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
+  readonly showStatusFilter: boolean
+  readonly hiddenStatuses: readonly ReportShotStatus[]
+  readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly imagesLoading: boolean
@@ -327,6 +336,7 @@ function ControlBar({
   const groupLabelId = useId()
   const sizeLabelId = useId()
   const viewLabelId = useId()
+  const statusLabelId = useId()
 
   const scopeOpts: ReadonlyArray<readonly [ProductInfoScope, string]> = [
     ["in-use", "In use"],
@@ -426,6 +436,27 @@ function ControlBar({
         </div>
       </div>
 
+      {showStatusFilter && (
+        <div className="sb-pir-control-group" role="group" aria-labelledby={statusLabelId}>
+          <span id={statusLabelId} className="sb-pir-control-label">
+            Hide statuses
+          </span>
+          <div className="sb-pir-seg">
+            {REPORT_STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-pir-seg-btn"
+                aria-pressed={hiddenStatuses.includes(opt.value)}
+                onClick={() => onToggleStatus(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       <button
         type="button"
         className="sb-pir-export-btn"
@@ -452,6 +483,7 @@ function ControlBar({
 export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.Element {
   const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, imagesLoading = false } = props
   const [printMode, setPrintMode] = useState(false)
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
 
   // No non-excluded product => the PDF would have zero pages (@react-pdf throws); gate Export.
   const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
@@ -478,6 +510,15 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
     onConfigChange({ ...config, imageSize })
   }
 
+  // R3 status filter — multi-select toggle set; an absent field default-merges to [].
+  const hiddenStatuses = config.hiddenStatuses ?? []
+  const toggleStatus = (status: ReportShotStatus): void => {
+    const set = new Set(hiddenStatuses)
+    if (set.has(status)) set.delete(status)
+    else set.add(status)
+    onConfigChange({ ...config, hiddenStatuses: [...set] })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.familyCount === 0
 
   return (
@@ -493,6 +534,9 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
         onSetImageSize={setImageSize}
         printMode={printMode}
         onSetPrintMode={setPrintMode}
+        showStatusFilter={reportConfigEnabled}
+        hiddenStatuses={hiddenStatuses}
+        onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}
         exporting={exporting}
         imagesLoading={imagesLoading}

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -19,9 +19,10 @@ import type {
   ReportModel,
   ReportProduct,
   ReportShot,
+  ReportShotStatus,
   ReportTalent,
 } from "../../lib/report/reportTypes"
-import { REPORT_LAYOUT_OPTIONS } from "../../lib/report/reportTypes"
+import { REPORT_LAYOUT_OPTIONS, REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
 import { hasAnyIncludedShot, sizeLabel } from "../../lib/report/reportModel"
 import { packShotSheets } from "../../lib/report/reportPdfHeights"
 import { REPORT_STYLES } from "./reportStyles"
@@ -432,6 +433,9 @@ function ControlBar({
   layout,
   onSetLayout,
   showLayout,
+  showStatusFilter,
+  hiddenStatuses,
+  onToggleStatus,
   onExportPdf,
   exporting,
   canExport,
@@ -446,6 +450,9 @@ function ControlBar({
   readonly layout: ReportLayout
   readonly onSetLayout: (v: ReportLayout) => void
   readonly showLayout: boolean
+  readonly showStatusFilter: boolean
+  readonly hiddenStatuses: readonly ReportShotStatus[]
+  readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly canExport: boolean
@@ -455,6 +462,7 @@ function ControlBar({
   const groupLabelId = useId()
   const looksLabelId = useId()
   const recipeLabelId = useId()
+  const statusLabelId = useId()
   return (
     <div className="sb-controlbar no-print" role="region" aria-label="Report controls">
       {showLayout ? (
@@ -550,6 +558,27 @@ function ControlBar({
         </div>
       </div>
 
+      {showStatusFilter && (
+        <div className="sb-control-group" role="group" aria-labelledby={statusLabelId}>
+          <span id={statusLabelId} className="sb-control-label">
+            Hide statuses
+          </span>
+          <div className="sb-seg">
+            {REPORT_STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-seg-btn"
+                aria-pressed={hiddenStatuses.includes(opt.value)}
+                onClick={() => onToggleStatus(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       <button
         type="button"
         className="sb-export-btn"
@@ -581,6 +610,7 @@ export function ReportView(props: ReportViewProps): JSX.Element {
   // Recipes ride their own flag; flag-off forces image-led so prod is byte-identical
   // to the live R1/R2 report regardless of any persisted config.layout.
   const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
   const layout: ReportLayout = recipesEnabled ? (config.layout ?? "image-led") : "image-led"
 
   const toggleExclude = (shotId: string): void => {
@@ -609,6 +639,16 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, layout: next })
   }
 
+  // R3 status filter — a multi-select toggle set (distinct from the single-select
+  // controls above). An absent field default-merges to [] at read.
+  const hiddenStatuses = config.hiddenStatuses ?? []
+  const toggleStatus = (status: ReportShotStatus): void => {
+    const set = new Set(hiddenStatuses)
+    if (set.has(status)) set.delete(status)
+    else set.add(status)
+    onConfigChange({ ...config, hiddenStatuses: [...set] })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
   // Export is blocked when every shot is excluded — a PDF with zero pages is corrupt.
   const canExport = hasAnyIncludedShot(model)
@@ -634,6 +674,9 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         layout={layout}
         onSetLayout={setLayout}
         showLayout={recipesEnabled}
+        showStatusFilter={reportConfigEnabled}
+        hiddenStatuses={hiddenStatuses}
+        onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}
         exporting={exporting}
         canExport={canExport}

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
-import { Copy, FileText, Plus, Trash2 } from "lucide-react"
+import { Copy, FileText, Pencil, Plus, Trash2 } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { badgeVariants } from "@/ui/badge"
@@ -18,6 +18,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
@@ -37,7 +44,7 @@ export default function ShotReportListPage() {
   const { id: projectId } = useParams<{ id: string }>()
   const { clientId } = useAuth()
   const navigate = useNavigate()
-  const { reports, loading, createShotReport, loadReport, deleteReport } =
+  const { reports, loading, createShotReport, loadReport, deleteReport, renameReport } =
     useExportReports(clientId, projectId)
 
   const shotReports = useMemo(
@@ -46,10 +53,13 @@ export default function ShotReportListPage() {
   )
 
   const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
   const [newName, setNewName] = useState("")
   const [recipe, setRecipe] = useState<ReportLayout>("image-led")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
+  const [pendingRename, setPendingRename] = useState<{ id: string; name: string } | null>(null)
+  const [renameDraft, setRenameDraft] = useState("")
 
   const openReport = useCallback(
     (reportId: string) => navigate(`/projects/${projectId}/export/report?reportId=${reportId}`),
@@ -103,6 +113,24 @@ export default function ShotReportListPage() {
     },
     [deleteReport],
   )
+
+  const openRename = useCallback((id: string, name: string) => {
+    setPendingRename({ id, name })
+    setRenameDraft(name)
+  }, [])
+
+  const handleRename = useCallback(async () => {
+    if (!pendingRename) return
+    const name = renameDraft.trim()
+    setPendingRename(null)
+    if (!name || name === pendingRename.name) return
+    try {
+      await renameReport(pendingRename.id, name)
+      toast.success("Report renamed")
+    } catch {
+      toast.error("Couldn't rename the report")
+    }
+  }, [pendingRename, renameDraft, renameReport])
 
   return (
     <div className="mx-auto w-full max-w-3xl">
@@ -181,6 +209,17 @@ export default function ShotReportListPage() {
               >
                 <Copy /> Recipe
               </Button>
+              {reportConfigEnabled && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => openRename(r.id, r.name)}
+                  disabled={busy}
+                  aria-label={`Rename ${r.name}`}
+                >
+                  <Pencil />
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="icon"
@@ -221,6 +260,39 @@ export default function ShotReportListPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {reportConfigEnabled && (
+        <Dialog
+          open={pendingRename !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingRename(null)
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Rename report</DialogTitle>
+            </DialogHeader>
+            <Input
+              value={renameDraft}
+              onChange={(e) => setRenameDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && renameDraft.trim()) void handleRename()
+              }}
+              placeholder="Report name…"
+              aria-label="Report name"
+              autoFocus
+            />
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setPendingRename(null)}>
+                Cancel
+              </Button>
+              <Button disabled={!renameDraft.trim()} onClick={() => void handleRename()}>
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   )
 }

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -88,7 +88,17 @@ export default function ShotReportPage() {
     [],
   )
 
-  const model = useMemo(() => deriveShotReportModel(data, config), [data, config])
+  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
+  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
+  // byte-identical. Build-time flag → not a memo dep.
+  const model = useMemo(
+    () =>
+      deriveShotReportModel(
+        data,
+        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+      ),
+    [data, config],
+  )
 
   // Resolve every image candidate to a data URL once the model is known.
   // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.

--- a/src-vnext/features/export/components/report/TalentReportListPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportListPage.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useMemo, useState } from "react"
 import { useNavigate, useParams } from "react-router-dom"
 import { toast } from "sonner"
-import { Plus, Trash2, Users } from "lucide-react"
+import { Pencil, Plus, Trash2, Users } from "lucide-react"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { Button, buttonVariants } from "@/ui/button"
 import { Input } from "@/ui/input"
 import {
@@ -15,6 +16,13 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/ui/alert-dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog"
 import { PageHeader } from "@/shared/components/PageHeader"
 import { EmptyState } from "@/shared/components/EmptyState"
 import { useExportReports } from "../../hooks/useExportReports"
@@ -29,19 +37,20 @@ export default function TalentReportListPage() {
   const { id: projectId } = useParams<{ id: string }>()
   const { clientId } = useAuth()
   const navigate = useNavigate()
-  const { reports, loading, createTalentReport, deleteReport } = useExportReports(
-    clientId,
-    projectId,
-  )
+  const { reports, loading, createTalentReport, deleteReport, renameReport } =
+    useExportReports(clientId, projectId)
 
   const talentReports = useMemo(
     () => reports.filter((r) => r.reportType === "talent"),
     [reports],
   )
 
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
   const [newName, setNewName] = useState("")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
+  const [pendingRename, setPendingRename] = useState<{ id: string; name: string } | null>(null)
+  const [renameDraft, setRenameDraft] = useState("")
 
   const openReport = useCallback(
     (reportId: string) =>
@@ -76,6 +85,24 @@ export default function TalentReportListPage() {
     },
     [deleteReport],
   )
+
+  const openRename = useCallback((id: string, name: string) => {
+    setPendingRename({ id, name })
+    setRenameDraft(name)
+  }, [])
+
+  const handleRename = useCallback(async () => {
+    if (!pendingRename) return
+    const name = renameDraft.trim()
+    setPendingRename(null)
+    if (!name || name === pendingRename.name) return
+    try {
+      await renameReport(pendingRename.id, name)
+      toast.success("Report renamed")
+    } catch {
+      toast.error("Couldn't rename the report")
+    }
+  }, [pendingRename, renameDraft, renameReport])
 
   return (
     <div className="mx-auto w-full max-w-3xl">
@@ -126,6 +153,17 @@ export default function TalentReportListPage() {
               <Button variant="outline" size="sm" onClick={() => openReport(r.id)}>
                 Open
               </Button>
+              {reportConfigEnabled && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => openRename(r.id, r.name)}
+                  disabled={busy}
+                  aria-label={`Rename ${r.name}`}
+                >
+                  <Pencil />
+                </Button>
+              )}
               <Button
                 variant="ghost"
                 size="icon"
@@ -166,6 +204,39 @@ export default function TalentReportListPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {reportConfigEnabled && (
+        <Dialog
+          open={pendingRename !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingRename(null)
+          }}
+        >
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Rename report</DialogTitle>
+            </DialogHeader>
+            <Input
+              value={renameDraft}
+              onChange={(e) => setRenameDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && renameDraft.trim()) void handleRename()
+              }}
+              placeholder="Report name…"
+              aria-label="Report name"
+              autoFocus
+            />
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setPendingRename(null)}>
+                Cancel
+              </Button>
+              <Button disabled={!renameDraft.trim()} onClick={() => void handleRename()}>
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   )
 }

--- a/src-vnext/features/export/components/report/TalentReportPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useParams, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
 import {
@@ -106,7 +107,17 @@ export default function TalentReportPage() {
     }
   }, [])
 
-  const model = useMemo(() => deriveTalentModel(data, config), [data, config])
+  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
+  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
+  // byte-identical. Build-time flag → not a memo dep.
+  const model = useMemo(
+    () =>
+      deriveTalentModel(
+        data,
+        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+      ),
+    [data, config],
+  )
 
   // Resolve every image candidate to a data URL once the model is known.
   // resolvePdfImageSrc caches module-side, so re-resolving on config change is cheap.

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -7,6 +7,7 @@
 import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
+import { isFeatureEnabled } from "@/shared/lib/flags"
 import { initials } from "@/features/library/components/talentUtils"
 import { resolveSrc, statusMeta } from "./reportShared"
 import { TALENT_STYLES } from "./talentStyles"
@@ -18,6 +19,8 @@ import type {
   TalentModel,
   TalentScope,
 } from "../../lib/report/talentTypes"
+import type { ReportShotStatus } from "../../lib/report/reportTypes"
+import { REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
 
 export interface TalentReportViewProps {
   readonly model: TalentModel
@@ -308,6 +311,9 @@ function ControlBar({
   onSetGroupBy,
   printMode,
   onSetPrintMode,
+  showStatusFilter,
+  hiddenStatuses,
+  onToggleStatus,
   onExportPdf,
   exporting,
   imagesLoading,
@@ -319,6 +325,9 @@ function ControlBar({
   readonly onSetGroupBy: (v: TalentGroupBy) => void
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
+  readonly showStatusFilter: boolean
+  readonly hiddenStatuses: readonly ReportShotStatus[]
+  readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly imagesLoading: boolean
@@ -327,6 +336,7 @@ function ControlBar({
   const scopeLabelId = useId()
   const groupLabelId = useId()
   const viewLabelId = useId()
+  const statusLabelId = useId()
 
   const scopeOpts: ReadonlyArray<readonly [TalentScope, string]> = [
     ["in-shots", "In shots"],
@@ -402,6 +412,27 @@ function ControlBar({
         </div>
       </div>
 
+      {showStatusFilter && (
+        <div className="sb-tr-control-group" role="group" aria-labelledby={statusLabelId}>
+          <span id={statusLabelId} className="sb-tr-control-label">
+            Hide statuses
+          </span>
+          <div className="sb-tr-seg">
+            {REPORT_STATUS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-tr-seg-btn"
+                aria-pressed={hiddenStatuses.includes(opt.value)}
+                onClick={() => onToggleStatus(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
       <button
         type="button"
         className="sb-tr-export-btn"
@@ -428,6 +459,7 @@ function ControlBar({
 export function TalentReportView(props: TalentReportViewProps): JSX.Element {
   const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, imagesLoading = false } = props
   const [printMode, setPrintMode] = useState(false)
+  const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
 
   const toggleExclude = (talentId: string): void => {
     const set = new Set(config.excludedTalentIds)
@@ -446,6 +478,15 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
     onConfigChange({ ...config, groupBy })
   }
 
+  // R3 status filter — multi-select toggle set; an absent field default-merges to [].
+  const hiddenStatuses = config.hiddenStatuses ?? []
+  const toggleStatus = (status: ReportShotStatus): void => {
+    const set = new Set(hiddenStatuses)
+    if (set.has(status)) set.delete(status)
+    else set.add(status)
+    onConfigChange({ ...config, hiddenStatuses: [...set] })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.talentCount === 0
   // No non-excluded talent => the PDF would have zero pages (@react-pdf throws); gate Export.
   const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
@@ -461,6 +502,9 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
         onSetGroupBy={setGroupBy}
         printMode={printMode}
         onSetPrintMode={setPrintMode}
+        showStatusFilter={reportConfigEnabled}
+        hiddenStatuses={hiddenStatuses}
+        onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}
         exporting={exporting}
         imagesLoading={imagesLoading}

--- a/src-vnext/features/export/hooks/useExportReports.ts
+++ b/src-vnext/features/export/hooks/useExportReports.ts
@@ -90,6 +90,8 @@ export interface UseExportReportsReturn {
     reportId: string,
     config: ExportReportConfig,
   ) => Promise<void>
+  /** Rename a report (R1). Top-level name-only merge; preserves config/pages/createdBy. */
+  readonly renameReport: (reportId: string, name: string) => Promise<void>
 }
 
 export function mapReport(
@@ -175,6 +177,22 @@ export function useExportReports(
       // Top-level merge: preserves name/pages/createdBy; replaces the small config blob whole.
       await updateDoc(docRef, {
         config,
+        updatedAt: serverTimestamp(),
+        updatedBy: user?.uid ?? "",
+      })
+    },
+    [clientId, projectId, user?.uid],
+  )
+
+  const renameReport = useCallback(
+    async (reportId: string, name: string) => {
+      if (!clientId || !projectId) return
+      const pathSegments = exportReportDocPath(clientId, projectId, reportId)
+      const docRef = doc(db, pathSegments[0]!, ...pathSegments.slice(1))
+      // Name-only top-level merge: preserves config/pages/createdBy (mirrors saveReportConfig).
+      // createdBy is untouched, so the exportReports update rule's createdBy invariant holds.
+      await updateDoc(docRef, {
+        name,
         updatedAt: serverTimestamp(),
         updatedBy: user?.uid ?? "",
       })
@@ -343,5 +361,6 @@ export function useExportReports(
     createProductInfoReport,
     createTalentReport,
     saveReportConfig,
+    renameReport,
   }
 }

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -218,6 +218,63 @@ describe("deriveProductInfoModel — library scope", () => {
   })
 })
 
+describe("deriveProductInfoModel — R3 status filter", () => {
+  it("drops a family whose ONLY appearance is a hidden status", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+          shot({ id: "s2", shotNumber: "02", status: "complete", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none", hiddenStatuses: ["on_hold"] }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toEqual(["fW"]) // fM only appeared in an on_hold shot
+    expect(model.project.familyCount).toBe(1)
+  })
+
+  it("keeps a family that also appears in a visible-status shot (drop-only; full appears retained)", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+          shot({ id: "s2", shotNumber: "02", status: "complete", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+        ],
+      }),
+      cfg({ groupBy: "none", hiddenStatuses: ["on_hold"] }),
+    )
+    const e = find(model, "fM")
+    expect(e).toBeDefined() // still visible via the complete shot
+    // Phase-A drop-only rule: survivors keep EVERY appearance, incl. the hidden-status one.
+    expect(e?.appears.map((a) => `${a.number}:${a.status}`)).toEqual(["01:on_hold", "02:complete"])
+  })
+
+  it("an omitted hiddenStatuses is byte-identical to [] — nothing dropped", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [shot({ id: "s1", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] })],
+    })
+    expect(flat(deriveProductInfoModel(d, cfg({ groupBy: "none" }))).map((i) => i.id)).toEqual(["fM"])
+    expect(flat(deriveProductInfoModel(d, cfg({ groupBy: "none", hiddenStatuses: [] }))).map((i) => i.id)).toEqual(["fM"])
+  })
+
+  it("does NOT drop a library never-shot family under a status filter (appears.length === 0 guard)", () => {
+    const model = deriveProductInfoModel(
+      data({
+        productFamilies: FAMILIES,
+        shots: [shot({ id: "s1", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] })],
+      }),
+      cfg({ productScope: "library", groupBy: "none", hiddenStatuses: ["on_hold"] }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("fW") // never styled into a shot -> survives the status filter
+    expect(ids).not.toContain("fM") // only appeared on_hold -> dropped
+  })
+})
+
 describe("deriveProductInfoModel — grouping", () => {
   const styled = () =>
     data({

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -181,6 +181,32 @@ describe("deriveShotReportModel", () => {
     expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["live"])
   })
 
+  it("R3: hides shots whose status is in hiddenStatuses (gone from every group + shotCount)", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({ id: "hold", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        shot({ id: "done", shotNumber: "02", status: "complete", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], hiddenStatuses: ["on_hold"] })
+    expect(model.groups.flatMap((g) => g.shots).map((s) => s.id)).toEqual(["done"])
+    expect(model.project.shotCount).toBe(1)
+  })
+
+  it("R3: an omitted hiddenStatuses is byte-identical to [] — nothing is hidden", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({ id: "hold", shotNumber: "01", status: "on_hold", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+      ],
+    })
+    const omitted = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [] })
+    const empty = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], hiddenStatuses: [] })
+    expect(omitted.groups.flatMap((g) => g.shots).map((s) => s.id)).toEqual(["hold"])
+    expect(empty.groups.flatMap((g) => g.shots).map((s) => s.id)).toEqual(["hold"])
+  })
+
   const twoLookShot = () =>
     data({
       productFamilies: FAMILIES,

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -23,4 +23,11 @@ describe("ReportConfig persistence round-trip", () => {
     const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
     expect(hydrated.layout).toBe("image-led")
   })
+
+  it("default-merges a pre-hiddenStatuses blob to hiddenStatuses [] (R3-filter forward-compat)", () => {
+    // A blob written before the status filter existed must hydrate to [] -> nothing hidden.
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led"}')
+    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    expect(hydrated.hiddenStatuses).toEqual([])
+  })
 })

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -158,6 +158,67 @@ describe("deriveTalentModel — appearances", () => {
   })
 })
 
+describe("deriveTalentModel — R3 status filter", () => {
+  it("drops a talent whose ONLY appearance is a hidden status", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({ id: "s1", shotNumber: "01", status: "todo", talentIds: ["tA"] }),
+          shot({ id: "s2", shotNumber: "02", status: "complete", talentIds: ["tB"] }),
+        ],
+      }),
+      cfg({ groupBy: "none", hiddenStatuses: ["todo"] }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toEqual(["tB"]) // tA only in a todo shot
+    expect(model.project.talentCount).toBe(1)
+  })
+
+  it("keeps a talent who also appears in a visible-status shot (drop-only; full appears retained)", () => {
+    const model = deriveTalentModel(
+      data({
+        talent: ROSTER,
+        shots: [
+          shot({ id: "s2", shotNumber: "2", status: "complete", talentIds: ["tA"] }),
+          shot({ id: "s10", shotNumber: "10", status: "todo", talentIds: ["tA"] }),
+        ],
+      }),
+      cfg({ groupBy: "none", hiddenStatuses: ["todo"] }),
+    )
+    const e = find(model, "tA")
+    expect(e).toBeDefined()
+    // Phase-A drop-only rule: survivors keep EVERY appearance, incl. the hidden-status one.
+    expect(e?.appears.map((a) => `${a.number}:${a.status}`)).toEqual(["2:complete", "10:todo"])
+  })
+
+  it("an omitted hiddenStatuses is byte-identical to [] — nothing dropped", () => {
+    const d = data({
+      talent: ROSTER,
+      shots: [shot({ id: "s1", shotNumber: "01", status: "todo", talentIds: ["tA"] })],
+    })
+    expect(flat(deriveTalentModel(d, cfg({ groupBy: "none" }))).map((i) => i.id)).toEqual(["tA"])
+    expect(flat(deriveTalentModel(d, cfg({ groupBy: "none", hiddenStatuses: [] }))).map((i) => i.id)).toEqual(["tA"])
+  })
+
+  it("does NOT drop a project-attached never-shot talent under a status filter (appears.length === 0 guard)", () => {
+    const model = deriveTalentModel(
+      data({
+        project: { id: "p1", name: "P", clientId: "c" } as ExportData["project"],
+        talent: [
+          tal({ id: "tA", name: "Ava", projectIds: ["p1"] }),
+          tal({ id: "tB", name: "Ben", projectIds: ["p1"] }),
+        ],
+        shots: [shot({ id: "s1", shotNumber: "01", status: "on_hold", talentIds: ["tB"] })],
+      }),
+      cfg({ talentScope: "project-attached", groupBy: "none", hiddenStatuses: ["on_hold"] }),
+    )
+    const ids = flat(model).map((i) => i.id)
+    expect(ids).toContain("tA") // never in a shot -> survives the status filter
+    expect(ids).not.toContain("tB") // appeared only in an on_hold shot -> dropped
+  })
+})
+
 describe("deriveTalentModel — entry field resolution", () => {
   it("name via buildDisplayName, gender label, agency/contact; blank gender -> null label", () => {
     const model = deriveTalentModel(

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -214,6 +214,8 @@ export function deriveProductInfoModel(
 ): ProductInfoModel {
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
   const excluded = new Set(config.excludedFamilyIds)
+  // R3: statuses to hide (undefined on pre-R3 blobs -> empty set -> no-op).
+  const hidden = new Set(config.hiddenStatuses ?? [])
   const aggByFamily = walkInUse(data.shots, familyById)
 
   // in-use: families styled into non-deleted shots, resolved against the library.
@@ -227,6 +229,14 @@ export function deriveProductInfoModel(
 
   const items = families
     .map((family) => toEntry(family, aggByFamily.get(family.id), excluded))
+    // R3: drop a family only when EVERY appearance is a hidden status. A never-shot
+    // library family (appears.length === 0) is kept — status can't hide what has no shots.
+    .filter(
+      (item) =>
+        hidden.size === 0 ||
+        item.appears.length === 0 ||
+        item.appears.some((a) => !hidden.has(a.status)),
+    )
     .sort((a, b) => a.styleName.localeCompare(b.styleName))
 
   return {

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -5,7 +5,7 @@
 // so screen and PDF can't drift. Image fields are *candidates* (a Storage path
 // or URL) resolved to data URLs once via reportImages — the model stays pure.
 
-import type { GenderKey } from "./reportTypes"
+import type { GenderKey, ReportShotStatus } from "./reportTypes"
 
 /** How families are grouped on the report. */
 export type ProductInfoGroupBy = "gender" | "product-type" | "none"
@@ -23,6 +23,8 @@ export interface ProductInfoConfig {
   readonly imageSize: ProductInfoImageSize
   /** Families excluded by the user — struck on screen, omitted from the PDF. */
   readonly excludedFamilyIds: readonly string[]
+  /** Shot statuses to HIDE (R3): a family is dropped only when ALL its appearances are hidden-status. Defaults to []. */
+  readonly hiddenStatuses?: readonly ReportShotStatus[]
 }
 
 export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
@@ -30,6 +32,7 @@ export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
   productScope: "in-use",
   imageSize: "m",
   excludedFamilyIds: [],
+  hiddenStatuses: [],
 }
 
 /** One shot a family is styled into: its number, the look labels it appears in there, and that shot's status. */

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -205,10 +205,12 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
   const talentById = new Map(data.talent.map((t) => [t.id, t]))
   const excluded = new Set(config.excludedShotIds)
+  // R3: statuses to hide entirely (undefined on pre-R3 blobs -> empty set -> no-op).
+  const hidden = new Set(config.hiddenStatuses ?? [])
   const primaryOnly = config.looksMode === "primary-only"
 
   const shots: ReportShot[] = data.shots
-    .filter((s) => !s.deleted)
+    .filter((s) => !s.deleted && !hidden.has(s.status))
     .map((shot): ReportShot => {
       const looks = resolveLooks(shot, familyById)
       // Gender resolves from ALL looks so grouping stays stable across looksMode.

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -32,6 +32,22 @@ export const REPORT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ReportLayout
     label: REPORT_LAYOUT_LABEL[value],
   }))
 
+// Status-filter (R3) display labels — the single source for the "Hide statuses"
+// multi-select shared by all three report views. An exhaustive typed literal (TS
+// flags a missing variant); the option list derives from it so the strings aren't
+// duplicated. ReportShotStatus is declared below (type aliases hoist within a module).
+export const REPORT_STATUS_LABEL: Record<ReportShotStatus, string> = {
+  complete: "Complete",
+  in_progress: "In progress",
+  on_hold: "On hold",
+  todo: "To do",
+}
+export const REPORT_STATUS_OPTIONS: ReadonlyArray<{ readonly value: ReportShotStatus; readonly label: string }> =
+  (Object.keys(REPORT_STATUS_LABEL) as ReportShotStatus[]).map((value) => ({
+    value,
+    label: REPORT_STATUS_LABEL[value],
+  }))
+
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
@@ -41,6 +57,8 @@ export interface ReportConfig {
   readonly looksMode?: ReportLooksMode
   /** Layout recipe. Defaults to "image-led" so pre-R3 blobs render unchanged. */
   readonly layout?: ReportLayout
+  /** Shot statuses to HIDE entirely (screen + PDF). Defaults to [] (nothing hidden); an absent field default-merges to []. */
+  readonly hiddenStatuses?: readonly ReportShotStatus[]
 }
 
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
@@ -48,6 +66,7 @@ export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   excludedShotIds: [],
   looksMode: "all",
   layout: "image-led",
+  hiddenStatuses: [],
 }
 
 /** Normalized gender bucket. "?" = unresolved (never silently dropped). */

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -167,6 +167,8 @@ function agencyBucketSort(a: string, b: string): number {
 /** Derive the resolved talent model from live export data + config. */
 export function deriveTalentModel(data: ExportData, config: TalentConfig): TalentModel {
   const excluded = new Set(config.excludedTalentIds)
+  // R3: statuses to hide (undefined on pre-R3 blobs -> empty set -> no-op).
+  const hidden = new Set(config.hiddenStatuses ?? [])
   const records =
     config.talentScope === "project-attached"
       ? projectAttachedTalent(data)
@@ -174,6 +176,14 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
 
   const items = records
     .map((t) => toEntry(t, data.shots, excluded))
+    // R3: drop a talent only when EVERY appearance is a hidden status. A project-attached
+    // talent with no appearances (appears.length === 0) is kept — status can't hide what has no shots.
+    .filter(
+      (item) =>
+        hidden.size === 0 ||
+        item.appears.length === 0 ||
+        item.appears.some((a) => !hidden.has(a.status)),
+    )
     .sort((a, b) => a.name.localeCompare(b.name))
 
   return {

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -20,12 +20,15 @@ export interface TalentConfig {
   readonly talentScope: TalentScope
   /** Talent excluded by the user — struck on screen, omitted from the PDF. */
   readonly excludedTalentIds: readonly string[]
+  /** Shot statuses to HIDE (R3): a talent is dropped only when ALL their appearances are hidden-status. Defaults to []. */
+  readonly hiddenStatuses?: readonly ReportShotStatus[]
 }
 
 export const DEFAULT_TALENT_CONFIG: TalentConfig = {
   groupBy: "none",
   talentScope: "in-shots",
   excludedTalentIds: [],
+  hiddenStatuses: [],
 }
 
 /** One shot a talent appears in: its number/title, the look labels there, and that shot's status. */

--- a/src-vnext/shared/lib/flags.ts
+++ b/src-vnext/shared/lib/flags.ts
@@ -147,6 +147,18 @@ export interface FeatureFlags {
    * URL/localStorage layer.
    */
   readonly featureTalentReport: boolean
+  /**
+   * Report configuration Phase A — the report-builder config controls that layer
+   * onto the existing report types: rename-after-create (all 3 report list pages)
+   * + the "Hide statuses" include/exclude-by-shot-status filter (all 3 report
+   * views). Gates ONLY the controls; the underlying model filter is inert while
+   * `config.hiddenStatuses` is empty (its only writer is the gated control), so
+   * flag-off is byte-identical. Default OFF; enabled via `VITE_REPORT_CONFIG=1`
+   * (or `true`) at build/dev time (featureTalentReport env-parse precedent). No
+   * URL/localStorage layer. Distinct from the per-type report flags — this rides
+   * on top of whichever report surfaces are already live/dark.
+   */
+  readonly featureReportConfig: boolean
 }
 
 const DEFAULT_FLAGS: FeatureFlags = {
@@ -164,6 +176,7 @@ const DEFAULT_FLAGS: FeatureFlags = {
   featureShotReportRecipes: false,
   featureProductInfoReport: false,
   featureTalentReport: false,
+  featureReportConfig: false,
 }
 
 /** '1' / 'true' (case-insensitive) parse, matching LoginPage.tsx:18-19. */
@@ -222,6 +235,9 @@ export function getFeatureFlags(): FeatureFlags {
     featureTalentReport:
       DEFAULT_FLAGS.featureTalentReport ||
       parseEnvFlag(import.meta.env.VITE_TALENT_REPORT),
+    featureReportConfig:
+      DEFAULT_FLAGS.featureReportConfig ||
+      parseEnvFlag(import.meta.env.VITE_REPORT_CONFIG),
   }
 }
 


### PR DESCRIPTION
## What
Phase A of the report-configuration initiative surfaced by the S3 batch eyeball (2026-08-04). Spec + phasing: `Projects/Shot Builder/outputs/2026-08-04-report-config/report-config-spec.md`.

Two features, across **all three report types** (shot / product-info / talent), behind a **new default-off flag** `featureReportConfig` (`VITE_REPORT_CONFIG`):

- **R1 — rename after create.** `renameReport(id, name)` = a name-only top-level merge that preserves `config`/`pages`/`createdBy` (mirrors `saveReportConfig`; the `createdBy` invariant holds → **no rules change**). Pencil affordance + rename dialog on all 3 report list pages.
- **R3 — include/exclude by shot status.** Optional `hiddenStatuses` on each config (DEFAULT-merged; **byte-identical when empty**). Shot report filters shots directly; product-info/talent drop an item **only when *every* appearance is a hidden status** (never-shot library / project-attached items are kept). Shared "Hide statuses" control in all 3 report views.

## Safety
- **Additive only** — no `firestore.rules` change, no migration (`exportReports` has no field-level validation; missing config fields DEFAULT-merge at read).
- **Flag-off byte-identical** — the controls are gated behind `featureReportConfig` (default OFF); the model filter is inert while `hiddenStatuses` is empty (its only writer is the gated control). So merge changes nothing in prod until the flag is flipped.
- **Deliberate go-live** — to enable, set `VITE_REPORT_CONFIG=1` in `deploy-live.yml` (both build blocks). The controls then appear on whichever report surfaces are already live (shot report today) + on product-info/talent when their flags flip.

## Gates (independently re-run)
- `typecheck:baseline` — ✅ 160/160, no new errors
- vitest — ✅ 79 model tests pass; R3 filter mutation-verified (revert → specific test goes red)
- `eslint --max-warnings=0` — ✅ clean
- `npm run build` — ✅ green

Built via a scout → TDD → adversarial-verify dynamic workflow; the status-filter semantics + rename no-clobber were verified with constructed counter-cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)