### PR TITLE
ci(deploy): flip VITE_REPORT_CONFIG on in prod

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -49,6 +49,7 @@ jobs:
           VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
           VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
+          VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -91,6 +92,7 @@ jobs:
           VITE_TALENT_AGENCY_COMBOBOX:       1   # Talent redesign: agency combobox (data already normalized)
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
           VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
+          VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
## What
Flips `VITE_REPORT_CONFIG=1` in **both** `deploy-live.yml` build blocks (kept byte-identical), turning on `featureReportConfig` — the report-config Phase A controls (#500):
- **rename-after-create** on all 3 report list pages
- **"Hide statuses"** include/exclude-by-shot-status filter in all 3 report views

## Effect on merge
- The two controls become **visible on the LIVE shot report** (`featureShotReport` is on in prod).
- Product Info + Talent reports stay **dark** behind their own flags — their controls come on when those flags flip.
- The client-facing PDF is unchanged until a producer actually uses a filter (`hiddenStatuses` defaults to empty).

## Before merging
⚠️ **Do a `:5174` mini-eyeball first** — confirm the rename dialog + "Hide statuses" control look right on the shot report. If you want them for the **Aug 10/11 shoot**, merge before the **Aug 8 freeze**; otherwise hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)