### PR TITLE
feat(export): report-config O2 — group Product Info & Talent by status

### DIFF
--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -363,6 +363,8 @@ function ControlBar({
     ["gender", "Gender"],
     ["product-type", "Type"],
     ["none", "None"],
+    // O2 status grouping rides the same flag as the sort controls.
+    ...(showSort ? [["status", "Status"] as const] : []),
   ]
   const sizeOpts: ReadonlyArray<readonly [ProductInfoImageSize, string]> = [
     ["s", "S"],

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -363,6 +363,8 @@ function ControlBar({
     ["none", "None"],
     ["gender", "Gender"],
     ["agency", "Agency"],
+    // O2 status grouping rides the same flag as the sort controls.
+    ...(showSort ? [["status", "Status"] as const] : []),
   ]
 
   return (

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -3,7 +3,11 @@ import {
   collectProductInfoImageCandidates,
   deriveProductInfoModel,
 } from "../productInfoModel"
-import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
+import {
+  DEFAULT_PRODUCT_INFO_CONFIG,
+  neutralizeProductInfoConfigForFlag,
+  type ProductInfoConfig,
+} from "../productInfoTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot } from "@/shared/types"
 
@@ -476,5 +480,72 @@ describe("deriveProductInfoModel — entry fields & images", () => {
     )
     expect(model.project.dateRange).toBe("Jun 2–4, 2026")
     expect(model.project.familyCount).toBe(2)
+  })
+})
+
+describe("deriveProductInfoModel — group-by status (O2)", () => {
+  // fM appears in a complete AND a todo shot; fW only in a complete shot.
+  const mixed = () =>
+    data({
+      productFamilies: [
+        fam({ id: "fM", styleName: "Merino Crew", gender: "men", productType: "Tops" }),
+        fam({ id: "fW", styleName: "Wool Pant", gender: "women", productType: "Bottoms" }),
+      ],
+      shots: [
+        shot({ id: "s1", shotNumber: "01", status: "complete", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+        shot({ id: "s2", shotNumber: "02", status: "todo", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+        shot({ id: "s3", shotNumber: "03", status: "complete", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+      ],
+    })
+
+  it("buckets each family by its MOST-OUTSTANDING appearance; one bucket per family, status-ordered", () => {
+    const model = deriveProductInfoModel(mixed(), cfg({ groupBy: "status" }))
+    // fM (complete+todo) → To do (least done); fW (complete only) → Complete. todo precedes complete.
+    expect(model.groups.map((g) => g.key)).toEqual(["todo", "complete"])
+    expect(model.groups.map((g) => g.label)).toEqual(["To do", "Complete"])
+    expect(model.groups.map((g) => g.items.map((i) => i.id))).toEqual([["fM"], ["fW"]])
+    // Each family lands in exactly one bucket — no double-counting.
+    expect(flat(model).map((i) => i.id).sort()).toEqual(["fM", "fW"])
+  })
+
+  it("preserves the R5 within-bucket order (order-by style, desc)", () => {
+    const d = data({
+      productFamilies: [
+        fam({ id: "fA", styleName: "Alpha", gender: "men" }),
+        fam({ id: "fZ", styleName: "Zeta", gender: "men" }),
+      ],
+      shots: [
+        shot({ id: "s1", shotNumber: "01", status: "todo", looks: [{ id: "l", order: 0, products: [{ familyId: "fA" }] }] }),
+        shot({ id: "s2", shotNumber: "02", status: "todo", looks: [{ id: "l", order: 0, products: [{ familyId: "fZ" }] }] }),
+      ],
+    })
+    const model = deriveProductInfoModel(d, cfg({ groupBy: "status", sortBy: "style", sortDir: "desc" }))
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.key).toBe("todo")
+    expect(model.groups[0]?.items.map((i) => i.styleName)).toEqual(["Zeta", "Alpha"])
+  })
+
+  it("puts never-shot library families in a trailing 'No shots' bucket", () => {
+    const d = data({
+      productFamilies: [
+        fam({ id: "fA", styleName: "Active", gender: "men" }),
+        fam({ id: "fZ", styleName: "Never", gender: "women" }),
+      ],
+      shots: [shot({ id: "s1", shotNumber: "01", status: "todo", looks: [{ id: "l", order: 0, products: [{ familyId: "fA" }] }] })],
+    })
+    const model = deriveProductInfoModel(d, cfg({ productScope: "library", groupBy: "status" }))
+    const last = model.groups[model.groups.length - 1]
+    expect(model.groups[0]?.key).toBe("todo") // real-status buckets first
+    expect(last?.label).toBe("No shots")
+    expect(last?.items.map((i) => i.id)).toEqual(["fZ"])
+  })
+
+  it("flag-off: the real neutralizer clamps a persisted 'status' + sort back to legacy gender order (byte-identical)", () => {
+    const d = mixed()
+    const persisted = cfg({ groupBy: "status", sortBy: "gender", sortDir: "desc", hiddenStatuses: ["todo"] })
+    // The shared pure neutralizer the page runs flag-off — not an inline copy.
+    const neutralized = neutralizeProductInfoConfigForFlag(persisted, false)
+    expect(deriveProductInfoModel(d, neutralized)).toEqual(deriveProductInfoModel(d, DEFAULT_PRODUCT_INFO_CONFIG))
+    expect(neutralizeProductInfoConfigForFlag(persisted, true)).toBe(persisted) // flag-on = identity
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { deriveShotReportModel, formatDateWindow, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
+import { deriveShotReportModel, formatDateWindow, mostOutstandingStatus, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
 import { DEFAULT_REPORT_CONFIG, neutralizeReportConfigForFlag, type ReportConfig } from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
@@ -544,5 +544,21 @@ describe("titleCaseSlug", () => {
   })
   it("capitalizes a single-char slug", () => {
     expect(titleCaseSlug("c")).toBe("C")
+  })
+})
+
+describe("mostOutstandingStatus (O2 status-grouping reduction)", () => {
+  it("returns the least-done (lowest STATUS_GROUP_ORDER) status among appearances", () => {
+    expect(mostOutstandingStatus(["complete", "todo"])).toBe("todo")
+    expect(mostOutstandingStatus(["complete", "on_hold"])).toBe("on_hold")
+    expect(mostOutstandingStatus(["on_hold", "in_progress"])).toBe("in_progress")
+    expect(mostOutstandingStatus(["complete", "complete"])).toBe("complete")
+  })
+  it("is order-insensitive", () => {
+    expect(mostOutstandingStatus(["todo", "complete"])).toBe("todo")
+    expect(mostOutstandingStatus(["complete", "todo"])).toBe("todo")
+  })
+  it("returns null for an item with no appearances", () => {
+    expect(mostOutstandingStatus([])).toBeNull()
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { collectTalentImageCandidates, deriveTalentModel } from "../talentModel"
-import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
+import { DEFAULT_TALENT_CONFIG, neutralizeTalentConfigForFlag, type TalentConfig } from "../talentTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { Shot, TalentRecord } from "@/shared/types"
 
@@ -389,5 +389,68 @@ describe("deriveTalentModel — project block & image candidates", () => {
       cfg({ groupBy: "none" }),
     )
     expect([...collectTalentImageCandidates(model)].sort()).toEqual(["other.jpg", "shared.jpg"])
+  })
+})
+
+describe("deriveTalentModel — group-by status (O2)", () => {
+  // tA appears in a complete AND a todo shot; tB only in a complete shot.
+  const mixed = () =>
+    data({
+      talent: ROSTER,
+      shots: [
+        shot({ id: "s1", shotNumber: "01", status: "complete", talentIds: ["tA"], looks: [{ id: "l", order: 0, products: [] }] }),
+        shot({ id: "s2", shotNumber: "02", status: "todo", talentIds: ["tA"], looks: [{ id: "l", order: 0, products: [] }] }),
+        shot({ id: "s3", shotNumber: "03", status: "complete", talentIds: ["tB"], looks: [{ id: "l", order: 0, products: [] }] }),
+      ],
+    })
+
+  it("buckets each talent by their MOST-OUTSTANDING appearance; one bucket per talent, status-ordered", () => {
+    const model = deriveTalentModel(mixed(), cfg({ groupBy: "status" }))
+    // tA (complete+todo) → To do; tB (complete only) → Complete. todo precedes complete.
+    expect(model.groups.map((g) => g.key)).toEqual(["todo", "complete"])
+    expect(model.groups.map((g) => g.label)).toEqual(["To do", "Complete"])
+    expect(model.groups.map((g) => g.items.map((i) => i.id))).toEqual([["tA"], ["tB"]])
+    expect(flat(model).map((i) => i.id).sort()).toEqual(["tA", "tB"])
+  })
+
+  it("preserves the R5 within-bucket order (order-by name, desc)", () => {
+    const roster = [
+      tal({ id: "t1", name: "Aaron", gender: "male", agency: "X" }),
+      tal({ id: "t2", name: "Zed", gender: "male", agency: "X" }),
+    ]
+    const d = data({
+      talent: roster,
+      shots: [
+        shot({ id: "s1", shotNumber: "01", status: "todo", talentIds: ["t1"], looks: [{ id: "l", order: 0, products: [] }] }),
+        shot({ id: "s2", shotNumber: "02", status: "todo", talentIds: ["t2"], looks: [{ id: "l", order: 0, products: [] }] }),
+      ],
+    })
+    const model = deriveTalentModel(d, cfg({ groupBy: "status", sortBy: "name", sortDir: "desc" }))
+    expect(model.groups).toHaveLength(1)
+    expect(model.groups[0]?.key).toBe("todo")
+    expect(model.groups[0]?.items.map((i) => i.name)).toEqual(["Zed", "Aaron"])
+  })
+
+  it("puts project-attached talent with no appearances in a trailing 'No shots' bucket", () => {
+    const d = data({
+      talent: [
+        tal({ id: "tA", name: "Ava Stone", gender: "female", agency: "Elite", projectIds: ["p1"] }),
+        tal({ id: "tZ", name: "Zoe Never", gender: "female", agency: "Next", projectIds: ["p1"] }),
+      ],
+      shots: [shot({ id: "s1", shotNumber: "01", status: "todo", talentIds: ["tA"], looks: [{ id: "l", order: 0, products: [] }] })],
+    })
+    const model = deriveTalentModel(d, cfg({ talentScope: "project-attached", groupBy: "status" }))
+    const last = model.groups[model.groups.length - 1]
+    expect(model.groups[0]?.key).toBe("todo") // real-status buckets first
+    expect(last?.label).toBe("No shots")
+    expect(last?.items.map((i) => i.id)).toEqual(["tZ"])
+  })
+
+  it("flag-off: the real neutralizer clamps a persisted 'status' + sort back to legacy name order (byte-identical)", () => {
+    const d = mixed()
+    const persisted = cfg({ groupBy: "status", sortBy: "agency", sortDir: "desc", hiddenStatuses: ["todo"] })
+    const neutralized = neutralizeTalentConfigForFlag(persisted, false)
+    expect(deriveTalentModel(d, neutralized)).toEqual(deriveTalentModel(d, DEFAULT_TALENT_CONFIG))
+    expect(neutralizeTalentConfigForFlag(persisted, true)).toBe(persisted) // flag-on = identity
   })
 })

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -2,6 +2,7 @@ import type { ProductAssignment, ProductFamily, Shot } from "@/shared/types"
 import { matchesHeroProductId } from "@/features/shots/lib/lookHeroes"
 import type { ExportData } from "../../hooks/useExportData"
 import {
+  buildStatusGroups,
   GROUP_LABEL,
   GROUP_ORDER,
   lookLabel,
@@ -223,6 +224,12 @@ function groupEntries(
         const inGroup = byType.get(key) ?? []
         return { key, label: key, count: inGroup.length, items: inGroup }
       })
+  }
+  if (groupBy === "status") {
+    // O2: one bucket per family, keyed by its most-outstanding appearance status.
+    return buildStatusGroups(items, (e) => e.appears.map((a) => a.status)).map(
+      (b): ProductInfoGroup => ({ key: b.key, label: b.label, count: b.count, items: b.items }),
+    )
   }
   return GROUP_ORDER.map((key): ProductInfoGroup => {
     const inGroup = items.filter((i) => i.gender === key)

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -8,8 +8,9 @@
 import type { GenderKey, ReportShotStatus } from "./reportTypes"
 import type { SortDir } from "./reportSort"
 
-/** How families are grouped on the report. */
-export type ProductInfoGroupBy = "gender" | "product-type" | "none"
+/** How families are grouped on the report. "status" (O2) buckets each family by its
+ *  most-outstanding appearance status (one bucket per family). */
+export type ProductInfoGroupBy = "gender" | "product-type" | "status" | "none"
 
 // Product-info order-by (R5) field vocabulary. Product families carry no
 // shot-number/status/talent at entry level (those live per-appearance in
@@ -59,12 +60,22 @@ export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
 
 /**
  * Flag-off rollback safety — see reportTypes.neutralizeReportConfigForFlag.
- * Product Info's `groupBy` was not widened in Phase B, so no groupBy clamp is
- * needed; only the gated-off sort/hidden fields are stripped.
+ * Strips the gated-off sort/hidden fields AND clamps the O2-widened `groupBy`
+ * back to its pre-O2 legal set, so a persisted "status" can't leak status-grouping
+ * flag-off (byte-identity).
  */
 export function neutralizeProductInfoConfigForFlag(config: ProductInfoConfig, flagOn: boolean): ProductInfoConfig {
   if (flagOn) return config
-  return { ...config, hiddenStatuses: [], sortBy: undefined, sortDir: undefined }
+  return {
+    ...config,
+    hiddenStatuses: [],
+    sortBy: undefined,
+    sortDir: undefined,
+    groupBy:
+      config.groupBy === "gender" || config.groupBy === "product-type" || config.groupBy === "none"
+        ? config.groupBy
+        : "gender",
+  }
 }
 
 /** One shot a family is styled into: its number, the look labels it appears in there, and that shot's status. */

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -217,6 +217,55 @@ export const STATUS_GROUP_ORDER: readonly ReportShotStatus[] = [
   "complete",
 ]
 
+/**
+ * Reduce an entry's many appearance-statuses to the ONE it groups under (O2):
+ * its **most-outstanding** (least-done) appearance = the status with the lowest
+ * `STATUS_GROUP_ORDER` index. So a product/talent appearing in any un-shot shot
+ * lands in that outstanding bucket, and each item appears in exactly one group.
+ * Returns `null` for an item with no appearances (a never-shot library entry) —
+ * the caller buckets those under a "No shots" group. An out-of-union status ranks
+ * last (never spuriously "most outstanding").
+ */
+export function mostOutstandingStatus(
+  statuses: readonly ReportShotStatus[],
+): ReportShotStatus | null {
+  let best: ReportShotStatus | null = null
+  let bestRank = Number.POSITIVE_INFINITY
+  for (const s of statuses) {
+    const idx = STATUS_GROUP_ORDER.indexOf(s)
+    const rank = idx === -1 ? Number.MAX_SAFE_INTEGER : idx
+    if (rank < bestRank) {
+      bestRank = rank
+      best = s
+    }
+  }
+  return best
+}
+
+/** Bucket key/label for entries with no appearances when grouping by status (O2). */
+export const NO_SHOTS_GROUP_KEY = "__no_shots__"
+export const NO_SHOTS_GROUP_LABEL = "No shots"
+
+/**
+ * Group entries (products/talent) by their most-outstanding appearance status (O2).
+ * One bucket per item; `statusesOf` extracts an item's appearance statuses. Buckets
+ * are ordered by `STATUS_GROUP_ORDER`; within a bucket the input order is preserved
+ * (so the R5 sort already applied to `items` survives). Items with no appearances
+ * fall into a trailing "No shots" bucket. The two report models map the result onto
+ * their own Group shape.
+ */
+export function buildStatusGroups<T>(
+  items: readonly T[],
+  statusesOf: (item: T) => readonly ReportShotStatus[],
+): ReadonlyArray<{ readonly key: string; readonly label: string; readonly count: number; readonly items: readonly T[] }> {
+  return orderedBuckets(
+    items,
+    (item) => mostOutstandingStatus(statusesOf(item)) ?? NO_SHOTS_GROUP_KEY,
+    (a, b) => compareByOrder(STATUS_GROUP_ORDER, a, b),
+    (k) => (k === NO_SHOTS_GROUP_KEY ? NO_SHOTS_GROUP_LABEL : REPORT_STATUS_LABEL[k as ReportShotStatus]),
+  )
+}
+
 // Secondary key for the shot sort — ALWAYS ascending (deterministic tie-break):
 // spec-mandated shot number, then id as the final determinism guarantee.
 const SHOT_TIEBREAK = (a: ReportShot, b: ReportShot): number =>

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -5,7 +5,7 @@ import {
   formatLabeledMeasurements,
 } from "@/features/library/lib/measurementOptions"
 import type { ExportData } from "../../hooks/useExportData"
-import { formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder, titleCaseSlug } from "./reportModel"
+import { buildStatusGroups, formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder, titleCaseSlug } from "./reportModel"
 import { compareText, sortItemsStable } from "./reportSort"
 import type {
   TalentAppearance,
@@ -130,6 +130,12 @@ function groupEntries(
         const inGroup = byLabel.get(key) ?? []
         return { key, label: key, count: inGroup.length, items: inGroup }
       })
+  }
+  if (groupBy === "status") {
+    // O2: one bucket per talent, keyed by their most-outstanding appearance status.
+    return buildStatusGroups(items, (t) => t.appears.map((a) => a.status)).map(
+      (b): TalentGroup => ({ key: b.key, label: b.label, count: b.count, items: b.items }),
+    )
   }
   // agency
   const byAgency = new Map<string, TalentEntry[]>()

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -9,8 +9,9 @@
 import type { ReportShotStatus } from "./reportTypes"
 import type { SortDir } from "./reportSort"
 
-/** How talent are grouped on the report. */
-export type TalentGroupBy = "none" | "gender" | "agency"
+/** How talent are grouped on the report. "status" (O2) buckets each talent by their
+ *  most-outstanding appearance status (one bucket per talent). */
+export type TalentGroupBy = "none" | "gender" | "agency" | "status"
 
 // Talent order-by (R5) field vocabulary. Exhaustive typed literal → the option
 // list derives from it.
@@ -54,12 +55,22 @@ export const DEFAULT_TALENT_CONFIG: TalentConfig = {
 
 /**
  * Flag-off rollback safety — see reportTypes.neutralizeReportConfigForFlag.
- * Talent's `groupBy` was not widened in Phase B, so no groupBy clamp is needed;
- * only the gated-off sort/hidden fields are stripped.
+ * Strips the gated-off sort/hidden fields AND clamps the O2-widened `groupBy`
+ * back to its pre-O2 legal set, so a persisted "status" can't leak status-grouping
+ * flag-off (byte-identity).
  */
 export function neutralizeTalentConfigForFlag(config: TalentConfig, flagOn: boolean): TalentConfig {
   if (flagOn) return config
-  return { ...config, hiddenStatuses: [], sortBy: undefined, sortDir: undefined }
+  return {
+    ...config,
+    hiddenStatuses: [],
+    sortBy: undefined,
+    sortDir: undefined,
+    groupBy:
+      config.groupBy === "none" || config.groupBy === "gender" || config.groupBy === "agency"
+        ? config.groupBy
+        : "none",
+  }
 }
 
 /** One shot a talent appears in: its number/title, the look labels there, and that shot's status. */


### PR DESCRIPTION
## Report-config O2 — group Product Info & Talent by status

Closes the O2 follow-up from Phase B (#502): widens `groupBy` on the **Product Info** and **Talent** reports with a **Status** option, completing R5's group-power parity.

### The reduction (Ted's call)
A product/talent spans many shots of differing status, so grouping "by status" needs a rule. Chosen: **one bucket per item, keyed by its most-outstanding (least-done) appearance** — the status with the lowest `STATUS_GROUP_ORDER` index. Reads as a prep-priority list ("what still needs shooting"); each item appears exactly once. Bucket order Todo → In progress → On hold → Complete (same as the shot report). Never-shot library / project-attached entries fall into a trailing **"No shots"** bucket.

### How
- Shared `mostOutstandingStatus()` + `buildStatusGroups<T>()` in `reportModel`, consumed by both models. DOM views **and** both @react-pdf renderers render the new buckets from `model.groups` with **zero renderer changes** (they use `group.label` + `group.items` only — no hardcoded group-key assumption).
- The "Status" group-by option is **flag-gated** on the same `featureReportConfig` (`showSort`), and the flag-off neutralizers now **clamp** the widened `groupBy` back to the pre-O2 set — so flag-off is byte-identical.

### ⚠️ This merges LIVE, not dark
`featureReportConfig` is **on in prod** (flipped in #501). So merging this ships the Status grouping **immediately to users**. It's additive — it only adds a "Status" option to the group-by control; existing behavior is unchanged unless someone selects it.

### Safety
- No `firestore.rules` change, no migration (nothing persisted changes shape).
- Gates: `typecheck:baseline` 0-new · `eslint --max-warnings=0` clean · **116 report tests** pass (new: reduction, within-bucket sort, No-shots edge, flag-off clamp via the real neutralizer) · `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7CeF25j7gGHbbyNYzVntn