### PR TITLE
feat(export): report-config Phase B — shared group×order config layer (flagged)

### DIFF
--- a/src-vnext/features/export/components/report/GroupSortControls.tsx
+++ b/src-vnext/features/export/components/report/GroupSortControls.tsx
@@ -1,0 +1,82 @@
+// Shared order-by / direction control (R2/R5) for all three report ControlBars.
+// Renders the "Order by" + "Direction" segmented controls only — the group-by
+// control stays in each view (per-view legacy option set + the shot report's
+// flag-on "Status" addition). The three views own distinct CSS namespaces
+// (sb-*, sb-pir-*, sb-tr-*), so the class names are passed in; the markup +
+// a11y (role="group" + useId'd label, aria-pressed) matches the existing segs.
+// Gated: each view renders this ONLY when featureReportConfig is on, so flag-off
+// is byte-identical (the controls never appear).
+
+import { useId } from "react"
+import type { JSX } from "react"
+import { SORT_DIR_OPTIONS, type SortDir } from "../../lib/report/reportSort"
+
+/** Per-view segmented-control class names (that view's CSS namespace). */
+export interface SortControlClasses {
+  readonly group: string
+  readonly label: string
+  readonly seg: string
+  readonly segBtn: string
+}
+
+export interface GroupSortControlsProps<S extends string> {
+  readonly classes: SortControlClasses
+  readonly sortOptions: ReadonlyArray<{ readonly value: S; readonly label: string }>
+  readonly sortBy: S
+  readonly onSortBy: (value: S) => void
+  readonly sortDir: SortDir
+  readonly onSortDir: (value: SortDir) => void
+}
+
+export function GroupSortControls<S extends string>({
+  classes,
+  sortOptions,
+  sortBy,
+  onSortBy,
+  sortDir,
+  onSortDir,
+}: GroupSortControlsProps<S>): JSX.Element {
+  const orderLabelId = useId()
+  const dirLabelId = useId()
+  return (
+    <>
+      <div className={classes.group} role="group" aria-labelledby={orderLabelId}>
+        <span id={orderLabelId} className={classes.label}>
+          Order by
+        </span>
+        <div className={classes.seg}>
+          {sortOptions.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={classes.segBtn}
+              aria-pressed={sortBy === opt.value}
+              onClick={() => onSortBy(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className={classes.group} role="group" aria-labelledby={dirLabelId}>
+        <span id={dirLabelId} className={classes.label}>
+          Direction
+        </span>
+        <div className={classes.seg}>
+          {SORT_DIR_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className={classes.segBtn}
+              aria-pressed={sortDir === opt.value}
+              onClick={() => onSortDir(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportPage.tsx
@@ -12,6 +12,7 @@ import {
 import { resolveReportImages } from "../../lib/report/reportImages"
 import {
   DEFAULT_PRODUCT_INFO_CONFIG,
+  neutralizeProductInfoConfigForFlag,
   type ProductInfoConfig,
 } from "../../lib/report/productInfoTypes"
 import { ProductInfoReportView } from "./ProductInfoReportView"
@@ -108,14 +109,14 @@ export default function ProductInfoReportPage() {
     }
   }, [])
 
-  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
-  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
-  // byte-identical. Build-time flag → not a memo dep.
+  // Flag-off rollback-safety: strip the gated-off Phase-A/B config fields so the
+  // derive runs its verbatim legacy path (byte-identical). Shared pure neutralizer
+  // so the flag-off test holds the real code. Build-time flag → not a memo dep.
   const model = useMemo(
     () =>
       deriveProductInfoModel(
         data,
-        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+        neutralizeProductInfoConfigForFlag(config, isFeatureEnabled("featureReportConfig")),
       ),
     [data, config],
   )

--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -18,9 +18,16 @@ import type {
   ProductInfoImageSize,
   ProductInfoModel,
   ProductInfoScope,
+  ProductInfoSortField,
+} from "../../lib/report/productInfoTypes"
+import {
+  DEFAULT_PRODUCT_INFO_CONFIG,
+  PRODUCT_INFO_SORT_FIELD_OPTIONS,
 } from "../../lib/report/productInfoTypes"
 import type { ReportShotStatus } from "../../lib/report/reportTypes"
 import { REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
+import type { SortDir } from "../../lib/report/reportSort"
+import { GroupSortControls } from "./GroupSortControls"
 
 export interface ProductInfoReportViewProps {
   readonly model: ProductInfoModel
@@ -309,6 +316,11 @@ function ControlBar({
   printMode,
   onSetPrintMode,
   showStatusFilter,
+  showSort,
+  sortBy,
+  onSetSortBy,
+  sortDir,
+  onSetSortDir,
   hiddenStatuses,
   onToggleStatus,
   onExportPdf,
@@ -325,6 +337,11 @@ function ControlBar({
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
   readonly showStatusFilter: boolean
+  readonly showSort: boolean
+  readonly sortBy: ProductInfoSortField
+  readonly onSetSortBy: (v: ProductInfoSortField) => void
+  readonly sortDir: SortDir
+  readonly onSetSortDir: (v: SortDir) => void
   readonly hiddenStatuses: readonly ReportShotStatus[]
   readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
@@ -392,6 +409,17 @@ function ControlBar({
           ))}
         </div>
       </div>
+
+      {showSort && (
+        <GroupSortControls
+          classes={{ group: "sb-pir-control-group", label: "sb-pir-control-label", seg: "sb-pir-seg", segBtn: "sb-pir-seg-btn" }}
+          sortOptions={PRODUCT_INFO_SORT_FIELD_OPTIONS}
+          sortBy={sortBy}
+          onSortBy={onSetSortBy}
+          sortDir={sortDir}
+          onSortDir={onSetSortDir}
+        />
+      )}
 
       <div className="sb-pir-control-group" role="group" aria-labelledby={sizeLabelId}>
         <span id={sizeLabelId} className="sb-pir-control-label">
@@ -519,6 +547,18 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
     onConfigChange({ ...config, hiddenStatuses: [...set] })
   }
 
+  // R5 order-by — absent fields default-merge to the shipped legacy order.
+  const sortBy: ProductInfoSortField = config.sortBy ?? DEFAULT_PRODUCT_INFO_CONFIG.sortBy ?? "style"
+  const sortDir: SortDir = config.sortDir ?? "asc"
+  const setSortBy = (next: ProductInfoSortField): void => {
+    if (next === sortBy) return
+    onConfigChange({ ...config, sortBy: next })
+  }
+  const setSortDir = (next: SortDir): void => {
+    if (next === sortDir) return
+    onConfigChange({ ...config, sortDir: next })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.familyCount === 0
 
   return (
@@ -535,6 +575,11 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
         printMode={printMode}
         onSetPrintMode={setPrintMode}
         showStatusFilter={reportConfigEnabled}
+        showSort={reportConfigEnabled}
+        sortBy={sortBy}
+        onSetSortBy={setSortBy}
+        sortDir={sortDir}
+        onSetSortDir={setSortDir}
         hiddenStatuses={hiddenStatuses}
         onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -20,13 +20,21 @@ import type {
   ReportProduct,
   ReportShot,
   ReportShotStatus,
+  ReportSortField,
   ReportTalent,
 } from "../../lib/report/reportTypes"
-import { REPORT_LAYOUT_OPTIONS, REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
+import {
+  DEFAULT_REPORT_CONFIG,
+  REPORT_LAYOUT_OPTIONS,
+  REPORT_SORT_FIELD_OPTIONS,
+  REPORT_STATUS_OPTIONS,
+} from "../../lib/report/reportTypes"
+import type { SortDir } from "../../lib/report/reportSort"
 import { hasAnyIncludedShot, sizeLabel } from "../../lib/report/reportModel"
 import { packShotSheets } from "../../lib/report/reportPdfHeights"
 import { REPORT_STYLES } from "./reportStyles"
 import { resolveSrc, statusMetaLegacy } from "./reportShared"
+import { GroupSortControls } from "./GroupSortControls"
 import { ProductionSheetReport } from "./ProductionSheetReport"
 import { BalancedRowsReport } from "./BalancedRowsReport"
 
@@ -434,6 +442,11 @@ function ControlBar({
   onSetLayout,
   showLayout,
   showStatusFilter,
+  showSort,
+  sortBy,
+  onSetSortBy,
+  sortDir,
+  onSetSortDir,
   hiddenStatuses,
   onToggleStatus,
   onExportPdf,
@@ -451,6 +464,13 @@ function ControlBar({
   readonly onSetLayout: (v: ReportLayout) => void
   readonly showLayout: boolean
   readonly showStatusFilter: boolean
+  // showSort gates BOTH the flag-on "Status" group-by option and the order-by/
+  // direction controls (== featureReportConfig). Flag-off → neither appears.
+  readonly showSort: boolean
+  readonly sortBy: ReportSortField
+  readonly onSetSortBy: (v: ReportSortField) => void
+  readonly sortDir: SortDir
+  readonly onSetSortDir: (v: SortDir) => void
   readonly hiddenStatuses: readonly ReportShotStatus[]
   readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
@@ -531,8 +551,29 @@ function ControlBar({
           >
             None
           </button>
+          {showSort && (
+            <button
+              type="button"
+              className="sb-seg-btn"
+              aria-pressed={groupBy === "status"}
+              onClick={() => onSetGroupBy("status")}
+            >
+              Status
+            </button>
+          )}
         </div>
       </div>
+
+      {showSort && (
+        <GroupSortControls
+          classes={{ group: "sb-control-group", label: "sb-control-label", seg: "sb-seg", segBtn: "sb-seg-btn" }}
+          sortOptions={REPORT_SORT_FIELD_OPTIONS}
+          sortBy={sortBy}
+          onSortBy={onSetSortBy}
+          sortDir={sortDir}
+          onSortDir={onSetSortDir}
+        />
+      )}
 
       <div className="sb-control-group" role="group" aria-labelledby={looksLabelId}>
         <span id={looksLabelId} className="sb-control-label">
@@ -649,6 +690,18 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, hiddenStatuses: [...set] })
   }
 
+  // R2 order-by — absent fields default-merge to the shipped legacy order.
+  const sortBy: ReportSortField = config.sortBy ?? DEFAULT_REPORT_CONFIG.sortBy ?? "shot-number"
+  const sortDir: SortDir = config.sortDir ?? "asc"
+  const setSortBy = (next: ReportSortField): void => {
+    if (next === sortBy) return
+    onConfigChange({ ...config, sortBy: next })
+  }
+  const setSortDir = (next: SortDir): void => {
+    if (next === sortDir) return
+    onConfigChange({ ...config, sortDir: next })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
   // Export is blocked when every shot is excluded — a PDF with zero pages is corrupt.
   const canExport = hasAnyIncludedShot(model)
@@ -675,6 +728,11 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         onSetLayout={setLayout}
         showLayout={recipesEnabled}
         showStatusFilter={reportConfigEnabled}
+        showSort={reportConfigEnabled}
+        sortBy={sortBy}
+        onSetSortBy={setSortBy}
+        sortDir={sortDir}
+        onSetSortDir={setSortDir}
         hiddenStatuses={hiddenStatuses}
         onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -10,7 +10,7 @@ import {
   collectReportImageCandidates,
   resolveReportImages,
 } from "../../lib/report/reportImages"
-import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../../lib/report/reportTypes"
+import { DEFAULT_REPORT_CONFIG, neutralizeReportConfigForFlag, type ReportConfig } from "../../lib/report/reportTypes"
 import { ReportView } from "./ReportView"
 
 // Integration layer: live export data -> resolved model -> image sidecar ->
@@ -88,14 +88,15 @@ export default function ShotReportPage() {
     [],
   )
 
-  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
-  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
-  // byte-identical. Build-time flag → not a memo dep.
+  // Flag-off rollback-safety: strip the gated-off Phase-A/B config fields so the
+  // derive runs its verbatim legacy path (byte-identical). The neutralizer is a
+  // shared pure fn so the flag-off byte-identity test holds the real code, not a
+  // copy. Build-time flag → not a memo dep.
   const model = useMemo(
     () =>
       deriveShotReportModel(
         data,
-        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+        neutralizeReportConfigForFlag(config, isFeatureEnabled("featureReportConfig")),
       ),
     [data, config],
   )

--- a/src-vnext/features/export/components/report/TalentReportPage.tsx
+++ b/src-vnext/features/export/components/report/TalentReportPage.tsx
@@ -12,6 +12,7 @@ import {
 import { resolveReportImages } from "../../lib/report/reportImages"
 import {
   DEFAULT_TALENT_CONFIG,
+  neutralizeTalentConfigForFlag,
   type TalentConfig,
 } from "../../lib/report/talentTypes"
 import { TalentReportView } from "./TalentReportView"
@@ -107,14 +108,14 @@ export default function TalentReportPage() {
     }
   }, [])
 
-  // R3 rollback-safety: when featureReportConfig is off, ignore any persisted
-  // hiddenStatuses (the control that clears it is gated off) so flag-off stays
-  // byte-identical. Build-time flag → not a memo dep.
+  // Flag-off rollback-safety: strip the gated-off Phase-A/B config fields so the
+  // derive runs its verbatim legacy path (byte-identical). Shared pure neutralizer
+  // so the flag-off test holds the real code. Build-time flag → not a memo dep.
   const model = useMemo(
     () =>
       deriveTalentModel(
         data,
-        isFeatureEnabled("featureReportConfig") ? config : { ...config, hiddenStatuses: [] },
+        neutralizeTalentConfigForFlag(config, isFeatureEnabled("featureReportConfig")),
       ),
     [data, config],
   )

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -18,9 +18,16 @@ import type {
   TalentGroupBy,
   TalentModel,
   TalentScope,
+  TalentSortField,
+} from "../../lib/report/talentTypes"
+import {
+  DEFAULT_TALENT_CONFIG,
+  TALENT_SORT_FIELD_OPTIONS,
 } from "../../lib/report/talentTypes"
 import type { ReportShotStatus } from "../../lib/report/reportTypes"
 import { REPORT_STATUS_OPTIONS } from "../../lib/report/reportTypes"
+import type { SortDir } from "../../lib/report/reportSort"
+import { GroupSortControls } from "./GroupSortControls"
 
 export interface TalentReportViewProps {
   readonly model: TalentModel
@@ -312,6 +319,11 @@ function ControlBar({
   printMode,
   onSetPrintMode,
   showStatusFilter,
+  showSort,
+  sortBy,
+  onSetSortBy,
+  sortDir,
+  onSetSortDir,
   hiddenStatuses,
   onToggleStatus,
   onExportPdf,
@@ -326,6 +338,11 @@ function ControlBar({
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
   readonly showStatusFilter: boolean
+  readonly showSort: boolean
+  readonly sortBy: TalentSortField
+  readonly onSetSortBy: (v: TalentSortField) => void
+  readonly sortDir: SortDir
+  readonly onSetSortDir: (v: SortDir) => void
   readonly hiddenStatuses: readonly ReportShotStatus[]
   readonly onToggleStatus: (v: ReportShotStatus) => void
   readonly onExportPdf: () => void
@@ -387,6 +404,17 @@ function ControlBar({
           ))}
         </div>
       </div>
+
+      {showSort && (
+        <GroupSortControls
+          classes={{ group: "sb-tr-control-group", label: "sb-tr-control-label", seg: "sb-tr-seg", segBtn: "sb-tr-seg-btn" }}
+          sortOptions={TALENT_SORT_FIELD_OPTIONS}
+          sortBy={sortBy}
+          onSortBy={onSetSortBy}
+          sortDir={sortDir}
+          onSortDir={onSetSortDir}
+        />
+      )}
 
       <div className="sb-tr-control-group" role="group" aria-labelledby={viewLabelId}>
         <span id={viewLabelId} className="sb-tr-control-label">
@@ -487,6 +515,18 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
     onConfigChange({ ...config, hiddenStatuses: [...set] })
   }
 
+  // R5 order-by — absent fields default-merge to the shipped legacy order.
+  const sortBy: TalentSortField = config.sortBy ?? DEFAULT_TALENT_CONFIG.sortBy ?? "name"
+  const sortDir: SortDir = config.sortDir ?? "asc"
+  const setSortBy = (next: TalentSortField): void => {
+    if (next === sortBy) return
+    onConfigChange({ ...config, sortBy: next })
+  }
+  const setSortDir = (next: SortDir): void => {
+    if (next === sortDir) return
+    onConfigChange({ ...config, sortDir: next })
+  }
+
   const isEmpty = model.groups.length === 0 || model.project.talentCount === 0
   // No non-excluded talent => the PDF would have zero pages (@react-pdf throws); gate Export.
   const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
@@ -503,6 +543,11 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
         printMode={printMode}
         onSetPrintMode={setPrintMode}
         showStatusFilter={reportConfigEnabled}
+        showSort={reportConfigEnabled}
+        sortBy={sortBy}
+        onSetSortBy={setSortBy}
+        sortDir={sortDir}
+        onSetSortDir={setSortDir}
         hiddenStatuses={hiddenStatuses}
         onToggleStatus={toggleStatus}
         onExportPdf={onExportPdf}

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -306,6 +306,39 @@ describe("deriveProductInfoModel — grouping", () => {
   })
 })
 
+describe("deriveProductInfoModel — R5 order-by (Phase B)", () => {
+  const styled = () =>
+    data({
+      productFamilies: [
+        fam({ id: "P1", styleName: "Zeta", gender: "men" }),
+        fam({ id: "P2", styleName: "Alpha", gender: "women" }),
+        fam({ id: "P3", styleName: "Beta", gender: "men" }),
+      ],
+      shots: [
+        shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [
+          { familyId: "P1" }, { familyId: "P2" }, { familyId: "P3" },
+        ] }] }),
+      ],
+    })
+
+  it("sortBy 'gender' asc: gender by GROUP_ORDER (W<M), styleName tie-break within a gender", () => {
+    const model = deriveProductInfoModel(styled(), cfg({ groupBy: "none", sortBy: "gender", sortDir: "asc" }))
+    // P2 (W) first; then M group tie-broken by styleName Beta(P3) < Zeta(P1)
+    expect(flat(model).map((i) => i.id)).toEqual(["P2", "P3", "P1"])
+  })
+
+  it("default sortBy 'style' reproduces alpha-by-styleName order (Alpha, Beta, Zeta)", () => {
+    const model = deriveProductInfoModel(styled(), cfg({ groupBy: "none", sortBy: "style", sortDir: "asc" }))
+    expect(flat(model).map((i) => i.styleName)).toEqual(["Alpha", "Beta", "Zeta"])
+    expect(flat(model).map((i) => i.id)).toEqual(["P2", "P3", "P1"])
+  })
+
+  it("an absent sortBy is byte-identical to the legacy styleName order", () => {
+    const legacy = deriveProductInfoModel(styled(), { groupBy: "none", productScope: "in-use", imageSize: "m", excludedFamilyIds: [] })
+    expect(flat(legacy).map((i) => i.styleName)).toEqual(["Alpha", "Beta", "Zeta"])
+  })
+})
+
 describe("deriveProductInfoModel — entry fields & images", () => {
   it("resolves styleNumber from styleNumbers[0] then styleNumber, gender label, and excluded flag", () => {
     const model = deriveProductInfoModel(

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { deriveShotReportModel, formatDateWindow, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
-import { DEFAULT_REPORT_CONFIG } from "../reportTypes"
+import { DEFAULT_REPORT_CONFIG, neutralizeReportConfigForFlag, type ReportConfig } from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
 
@@ -389,6 +389,114 @@ describe("deriveShotReportModel", () => {
     const primary = deriveShotReportModel(d, { groupBy: "gender", excludedShotIds: [], looksMode: "primary-only" })
     expect(all.groups.find((g) => g.shots.some((s) => s.id === "s1"))?.key).toBe("M")
     expect(primary.groups.find((g) => g.shots.some((s) => s.id === "s1"))?.key).toBe("M")
+  })
+})
+
+describe("deriveShotReportModel — R2 order-by (Phase B)", () => {
+  // Worked example: groupBy 'status', sortBy 'talent', sortDir 'asc'. Ties fall to
+  // the shot-number tie-break. Four shots, two talent names shared across statuses.
+  const worked = () =>
+    data({
+      talent: [talent("tZoe", "Zoe"), talent("tAlice", "Alice"), talent("tBob", "Bob")],
+      shots: [
+        shot({ id: "S1", shotNumber: "01", status: "complete", talentIds: ["tZoe"] }),
+        shot({ id: "S2", shotNumber: "02", status: "todo", talentIds: ["tAlice"] }),
+        shot({ id: "S3", shotNumber: "03", status: "complete", talentIds: ["tBob"] }),
+        shot({ id: "S4", shotNumber: "04", status: "todo", talentIds: ["tAlice"] }),
+      ],
+    })
+
+  it("groups by status (workflow order, empties dropped) and sorts by talent within each group", () => {
+    const model = deriveShotReportModel(worked(), {
+      groupBy: "status",
+      excludedShotIds: [],
+      sortBy: "talent",
+      sortDir: "asc",
+    })
+    expect(model.groups.map((g) => g.key)).toEqual(["todo", "complete"]) // in_progress/on_hold dropped
+    expect(model.groups.map((g) => g.label)).toEqual(["To do", "Complete"])
+    // todo: both "Alice" -> tie-break shot-number 02<04
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["S2", "S4"])
+    // complete: "Bob" < "Zoe"
+    expect(model.groups[1]?.shots.map((s) => s.id)).toEqual(["S3", "S1"])
+  })
+
+  it("flag-off byte-identical: a flag-ON config, run through the ShotReportPage neutralizer, deep-equals the default", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({ id: "S1", shotNumber: "01", status: "complete", tags: [{ id: "g", label: "Women", color: "b", category: "gender" }], looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        shot({ id: "S2", shotNumber: "02", status: "todo", tags: [{ id: "g", label: "Men", color: "b", category: "gender" }], looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+        shot({ id: "S3", shotNumber: "03", status: "complete", tags: [{ id: "g", label: "Women", color: "b", category: "gender" }], looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        shot({ id: "S4", shotNumber: "04", status: "todo", tags: [{ id: "g", label: "Men", color: "b", category: "gender" }], looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+      ],
+    })
+    const persisted: ReportConfig = {
+      groupBy: "status",
+      excludedShotIds: [],
+      sortBy: "talent",
+      sortDir: "desc",
+      hiddenStatuses: ["todo"],
+    }
+    // The REAL neutralizer the ShotReportPage runs flag-off (shared pure fn), so
+    // this test breaks if that code path ever diverges — not an inline copy of it.
+    const neutralized = neutralizeReportConfigForFlag(persisted, false)
+    expect(deriveShotReportModel(d, neutralized)).toEqual(deriveShotReportModel(d, DEFAULT_REPORT_CONFIG))
+  })
+
+  it("crash-safe: an out-of-union persisted sortBy falls back to shot-number order, never throws", () => {
+    // exportReports writes schemaless (no rules validation), so a hand-edited/corrupt
+    // sortBy can reach the derive. It must degrade, not kill the whole report render.
+    const d = data({
+      shots: [
+        shot({ id: "S_a", shotNumber: "10", status: "todo" }),
+        shot({ id: "S_b", shotNumber: "02", status: "todo" }),
+      ],
+    })
+    const corrupt = { groupBy: "none", excludedShotIds: [], sortBy: "not-a-field", sortDir: "asc" } as unknown as ReportConfig
+    const model = deriveShotReportModel(d, corrupt)
+    // Falls back to the shot-number comparator: "02" before "10".
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["S_b", "S_a"])
+  })
+
+  it("stable + deterministic: equal-status shots break the tie NUMERICALLY (2 before 10), not lexicographically", () => {
+    const model = deriveShotReportModel(
+      data({
+        shots: [
+          shot({ id: "S_a", shotNumber: "10", status: "todo" }),
+          shot({ id: "S_b", shotNumber: "02", status: "todo" }),
+        ],
+      }),
+      { groupBy: "none", excludedShotIds: [], sortBy: "status", sortDir: "asc" },
+    )
+    expect(model.groups[0]?.key).toBe("all")
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["S_b", "S_a"])
+  })
+
+  it("desc flips the primary key only — the shot-number tie-break stays ascending", () => {
+    const a = deriveShotReportModel(
+      data({
+        shots: [
+          shot({ id: "S1", shotNumber: "01", status: "todo" }),
+          shot({ id: "S2", shotNumber: "02", status: "todo" }),
+          shot({ id: "S3", shotNumber: "03", status: "todo" }),
+        ],
+      }),
+      { groupBy: "none", excludedShotIds: [], sortBy: "shot-number", sortDir: "desc" },
+    )
+    expect(a.groups[0]?.shots.map((s) => s.id)).toEqual(["S3", "S2", "S1"])
+
+    const b = deriveShotReportModel(
+      data({
+        shots: [
+          shot({ id: "S_x", shotNumber: "10", status: "todo" }),
+          shot({ id: "S_y", shotNumber: "02", status: "todo" }),
+        ],
+      }),
+      { groupBy: "none", excludedShotIds: [], sortBy: "status", sortDir: "desc" },
+    )
+    // status desc reorders buckets, but the two equal-status shots keep ASC shot-number tie-break
+    expect(b.groups[0]?.shots.map((s) => s.id)).toEqual(["S_y", "S_x"])
   })
 })
 

--- a/src-vnext/features/export/lib/report/__tests__/reportSort.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportSort.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest"
+import {
+  SORT_DIR_OPTIONS,
+  compareByOrder,
+  compareShotNumber,
+  compareText,
+  orderedBuckets,
+  shotNumberSortKey,
+  sortItemsStable,
+} from "../reportSort"
+
+describe("comparator primitives", () => {
+  it("compareShotNumber is numeric-aware (2 before 10, not lexicographic)", () => {
+    expect(compareShotNumber("2", "10")).toBeLessThan(0)
+    expect(compareShotNumber("10", "2")).toBeGreaterThan(0)
+    // non-numerics sort alpha AFTER numerics
+    expect(compareShotNumber("A", "10")).toBeGreaterThan(0)
+    expect(compareShotNumber("A", "B")).toBeLessThan(0)
+  })
+
+  it("shotNumberSortKey tags numerics [0,n,raw] and non-numerics [1,0,raw]", () => {
+    expect(shotNumberSortKey("07")).toEqual([0, 7, "07"])
+    expect(shotNumberSortKey("A1")).toEqual([1, 0, "A1"])
+  })
+
+  it("compareText is null-safe (nullish sorts as empty string)", () => {
+    expect(compareText(null, "a")).toBeLessThan(0)
+    expect(compareText("a", undefined)).toBeGreaterThan(0)
+    expect(compareText(null, undefined)).toBe(0)
+  })
+
+  it("compareByOrder: knowns by index, unknowns after knowns, unknown ties alpha", () => {
+    const order = ["todo", "complete"]
+    expect(compareByOrder(order, "todo", "complete")).toBeLessThan(0)
+    expect(compareByOrder(order, "complete", "todo")).toBeGreaterThan(0)
+    expect(compareByOrder(order, "todo", "zzz-unknown")).toBeLessThan(0) // known before unknown
+    expect(compareByOrder(order, "zzz-unknown", "todo")).toBeGreaterThan(0)
+    expect(compareByOrder(order, "alpha", "beta")).toBeLessThan(0) // both unknown -> alpha
+  })
+})
+
+describe("sortItemsStable", () => {
+  const items = [
+    { id: "a", k: 1, n: "10" },
+    { id: "b", k: 1, n: "02" },
+    { id: "c", k: 0, n: "03" },
+  ]
+  const primaryK = (x: { k: number }, y: { k: number }): number => x.k - y.k
+  const tieByN = (x: { n: string }, y: { n: string }): number => compareShotNumber(x.n, y.n)
+
+  it("orders by primary, breaking ties with the ALWAYS-ascending tie-break (numeric)", () => {
+    const out = sortItemsStable(items, primaryK, tieByN, "asc")
+    // k:0 first (c), then k:1 tie broken numeric 02(b) < 10(a)
+    expect(out.map((x) => x.id)).toEqual(["c", "b", "a"])
+  })
+
+  it("desc flips the PRIMARY only; the tie-break stays ascending", () => {
+    const out = sortItemsStable(items, primaryK, tieByN, "desc")
+    // primary reversed: k:1 group first, but WITHIN it tie-break is still asc (02 before 10)
+    expect(out.map((x) => x.id)).toEqual(["b", "a", "c"])
+  })
+
+  it("does not mutate the input array", () => {
+    const input = [...items]
+    sortItemsStable(input, primaryK, tieByN, "asc")
+    expect(input.map((x) => x.id)).toEqual(["a", "b", "c"])
+  })
+
+  it("SORT_DIR_OPTIONS exposes asc + desc with labels", () => {
+    expect(SORT_DIR_OPTIONS.map((o) => o.value)).toEqual(["asc", "desc"])
+  })
+})
+
+describe("orderedBuckets", () => {
+  const items = [
+    { id: "s1", g: "complete" },
+    { id: "s2", g: "todo" },
+    { id: "s3", g: "complete" },
+    { id: "s4", g: "todo" },
+  ]
+  const order = ["todo", "in_progress", "on_hold", "complete"]
+
+  it("partitions in input order, sorts bucket keys, and DROPS empty buckets", () => {
+    const buckets = orderedBuckets(
+      items,
+      (x) => x.g,
+      (a, b) => compareByOrder(order, a, b),
+      (k) => k.toUpperCase(),
+    )
+    // in_progress / on_hold never appear (empty); todo before complete
+    expect(buckets.map((b) => b.key)).toEqual(["todo", "complete"])
+    expect(buckets.map((b) => b.label)).toEqual(["TODO", "COMPLETE"])
+    expect(buckets[0]?.items.map((x) => x.id)).toEqual(["s2", "s4"]) // input order preserved
+    expect(buckets[1]?.count).toBe(2)
+  })
+})

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest"
 import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../reportTypes"
+import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
+import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
 
 describe("ReportConfig persistence round-trip", () => {
   it("survives JSON serialize/parse unchanged (Firestore-safe — no Set/Date)", () => {
@@ -29,5 +31,50 @@ describe("ReportConfig persistence round-trip", () => {
     const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led"}')
     const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
     expect(hydrated.hiddenStatuses).toEqual([])
+  })
+
+  it("default-merges a pre-Phase-B blob to sortBy 'shot-number' / sortDir 'asc' (R2 forward-compat)", () => {
+    // A blob written before order-by existed must hydrate to the shipped legacy order.
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led","hiddenStatuses":[]}')
+    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    expect(hydrated.sortBy).toBe("shot-number")
+    expect(hydrated.sortDir).toBe("asc")
+  })
+
+  it("round-trips sortBy/sortDir + the widened groupBy 'status' through JSON unchanged", () => {
+    const config: ReportConfig = { groupBy: "status", excludedShotIds: [], sortBy: "talent", sortDir: "desc" }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("ProductInfoConfig persistence round-trip (Phase B)", () => {
+  it("default-merges a pre-Phase-B blob to sortBy 'style' / sortDir 'asc'", () => {
+    const stored = JSON.parse('{"groupBy":"gender","productScope":"in-use","imageSize":"m","excludedFamilyIds":[]}')
+    const hydrated: ProductInfoConfig = { ...DEFAULT_PRODUCT_INFO_CONFIG, ...stored }
+    expect(hydrated.sortBy).toBe("style")
+    expect(hydrated.sortDir).toBe("asc")
+  })
+
+  it("round-trips sortBy/sortDir through JSON unchanged", () => {
+    const config: ProductInfoConfig = {
+      groupBy: "none", productScope: "in-use", imageSize: "m", excludedFamilyIds: [], sortBy: "gender", sortDir: "desc",
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("TalentConfig persistence round-trip (Phase B)", () => {
+  it("default-merges a pre-Phase-B blob to sortBy 'name' / sortDir 'asc'", () => {
+    const stored = JSON.parse('{"groupBy":"none","talentScope":"in-shots","excludedTalentIds":[]}')
+    const hydrated: TalentConfig = { ...DEFAULT_TALENT_CONFIG, ...stored }
+    expect(hydrated.sortBy).toBe("name")
+    expect(hydrated.sortDir).toBe("asc")
+  })
+
+  it("round-trips sortBy/sortDir through JSON unchanged", () => {
+    const config: TalentConfig = {
+      groupBy: "agency", talentScope: "in-shots", excludedTalentIds: [], sortBy: "agency", sortDir: "desc",
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -331,6 +331,35 @@ describe("deriveTalentModel — grouping", () => {
   })
 })
 
+describe("deriveTalentModel — R5 order-by (Phase B)", () => {
+  const styled = () =>
+    data({
+      talent: [
+        tal({ id: "T1", name: "Xander", agency: "Elite" }),
+        tal({ id: "T2", name: "Amy", agency: "Next" }),
+        tal({ id: "T3", name: "Bea", agency: "Elite" }),
+      ],
+      shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["T1", "T2", "T3"] })],
+    })
+
+  it("sortBy 'agency' asc: agencyBucketSort (Elite<Next), name tie-break within an agency", () => {
+    const model = deriveTalentModel(styled(), cfg({ groupBy: "none", sortBy: "agency", sortDir: "asc" }))
+    // Elite group tie-broken Bea(T3) < Xander(T1), then Next (T2)
+    expect(flat(model).map((i) => i.id)).toEqual(["T3", "T1", "T2"])
+  })
+
+  it("default sortBy 'name' reproduces the legacy alpha-by-name order (Amy, Bea, Xander)", () => {
+    const model = deriveTalentModel(styled(), cfg({ groupBy: "none", sortBy: "name", sortDir: "asc" }))
+    expect(flat(model).map((i) => i.name)).toEqual(["Amy", "Bea", "Xander"])
+    expect(flat(model).map((i) => i.id)).toEqual(["T2", "T3", "T1"])
+  })
+
+  it("an absent sortBy is byte-identical to the legacy name order", () => {
+    const legacy = deriveTalentModel(styled(), { groupBy: "none", talentScope: "in-shots", excludedTalentIds: [] })
+    expect(flat(legacy).map((i) => i.name)).toEqual(["Amy", "Bea", "Xander"])
+  })
+})
+
 describe("deriveTalentModel — project block & image candidates", () => {
   it("dateRange + talentCount surface on the project block", () => {
     const model = deriveTalentModel(

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -11,6 +11,7 @@ import {
   formatDateWindow,
   titleCaseSlug,
 } from "./reportModel"
+import { compareByOrder, compareText, sortItemsStable } from "./reportSort"
 import type { GenderKey, ReportShotStatus } from "./reportTypes"
 import type {
   ProductInfoAppearance,
@@ -18,6 +19,7 @@ import type {
   ProductInfoEntry,
   ProductInfoGroup,
   ProductInfoModel,
+  ProductInfoSortField,
 } from "./productInfoTypes"
 
 // Pure derivation: ExportData + ProductInfoConfig -> ProductInfoModel. No async,
@@ -179,6 +181,27 @@ function toEntry(
   }
 }
 
+// Secondary key for the product sort — ALWAYS ascending (deterministic tie-break).
+// Products have no shot number; the deterministic secondary is styleName then id.
+const PRODUCT_TIEBREAK = (a: ProductInfoEntry, b: ProductInfoEntry): number =>
+  compareText(a.styleName, b.styleName) || compareText(a.id, b.id)
+
+/** Primary comparator for a product-info sort field (R5). */
+function productPrimaryFor(
+  sortBy: ProductInfoSortField,
+): (a: ProductInfoEntry, b: ProductInfoEntry) => number {
+  switch (sortBy) {
+    case "style":
+      return (a, b) => compareText(a.styleName, b.styleName)
+    case "gender":
+      return (a, b) => compareByOrder(GROUP_ORDER, a.gender, b.gender)
+    default:
+      // Runtime safety (see reportModel.shotPrimaryFor): an out-of-union persisted
+      // sortBy falls back to the default field, never returns undefined.
+      return (a, b) => compareText(a.styleName, b.styleName)
+  }
+}
+
 function groupEntries(
   items: readonly ProductInfoEntry[],
   groupBy: ProductInfoConfig["groupBy"],
@@ -227,7 +250,7 @@ export function deriveProductInfoModel(
           .map((id) => familyById.get(id))
           .filter((f): f is ProductFamily => f != null && f.deleted !== true)
 
-  const items = families
+  const built = families
     .map((family) => toEntry(family, aggByFamily.get(family.id), excluded))
     // R3: drop a family only when EVERY appearance is a hidden status. A never-shot
     // library family (appears.length === 0) is kept — status can't hide what has no shots.
@@ -237,7 +260,13 @@ export function deriveProductInfoModel(
         item.appears.length === 0 ||
         item.appears.some((a) => !hidden.has(a.status)),
     )
-    .sort((a, b) => a.styleName.localeCompare(b.styleName))
+
+  // R5 order-by. Absent sortBy → verbatim legacy styleName order (flag-off
+  // byte-identical). Defined → the shared stable engine with the id tie-break.
+  const items =
+    config.sortBy === undefined
+      ? [...built].sort((a, b) => a.styleName.localeCompare(b.styleName))
+      : sortItemsStable(built, productPrimaryFor(config.sortBy), PRODUCT_TIEBREAK, config.sortDir ?? "asc")
 
   return {
     project: {

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -6,9 +6,25 @@
 // or URL) resolved to data URLs once via reportImages — the model stays pure.
 
 import type { GenderKey, ReportShotStatus } from "./reportTypes"
+import type { SortDir } from "./reportSort"
 
 /** How families are grouped on the report. */
 export type ProductInfoGroupBy = "gender" | "product-type" | "none"
+
+// Product-info order-by (R5) field vocabulary. Product families carry no
+// shot-number/status/talent at entry level (those live per-appearance in
+// appears[]), so only entry-level keys are offered this ship. Exhaustive typed
+// literal → the option list derives from it.
+export type ProductInfoSortField = "style" | "gender"
+export const PRODUCT_INFO_SORT_FIELD_LABEL: Record<ProductInfoSortField, string> = {
+  style: "Style",
+  gender: "Gender",
+}
+export const PRODUCT_INFO_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: ProductInfoSortField; readonly label: string }> =
+  (Object.keys(PRODUCT_INFO_SORT_FIELD_LABEL) as ProductInfoSortField[]).map((value) => ({
+    value,
+    label: PRODUCT_INFO_SORT_FIELD_LABEL[value],
+  }))
 
 /** Which families surface: those styled into shots, or the whole library. */
 export type ProductInfoScope = "in-use" | "library"
@@ -25,6 +41,10 @@ export interface ProductInfoConfig {
   readonly excludedFamilyIds: readonly string[]
   /** Shot statuses to HIDE (R3): a family is dropped only when ALL its appearances are hidden-status. Defaults to []. */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
+  /** R5 order-by: primary sort key within each group. Absent → legacy styleName order (flag-off byte-identical). */
+  readonly sortBy?: ProductInfoSortField
+  /** R5 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
+  readonly sortDir?: SortDir
 }
 
 export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
@@ -33,6 +53,18 @@ export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
   imageSize: "m",
   excludedFamilyIds: [],
   hiddenStatuses: [],
+  sortBy: "style",
+  sortDir: "asc",
+}
+
+/**
+ * Flag-off rollback safety — see reportTypes.neutralizeReportConfigForFlag.
+ * Product Info's `groupBy` was not widened in Phase B, so no groupBy clamp is
+ * needed; only the gated-off sort/hidden fields are stripped.
+ */
+export function neutralizeProductInfoConfigForFlag(config: ProductInfoConfig, flagOn: boolean): ProductInfoConfig {
+  if (flagOn) return config
+  return { ...config, hiddenStatuses: [], sortBy: undefined, sortDir: undefined }
 }
 
 /** One shot a family is styled into: its number, the look labels it appears in there, and that shot's status. */

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -9,6 +9,7 @@ import type {
 import type { ExportData } from "../../hooks/useExportData"
 import { humanizeLabel } from "@/shared/lib/textUtils"
 import {
+  REPORT_STATUS_LABEL,
   type GenderKey,
   type ReportConfig,
   type ReportGroup,
@@ -16,8 +17,22 @@ import {
   type ReportModel,
   type ReportProduct,
   type ReportShot,
+  type ReportShotStatus,
+  type ReportSortField,
   type ReportTalent,
 } from "./reportTypes"
+import {
+  compareByOrder,
+  compareShotNumber,
+  compareText,
+  orderedBuckets,
+  shotNumberSortKey,
+  sortItemsStable,
+} from "./reportSort"
+
+// Re-exported so talentModel / productInfoModel keep their existing
+// `import { shotNumberSortKey } from "./reportModel"` — single source of truth.
+export { shotNumberSortKey } from "./reportSort"
 
 // Pure derivation: ExportData + config -> ReportModel. No async, no image bytes
 // (image fields are path/URL candidates resolved later). The single source both
@@ -154,12 +169,6 @@ function resolveTalent(
   })
 }
 
-/** Sort key for shot numbers: numerics first (ascending), then non-numerics alpha. */
-export function shotNumberSortKey(n: string): [number, number, string] {
-  const num = Number.parseInt(n, 10)
-  return Number.isNaN(num) ? [1, 0, n] : [0, num, n]
-}
-
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
 
 /** Parse a "YYYY-MM-DD" date-only string into parts; null if malformed. (No Date() — avoids TZ shift.) */
@@ -200,6 +209,39 @@ export const GROUP_LABEL: Record<GenderKey, string> = {
   "?": "Unresolved",
 }
 
+// Fixed bucket + sort order for shot status (workflow order, O4). Mirrors GROUP_ORDER.
+export const STATUS_GROUP_ORDER: readonly ReportShotStatus[] = [
+  "todo",
+  "in_progress",
+  "on_hold",
+  "complete",
+]
+
+// Secondary key for the shot sort — ALWAYS ascending (deterministic tie-break):
+// spec-mandated shot number, then id as the final determinism guarantee.
+const SHOT_TIEBREAK = (a: ReportShot, b: ReportShot): number =>
+  compareShotNumber(a.number, b.number) || compareText(a.id, b.id)
+
+/** Primary comparator for a shot sort field (R2). Item-shape-local (needs GROUP_ORDER / STATUS_GROUP_ORDER). */
+function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot) => number {
+  switch (sortBy) {
+    case "shot-number":
+      return (a, b) => compareShotNumber(a.number, b.number)
+    case "talent":
+      return (a, b) => compareText(a.talent[0]?.name, b.talent[0]?.name)
+    case "status":
+      return (a, b) => compareByOrder(STATUS_GROUP_ORDER, a.status, b.status)
+    case "gender":
+      return (a, b) => compareByOrder(GROUP_ORDER, a.gender, b.gender)
+    default:
+      // Runtime safety: exportReports writes schemaless (no rules validation), so a
+      // persisted/hand-edited config could carry an out-of-union sortBy. Fall back to
+      // the default field rather than returning undefined (which sortItemsStable would
+      // call, throwing and killing the whole report render).
+      return (a, b) => compareShotNumber(a.number, b.number)
+  }
+}
+
 /** Derive the resolved report model from live export data + config. */
 export function deriveShotReportModel(data: ExportData, config: ReportConfig): ReportModel {
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
@@ -209,7 +251,7 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
   const hidden = new Set(config.hiddenStatuses ?? [])
   const primaryOnly = config.looksMode === "primary-only"
 
-  const shots: ReportShot[] = data.shots
+  const built: ReportShot[] = data.shots
     .filter((s) => !s.deleted && !hidden.has(s.status))
     .map((shot): ReportShot => {
       const looks = resolveLooks(shot, familyById)
@@ -232,19 +274,39 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
         hasImage: visibleLooks.some((l) => l.hasReference),
       }
     })
-    .sort((a, b) => {
-      const [ak, an, as] = shotNumberSortKey(a.number)
-      const [bk, bn, bs] = shotNumberSortKey(b.number)
-      return ak - bk || an - bn || as.localeCompare(bs)
-    })
+
+  // R2 order-by. Absent sortBy → verbatim legacy comparator (flag-off byte-identical
+  // by construction). Defined → the shared stable engine with the id tie-break.
+  const shots: ReportShot[] =
+    config.sortBy === undefined
+      ? [...built].sort((a, b) => {
+          const [ak, an, as] = shotNumberSortKey(a.number)
+          const [bk, bn, bs] = shotNumberSortKey(b.number)
+          return ak - bk || an - bn || as.localeCompare(bs)
+        })
+      : sortItemsStable(built, shotPrimaryFor(config.sortBy), SHOT_TIEBREAK, config.sortDir ?? "asc")
 
   const groups: ReportGroup[] =
     config.groupBy === "none"
       ? [{ key: "all", label: "All shots", count: shots.length, shots }]
-      : GROUP_ORDER.map((key): ReportGroup => {
-          const inGroup = shots.filter((s) => s.gender === key)
-          return { key, label: GROUP_LABEL[key], count: inGroup.length, shots: inGroup }
-        }).filter((g) => g.count > 0)
+      : config.groupBy === "status"
+        ? orderedBuckets(
+            shots,
+            (s) => s.status,
+            (a, b) => compareByOrder(STATUS_GROUP_ORDER, a, b),
+            (k) => REPORT_STATUS_LABEL[k as ReportShotStatus],
+          ).map(
+            (b): ReportGroup => ({
+              key: b.key as ReportShotStatus,
+              label: b.label,
+              count: b.count,
+              shots: b.items,
+            }),
+          )
+        : GROUP_ORDER.map((key): ReportGroup => {
+            const inGroup = shots.filter((s) => s.gender === key)
+            return { key, label: GROUP_LABEL[key], count: inGroup.length, shots: inGroup }
+          }).filter((g) => g.count > 0)
 
   return {
     project: {

--- a/src-vnext/features/export/lib/report/reportSort.ts
+++ b/src-vnext/features/export/lib/report/reportSort.ts
@@ -1,0 +1,96 @@
+// Shared sort engine + comparator primitives for the report models (R2/R5).
+// A LEAF module: it imports from NO model or type file, so reportModel /
+// productInfoModel / talentModel import FROM it with zero risk of a cycle. It
+// owns the cross-type sort direction vocabulary and the ONE stable-sort engine,
+// so the DOM views and every @react-pdf renderer inherit an identical, tie-broken
+// order by consuming the already-sorted model (they never re-sort).
+
+/** Sort direction, shared by all three report types. */
+export type SortDir = "asc" | "desc"
+
+// Direction display labels — the single source for the shared Order-by/Direction
+// control. An exhaustive typed literal (TS flags a missing variant); the option
+// list derives from it so the strings aren't duplicated (mirrors REPORT_LAYOUT_*).
+export const SORT_DIR_LABEL: Record<SortDir, string> = {
+  asc: "Ascending",
+  desc: "Descending",
+}
+export const SORT_DIR_OPTIONS: ReadonlyArray<{ readonly value: SortDir; readonly label: string }> =
+  (Object.keys(SORT_DIR_LABEL) as SortDir[]).map((value) => ({
+    value,
+    label: SORT_DIR_LABEL[value],
+  }))
+
+/** Sort key for shot numbers: numerics first (ascending), then non-numerics alpha.
+ *  Relocated verbatim from reportModel (a pure leaf util) and re-exported there. */
+export function shotNumberSortKey(n: string): [number, number, string] {
+  const num = Number.parseInt(n, 10)
+  return Number.isNaN(num) ? [1, 0, n] : [0, num, n]
+}
+
+/** Numeric-aware shot-number compare ("2" before "10"), non-numerics alpha last. */
+export function compareShotNumber(a: string, b: string): number {
+  const [ak, an, as] = shotNumberSortKey(a)
+  const [bk, bn, bs] = shotNumberSortKey(b)
+  return ak - bk || an - bn || as.localeCompare(bs)
+}
+
+/** Null-safe text compare (nullish sorts as ""). */
+export function compareText(a: string | null | undefined, b: string | null | undefined): number {
+  return (a ?? "").localeCompare(b ?? "")
+}
+
+/** Ordinal compare against a fixed order: knowns by index, then unknowns after knowns, ties alpha. */
+export function compareByOrder(order: readonly string[], a: string, b: string): number {
+  const ai = order.indexOf(a)
+  const bi = order.indexOf(b)
+  if (ai !== -1 && bi !== -1) return ai - bi
+  if (ai !== -1) return -1
+  if (bi !== -1) return 1
+  return compareText(a, b)
+}
+
+/**
+ * THE ENGINE. Stable, deterministic sort. `dir` flips the PRIMARY key ONLY —
+ * the tie-break is ALWAYS ascending, so duplicate-primary-key cases are ordered
+ * identically on every engine and every Firestore read order (the @react-pdf
+ * worker path included). Array.sort is stable in every supported engine, but the
+ * explicit tie-break means correctness never relies on that.
+ */
+export function sortItemsStable<T>(
+  items: readonly T[],
+  primary: (a: T, b: T) => number,
+  tieBreak: (a: T, b: T) => number,
+  dir: SortDir,
+): T[] {
+  const factor = dir === "desc" ? -1 : 1
+  return [...items].sort((a, b) => {
+    const p = factor * primary(a, b)
+    return p !== 0 ? p : tieBreak(a, b)
+  })
+}
+
+/**
+ * Partition `items` into buckets keyed by `keyOf`, preserving input (already-sorted)
+ * order within each bucket, then order the buckets by `keyOrder`. Empty buckets never
+ * appear (only keys present in `items` get a bucket) — matching the gender-group
+ * "drop empties" rule. Used for the shot report's new status grouping.
+ */
+export function orderedBuckets<T>(
+  items: readonly T[],
+  keyOf: (t: T) => string,
+  keyOrder: (a: string, b: string) => number,
+  label: (k: string) => string,
+): ReadonlyArray<{ readonly key: string; readonly label: string; readonly count: number; readonly items: readonly T[] }> {
+  const byKey = new Map<string, T[]>()
+  for (const item of items) {
+    const k = keyOf(item)
+    const bucket = byKey.get(k)
+    if (bucket) bucket.push(item)
+    else byKey.set(k, [item])
+  }
+  return [...byKey.keys()].sort(keyOrder).map((k) => {
+    const inGroup = byKey.get(k) ?? []
+    return { key: k, label: label(k), count: inGroup.length, items: inGroup }
+  })
+}

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -4,7 +4,9 @@
 // or URL) resolved to data URLs once via reportImages, keyed in a sidecar map —
 // the model stays pure (no async, no image bytes).
 
-export type ReportGroupBy = "gender" | "none"
+import type { SortDir } from "./reportSort"
+
+export type ReportGroupBy = "gender" | "none" | "status"
 
 /** Which looks each shot shows: every look, or only the primary (alts hidden). */
 export type ReportLooksMode = "all" | "primary-only"
@@ -48,6 +50,22 @@ export const REPORT_STATUS_OPTIONS: ReadonlyArray<{ readonly value: ReportShotSt
     label: REPORT_STATUS_LABEL[value],
   }))
 
+// Shot-report order-by (R2) field vocabulary. Exhaustive typed literal → the
+// option list derives from it (same pattern as REPORT_LAYOUT_*). Sort is applied
+// WITHIN each group at derive time via the shared sortItemsStable engine.
+export type ReportSortField = "shot-number" | "talent" | "status" | "gender"
+export const REPORT_SORT_FIELD_LABEL: Record<ReportSortField, string> = {
+  "shot-number": "Shot #",
+  talent: "Talent",
+  status: "Status",
+  gender: "Gender",
+}
+export const REPORT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: ReportSortField; readonly label: string }> =
+  (Object.keys(REPORT_SORT_FIELD_LABEL) as ReportSortField[]).map((value) => ({
+    value,
+    label: REPORT_SORT_FIELD_LABEL[value],
+  }))
+
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
@@ -59,6 +77,10 @@ export interface ReportConfig {
   readonly layout?: ReportLayout
   /** Shot statuses to HIDE entirely (screen + PDF). Defaults to [] (nothing hidden); an absent field default-merges to []. */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
+  /** R2 order-by: primary sort key applied within each group. Absent → legacy shot-number order (flag-off byte-identical). */
+  readonly sortBy?: ReportSortField
+  /** R2 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
+  readonly sortDir?: SortDir
 }
 
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
@@ -67,6 +89,29 @@ export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   looksMode: "all",
   layout: "image-led",
   hiddenStatuses: [],
+  sortBy: "shot-number",
+  sortDir: "asc",
+}
+
+/**
+ * Flag-off rollback safety. When `featureReportConfig` is OFF, strip every
+ * Phase-A/B config field whose control is gated off (so a user can no longer
+ * clear it) and clamp the widened `groupBy` back to its pre-Phase-B values —
+ * so the derive runs its verbatim legacy path and output stays byte-identical.
+ * Exported (not inlined in the page) so the flag-off byte-identity test exercises
+ * the REAL code the page runs, not a copy — see reportModel flag-off test.
+ */
+export function neutralizeReportConfigForFlag(config: ReportConfig, flagOn: boolean): ReportConfig {
+  if (flagOn) return config
+  return {
+    ...config,
+    hiddenStatuses: [],
+    sortBy: undefined,
+    sortDir: undefined,
+    // A persisted "status" would otherwise render as gender flag-off (not
+    // byte-identical). The two legacy values were always user-settable.
+    groupBy: config.groupBy === "gender" || config.groupBy === "none" ? config.groupBy : "gender",
+  }
 }
 
 /** Normalized gender bucket. "?" = unresolved (never silently dropped). */
@@ -123,7 +168,7 @@ export interface ReportShot {
 }
 
 export interface ReportGroup {
-  readonly key: GenderKey | "all"
+  readonly key: GenderKey | "all" | ReportShotStatus
   readonly label: string
   readonly count: number
   readonly shots: readonly ReportShot[]

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -6,6 +6,7 @@ import {
 } from "@/features/library/lib/measurementOptions"
 import type { ExportData } from "../../hooks/useExportData"
 import { formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder, titleCaseSlug } from "./reportModel"
+import { compareText, sortItemsStable } from "./reportSort"
 import type {
   TalentAppearance,
   TalentConfig,
@@ -13,6 +14,7 @@ import type {
   TalentGroup,
   TalentMeasurement,
   TalentModel,
+  TalentSortField,
 } from "./talentTypes"
 
 // Pure derivation: ExportData + TalentConfig -> TalentModel. No async, no image
@@ -164,6 +166,26 @@ function agencyBucketSort(a: string, b: string): number {
   return a.localeCompare(b)
 }
 
+// Secondary key for the talent sort — ALWAYS ascending (deterministic tie-break).
+const TALENT_TIEBREAK = (a: TalentEntry, b: TalentEntry): number =>
+  compareText(a.name, b.name) || compareText(a.id, b.id)
+
+/** Primary comparator for a talent sort field (R5). Reuses the bucket-order sorts. */
+function talentPrimaryFor(sortBy: TalentSortField): (a: TalentEntry, b: TalentEntry) => number {
+  switch (sortBy) {
+    case "name":
+      return (a, b) => compareText(a.name, b.name)
+    case "gender":
+      return (a, b) => genderBucketSort(a.genderLabel ?? UNRESOLVED, b.genderLabel ?? UNRESOLVED)
+    case "agency":
+      return (a, b) => agencyBucketSort(a.agency ?? NO_AGENCY, b.agency ?? NO_AGENCY)
+    default:
+      // Runtime safety (see reportModel.shotPrimaryFor): an out-of-union persisted
+      // sortBy falls back to the default field, never returns undefined.
+      return (a, b) => compareText(a.name, b.name)
+  }
+}
+
 /** Derive the resolved talent model from live export data + config. */
 export function deriveTalentModel(data: ExportData, config: TalentConfig): TalentModel {
   const excluded = new Set(config.excludedTalentIds)
@@ -174,7 +196,7 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
       ? projectAttachedTalent(data)
       : inShotsTalent(data)
 
-  const items = records
+  const built = records
     .map((t) => toEntry(t, data.shots, excluded))
     // R3: drop a talent only when EVERY appearance is a hidden status. A project-attached
     // talent with no appearances (appears.length === 0) is kept — status can't hide what has no shots.
@@ -184,7 +206,13 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
         item.appears.length === 0 ||
         item.appears.some((a) => !hidden.has(a.status)),
     )
-    .sort((a, b) => a.name.localeCompare(b.name))
+
+  // R5 order-by. Absent sortBy → verbatim legacy name order (flag-off byte-identical).
+  // Defined → the shared stable engine with the id tie-break.
+  const items =
+    config.sortBy === undefined
+      ? [...built].sort((a, b) => a.name.localeCompare(b.name))
+      : sortItemsStable(built, talentPrimaryFor(config.sortBy), TALENT_TIEBREAK, config.sortDir ?? "asc")
 
   return {
     project: {

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -7,9 +7,24 @@
 // the model stays pure.
 
 import type { ReportShotStatus } from "./reportTypes"
+import type { SortDir } from "./reportSort"
 
 /** How talent are grouped on the report. */
 export type TalentGroupBy = "none" | "gender" | "agency"
+
+// Talent order-by (R5) field vocabulary. Exhaustive typed literal → the option
+// list derives from it.
+export type TalentSortField = "name" | "gender" | "agency"
+export const TALENT_SORT_FIELD_LABEL: Record<TalentSortField, string> = {
+  name: "Name",
+  gender: "Gender",
+  agency: "Agency",
+}
+export const TALENT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: TalentSortField; readonly label: string }> =
+  (Object.keys(TALENT_SORT_FIELD_LABEL) as TalentSortField[]).map((value) => ({
+    value,
+    label: TALENT_SORT_FIELD_LABEL[value],
+  }))
 
 /** Which talent surface: those slotted into shots, or every project-attached talent. */
 export type TalentScope = "in-shots" | "project-attached"
@@ -22,6 +37,10 @@ export interface TalentConfig {
   readonly excludedTalentIds: readonly string[]
   /** Shot statuses to HIDE (R3): a talent is dropped only when ALL their appearances are hidden-status. Defaults to []. */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
+  /** R5 order-by: primary sort key within each group. Absent → legacy name order (flag-off byte-identical). */
+  readonly sortBy?: TalentSortField
+  /** R5 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
+  readonly sortDir?: SortDir
 }
 
 export const DEFAULT_TALENT_CONFIG: TalentConfig = {
@@ -29,6 +48,18 @@ export const DEFAULT_TALENT_CONFIG: TalentConfig = {
   talentScope: "in-shots",
   excludedTalentIds: [],
   hiddenStatuses: [],
+  sortBy: "name",
+  sortDir: "asc",
+}
+
+/**
+ * Flag-off rollback safety — see reportTypes.neutralizeReportConfigForFlag.
+ * Talent's `groupBy` was not widened in Phase B, so no groupBy clamp is needed;
+ * only the gated-off sort/hidden fields are stripped.
+ */
+export function neutralizeTalentConfigForFlag(config: TalentConfig, flagOn: boolean): TalentConfig {
+  if (flagOn) return config
+  return { ...config, hiddenStatuses: [], sortBy: undefined, sortDir: undefined }
 }
 
 /** One shot a talent appears in: its number/title, the look labels there, and that shot's status. */


### PR DESCRIPTION
## Report-config Phase B — shared group×order config layer

Continues the report-config initiative (Phase A = #500). **Dark** behind the existing `featureReportConfig` flag; flag-off is byte-identical in **both** the derive and the DOM, so merging changes nothing in prod until the flag is flipped.

### What shipped (R2 + R5 order-by)
- **Order-by across all 3 report types** — `sortBy` × `sortDir`, applied *within* each group at derive time. New leaf module `reportSort.ts` owns the single stable-sort engine (tie-break always ascending, secondary = id), consumed by the DOM views **and** all four @react-pdf renderers from one sorted model — so screen and PDF stay in lockstep (no renderer re-sorts).
- **Status grouping** on the shot report (the "group by status, order by talent" case).
- Shared **`GroupSortControls`** panel serving all three types, gated on `featureReportConfig` (`showSort`).

### Hardening (beyond the base build)
- Flag-off neutralizer extracted to pure `neutralize*ConfigForFlag()` fns — the byte-identity test now exercises the **real page code**, not an inline copy.
- `primaryFor` switches fall back to the default field on an out-of-union persisted `sortBy` (schemaless `exportReports` write-through) instead of throwing.

### Deferred (O2)
Group-by *widening* for Product Info / Talent (group by status/talent) needs a reduction over `appears[]` that changes bucket membership — a semantics decision, not a mechanic. Deferred; order-by power landed for all three.

### Safety
- No `firestore.rules` change, no migration (new config fields are optional, default-merge at read).
- Gates: `typecheck:baseline` 0-new · `eslint --max-warnings=0` clean · **105 report tests** pass · `npm run build` clean.

Go-live = flip `VITE_REPORT_CONFIG=1` in `deploy-live.yml` after a `:5174` worked-example eyeball (DOM + PDF) — separate, post-shoot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7CeF25j7gGHbbyNYzVntn