### PR TITLE
feat(export): report-config Phase C — layout/density parity for Product Info + Talent (flagged)

### DIFF
--- a/src-vnext/features/export/components/report/ProductInfoReportView.tsx
+++ b/src-vnext/features/export/components/report/ProductInfoReportView.tsx
@@ -16,12 +16,15 @@ import type {
   ProductInfoGroup,
   ProductInfoGroupBy,
   ProductInfoImageSize,
+  ProductInfoLayout,
   ProductInfoModel,
   ProductInfoScope,
   ProductInfoSortField,
 } from "../../lib/report/productInfoTypes"
 import {
   DEFAULT_PRODUCT_INFO_CONFIG,
+  PRODUCT_INFO_LAYOUT_GEOMETRY,
+  PRODUCT_INFO_LAYOUT_OPTIONS,
   PRODUCT_INFO_SORT_FIELD_OPTIONS,
 } from "../../lib/report/productInfoTypes"
 import type { ReportShotStatus } from "../../lib/report/reportTypes"
@@ -145,6 +148,120 @@ function ProductCard({
 }
 
 // ---------------------------------------------------------------------------
+// INDEX layout — one compact spec-sheet row per family: small thumb + name +
+// meta line (style# · colours · sizes) + shot count with status dots. The dense
+// pole that reaches print/PDF. RED-FREE per the locked design system: the hero
+// mark is the canonical INK dot + uppercase INK tag (weight, not colour) — NOT
+// the gallery's shipped red hero tag (frozen by byte-identity) and NOT the comp's
+// boxed outlined tag (the carried critic fix).
+// ---------------------------------------------------------------------------
+function ProductIndexRow({
+  entry,
+  imageMap,
+  onToggleExclude,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (familyId: string) => void
+}): JSX.Element {
+  const src = resolveSrc(imageMap, entry.image)
+  const appears = entry.appears
+  const styleNo = entry.styleNumber && entry.styleNumber.trim() !== "" ? entry.styleNumber : null
+  const dots = appears.slice(0, 6)
+
+  return (
+    <article className={"sb-pir-irow" + (entry.isHero ? " sb-pir-is-hero" : "") + (entry.excluded ? " sb-pir-excluded" : "")}>
+      <button
+        type="button"
+        className="sb-pir-exclude-toggle no-print"
+        aria-pressed={entry.excluded}
+        onClick={() => onToggleExclude(entry.id)}
+        title={entry.excluded ? "Restore this product to the report" : "Exclude this product from the report"}
+      >
+        {entry.excluded ? "Restore" : "Exclude"}
+      </button>
+
+      <div className="sb-pir-ithumb">
+        {src ? (
+          <img src={src} alt={`${entry.styleName} — product image`} loading="lazy" />
+        ) : (
+          <div className="sb-pir-ithumb-noimg" aria-hidden="true">
+            —
+          </div>
+        )}
+      </div>
+
+      <div className="sb-pir-imain">
+        <div className="sb-pir-iname-line">
+          <span className="sb-pir-iname">{entry.styleName}</span>
+          {entry.isHero ? (
+            <span className="sb-pir-index-hero">
+              <span className="sb-pir-index-hero-dot" aria-hidden="true" />
+              <span className="sb-pir-index-hero-tag">Hero</span>
+            </span>
+          ) : null}
+        </div>
+        <div className="sb-pir-imeta">
+          {styleNo ? <span className="sb-pir-style-no">{styleNo}</span> : null}
+          {styleNo ? <span className="sb-pir-imeta-sep">·</span> : null}
+          {entry.colours.length ? (
+            <span>{entry.colours.join(", ")}</span>
+          ) : (
+            <span className="sb-pending">TBD</span>
+          )}
+          <span className="sb-pir-imeta-sep">·</span>
+          {entry.sizes.length ? (
+            <span className="sb-tabular">{entry.sizes.join(" · ")}</span>
+          ) : entry.sizePending ? (
+            <span className="sb-pending">Size pending</span>
+          ) : (
+            <span className="sb-pending">—</span>
+          )}
+        </div>
+      </div>
+
+      <div className="sb-pir-ishots">
+        <span className="sb-pir-ishots-n">{appears.length}</span>
+        {dots.length ? (
+          <span className="sb-pir-ishots-dots">
+            {dots.map((a, i) => {
+              const st = statusMeta(a.status)
+              return (
+                <span
+                  className={"sb-status-dot " + st.dotClass}
+                  title={st.label}
+                  aria-hidden="true"
+                  key={`${entry.id}-d-${i}`}
+                />
+              )
+            })}
+          </span>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+// Pick the per-family renderer for a layout (gallery card vs. compact index row).
+function FamilyItem({
+  entry,
+  imageMap,
+  onToggleExclude,
+  layout,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (familyId: string) => void
+  readonly layout: ProductInfoLayout
+}): JSX.Element {
+  return layout === "index" ? (
+    <ProductIndexRow entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+  ) : (
+    <ProductCard entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Masthead band — Products / Women / Men / Heroes / Window.
 // ---------------------------------------------------------------------------
 function Masthead({ model }: { readonly model: ProductInfoModel }): JSX.Element {
@@ -200,10 +317,12 @@ function GroupSection({
   group,
   imageMap,
   onToggleExclude,
+  layout,
 }: {
   readonly group: ProductInfoGroup
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (familyId: string) => void
+  readonly layout: ProductInfoLayout
 }): JSX.Element {
   const shown = group.items.filter((e) => !e.excluded).length
   return (
@@ -216,7 +335,13 @@ function GroupSection({
       </div>
       <div className="sb-pir-grid">
         {group.items.map((entry) => (
-          <ProductCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+          <FamilyItem
+            key={entry.id}
+            entry={entry}
+            imageMap={imageMap}
+            onToggleExclude={onToggleExclude}
+            layout={layout}
+          />
         ))}
       </div>
     </section>
@@ -230,25 +355,24 @@ function GroupSection({
 // scope; the comp's CSS-only print clipping must NOT recur). Only PDF-bound
 // (non-excluded) entries are paginated.
 // ---------------------------------------------------------------------------
-const PRINT_COLS = 4
-const PRINT_ROWS = 3
-const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
-
 interface Sheet {
   readonly groupLabel: string
   readonly cont: boolean
   readonly items: readonly ProductInfoEntry[]
 }
 
+// Layout-aware pagination from the SHARED geometry (PRODUCT_INFO_LAYOUT_GEOMETRY)
+// so the on-screen paged preview and the @react-pdf export pack identically.
 function buildSheets(model: ProductInfoModel): readonly Sheet[] {
+  const perSheet = PRODUCT_INFO_LAYOUT_GEOMETRY[model.layout].cardsPerSheet
   const sheets: Sheet[] = []
   for (const group of model.groups) {
     const printable = group.items.filter((e) => !e.excluded)
-    for (let i = 0; i < printable.length; i += CARDS_PER_SHEET) {
+    for (let i = 0; i < printable.length; i += perSheet) {
       sheets.push({
         groupLabel: group.label,
         cont: i > 0,
-        items: printable.slice(i, i + CARDS_PER_SHEET),
+        items: printable.slice(i, i + perSheet),
       })
     }
   }
@@ -265,13 +389,14 @@ function PagedView({
   readonly onToggleExclude: (familyId: string) => void
 }): JSX.Element {
   const sheets = useMemo(() => buildSheets(model), [model])
+  const printCols = PRODUCT_INFO_LAYOUT_GEOMETRY[model.layout].printCols
   const projLine = model.project.client
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
   const totalPages = sheets.length
 
   return (
-    <div className="sb-pir-paged" style={{ ["--sb-pir-print-cols" as string]: PRINT_COLS }}>
+    <div className="sb-pir-paged" style={{ ["--sb-pir-print-cols" as string]: printCols }}>
       {sheets.map((sheet, idx) => (
         <section className="sb-pir-sheet" key={`pir-sheet-${idx}`}>
           <div className="sb-pir-sheet-head">
@@ -286,7 +411,13 @@ function PagedView({
           </div>
           <div className="sb-pir-sheet-body">
             {sheet.items.map((entry) => (
-              <ProductCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+              <FamilyItem
+                key={entry.id}
+                entry={entry}
+                imageMap={imageMap}
+                onToggleExclude={onToggleExclude}
+                layout={model.layout}
+              />
             ))}
           </div>
           <div className="sb-pir-sheet-foot">
@@ -311,8 +442,12 @@ function ControlBar({
   onSetScope,
   groupBy,
   onSetGroupBy,
+  layout,
+  onSetLayout,
+  showLayout,
   imageSize,
   onSetImageSize,
+  showImageSize,
   printMode,
   onSetPrintMode,
   showStatusFilter,
@@ -332,8 +467,12 @@ function ControlBar({
   readonly onSetScope: (v: ProductInfoScope) => void
   readonly groupBy: ProductInfoGroupBy
   readonly onSetGroupBy: (v: ProductInfoGroupBy) => void
+  readonly layout: ProductInfoLayout
+  readonly onSetLayout: (v: ProductInfoLayout) => void
+  readonly showLayout: boolean
   readonly imageSize: ProductInfoImageSize
   readonly onSetImageSize: (v: ProductInfoImageSize) => void
+  readonly showImageSize: boolean
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
   readonly showStatusFilter: boolean
@@ -351,6 +490,7 @@ function ControlBar({
 }): JSX.Element {
   const scopeLabelId = useId()
   const groupLabelId = useId()
+  const layoutLabelId = useId()
   const sizeLabelId = useId()
   const viewLabelId = useId()
   const statusLabelId = useId()
@@ -423,24 +563,47 @@ function ControlBar({
         />
       )}
 
-      <div className="sb-pir-control-group" role="group" aria-labelledby={sizeLabelId}>
-        <span id={sizeLabelId} className="sb-pir-control-label">
-          Image size
-        </span>
-        <div className="sb-pir-seg">
-          {sizeOpts.map(([v, label]) => (
-            <button
-              key={v}
-              type="button"
-              className="sb-pir-seg-btn"
-              aria-pressed={imageSize === v}
-              onClick={() => onSetImageSize(v)}
-            >
-              {label}
-            </button>
-          ))}
+      {showLayout && (
+        <div className="sb-pir-control-group" role="group" aria-labelledby={layoutLabelId}>
+          <span id={layoutLabelId} className="sb-pir-control-label">
+            Layout
+          </span>
+          <div className="sb-pir-seg">
+            {PRODUCT_INFO_LAYOUT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-pir-seg-btn"
+                aria-pressed={layout === opt.value}
+                onClick={() => onSetLayout(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
         </div>
-      </div>
+      )}
+
+      {showImageSize && (
+        <div className="sb-pir-control-group" role="group" aria-labelledby={sizeLabelId}>
+          <span id={sizeLabelId} className="sb-pir-control-label">
+            Image size
+          </span>
+          <div className="sb-pir-seg">
+            {sizeOpts.map(([v, label]) => (
+              <button
+                key={v}
+                type="button"
+                className="sb-pir-seg-btn"
+                aria-pressed={imageSize === v}
+                onClick={() => onSetImageSize(v)}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       <div className="sb-pir-control-group" role="group" aria-labelledby={viewLabelId}>
         <span id={viewLabelId} className="sb-pir-control-label">
@@ -540,6 +703,14 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
     onConfigChange({ ...config, imageSize })
   }
 
+  // R4 density — the report body reads the RESOLVED (neutralized) model.layout so
+  // screen + PDF can't drift; the picker writes raw config.layout.
+  const layout = model.layout
+  const setLayout = (next: ProductInfoLayout): void => {
+    if (next === (config.layout ?? "gallery")) return
+    onConfigChange({ ...config, layout: next })
+  }
+
   // R3 status filter — multi-select toggle set; an absent field default-merges to [].
   const hiddenStatuses = config.hiddenStatuses ?? []
   const toggleStatus = (status: ReportShotStatus): void => {
@@ -564,7 +735,11 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
   const isEmpty = model.groups.length === 0 || model.project.familyCount === 0
 
   return (
-    <div className={"sb-pir-root" + (printMode ? " sb-pir-print-mode" : "")} data-size={config.imageSize}>
+    <div
+      className={"sb-pir-root" + (printMode ? " sb-pir-print-mode" : "")}
+      data-size={config.imageSize}
+      data-layout={layout}
+    >
       <style>{PRODUCT_INFO_STYLES}</style>
 
       <ControlBar
@@ -572,8 +747,12 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
         onSetScope={setScope}
         groupBy={config.groupBy}
         onSetGroupBy={setGroupBy}
+        layout={layout}
+        onSetLayout={setLayout}
+        showLayout={reportConfigEnabled}
         imageSize={config.imageSize}
         onSetImageSize={setImageSize}
+        showImageSize={layout === "gallery"}
         printMode={printMode}
         onSetPrintMode={setPrintMode}
         showStatusFilter={reportConfigEnabled}
@@ -605,6 +784,7 @@ export function ProductInfoReportView(props: ProductInfoReportViewProps): JSX.El
                   group={group}
                   imageMap={imageMap}
                   onToggleExclude={toggleExclude}
+                  layout={layout}
                 />
               ))}
             </div>

--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -4,24 +4,29 @@
 // Consumes the resolved TalentModel + an image *sidecar* map (candidate -> data URL).
 // No red on this surface — status uses neutral/amber dots only. Ported from comp-talent.html.
 
-import { useId, useMemo, useState } from "react"
-import type { JSX } from "react"
+import { useId, useMemo, useRef, useState } from "react"
+import type { CSSProperties, JSX, PointerEvent as ReactPointerEvent } from "react"
 import { Loader2 } from "lucide-react"
 import { isFeatureEnabled } from "@/shared/lib/flags"
 import { initials } from "@/features/library/components/talentUtils"
 import { resolveSrc, statusMeta } from "./reportShared"
 import { TALENT_STYLES } from "./talentStyles"
 import type {
+  HeadshotCrop,
   TalentConfig,
   TalentEntry,
   TalentGroup,
   TalentGroupBy,
+  TalentLayout,
   TalentModel,
   TalentScope,
   TalentSortField,
 } from "../../lib/report/talentTypes"
 import {
+  cropFocalPercents,
+  cropZoomTransform,
   DEFAULT_TALENT_CONFIG,
+  TALENT_LAYOUT_OPTIONS,
   TALENT_SORT_FIELD_OPTIONS,
 } from "../../lib/report/talentTypes"
 import type { ReportShotStatus } from "../../lib/report/reportTypes"
@@ -149,6 +154,189 @@ function TalentCard({
 }
 
 // ---------------------------------------------------------------------------
+// Contact-sheet card (R4 density variant) — compact casting board. Headshot-forward
+// uniform grid; HIDES the contact block, measurement grid, and per-shot "In shots"
+// list. SHOWS headshot + name + HOLD flag (the one red — talent with any on-hold
+// shot) + gender + agency + shot count. Part 2: fixed 4:5 COVER crop with an
+// adjustable focal point + zoom (entry.crop, folded from the neutralized config so
+// the PDF reads the SAME value); the picker below is screen-only + flag-gated.
+// ---------------------------------------------------------------------------
+function talentHasHold(entry: TalentEntry): boolean {
+  return entry.appears.some((a) => a.status === "on_hold")
+}
+
+// The contact-sheet headshot's crop style — a COVER crop into the fixed 4:5 frame,
+// focal point + zoom from entry.crop. Derived from the SAME cropFocalPercents /
+// cropZoomTransform helpers the PDF uses, so screen + PDF can't drift.
+function contactCropStyle(crop: HeadshotCrop): CSSProperties {
+  const focal = cropFocalPercents(crop)
+  const position = `${focal.x} ${focal.y}`
+  const zoom = cropZoomTransform(crop)
+  return {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    objectPosition: position,
+    ...(zoom ? { transform: zoom, transformOrigin: position } : {}),
+  }
+}
+
+const clamp01 = (v: number): number => Math.min(1, Math.max(0, v))
+const round2 = (v: number): number => Math.round(v * 100) / 100
+
+// Lightweight per-headshot crop editor (screen-only): a draggable focal-point dot
+// over a mini preview + a zoom slider. Writes the whole crop back via onChange.
+// NOT the full react-easy-crop rect/rotation editor — that's a deferred follow-up.
+function CropPicker({
+  crop,
+  onChange,
+  label,
+}: {
+  readonly crop: HeadshotCrop
+  readonly onChange: (next: HeadshotCrop) => void
+  readonly label: string
+}): JSX.Element {
+  const surfaceRef = useRef<HTMLDivElement | null>(null)
+
+  const setFocal = (clientX: number, clientY: number): void => {
+    const el = surfaceRef.current
+    if (!el) return
+    const r = el.getBoundingClientRect()
+    if (r.width === 0 || r.height === 0) return
+    onChange({
+      ...crop,
+      x: round2(clamp01((clientX - r.left) / r.width)),
+      y: round2(clamp01((clientY - r.top) / r.height)),
+    })
+  }
+  const onPointerDown = (e: ReactPointerEvent<HTMLDivElement>): void => {
+    e.preventDefault()
+    e.currentTarget.setPointerCapture?.(e.pointerId)
+    setFocal(e.clientX, e.clientY)
+  }
+  const onPointerMove = (e: ReactPointerEvent<HTMLDivElement>): void => {
+    if (e.buttons !== 1) return // only while dragging
+    setFocal(e.clientX, e.clientY)
+  }
+
+  const focal = cropFocalPercents(crop)
+  return (
+    <div className="sb-tr-crop-picker no-print" role="group" aria-label={`Adjust ${label}'s headshot crop`}>
+      <div
+        ref={surfaceRef}
+        className="sb-tr-crop-surface"
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        title="Drag to set the focal point"
+      >
+        <span className="sb-tr-crop-focal" style={{ left: focal.x, top: focal.y }} aria-hidden="true" />
+      </div>
+      <label className="sb-tr-crop-zoom">
+        <span className="sb-tr-crop-zoom-label">Zoom</span>
+        <input
+          type="range"
+          min={1}
+          max={3}
+          step={0.05}
+          value={crop.scale}
+          aria-label={`Zoom ${label}'s headshot`}
+          onChange={(e) => onChange({ ...crop, scale: round2(Number(e.target.value)) })}
+        />
+      </label>
+    </div>
+  )
+}
+
+function ContactSheetCard({
+  entry,
+  imageMap,
+  onToggleExclude,
+  showCropPicker,
+  onSetCrop,
+}: {
+  readonly entry: TalentEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (talentId: string) => void
+  readonly showCropPicker: boolean
+  readonly onSetCrop?: (talentId: string, crop: HeadshotCrop) => void
+}): JSX.Element {
+  const src = resolveSrc(imageMap, entry.headshot)
+  const n = entry.appears.length
+  return (
+    <article className={"sb-tr-cs-card" + (entry.excluded ? " sb-tr-excluded" : "")}>
+      <button
+        type="button"
+        className="sb-tr-exclude-toggle no-print"
+        aria-pressed={entry.excluded}
+        onClick={() => onToggleExclude(entry.id)}
+        title={entry.excluded ? "Restore this talent to the report" : "Exclude this talent from the report"}
+      >
+        {entry.excluded ? "Restore" : "Exclude"}
+      </button>
+
+      <div className="sb-tr-cs-frame">
+        {src ? (
+          <img src={src} alt={`${entry.name} — headshot`} loading="lazy" style={contactCropStyle(entry.crop)} />
+        ) : (
+          <div className="sb-tr-cs-initials">{initials(entry.name)}</div>
+        )}
+        {showCropPicker && onSetCrop && src ? (
+          <CropPicker crop={entry.crop} onChange={(next) => onSetCrop(entry.id, next)} label={entry.name} />
+        ) : null}
+      </div>
+
+      <div className="sb-tr-cs-name-row">
+        <span className="sb-tr-cs-name">{entry.name}</span>
+        {talentHasHold(entry) ? <span className="sb-tr-hold-flag">Hold</span> : null}
+      </div>
+
+      {entry.genderLabel || entry.agency ? (
+        <div className="sb-tr-cs-meta">
+          {entry.genderLabel ? <span className="sb-tr-badge-gender">{entry.genderLabel}</span> : null}
+          {entry.agency ? <span className="sb-tr-agency">{entry.agency}</span> : null}
+        </div>
+      ) : null}
+
+      <div className="sb-tr-cs-stat">
+        <span className="sb-tr-cs-count">
+          {n} {n === 1 ? "shot" : "shots"}
+        </span>
+      </div>
+    </article>
+  )
+}
+
+// Pick the card component for the resolved density — one place both the fluid grid
+// and the paged view route through, so screen never drifts from the model's layout.
+function CardForLayout({
+  entry,
+  imageMap,
+  onToggleExclude,
+  layout,
+  showCropPicker = false,
+  onSetCrop,
+}: {
+  readonly entry: TalentEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly onToggleExclude: (talentId: string) => void
+  readonly layout: TalentLayout
+  readonly showCropPicker?: boolean
+  readonly onSetCrop?: (talentId: string, crop: HeadshotCrop) => void
+}): JSX.Element {
+  return layout === "contact-sheet" ? (
+    <ContactSheetCard
+      entry={entry}
+      imageMap={imageMap}
+      onToggleExclude={onToggleExclude}
+      showCropPicker={showCropPicker}
+      onSetCrop={onSetCrop}
+    />
+  ) : (
+    <TalentCard entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Masthead band — Talent / Agencies / Window.
 // ---------------------------------------------------------------------------
 function Masthead({ model }: { readonly model: TalentModel }): JSX.Element {
@@ -199,10 +387,16 @@ function GroupSection({
   group,
   imageMap,
   onToggleExclude,
+  layout,
+  showCropPicker,
+  onSetCrop,
 }: {
   readonly group: TalentGroup
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (talentId: string) => void
+  readonly layout: TalentLayout
+  readonly showCropPicker: boolean
+  readonly onSetCrop: (talentId: string, crop: HeadshotCrop) => void
 }): JSX.Element {
   const shown = group.items.filter((e) => !e.excluded).length
   return (
@@ -213,7 +407,15 @@ function GroupSection({
       </div>
       <div className="sb-tr-grid">
         {group.items.map((entry) => (
-          <TalentCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+          <CardForLayout
+            key={entry.id}
+            entry={entry}
+            imageMap={imageMap}
+            onToggleExclude={onToggleExclude}
+            layout={layout}
+            showCropPicker={showCropPicker}
+            onSetCrop={onSetCrop}
+          />
         ))}
       </div>
     </section>
@@ -227,9 +429,16 @@ function GroupSection({
 // at DOM scope; the comp's CSS-only print clipping must NOT recur). Only PDF-bound
 // (non-excluded) entries are paginated.
 // ---------------------------------------------------------------------------
-const PRINT_COLS = 2
-const PRINT_ROWS = 3
-const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
+// Per-layout print geometry, kept in LOCKSTEP with reportPdfTalent's paginate().
+// detail = the shipped 2×3 (6/sheet) call-sheet grid; contact-sheet = a denser
+// 4-up casting board with a fixed 4:5 COVER crop (part 2). The 4:5 crop is much
+// taller than part-1's native-cap headshot, so the sheet packs 4×2 = 8 (not 12).
+// perSheet drives pagination; cols drives the paged grid var so a card never
+// straddles a break. EYEBALL-GATE the perSheet vs the real rendered sheet height.
+const LAYOUT_PRINT: Record<TalentLayout, { readonly cols: number; readonly perSheet: number }> = {
+  detail: { cols: 2, perSheet: 6 },
+  "contact-sheet": { cols: 4, perSheet: 8 },
+}
 
 interface Sheet {
   readonly groupLabel: string
@@ -238,14 +447,15 @@ interface Sheet {
 }
 
 function buildSheets(model: TalentModel): readonly Sheet[] {
+  const perSheet = LAYOUT_PRINT[model.layout].perSheet
   const sheets: Sheet[] = []
   for (const group of model.groups) {
     const printable = group.items.filter((e) => !e.excluded)
-    for (let i = 0; i < printable.length; i += CARDS_PER_SHEET) {
+    for (let i = 0; i < printable.length; i += perSheet) {
       sheets.push({
         groupLabel: group.label,
         cont: i > 0,
-        items: printable.slice(i, i + CARDS_PER_SHEET),
+        items: printable.slice(i, i + perSheet),
       })
     }
   }
@@ -276,7 +486,7 @@ function PagedView({
   }
 
   return (
-    <div className="sb-tr-paged" style={{ ["--sb-tr-print-cols" as string]: PRINT_COLS }}>
+    <div className="sb-tr-paged" style={{ ["--sb-tr-print-cols" as string]: LAYOUT_PRINT[model.layout].cols }}>
       {sheets.map((sheet, idx) => (
         <section className="sb-tr-sheet" key={`tr-sheet-${idx}`}>
           <div className="sb-tr-sheet-head">
@@ -291,7 +501,7 @@ function PagedView({
           </div>
           <div className="sb-tr-sheet-body">
             {sheet.items.map((entry) => (
-              <TalentCard key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+              <CardForLayout key={entry.id} entry={entry} imageMap={imageMap} onToggleExclude={onToggleExclude} layout={model.layout} />
             ))}
           </div>
           <div className="sb-tr-sheet-foot">
@@ -316,6 +526,9 @@ function ControlBar({
   onSetScope,
   groupBy,
   onSetGroupBy,
+  layout,
+  onSetLayout,
+  showLayout,
   printMode,
   onSetPrintMode,
   showStatusFilter,
@@ -335,6 +548,9 @@ function ControlBar({
   readonly onSetScope: (v: TalentScope) => void
   readonly groupBy: TalentGroupBy
   readonly onSetGroupBy: (v: TalentGroupBy) => void
+  readonly layout: TalentLayout
+  readonly onSetLayout: (v: TalentLayout) => void
+  readonly showLayout: boolean
   readonly printMode: boolean
   readonly onSetPrintMode: (v: boolean) => void
   readonly showStatusFilter: boolean
@@ -352,6 +568,7 @@ function ControlBar({
 }): JSX.Element {
   const scopeLabelId = useId()
   const groupLabelId = useId()
+  const layoutLabelId = useId()
   const viewLabelId = useId()
   const statusLabelId = useId()
 
@@ -406,6 +623,27 @@ function ControlBar({
           ))}
         </div>
       </div>
+
+      {showLayout && (
+        <div className="sb-tr-control-group" role="group" aria-labelledby={layoutLabelId}>
+          <span id={layoutLabelId} className="sb-tr-control-label">
+            Layout
+          </span>
+          <div className="sb-tr-seg">
+            {TALENT_LAYOUT_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                className="sb-tr-seg-btn"
+                aria-pressed={layout === opt.value}
+                onClick={() => onSetLayout(opt.value)}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {showSort && (
         <GroupSortControls
@@ -508,6 +746,20 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
     onConfigChange({ ...config, groupBy })
   }
 
+  // R4 density — the control reads the RAW config (default-merged); the render reads
+  // model.layout (already flag-neutralized), so screen + PDF can't drift.
+  const layout: TalentLayout = config.layout ?? DEFAULT_TALENT_CONFIG.layout ?? "detail"
+  const setLayout = (next: TalentLayout): void => {
+    if (next === layout) return
+    onConfigChange({ ...config, layout: next })
+  }
+
+  // R4 part 2 — per-talent headshot crop. Writes config.headshotCrops[id]; render
+  // reads model.crop (flag-neutralized), so screen + PDF can't drift.
+  const setCrop = (talentId: string, crop: HeadshotCrop): void => {
+    onConfigChange({ ...config, headshotCrops: { ...(config.headshotCrops ?? {}), [talentId]: crop } })
+  }
+
   // R3 status filter — multi-select toggle set; an absent field default-merges to [].
   const hiddenStatuses = config.hiddenStatuses ?? []
   const toggleStatus = (status: ReportShotStatus): void => {
@@ -534,7 +786,7 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
   const canExport = model.groups.some((g) => g.items.some((i) => !i.excluded))
 
   return (
-    <div className={"sb-tr-root" + (printMode ? " sb-tr-print-mode" : "")}>
+    <div className={"sb-tr-root" + (printMode ? " sb-tr-print-mode" : "")} data-layout={model.layout}>
       <style>{TALENT_STYLES}</style>
 
       <ControlBar
@@ -542,6 +794,9 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
         onSetScope={setScope}
         groupBy={config.groupBy}
         onSetGroupBy={setGroupBy}
+        layout={layout}
+        onSetLayout={setLayout}
+        showLayout={reportConfigEnabled}
         printMode={printMode}
         onSetPrintMode={setPrintMode}
         showStatusFilter={reportConfigEnabled}
@@ -573,6 +828,9 @@ export function TalentReportView(props: TalentReportViewProps): JSX.Element {
                   group={group}
                   imageMap={imageMap}
                   onToggleExclude={toggleExclude}
+                  layout={model.layout}
+                  showCropPicker={reportConfigEnabled}
+                  onSetCrop={setCrop}
                 />
               ))}
             </div>

--- a/src-vnext/features/export/components/report/__tests__/productInfoLayouts.parity.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/productInfoLayouts.parity.test.tsx
@@ -1,0 +1,248 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+// -----------------------------------------------------------------------------
+// Product Info LAYOUT (density) DOM-vs-PDF parity — the load-bearing Phase C test.
+// The DOM view (ProductInfoReportView) and the @react-pdf renderer
+// (ProductInfoPdfDocument) both read the SAME resolved `model.layout` and the
+// SAME pure geometry (PRODUCT_INFO_LAYOUT_GEOMETRY), so a density change can't
+// drift between screen and print. This test is FALSIFIABLE by construction:
+// mutate a per-layout column/per-sheet count on ONE renderer and a named case
+// below goes red.
+//
+// @react-pdf is mocked so View/Text/Image/Page/Document render to queryable DOM
+// nodes with a serialized `data-style` (mirrors blockConsumers.parity.test.tsx).
+// -----------------------------------------------------------------------------
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  const ser = (s: unknown) => {
+    try {
+      return s == null ? undefined : JSON.stringify(s)
+    } catch {
+      return undefined
+    }
+  }
+  const passthrough =
+    (tag: string) =>
+    (props: Record<string, unknown>) => {
+      const { style, children, render, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+        render?: unknown
+      } & Record<string, unknown>
+      void render
+      return React.createElement(tag, { ...rest, "data-style": ser(style) }, children as React.ReactNode)
+    }
+  return {
+    Document: passthrough("pdf-document"),
+    Page: passthrough("pdf-page"),
+    View: passthrough("pdf-view"),
+    Text: passthrough("pdf-text"),
+    Image: passthrough("pdf-image"),
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render } from "@testing-library/react"
+import { ProductInfoReportView } from "../ProductInfoReportView"
+import { ProductInfoPdfDocument } from "../../../lib/report/reportPdfProductInfo"
+import { COLOR } from "../../../lib/report/reportPdfShared"
+import {
+  DEFAULT_PRODUCT_INFO_CONFIG,
+  PRODUCT_INFO_LAYOUT_GEOMETRY,
+  type ProductInfoConfig,
+  type ProductInfoEntry,
+  type ProductInfoLayout,
+  type ProductInfoModel,
+} from "../../../lib/report/productInfoTypes"
+
+// A single group (Women) with enough families that BOTH densities fill their
+// first sheet/page (gallery 12, index 20 — both < 26), so first-sheet count ==
+// cardsPerSheet on each surface.
+const N = 26
+
+function entry(i: number): ProductInfoEntry {
+  return {
+    id: `f${String(i)}`,
+    styleName: `Style-${String(i).padStart(2, "0")}`,
+    styleNumber: `SN-${String(i)}`,
+    gender: "W",
+    genderLabel: "Women",
+    productType: "Tops",
+    image: null,
+    colours: ["Black"],
+    sizes: ["M"],
+    sizePending: false,
+    isHero: i === 1, // one hero → exercises the hero mark on both surfaces
+    excluded: false,
+    appears: [{ number: String(i), looks: ["Primary"], status: "complete" }],
+  }
+}
+
+function fixtureModel(layout: ProductInfoLayout): ProductInfoModel {
+  const items = Array.from({ length: N }, (_, i) => entry(i + 1))
+  return {
+    project: { name: "Q2-26 No. 3", client: "unbound-merino", dateRange: "Jun 2–6, 2026", familyCount: N },
+    groups: [{ key: "W", label: "Women", count: N, items }],
+    layout,
+  }
+}
+
+const cfg = (over: Partial<ProductInfoConfig> = {}): ProductInfoConfig => ({
+  ...DEFAULT_PRODUCT_INFO_CONFIG,
+  ...over,
+})
+
+function renderDom(layout: ProductInfoLayout) {
+  return render(
+    <ProductInfoReportView
+      model={fixtureModel(layout)}
+      imageMap={new Map()}
+      config={cfg({ layout })}
+      onConfigChange={() => {}}
+      onExportPdf={() => {}}
+    />,
+  )
+}
+
+function renderPdf(layout: ProductInfoLayout) {
+  return render(<ProductInfoPdfDocument model={fixtureModel(layout)} imageMap={new Map()} />)
+}
+
+const NAMES = new Set(Array.from({ length: N }, (_, i) => `Style-${String(i + 1).padStart(2, "0")}`))
+
+// Count how many product-name cells land on the FIRST print sheet / PDF page.
+function domFirstSheetCards(container: HTMLElement): number {
+  const firstSheet = container.querySelector(".sb-pir-sheet .sb-pir-sheet-body")
+  return firstSheet ? firstSheet.children.length : -1
+}
+function pdfFirstPageCards(container: HTMLElement): number {
+  const firstPage = container.querySelector("pdf-page")
+  if (!firstPage) return -1
+  return Array.from(firstPage.querySelectorAll("pdf-text")).filter((t) =>
+    NAMES.has((t.textContent ?? "").trim()),
+  ).length
+}
+
+function pdfStyles(container: HTMLElement): Record<string, unknown>[] {
+  return Array.from(container.querySelectorAll("pdf-view")).map((v) => {
+    const raw = v.getAttribute("data-style")
+    return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+  })
+}
+
+const LAYOUTS: readonly ProductInfoLayout[] = ["gallery", "index"]
+
+describe("Product Info layout — geometry is the single source both renderers read", () => {
+  it("gallery and index declare DIFFERENT per-sheet packing (so the densities are real)", () => {
+    expect(PRODUCT_INFO_LAYOUT_GEOMETRY.gallery.cardsPerSheet).not.toBe(
+      PRODUCT_INFO_LAYOUT_GEOMETRY.index.cardsPerSheet,
+    )
+    expect(PRODUCT_INFO_LAYOUT_GEOMETRY.index.cardsPerSheet).toBeGreaterThan(
+      PRODUCT_INFO_LAYOUT_GEOMETRY.gallery.cardsPerSheet,
+    )
+  })
+
+  it.each(LAYOUTS)(
+    "DOM print sheet AND PDF page pack the SAME cards-per-sheet for layout=%s",
+    (layout) => {
+      const expected = PRODUCT_INFO_LAYOUT_GEOMETRY[layout].cardsPerSheet
+      const dom = domFirstSheetCards(renderDom(layout).container)
+      const pdf = pdfFirstPageCards(renderPdf(layout).container)
+      expect(dom).toBe(expected) // DOM PagedView reads the shared geometry
+      expect(pdf).toBe(expected) // @react-pdf paginate reads the shared geometry
+      expect(dom).toBe(pdf) // ...and therefore can't drift
+    },
+  )
+})
+
+describe("Product Info layout — structural block selection matches DOM<->PDF", () => {
+  it("gallery shows the per-shot 'Appears in' block on BOTH surfaces", () => {
+    const dom = renderDom("gallery").container
+    const pdf = renderPdf("gallery").container
+    expect(dom.querySelectorAll(".sb-pir-appears").length).toBeGreaterThan(0)
+    expect(
+      Array.from(pdf.querySelectorAll("pdf-text")).some((t) =>
+        (t.textContent ?? "").startsWith("Appears in"),
+      ),
+    ).toBe(true)
+  })
+
+  it("index HIDES the per-shot 'Appears in' block on BOTH surfaces (compact rows)", () => {
+    const dom = renderDom("index").container
+    const pdf = renderPdf("index").container
+    expect(dom.querySelectorAll(".sb-pir-appears").length).toBe(0)
+    expect(
+      Array.from(pdf.querySelectorAll("pdf-text")).some((t) =>
+        (t.textContent ?? "").startsWith("Appears in"),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe("Product Info layout — canonical hero mark (critic fix: index is red-free / ink)", () => {
+  it("gallery PDF keeps its shipped RED hero mark (byte-identity — unchanged)", () => {
+    const styles = pdfStyles(renderPdf("gallery").container)
+    expect(styles.some((s) => s.backgroundColor === COLOR.accent)).toBe(true)
+  })
+
+  it("index PDF uses the canonical INK hero mark and paints NO red anywhere", () => {
+    const styles = pdfStyles(renderPdf("index").container)
+    // Red-free surface (locked design system: RED owns HOLD; Product Info index is red-free).
+    expect(styles.some((s) => s.backgroundColor === COLOR.accent)).toBe(false)
+    // The canonical hero mark is an ink dot (backgroundColor === COLOR.text).
+    expect(styles.some((s) => s.backgroundColor === COLOR.text)).toBe(true)
+  })
+
+  it("index DOM hero mark uses the ink class, not the red gallery hero tag", () => {
+    const dom = renderDom("index").container
+    expect(dom.querySelectorAll(".sb-pir-index-hero").length).toBeGreaterThan(0)
+    // The red gallery hero tag must not appear on the index surface.
+    expect(dom.querySelectorAll(".sb-pir-irow .sb-pir-hero-tag").length).toBe(0)
+  })
+})
+
+describe("Product Info layout picker — gated behind featureReportConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("flag OFF: no Layout control renders (control bar byte-identical)", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "")
+    const { queryByText } = renderDom("gallery")
+    expect(queryByText("Layout")).toBeNull()
+  })
+
+  it("flag ON: Layout control renders and selecting Index emits config.layout='index'", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const onConfigChange = vi.fn()
+    const config = cfg({ layout: "gallery" })
+    const { getByText, getByRole } = render(
+      <ProductInfoReportView
+        model={fixtureModel("gallery")}
+        imageMap={new Map()}
+        config={config}
+        onConfigChange={onConfigChange}
+        onExportPdf={() => {}}
+      />,
+    )
+    expect(getByText("Layout")).not.toBeNull()
+    // Image size stays available while the resolved layout is gallery.
+    expect(getByText("Image size")).not.toBeNull()
+    getByRole("button", { name: "Index" }).click()
+    expect(onConfigChange).toHaveBeenCalledWith(expect.objectContaining({ layout: "index" }))
+  })
+
+  it("flag ON + resolved index layout: the gallery-only Image size knob is hidden", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const { queryByText } = render(
+      <ProductInfoReportView
+        model={fixtureModel("index")}
+        imageMap={new Map()}
+        config={cfg({ layout: "index" })}
+        onConfigChange={() => {}}
+        onExportPdf={() => {}}
+      />,
+    )
+    expect(queryByText("Image size")).toBeNull()
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/talentHeadshotCrop.parity.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/talentHeadshotCrop.parity.test.tsx
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+// Falsifiable DOM-vs-PDF parity for the ADJUSTABLE HEADSHOT CROP (R4 Phase C,
+// Talent part 2). The contact-sheet layout crops each headshot into a fixed 4:5
+// frame; the per-talent crop {scale,x,y} is folded onto the resolved model entry
+// (entry.crop), so BOTH the DOM <img> and the @react-pdf <Image> read the SAME
+// value. This proves screen and PDF can't drift on the crop.
+//
+// The load-bearing claim: for a given entry.crop, the DOM img's object-position +
+// transform equal the PDF Image's objectPositionX/Y + transform (same focal point,
+// same zoom). Mutate the crop math on either side and the matching assertion reds.
+//
+// Mock @react-pdf into queryable DOM (mirrors blockConsumers.parity) — but here we
+// ALSO serialize the Image style (flattened from an array) to data-style so the
+// PDF Image's crop props are inspectable.
+
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  // Flatten @react-pdf's array-of-styles into one object, then JSON-serialize.
+  const flatten = (s: unknown): Record<string, unknown> => {
+    if (Array.isArray(s)) return Object.assign({}, ...s.map(flatten))
+    return (s ?? {}) as Record<string, unknown>
+  }
+  const ser = (s: unknown) => {
+    try {
+      return JSON.stringify(flatten(s))
+    } catch {
+      return undefined
+    }
+  }
+  return {
+    Document: (p: Record<string, unknown>) =>
+      React.createElement("pdf-document", null, p.children as React.ReactNode),
+    Page: (p: Record<string, unknown>) =>
+      React.createElement("pdf-page", null, p.children as React.ReactNode),
+    View: (p: Record<string, unknown>) => {
+      const { style, children, ...rest } = p as { style?: unknown; children?: unknown } & Record<string, unknown>
+      return React.createElement("pdf-view", { ...rest, "data-style": ser(style) }, children as React.ReactNode)
+    },
+    Text: (p: Record<string, unknown>) =>
+      React.createElement("pdf-text", null, p.children as React.ReactNode),
+    Image: (p: Record<string, unknown>) => {
+      const { style } = p as { style?: unknown }
+      return React.createElement("pdf-image", { "data-style": ser(style) })
+    },
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TalentReportView } from "../TalentReportView"
+import { TalentPdfDocument } from "../../../lib/report/reportPdfTalent"
+import {
+  DEFAULT_TALENT_CONFIG,
+  DEFAULT_HEADSHOT_CROP,
+} from "../../../lib/report/talentTypes"
+import type {
+  HeadshotCrop,
+  TalentEntry,
+  TalentLayout,
+  TalentModel,
+} from "../../../lib/report/talentTypes"
+
+const noop = (): void => {}
+const IMG = "candidate.jpg"
+// Empty resolveSrc returns null (candidate not in map) -> initials render, no <img>.
+// A populated map makes both renderers draw the actual image so its crop style shows.
+const IMAGE_MAP = new Map([[IMG, "data:image/png;base64,AAAA"]])
+
+function entry(over: Partial<TalentEntry> & { id: string; name: string }): TalentEntry {
+  return {
+    id: over.id,
+    name: over.name,
+    gender: over.gender ?? "female",
+    genderLabel: over.genderLabel ?? "Female",
+    agency: over.agency ?? "Elite",
+    email: over.email ?? null,
+    phone: over.phone ?? null,
+    web: over.web ?? null,
+    headshot: over.headshot ?? IMG,
+    measurements: over.measurements ?? [],
+    excluded: over.excluded ?? false,
+    appears: over.appears ?? [],
+    crop: over.crop ?? DEFAULT_HEADSHOT_CROP,
+  }
+}
+
+function modelOf(items: readonly TalentEntry[], layout: TalentLayout): TalentModel {
+  return {
+    project: { name: "Q2-26 No. 3", client: "Unbound Merino", dateRange: "Jun 2–6, 2026", talentCount: items.length },
+    groups: [{ key: "all", label: "All talent", count: items.length, items }],
+    layout,
+  }
+}
+
+function renderDom(model: TalentModel, onConfigChange: (c: unknown) => void = noop, config = { ...DEFAULT_TALENT_CONFIG, layout: model.layout }) {
+  return render(
+    <TalentReportView
+      model={model}
+      imageMap={IMAGE_MAP}
+      config={config as never}
+      onConfigChange={onConfigChange as never}
+      onExportPdf={noop}
+    />,
+  )
+}
+function renderPdf(model: TalentModel) {
+  return render(<TalentPdfDocument model={model} imageMap={IMAGE_MAP} />)
+}
+
+// The screen headshot lives in the FLUID grid (not the hidden paged preview);
+// scope reads to it so the paged copy never confuses the count.
+function domHeadshotImg(container: HTMLElement): HTMLImageElement {
+  const img = container.querySelector<HTMLImageElement>(".sb-tr-fluid .sb-tr-cs-frame img")
+  if (!img) throw new Error("no contact-sheet headshot img rendered")
+  return img
+}
+function pdfImageStyle(container: HTMLElement): Record<string, unknown> {
+  const el = container.querySelector("pdf-image")
+  const raw = el?.getAttribute("data-style")
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+}
+
+describe("headshot crop — DOM img and PDF Image read the SAME crop value", () => {
+  it("a custom crop places the same focal point + zoom on BOTH surfaces", () => {
+    const CROP: HeadshotCrop = { scale: 1.5, x: 0.25, y: 0.1 }
+    const model = modelOf([entry({ id: "tA", name: "Ava Stone", crop: CROP })], "contact-sheet")
+
+    const img = domHeadshotImg(renderDom(model).container)
+    const pdf = pdfImageStyle(renderPdf(model).container)
+
+    // focal point — DOM shorthand "25% 10%" equals PDF X/Y "25%","10%"
+    expect(img.style.objectPosition).toBe("25% 10%")
+    expect(pdf.objectPositionX).toBe("25%")
+    expect(pdf.objectPositionY).toBe("10%")
+    expect(img.style.objectPosition).toBe(`${String(pdf.objectPositionX)} ${String(pdf.objectPositionY)}`)
+
+    // zoom — same transform string on both surfaces
+    expect(img.style.transform).toBe("scale(1.5)")
+    expect(pdf.transform).toBe("scale(1.5)")
+
+    // the crop is a COVER crop on both (fixed 4:5 frame)
+    expect(img.style.objectFit).toBe("cover")
+    expect(pdf.objectFit).toBe("cover")
+  })
+
+  it("the default crop centers the focal point and applies no zoom on BOTH surfaces", () => {
+    const model = modelOf([entry({ id: "tA", name: "Ava Stone" })], "contact-sheet") // default crop
+    const img = domHeadshotImg(renderDom(model).container)
+    const pdf = pdfImageStyle(renderPdf(model).container)
+
+    expect(img.style.objectPosition).toBe("50% 50%")
+    expect(pdf.objectPositionX).toBe("50%")
+    expect(pdf.objectPositionY).toBe("50%")
+    // scale 1 => no transform on either surface
+    expect(img.style.transform).toBe("")
+    expect(pdf.transform).toBeUndefined()
+  })
+})
+
+describe("headshot crop — detail layout is never cropped", () => {
+  it("detail keeps a native-aspect (contain) headshot, no cover/object-position", () => {
+    const CROP: HeadshotCrop = { scale: 2, x: 0.9, y: 0.9 }
+    // Even with a crop present on the entry, the detail card ignores it.
+    const model = modelOf([entry({ id: "tA", name: "Ava Stone", crop: CROP })], "detail")
+    const dom = renderDom(model).container
+    const pdf = renderPdf(model).container
+    // detail DOM headshot is .sb-tr-headshot-frame (not .sb-tr-cs-frame)
+    const detailImg = dom.querySelector<HTMLImageElement>(".sb-tr-fluid .sb-tr-headshot-frame img")
+    expect(detailImg).not.toBeNull()
+    expect(detailImg?.style.objectFit).not.toBe("cover")
+    // no contact-sheet crop frame at all in detail
+    expect(dom.querySelector(".sb-tr-cs-frame")).toBeNull()
+    // the PDF detail Image is objectFit contain, no focal offset
+    const pdfImg = pdfImageStyle(pdf)
+    expect(pdfImg.objectPositionX).toBeUndefined()
+    expect(pdfImg.transform).toBeUndefined()
+  })
+})
+
+describe("headshot crop picker — screen-only, gated behind featureReportConfig", () => {
+  afterEach(() => vi.unstubAllEnvs())
+
+  it("flag OFF: no crop picker renders", () => {
+    const { container } = renderDom(modelOf([entry({ id: "tA", name: "Ava Stone" })], "contact-sheet"))
+    expect(container.querySelectorAll('input[type="range"]').length).toBe(0)
+    expect(container.querySelector(".sb-tr-crop-picker")).toBeNull()
+  })
+
+  it("flag ON + contact-sheet: a zoom slider + focal dot render (screen-only)", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const { container } = renderDom(modelOf([entry({ id: "tA", name: "Ava Stone" })], "contact-sheet"))
+    const picker = container.querySelector(".sb-tr-crop-picker")
+    expect(picker).not.toBeNull()
+    expect(picker?.classList.contains("no-print")).toBe(true) // never prints
+    // exactly one slider (fluid card only — the paged preview carries no picker)
+    expect(container.querySelectorAll('input[type="range"]').length).toBe(1)
+    expect(container.querySelector(".sb-tr-crop-focal")).not.toBeNull()
+  })
+
+  it("flag ON + detail: NO crop picker (crop is contact-sheet only)", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const { container } = renderDom(modelOf([entry({ id: "tA", name: "Ava Stone" })], "detail"))
+    expect(container.querySelectorAll('input[type="range"]').length).toBe(0)
+    expect(container.querySelector(".sb-tr-crop-picker")).toBeNull()
+  })
+
+  it("flag ON: dragging the zoom slider writes headshotCrops[id].scale via onConfigChange", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const spy = vi.fn()
+    renderDom(modelOf([entry({ id: "tA", name: "Ava Stone" })], "contact-sheet"), spy)
+    const slider = screen.getByRole("slider")
+    fireEvent.change(slider, { target: { value: "2" } })
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        headshotCrops: expect.objectContaining({ tA: expect.objectContaining({ scale: 2 }) }),
+      }),
+    )
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/talentReportLayouts.parity.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/talentReportLayouts.parity.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, afterEach } from "vitest"
+
+// Falsifiable DOM-vs-PDF parity for the Talent density enum (R4 Phase C).
+// One resolved TalentModel feeds BOTH the DOM TalentReportView and the @react-pdf
+// TalentPdfDocument, so screen and PDF can't drift. We mock @react-pdf into
+// queryable DOM (mirrors ExportPdfDocument.test + blockConsumers.parity) so the
+// PDF renderer's structural selection is inspectable by text content / node count.
+//
+// The load-bearing claim: contact-sheet HIDES the contact block + measurements
+// grid + per-shot "In shots" list on BOTH surfaces and packs a denser grid;
+// detail SHOWS all. Mutate a hidden-block condition on either side and the
+// matching assertion goes red.
+
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  return {
+    Document: (p: Record<string, unknown>) =>
+      React.createElement("pdf-document", null, p.children as React.ReactNode),
+    Page: (p: Record<string, unknown>) =>
+      React.createElement("pdf-page", null, p.children as React.ReactNode),
+    View: (p: Record<string, unknown>) =>
+      React.createElement("pdf-view", null, p.children as React.ReactNode),
+    Text: (p: Record<string, unknown>) =>
+      React.createElement("pdf-text", null, p.children as React.ReactNode),
+    Image: () => React.createElement("pdf-image", null),
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render, screen, fireEvent } from "@testing-library/react"
+import { TalentReportView } from "../TalentReportView"
+import { TalentPdfDocument } from "../../../lib/report/reportPdfTalent"
+import { DEFAULT_HEADSHOT_CROP, DEFAULT_TALENT_CONFIG } from "../../../lib/report/talentTypes"
+import type {
+  TalentEntry,
+  TalentLayout,
+  TalentModel,
+} from "../../../lib/report/talentTypes"
+
+const noop = (): void => {}
+
+function entry(over: Partial<TalentEntry> & { id: string; name: string }): TalentEntry {
+  return {
+    id: over.id,
+    name: over.name,
+    gender: over.gender ?? "female",
+    genderLabel: over.genderLabel ?? "Female",
+    agency: over.agency ?? "Elite",
+    email: over.email ?? null,
+    phone: over.phone ?? null,
+    web: over.web ?? null,
+    headshot: over.headshot ?? null,
+    measurements: over.measurements ?? [],
+    excluded: over.excluded ?? false,
+    appears: over.appears ?? [],
+    crop: over.crop ?? DEFAULT_HEADSHOT_CROP,
+  }
+}
+
+// A talent carrying every optional block + an on-hold appearance (drives the HOLD flag).
+const AVA: TalentEntry = entry({
+  id: "tA",
+  name: "Ava Stone",
+  agency: "Elite",
+  email: "ava@example.co",
+  measurements: [{ label: "Height", value: `5'10"` }],
+  appears: [{ number: "01", title: "Trail Crew", looks: ["Primary"], status: "on_hold" }],
+})
+
+function modelOf(items: readonly TalentEntry[], layout: TalentLayout): TalentModel {
+  return {
+    project: {
+      name: "Q2-26 No. 3",
+      client: "Unbound Merino",
+      dateRange: "Jun 2–6, 2026",
+      talentCount: items.length,
+    },
+    groups: [{ key: "all", label: "All talent", count: items.length, items }],
+    layout,
+  }
+}
+
+function renderDom(model: TalentModel, onConfigChange: (c: unknown) => void = noop) {
+  return render(
+    <TalentReportView
+      model={model}
+      imageMap={new Map()}
+      config={{ ...DEFAULT_TALENT_CONFIG, layout: model.layout }}
+      onConfigChange={onConfigChange as never}
+      onExportPdf={noop}
+    />,
+  )
+}
+
+function renderPdf(model: TalentModel) {
+  return render(<TalentPdfDocument model={model} imageMap={new Map()} />)
+}
+
+describe("Talent layout — content parity (DOM vs PDF consume one model)", () => {
+  it("detail SHOWS contact + measurements + per-shot list on BOTH surfaces", () => {
+    const model = modelOf([AVA], "detail")
+    const dom = renderDom(model).container.textContent ?? ""
+    const pdf = renderPdf(model).container.textContent ?? ""
+    for (const surface of [dom, pdf]) {
+      expect(surface).toContain("Email") // contact block
+      expect(surface).toContain("Height") // measurements grid
+      expect(surface).toContain("Trail Crew") // per-shot "In shots" list
+    }
+  })
+
+  it("contact-sheet HIDES contact + measurements + per-shot list on BOTH surfaces", () => {
+    const model = modelOf([AVA], "contact-sheet")
+    const dom = renderDom(model).container.textContent ?? ""
+    const pdf = renderPdf(model).container.textContent ?? ""
+    for (const surface of [dom, pdf]) {
+      expect(surface).not.toContain("Email") // no contact block
+      expect(surface).not.toContain("Height") // no measurements grid
+      expect(surface).not.toContain(`5'10"`) // ...not even the measurement value
+      expect(surface).not.toContain("Trail Crew") // no per-shot list
+      // casting-board essentials remain on both surfaces
+      expect(surface).toContain("Ava Stone") // name
+      expect(surface).toContain("Elite") // agency
+    }
+  })
+
+  it("contact-sheet shows the RED=HOLD flag for a talent with an on-hold shot (BOTH surfaces)", () => {
+    const model = modelOf([AVA], "contact-sheet")
+    const dom = (renderDom(model).container.textContent ?? "").toLowerCase()
+    const pdf = (renderPdf(model).container.textContent ?? "").toLowerCase()
+    expect(dom).toContain("hold")
+    expect(pdf).toContain("hold")
+  })
+})
+
+describe("Talent layout — density parity (contact-sheet packs denser)", () => {
+  const eight = Array.from({ length: 8 }, (_, i) => entry({ id: `t${i}`, name: `Talent ${i}` }))
+
+  it("contact-sheet fits more talent per sheet than detail on BOTH surfaces", () => {
+    const detailSheets = renderDom(modelOf(eight, "detail")).container.querySelectorAll(".sb-tr-sheet").length
+    const contactSheets = renderDom(modelOf(eight, "contact-sheet")).container.querySelectorAll(".sb-tr-sheet").length
+    const detailPages = renderPdf(modelOf(eight, "detail")).container.querySelectorAll("pdf-page").length
+    const contactPages = renderPdf(modelOf(eight, "contact-sheet")).container.querySelectorAll("pdf-page").length
+
+    expect(contactSheets).toBeLessThan(detailSheets) // denser on screen
+    expect(contactPages).toBeLessThan(detailPages) // denser in PDF
+    expect(contactSheets).toBe(1) // 8 talent land on one contact sheet
+    expect(contactPages).toBe(1)
+  })
+})
+
+describe("Talent layout picker — gated behind featureReportConfig", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it("flag OFF: no Layout control renders (byte-identical control bar)", () => {
+    const { queryByText } = renderDom(modelOf([AVA], "detail"))
+    expect(queryByText("Layout")).toBeNull()
+    expect(queryByText("Contact sheet")).toBeNull()
+  })
+
+  it("flag ON: the Layout segmented control renders with both options", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const { getByText } = renderDom(modelOf([AVA], "detail"))
+    expect(getByText("Layout")).not.toBeNull()
+    expect(getByText("Detail")).not.toBeNull()
+    expect(getByText("Contact sheet")).not.toBeNull()
+  })
+
+  it("flag ON: clicking a layout option calls onConfigChange with the new layout", () => {
+    vi.stubEnv("VITE_REPORT_CONFIG", "1")
+    const spy = vi.fn()
+    renderDom(modelOf([AVA], "detail"), spy)
+    fireEvent.click(screen.getByText("Contact sheet"))
+    expect(spy).toHaveBeenCalledWith(expect.objectContaining({ layout: "contact-sheet" }))
+  })
+})

--- a/src-vnext/features/export/components/report/productInfoStyles.ts
+++ b/src-vnext/features/export/components/report/productInfoStyles.ts
@@ -247,6 +247,64 @@ export const PRODUCT_INFO_STYLES = `
 .sb-pir-excluded .sb-pir-card-name { text-decoration: line-through; text-decoration-thickness: 1px; }
 .sb-pir-excluded .sb-pir-exclude-toggle { opacity: 1; }
 
+/* ======================================================================== */
+/* INDEX layout (R4 density) — compact spec-sheet rows. RED-FREE: the hero    */
+/* mark is the canonical INK dot + uppercase INK tag (weight, not colour).    */
+/* Only applies under [data-layout="index"] so gallery stays byte-identical.  */
+/* ======================================================================== */
+.sb-pir-root[data-layout="index"] .sb-pir-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: 0 clamp(24px, 3vw, 48px);
+}
+.sb-pir-irow {
+  position: relative;
+  display: grid;
+  grid-template-columns: 34px minmax(0, 1fr) auto;
+  gap: 10px; align-items: center;
+  padding: 7px 0; border-bottom: 1px solid var(--sb-rule);
+}
+.sb-pir-ithumb {
+  width: 34px; height: 44px; background: var(--sb-surface);
+  border: 1px solid var(--sb-rule); border-radius: 1px; overflow: hidden;
+  display: flex; align-items: center; justify-content: center;
+}
+.sb-pir-ithumb img { width: 100%; height: 100%; object-fit: contain; display: block; }
+.sb-pir-ithumb-noimg {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); color: var(--sb-ink-disabled);
+}
+.sb-pir-imain { min-width: 0; }
+.sb-pir-iname-line { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; margin-bottom: 2px; }
+.sb-pir-iname {
+  font-family: var(--sb-font-display); font-weight: 600; font-size: var(--sb-t-sm);
+  line-height: 1.14; letter-spacing: -0.005em; color: var(--sb-ink);
+}
+.sb-pir-irow.sb-pir-is-hero .sb-pir-iname { font-weight: 800; }
+.sb-pir-imeta {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); color: var(--sb-ink-2);
+  line-height: 1.35; display: flex; align-items: baseline; gap: 6px; flex-wrap: wrap;
+}
+.sb-pir-imeta .sb-pir-style-no { font-variant-numeric: tabular-nums; letter-spacing: 0.01em; }
+.sb-pir-imeta-sep { color: var(--sb-ink-disabled); }
+.sb-pir-ishots { display: flex; align-items: center; gap: 5px; justify-self: end; white-space: nowrap; }
+.sb-pir-ishots-n {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-xs); font-weight: 600;
+  color: var(--sb-ink); font-variant-numeric: tabular-nums;
+}
+.sb-pir-ishots-dots { display: inline-flex; gap: 3px; }
+
+/* canonical INK hero mark (dot + uppercase tag by weight) — NOT the red gallery tag */
+.sb-pir-index-hero { display: inline-flex; align-items: center; gap: 4px; }
+.sb-pir-index-hero-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--sb-ink); flex: 0 0 auto; }
+.sb-pir-index-hero-tag {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink);
+}
+
+/* Index paged sheet — tighter body, no big card gaps (cols come from --sb-pir-print-cols=2) */
+.sb-pir-root[data-layout="index"] .sb-pir-sheet-body { gap: 0 0.42in; align-content: start; }
+.sb-pir-root[data-layout="index"] .sb-pir-sheet .sb-pir-irow { padding: 5px 0; }
+
 /* paged (print preview) — hidden on screen until print-mode -------------- */
 .sb-pir-paged { display: none; }
 .sb-pir-sheet { display: none; }

--- a/src-vnext/features/export/components/report/talentStyles.ts
+++ b/src-vnext/features/export/components/report/talentStyles.ts
@@ -23,6 +23,7 @@ export const TALENT_STYLES = `
   --sb-ink-disabled: oklch(0.72 0.008 55);
   --sb-rule: oklch(0.90 0.004 50);
   --sb-rule-strong: oklch(0.83 0.005 50);
+  --sb-red: #eb1400;   /* Immediate Red — owns HOLD, and ONLY hold, on this surface */
 
   /* Type scale (px) */
   --sb-t-3xs: 9px; --sb-t-2xs: 10px; --sb-t-xs: 12px; --sb-t-sm: 13px;
@@ -233,6 +234,79 @@ export const TALENT_STYLES = `
 .sb-tr-s-title { color: var(--sb-ink-2); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .sb-tr-s-looks { flex: 0 0 auto; color: var(--sb-ink-3); font-size: var(--sb-t-xs); }
 
+/* ============ contact-sheet density (R4) ============ */
+/* Casting board: headshot-forward uniform grid, denser than detail. Hides
+   contact/measurements/per-shot list (done in the card). Part 2: fixed 4:5 COVER
+   crop with an adjustable focal point + zoom (inline style from entry.crop, matched
+   to the PDF). RED = HOLD only. */
+.sb-tr-root[data-layout="contact-sheet"] .sb-tr-grid {
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: clamp(18px, 2vw, 26px);
+}
+.sb-tr-cs-card { display: flex; flex-direction: column; gap: 9px; position: relative; break-inside: avoid; }
+.sb-tr-cs-frame {
+  width: 100%; aspect-ratio: 4 / 5; position: relative;
+  background: var(--sb-surface-sub);
+  border: 1px solid var(--sb-rule); border-radius: 2px; overflow: hidden;
+}
+/* base cover — the per-crop object-position/transform arrive inline on the img */
+.sb-tr-cs-frame img { display: block; width: 100%; height: 100%; object-fit: cover; }
+.sb-tr-cs-initials {
+  width: 100%; height: 100%; display: flex; align-items: center; justify-content: center;
+  font-family: var(--sb-font-display); font-size: var(--sb-t-2xl); color: var(--sb-ink-3);
+}
+
+/* headshot crop picker (SCREEN-ONLY, flag-gated) — a draggable focal-point dot over
+   a dim surface + a zoom slider. Appears on card hover so the grid stays clean. No
+   red here (RED stays HOLD-only) and no drop shadow (rings use outline/border). */
+.sb-tr-crop-picker {
+  position: absolute; inset: 0; display: flex; flex-direction: column;
+  opacity: 0; pointer-events: none; transition: opacity 0.12s ease;
+}
+.sb-tr-cs-card:hover .sb-tr-crop-picker,
+.sb-tr-cs-card:focus-within .sb-tr-crop-picker { opacity: 1; pointer-events: auto; }
+.sb-tr-crop-surface {
+  flex: 1 1 auto; position: relative; cursor: crosshair; touch-action: none;
+  background: color-mix(in oklch, var(--sb-ink) 20%, transparent);
+}
+.sb-tr-crop-focal {
+  position: absolute; width: 16px; height: 16px; transform: translate(-50%, -50%);
+  border-radius: 50%; border: 2px solid var(--sb-paper);
+  outline: 1px solid var(--sb-ink); background: color-mix(in oklch, var(--sb-ink) 55%, transparent);
+  pointer-events: none;
+}
+.sb-tr-crop-zoom {
+  display: flex; align-items: center; gap: 8px; padding: 6px 9px;
+  background: color-mix(in oklch, var(--sb-paper) 90%, transparent);
+  backdrop-filter: blur(4px); border-top: 1px solid var(--sb-rule);
+}
+.sb-tr-crop-zoom-label {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase; color: var(--sb-ink-2); flex: 0 0 auto;
+}
+.sb-tr-crop-zoom input[type="range"] { flex: 1 1 auto; min-width: 0; accent-color: var(--sb-ink); }
+.sb-tr-cs-name-row { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.sb-tr-cs-name {
+  font-family: var(--sb-font-display); font-weight: 600; font-size: var(--sb-t-lg);
+  line-height: 1.1; letter-spacing: -0.005em; color: var(--sb-ink);
+}
+.sb-tr-cs-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.sb-tr-cs-stat {
+  display: flex; align-items: baseline; justify-content: space-between; gap: 10px;
+  padding-top: 7px; border-top: 1px solid var(--sb-rule);
+}
+.sb-tr-cs-count {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-2xs); font-weight: 600;
+  letter-spacing: 0.06em; text-transform: uppercase; color: var(--sb-ink-2);
+}
+/* the one red on this surface — talent with any on-hold shot */
+.sb-tr-hold-flag {
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-red);
+}
+.sb-tr-hold-flag::before { content: ""; width: 8px; height: 8px; background: var(--sb-red); border-radius: 1px; }
+
 /* per-card exclude toggle (screen only) */
 .sb-tr-exclude-toggle {
   position: absolute; top: 8px; right: 8px; z-index: 3;
@@ -243,13 +317,16 @@ export const TALENT_STYLES = `
   padding: 5px 11px; opacity: 0; transition: opacity 0.12s ease;
 }
 .sb-tr-card:hover .sb-tr-exclude-toggle,
-.sb-tr-card:focus-within .sb-tr-exclude-toggle { opacity: 1; }
+.sb-tr-card:focus-within .sb-tr-exclude-toggle,
+.sb-tr-cs-card:hover .sb-tr-exclude-toggle,
+.sb-tr-cs-card:focus-within .sb-tr-exclude-toggle { opacity: 1; }
 .sb-tr-exclude-toggle[aria-pressed="true"] { opacity: 1; color: var(--sb-ink); border-color: var(--sb-ink); }
 .sb-tr-exclude-toggle:focus-visible { outline: 2px solid var(--sb-ink); outline-offset: 2px; opacity: 1; }
 
 /* excluded — visible but struck + dimmed (reversible) */
 .sb-tr-excluded { opacity: 0.42; }
-.sb-tr-excluded .sb-tr-name { text-decoration: line-through; text-decoration-thickness: 1px; }
+.sb-tr-excluded .sb-tr-name,
+.sb-tr-excluded .sb-tr-cs-name { text-decoration: line-through; text-decoration-thickness: 1px; }
 .sb-tr-excluded .sb-tr-exclude-toggle { opacity: 1; }
 
 /* paged (print preview) — hidden on screen until print-mode -------------- */

--- a/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/productInfoModel.test.ts
@@ -540,12 +540,42 @@ describe("deriveProductInfoModel — group-by status (O2)", () => {
     expect(last?.items.map((i) => i.id)).toEqual(["fZ"])
   })
 
-  it("flag-off: the real neutralizer clamps a persisted 'status' + sort back to legacy gender order (byte-identical)", () => {
+  it("flag-off: the real neutralizer clamps a persisted 'status' + sort + layout back to legacy gender/gallery (byte-identical)", () => {
     const d = mixed()
-    const persisted = cfg({ groupBy: "status", sortBy: "gender", sortDir: "desc", hiddenStatuses: ["todo"] })
+    // Include a persisted layout:"index" — flag-off must clamp it to gallery so model.layout
+    // (and every other field) matches the default derive exactly.
+    const persisted = cfg({ groupBy: "status", sortBy: "gender", sortDir: "desc", hiddenStatuses: ["todo"], layout: "index" })
     // The shared pure neutralizer the page runs flag-off — not an inline copy.
     const neutralized = neutralizeProductInfoConfigForFlag(persisted, false)
+    expect(neutralized.layout).toBe("gallery")
     expect(deriveProductInfoModel(d, neutralized)).toEqual(deriveProductInfoModel(d, DEFAULT_PRODUCT_INFO_CONFIG))
     expect(neutralizeProductInfoConfigForFlag(persisted, true)).toBe(persisted) // flag-on = identity
+  })
+})
+
+describe("deriveProductInfoModel — layout (R4 density) folded onto the model", () => {
+  const one = () =>
+    data({
+      productFamilies: [fam({ id: "fM", styleName: "Merino Crew", gender: "men" })],
+      shots: [shot({ id: "s1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] })],
+    })
+
+  it("defaults model.layout to 'gallery' when config carries no layout (pre-Phase-C blob)", () => {
+    const { layout, ...rest } = DEFAULT_PRODUCT_INFO_CONFIG
+    void layout
+    const model = deriveProductInfoModel(one(), rest as typeof DEFAULT_PRODUCT_INFO_CONFIG)
+    expect(model.layout).toBe("gallery")
+  })
+
+  it("carries an explicit config.layout onto model.layout (both variants)", () => {
+    expect(deriveProductInfoModel(one(), cfg({ layout: "gallery" })).layout).toBe("gallery")
+    expect(deriveProductInfoModel(one(), cfg({ layout: "index" })).layout).toBe("index")
+  })
+
+  it("layout is presentation-only — it never changes grouping/items", () => {
+    const gallery = deriveProductInfoModel(one(), cfg({ layout: "gallery" }))
+    const index = deriveProductInfoModel(one(), cfg({ layout: "index" }))
+    expect(index.groups).toEqual(gallery.groups)
+    expect(index.project).toEqual(gallery.project)
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -61,6 +61,22 @@ describe("ProductInfoConfig persistence round-trip (Phase B)", () => {
     }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
   })
+
+  it("default-merges a pre-Phase-C blob (no layout) to layout 'gallery' (R4 forward-compat)", () => {
+    // A doc written before the density variant existed must hydrate to the shipped gallery layout.
+    const stored = JSON.parse(
+      '{"groupBy":"gender","productScope":"in-use","imageSize":"m","excludedFamilyIds":[],"sortBy":"style","sortDir":"asc"}',
+    )
+    const hydrated: ProductInfoConfig = { ...DEFAULT_PRODUCT_INFO_CONFIG, ...stored }
+    expect(hydrated.layout).toBe("gallery")
+  })
+
+  it("round-trips a persisted layout 'index' through JSON unchanged", () => {
+    const config: ProductInfoConfig = {
+      groupBy: "none", productScope: "in-use", imageSize: "m", excludedFamilyIds: [], layout: "index",
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
 })
 
 describe("TalentConfig persistence round-trip (Phase B)", () => {
@@ -74,6 +90,46 @@ describe("TalentConfig persistence round-trip (Phase B)", () => {
   it("round-trips sortBy/sortDir through JSON unchanged", () => {
     const config: TalentConfig = {
       groupBy: "agency", talentScope: "in-shots", excludedTalentIds: [], sortBy: "agency", sortDir: "desc",
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("TalentConfig layout density (Phase C)", () => {
+  it("default-merges a pre-Phase-C blob (no layout) to layout 'detail' (R4 forward-compat)", () => {
+    // A doc written before the density variant existed must hydrate to the shipped detail layout.
+    const stored = JSON.parse(
+      '{"groupBy":"none","talentScope":"in-shots","excludedTalentIds":[],"sortBy":"name","sortDir":"asc"}',
+    )
+    const hydrated: TalentConfig = { ...DEFAULT_TALENT_CONFIG, ...stored }
+    expect(hydrated.layout).toBe("detail")
+  })
+
+  it("round-trips a persisted layout 'contact-sheet' through JSON unchanged", () => {
+    const config: TalentConfig = {
+      groupBy: "none", talentScope: "in-shots", excludedTalentIds: [], layout: "contact-sheet",
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("TalentConfig headshot crop (Phase C, R4 part 2)", () => {
+  it("default-merges a pre-crop blob (no headshotCrops) to an empty {} map", () => {
+    // A doc written before the adjustable crop existed must hydrate to no crops.
+    const stored = JSON.parse(
+      '{"groupBy":"none","talentScope":"in-shots","excludedTalentIds":[],"layout":"contact-sheet"}',
+    )
+    const hydrated: TalentConfig = { ...DEFAULT_TALENT_CONFIG, ...stored }
+    expect(hydrated.headshotCrops).toEqual({})
+  })
+
+  it("round-trips a persisted per-talent crop map through JSON unchanged", () => {
+    const config: TalentConfig = {
+      groupBy: "none",
+      talentScope: "in-shots",
+      excludedTalentIds: [],
+      layout: "contact-sheet",
+      headshotCrops: { tA: { scale: 1.5, x: 0.25, y: 0.1 } },
     }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
   })

--- a/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/talentModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { collectTalentImageCandidates, deriveTalentModel } from "../talentModel"
-import { DEFAULT_TALENT_CONFIG, neutralizeTalentConfigForFlag, type TalentConfig } from "../talentTypes"
+import { DEFAULT_HEADSHOT_CROP, DEFAULT_TALENT_CONFIG, neutralizeTalentConfigForFlag, type TalentConfig } from "../talentTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { Shot, TalentRecord } from "@/shared/types"
 
@@ -452,5 +452,74 @@ describe("deriveTalentModel — group-by status (O2)", () => {
     const neutralized = neutralizeTalentConfigForFlag(persisted, false)
     expect(deriveTalentModel(d, neutralized)).toEqual(deriveTalentModel(d, DEFAULT_TALENT_CONFIG))
     expect(neutralizeTalentConfigForFlag(persisted, true)).toBe(persisted) // flag-on = identity
+  })
+})
+
+describe("deriveTalentModel — layout density (Phase C, R4)", () => {
+  const withHold = () =>
+    data({
+      talent: ROSTER,
+      shots: [shot({ id: "s1", shotNumber: "01", status: "on_hold", talentIds: ["tA"] })],
+    })
+
+  it("flag-on: config.layout folds onto the model (detail | contact-sheet)", () => {
+    const d = withHold()
+    expect(deriveTalentModel(d, cfg({ layout: "contact-sheet" })).layout).toBe("contact-sheet")
+    expect(deriveTalentModel(d, cfg({ layout: "detail" })).layout).toBe("detail")
+  })
+
+  it("an absent layout folds onto the model as 'detail' (forward-compat default)", () => {
+    const d = withHold()
+    const legacy = deriveTalentModel(d, { groupBy: "none", talentScope: "in-shots", excludedTalentIds: [] })
+    expect(legacy.layout).toBe("detail")
+  })
+
+  it("flag-off: a persisted contact-sheet layout neutralizes back to 'detail' (byte-identical model)", () => {
+    const d = withHold()
+    const persisted = cfg({ layout: "contact-sheet" })
+    const neutralized = neutralizeTalentConfigForFlag(persisted, false)
+    const off = deriveTalentModel(d, neutralized)
+    expect(off.layout).toBe("detail")
+    // Byte-identity: the whole model equals the default-config model (layout stripped).
+    expect(off).toEqual(deriveTalentModel(d, DEFAULT_TALENT_CONFIG))
+    // Flag-on leaves a persisted layout intact.
+    expect(deriveTalentModel(d, neutralizeTalentConfigForFlag(persisted, true)).layout).toBe("contact-sheet")
+  })
+})
+
+describe("deriveTalentModel — adjustable headshot crop (Phase C, R4 part 2)", () => {
+  const withTwo = () =>
+    data({
+      talent: ROSTER,
+      shots: [shot({ id: "s1", shotNumber: "01", talentIds: ["tA", "tB"] })],
+    })
+
+  it("an absent headshotCrops folds the DEFAULT crop {scale:1,x:.5,y:.5} onto every entry", () => {
+    const model = deriveTalentModel(withTwo(), cfg({ groupBy: "none" }))
+    expect(find(model, "tA")?.crop).toEqual(DEFAULT_HEADSHOT_CROP)
+    expect(find(model, "tB")?.crop).toEqual({ scale: 1, x: 0.5, y: 0.5 })
+  })
+
+  it("flag-on: a per-talent headshotCrops entry folds onto that entry's crop; others stay default", () => {
+    const crop = { scale: 1.8, x: 0.25, y: 0.1 }
+    const model = deriveTalentModel(withTwo(), cfg({ groupBy: "none", headshotCrops: { tA: crop } }))
+    expect(find(model, "tA")?.crop).toEqual(crop)
+    expect(find(model, "tB")?.crop).toEqual(DEFAULT_HEADSHOT_CROP) // no override -> default
+  })
+
+  it("flag-off: the neutralizer clamps headshotCrops to {} so every entry's crop is the default (byte-identical)", () => {
+    const d = withTwo()
+    const persisted = cfg({ groupBy: "none", headshotCrops: { tA: { scale: 2, x: 0.9, y: 0.05 } } })
+    const neutralized = neutralizeTalentConfigForFlag(persisted, false)
+    const off = deriveTalentModel(d, neutralized)
+    expect(find(off, "tA")?.crop).toEqual(DEFAULT_HEADSHOT_CROP)
+    // Whole model equals the default-config model — the crop leaves no trace flag-off.
+    expect(off).toEqual(deriveTalentModel(d, DEFAULT_TALENT_CONFIG))
+    // Flag-on leaves a persisted crop intact.
+    expect(find(deriveTalentModel(d, neutralizeTalentConfigForFlag(persisted, true)), "tA")?.crop).toEqual({
+      scale: 2,
+      x: 0.9,
+      y: 0.05,
+    })
   })
 })

--- a/src-vnext/features/export/lib/report/productInfoModel.ts
+++ b/src-vnext/features/export/lib/report/productInfoModel.ts
@@ -283,6 +283,10 @@ export function deriveProductInfoModel(
       familyCount: items.length,
     },
     groups: groupEntries(items, config.groupBy),
+    // R4 density: presentation-only, folded onto the model from the (already
+    // neutralized) config so DOM + PDF read one pre-clamped value. Never used for
+    // grouping/sorting above. Absent → the shipped "gallery" output.
+    layout: config.layout ?? "gallery",
   }
 }
 

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -33,6 +33,51 @@ export type ProductInfoScope = "in-use" | "library"
 /** Image / column density. S/M/L is a display knob only (no letterbox). */
 export type ProductInfoImageSize = "s" | "m" | "l"
 
+/**
+ * Density variant (R4/Phase C). Mirrors the shot report's REPORT_LAYOUT_* pattern.
+ * - "gallery": image-forward editorial card grid — the shipped R4 output (default,
+ *   so flag-off + pre-Phase-C blobs resolve here and stay BYTE-IDENTICAL).
+ * - "index": compact spec/pull sheet — small thumb + tight tabular rows, more
+ *   families per landscape sheet. The density that actually reaches print/PDF
+ *   (imageSize never did — it is screen-only).
+ * Presentation-only: deriveProductInfoModel folds it onto the model but never
+ * reads it for grouping/sorting, so both renderers read one pre-neutralized value.
+ */
+export type ProductInfoLayout = "gallery" | "index"
+
+// Layout display labels — the single source for the picker + the in-report switch.
+// An exhaustive typed literal (TS flags a missing variant); the option list derives
+// from it so the strings aren't duplicated (mirror REPORT_LAYOUT_LABEL/OPTIONS).
+export const PRODUCT_INFO_LAYOUT_LABEL: Record<ProductInfoLayout, string> = {
+  gallery: "Gallery",
+  index: "Index",
+}
+export const PRODUCT_INFO_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: ProductInfoLayout; readonly label: string }> =
+  (Object.keys(PRODUCT_INFO_LAYOUT_LABEL) as ProductInfoLayout[]).map((value) => ({
+    value,
+    label: PRODUCT_INFO_LAYOUT_LABEL[value],
+  }))
+
+/**
+ * Per-layout print/PDF packing — the SINGLE source of truth both renderers read
+ * so the on-screen paged preview and the @react-pdf export can't drift. `printCols`
+ * drives the grid column count; `cardsPerSheet` drives pagination. EYEBALL-GATE
+ * these against a real render (see reportPdfProductInfo IMAGE_MAX_HEIGHT note).
+ */
+export interface ProductInfoLayoutGeometry {
+  readonly printCols: number
+  readonly cardsPerSheet: number
+}
+export const PRODUCT_INFO_LAYOUT_GEOMETRY: Record<ProductInfoLayout, ProductInfoLayoutGeometry> = {
+  // gallery = the shipped pre-Phase-C packing (4×3). NOTE: a real render shows only ~8 fit a
+  // landscape sheet, so gallery strands a partial page — a PRE-EXISTING defect kept byte-identical
+  // here; recalibration is a separate follow-up (see Phase C notes).
+  gallery: { printCols: 4, cardsPerSheet: 12 },
+  // index = new Phase-C variant. Calibrated against a real render (Q2-26 data): exactly 10 rows × 2
+  // fit one landscape sheet (22 stranded 2; 20 packs clean). Page-wrap is the safety net.
+  index: { printCols: 2, cardsPerSheet: 20 },
+}
+
 /** Persisted config — serializable; optional fields default-merge from older blobs. */
 export interface ProductInfoConfig {
   readonly groupBy: ProductInfoGroupBy
@@ -46,6 +91,8 @@ export interface ProductInfoConfig {
   readonly sortBy?: ProductInfoSortField
   /** R5 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
   readonly sortDir?: SortDir
+  /** R4 density variant. Absent → "gallery" (the shipped output; flag-off byte-identical). */
+  readonly layout?: ProductInfoLayout
 }
 
 export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
@@ -56,6 +103,7 @@ export const DEFAULT_PRODUCT_INFO_CONFIG: ProductInfoConfig = {
   hiddenStatuses: [],
   sortBy: "style",
   sortDir: "asc",
+  layout: "gallery",
 }
 
 /**
@@ -71,6 +119,9 @@ export function neutralizeProductInfoConfigForFlag(config: ProductInfoConfig, fl
     hiddenStatuses: [],
     sortBy: undefined,
     sortDir: undefined,
+    // R4: the density picker is gated, so flag-off must clamp back to the shipped
+    // "gallery" output (a persisted "index" would otherwise leak the dense layout).
+    layout: "gallery",
     groupBy:
       config.groupBy === "gender" || config.groupBy === "product-type" || config.groupBy === "none"
         ? config.groupBy
@@ -121,4 +172,7 @@ export interface ProductInfoModel {
     readonly familyCount: number
   }
   readonly groups: readonly ProductInfoGroup[]
+  /** R4 density variant, resolved from the (neutralized) config at derive time.
+   *  Both the DOM view and the PDF read THIS pre-clamped value so they can't drift. */
+  readonly layout: ProductInfoLayout
 }

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -17,8 +17,10 @@ import type {
   ProductInfoAppearance,
   ProductInfoEntry,
   ProductInfoGroup,
+  ProductInfoLayout,
   ProductInfoModel,
 } from "./productInfoTypes"
+import { PRODUCT_INFO_LAYOUT_GEOMETRY } from "./productInfoTypes"
 import { COLOR, FONT, PAGE, STATUS, has } from "./reportPdfShared"
 
 const PAD_X = 36
@@ -26,9 +28,8 @@ const PAD_TOP = 34
 const PAD_BOTTOM = 30
 const COL_GAP = 22
 const ROW_GAP = 18
-const PRINT_COLS = 4
-const PRINT_ROWS = 3
-const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
+// Gallery packing derives from the SHARED geometry so screen + PDF can't drift.
+const PRINT_COLS = PRODUCT_INFO_LAYOUT_GEOMETRY.gallery.printCols
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
 // Card width derives from the COLUMN count (not cards-per-sheet): a 4-up card is
 // (content - 3 col gaps) / 4. Matches the on-screen PagedView's 4-col grid.
@@ -38,6 +39,14 @@ const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // 4×3 (12/page) three card rows stack on one landscape sheet, so the cap is far
 // tighter than the old 3-up (1 row) value of 232. EYEBALL-GATE this number.
 const IMAGE_MAX_HEIGHT = 96
+
+// INDEX density (R4): compact 2-up spec-sheet rows, ~22 per landscape sheet. A
+// small fixed thumb + name + one meta line + shot count. RED-FREE (ink hero mark).
+// EYEBALL-GATE the row height: 11 rows × 2 cols must fit the usable landscape body.
+const IDX_COLS = PRODUCT_INFO_LAYOUT_GEOMETRY.index.printCols
+const IDX_CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (IDX_COLS - 1)) / IDX_COLS
+const IDX_THUMB_W = 26
+const IDX_THUMB_H = 33
 
 const s = StyleSheet.create({
   page: {
@@ -196,6 +205,55 @@ const s = StyleSheet.create({
   },
 })
 
+// INDEX layout styles — compact rows, RED-FREE (locked design system: RED owns
+// HOLD; Product Info index paints no red). Hero mark = canonical INK dot +
+// uppercase INK tag (weight, not colour) — NOT the gallery's red hero mark
+// (frozen by byte-identity) and NOT the comp's boxed tag (carried critic fix).
+const si = StyleSheet.create({
+  cards: { flexDirection: "row", flexWrap: "wrap", columnGap: COL_GAP, rowGap: 4 },
+  row: {
+    width: IDX_CARD_WIDTH,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 4,
+    borderBottomWidth: 0.5,
+    borderBottomColor: COLOR.rule,
+  },
+  thumb: {
+    width: IDX_THUMB_W,
+    height: IDX_THUMB_H,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    backgroundColor: COLOR.surface,
+    alignItems: "center",
+    justifyContent: "center",
+    overflow: "hidden",
+    marginRight: 8,
+  },
+  thumbImage: { width: IDX_THUMB_W, height: IDX_THUMB_H, objectFit: "contain" },
+  thumbNo: { fontFamily: FONT.ui, fontSize: 6, color: COLOR.textDisabled },
+  main: { flex: 1 },
+  nameLine: { flexDirection: "row", alignItems: "center", flexWrap: "wrap" },
+  name: { fontFamily: FONT.display, fontSize: 9, color: COLOR.text, letterSpacing: -0.1 },
+  meta: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary, marginTop: 1.5 },
+
+  // canonical INK hero mark (dot + uppercase tag by weight)
+  heroMark: { flexDirection: "row", alignItems: "center", marginLeft: 5 },
+  heroDot: { width: 5, height: 5, backgroundColor: COLOR.text, borderRadius: 2.5, marginRight: 3 },
+  heroLabel: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.text,
+  },
+
+  shots: { flexDirection: "row", alignItems: "center", marginLeft: 8 },
+  shotsNum: { fontFamily: FONT.uiBold, fontSize: 7.5, color: COLOR.text, marginRight: 4 },
+  shotsDots: { flexDirection: "row", alignItems: "center" },
+  statusDot: { width: 4.5, height: 4.5, borderRadius: 2.25, marginRight: 2.5 },
+})
+
 // ---------------------------------------------------------------------------
 // Pagination: up to CARDS_PER_SHEET printable cards per landscape sheet, never
 // spanning a group (a new group starts a fresh sheet, mirroring the shot-report
@@ -210,16 +268,19 @@ interface Sheet {
 }
 
 function paginate(model: ProductInfoModel): readonly Sheet[] {
+  // Layout-aware from the SHARED geometry so the on-screen paged preview and this
+  // PDF pack identically (parity is falsifiable — see productInfoLayouts.parity).
+  const perSheet = PRODUCT_INFO_LAYOUT_GEOMETRY[model.layout].cardsPerSheet
   const sheets: Sheet[] = []
   for (const group of model.groups) {
     const visible = group.items.filter((i) => !i.excluded)
     if (visible.length === 0) continue
-    for (let i = 0; i < visible.length; i += CARDS_PER_SHEET) {
+    for (let i = 0; i < visible.length; i += perSheet) {
       sheets.push({
         group,
         groupItemCount: visible.length,
         fromIndex: i + 1,
-        items: visible.slice(i, i + CARDS_PER_SHEET),
+        items: visible.slice(i, i + perSheet),
       })
     }
   }
@@ -324,6 +385,72 @@ function Card({
   )
 }
 
+// INDEX card — one compact spec-sheet row (thumb · name+meta · shots). Mirrors
+// the DOM ProductIndexRow: no per-shot "Appears in" block, RED-FREE ink hero mark.
+function IndexCard({
+  entry,
+  imageMap,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+}): JSX.Element {
+  const src = has(entry.image) ? imageMap.get(entry.image) : undefined
+  const n = entry.appears.length
+  const styleNo = has(entry.styleNumber) ? entry.styleNumber : null
+  const coloursStr = entry.colours.length > 0 ? entry.colours.join(", ") : "TBD"
+  const sizesStr =
+    entry.sizes.length > 0 ? entry.sizes.join(" · ") : entry.sizePending ? "Size pending" : "—"
+  const meta = [styleNo, coloursStr, sizesStr].filter((x): x is string => x != null).join("   ·   ")
+  const dots = entry.appears.slice(0, 6)
+
+  return (
+    <View style={si.row} wrap={false}>
+      <View style={si.thumb}>
+        {src ? <Image src={src} style={si.thumbImage} /> : <Text style={si.thumbNo}>—</Text>}
+      </View>
+
+      <View style={si.main}>
+        <View style={si.nameLine}>
+          <Text style={si.name}>{has(entry.styleName) ? entry.styleName : "Unnamed product"}</Text>
+          {entry.isHero ? (
+            <View style={si.heroMark}>
+              <View style={si.heroDot} />
+              <Text style={si.heroLabel}>Hero</Text>
+            </View>
+          ) : null}
+        </View>
+        <Text style={si.meta}>{meta}</Text>
+      </View>
+
+      <View style={si.shots}>
+        <Text style={si.shotsNum}>{String(n)}</Text>
+        <View style={si.shotsDots}>
+          {dots.map((a, i) => (
+            <View key={i} style={[si.statusDot, { backgroundColor: STATUS[a.status].color }]} />
+          ))}
+        </View>
+      </View>
+    </View>
+  )
+}
+
+// Pick the per-family renderer for a layout (gallery card vs. compact index row).
+function FamilyItem({
+  entry,
+  imageMap,
+  layout,
+}: {
+  readonly entry: ProductInfoEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly layout: ProductInfoLayout
+}): JSX.Element {
+  return layout === "index" ? (
+    <IndexCard entry={entry} imageMap={imageMap} />
+  ) : (
+    <Card entry={entry} imageMap={imageMap} />
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Document
 // ---------------------------------------------------------------------------
@@ -377,9 +504,9 @@ export function ProductInfoPdfDocument(props: {
               </View>
             ) : null}
 
-            <View style={s.cards}>
+            <View style={model.layout === "index" ? si.cards : s.cards}>
               {sheet.items.map((entry) => (
-                <Card key={entry.id} entry={entry} imageMap={imageMap} />
+                <FamilyItem key={entry.id} entry={entry} imageMap={imageMap} layout={model.layout} />
               ))}
             </View>
 

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -15,11 +15,14 @@
 import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
 import type {
+  HeadshotCrop,
   TalentAppearance,
   TalentEntry,
   TalentGroup,
+  TalentLayout,
   TalentModel,
 } from "./talentTypes"
+import { cropFocalPercents, cropZoomTransform } from "./talentTypes"
 import { initials } from "@/features/library/components/talentUtils"
 import { COLOR, FONT, PAGE, STATUS, has, breakLongToken } from "./reportPdfShared"
 
@@ -40,6 +43,69 @@ const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // At 2×3 (6/page) three card rows stack on one landscape sheet, so the cap is
 // tighter than the old 3-up (1 row) value of 168. EYEBALL-GATE this number.
 const HEADSHOT_MAX_HEIGHT = 120
+
+// contact-sheet (R4 density) — a denser casting board with a FIXED 4:5 COVER crop
+// (part 2). A full-width 4:5 crop is much taller than part-1's 96pt native cap, so
+// the sheet packs 4×2 = 8 (not 12) and the crop frame is a fixed 4:5 centered in the
+// wider card. Kept in LOCKSTEP with TalentReportView's LAYOUT_PRINT. The detail
+// constants above are untouched so the shipped detail PDF stays byte-identical.
+const CS_PRINT_COLS = 4
+// EYEBALL-GATE: two rows of the 4:5 crop must clear one landscape sheet without
+// stranding a row to a 2nd page. If they don't, reduce the frame height (below) or
+// this count — and update TalentReportView.LAYOUT_PRINT + the density parity test together.
+const CS_CARDS_PER_SHEET = 8 // 4×2
+const CS_CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (CS_PRINT_COLS - 1)) / CS_PRINT_COLS
+// Fixed 4:5 crop frame (portrait). Height is bounded so two card rows fit one
+// landscape sheet; width follows 4:5 and the frame centers in the wider card.
+// EYEBALL-GATE both numbers against a real render.
+const CS_FRAME_HEIGHT = 140
+const CS_FRAME_WIDTH = (CS_FRAME_HEIGHT * 4) / 5
+
+interface Geom {
+  readonly perSheet: number
+  readonly cardWidth: number
+  readonly headshotMax: number
+  /** contact-sheet 4:5 crop frame (0 for detail, which is native-aspect). */
+  readonly frameWidth: number
+  readonly frameHeight: number
+}
+function geomFor(layout: TalentLayout): Geom {
+  return layout === "contact-sheet"
+    ? {
+        perSheet: CS_CARDS_PER_SHEET,
+        cardWidth: CS_CARD_WIDTH,
+        headshotMax: CS_FRAME_HEIGHT,
+        frameWidth: CS_FRAME_WIDTH,
+        frameHeight: CS_FRAME_HEIGHT,
+      }
+    : {
+        perSheet: CARDS_PER_SHEET,
+        cardWidth: CARD_WIDTH,
+        headshotMax: HEADSHOT_MAX_HEIGHT,
+        frameWidth: 0,
+        frameHeight: 0,
+      }
+}
+
+// The contact-sheet headshot's crop style — a COVER crop into the fixed 4:5 frame,
+// focal point + zoom from entry.crop. Uses the SAME cropFocalPercents / cropZoomTransform
+// helpers the DOM uses, so screen + PDF can't drift on the crop.
+function contactCropStyle(crop: HeadshotCrop) {
+  const focal = cropFocalPercents(crop)
+  const zoom = cropZoomTransform(crop)
+  return {
+    width: "100%",
+    height: "100%",
+    objectFit: "cover",
+    objectPositionX: focal.x,
+    objectPositionY: focal.y,
+    ...(zoom ? { transform: zoom, transformOrigin: `${focal.x} ${focal.y}` } : {}),
+  } as const
+}
+
+function talentHasHold(entry: TalentEntry): boolean {
+  return entry.appears.some((a) => a.status === "on_hold")
+}
 
 const s = StyleSheet.create({
   page: {
@@ -199,6 +265,54 @@ const s = StyleSheet.create({
   shotLooks: { fontFamily: FONT.ui, fontSize: 6.5, color: COLOR.textSubtle, marginLeft: 4 },
   shotsEmpty: { fontFamily: FONT.bodyItalic, fontSize: 7, color: COLOR.textSubtle },
 
+  // contact-sheet (R4 density) — compact casting card: a fixed 4:5 COVER-crop frame
+  // (centered) + name + HOLD flag + gender + agency + shot count. Frame width/height
+  // applied inline (per-layout); the per-crop object-position/transform arrive inline
+  // on the Image from contactCropStyle(entry.crop).
+  csCard: { flexDirection: "column" },
+  csFrame: {
+    alignSelf: "center",
+    backgroundColor: COLOR.surfaceSubtle,
+    borderWidth: 0.5,
+    borderColor: COLOR.rule,
+    overflow: "hidden",
+  },
+  csInitials: {
+    width: "100%",
+    height: "100%",
+    backgroundColor: COLOR.surfaceSubtle,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  csInitialsText: { fontFamily: FONT.display, fontSize: 24, color: COLOR.textSubtle },
+  csNameRow: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginTop: 7, marginBottom: 3 },
+  csName: { fontFamily: FONT.display, fontSize: 11, color: COLOR.text, letterSpacing: -0.1, marginRight: 6 },
+  // The one red on this surface — talent with any on-hold shot.
+  csHoldFlag: { flexDirection: "row", alignItems: "center" },
+  csHoldDot: { width: 6, height: 6, backgroundColor: COLOR.accent, borderRadius: 1, marginRight: 3 },
+  csHold: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6,
+    letterSpacing: 0.8,
+    textTransform: "uppercase",
+    color: COLOR.accent,
+  },
+  csMeta: { flexDirection: "row", alignItems: "center", flexWrap: "wrap", marginBottom: 6 },
+  csStat: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    borderTopWidth: 0.5,
+    borderTopColor: COLOR.rule,
+    paddingTop: 5,
+  },
+  csCount: {
+    fontFamily: FONT.uiBold,
+    fontSize: 6.5,
+    letterSpacing: 0.6,
+    textTransform: "uppercase",
+    color: COLOR.textSecondary,
+  },
+
   footer: {
     position: "absolute",
     bottom: 14,
@@ -231,16 +345,17 @@ interface Sheet {
 }
 
 function paginate(model: TalentModel): readonly Sheet[] {
+  const perSheet = geomFor(model.layout).perSheet
   const sheets: Sheet[] = []
   for (const group of model.groups) {
     const visible = group.items.filter((i) => !i.excluded)
     if (visible.length === 0) continue
-    for (let i = 0; i < visible.length; i += CARDS_PER_SHEET) {
+    for (let i = 0; i < visible.length; i += perSheet) {
       sheets.push({
         group,
         groupItemCount: visible.length,
         fromIndex: i + 1,
-        items: visible.slice(i, i + CARDS_PER_SHEET),
+        items: visible.slice(i, i + perSheet),
       })
     }
   }
@@ -341,6 +456,61 @@ function Card({
   )
 }
 
+// contact-sheet card (R4 density) — compact casting board. HIDES the contact block,
+// measurement grid, and per-shot list; SHOWS headshot + name + HOLD flag (the one
+// red) + gender + agency + shot count. Part 2: a fixed 4:5 COVER crop with an
+// adjustable focal point + zoom (entry.crop, matched to the DOM).
+function ContactCard({
+  entry,
+  imageMap,
+  width,
+  frameWidth,
+  frameHeight,
+}: {
+  readonly entry: TalentEntry
+  readonly imageMap: ReadonlyMap<string, string>
+  readonly width: number
+  readonly frameWidth: number
+  readonly frameHeight: number
+}): JSX.Element {
+  const src = has(entry.headshot) ? imageMap.get(entry.headshot) : undefined
+  const n = entry.appears.length
+  return (
+    <View style={[s.csCard, { width }]} wrap={false}>
+      <View style={[s.csFrame, { width: frameWidth, height: frameHeight }]}>
+        {src ? (
+          <Image src={src} style={contactCropStyle(entry.crop)} />
+        ) : (
+          <View style={s.csInitials}>
+            <Text style={s.csInitialsText}>{initials(entry.name)}</Text>
+          </View>
+        )}
+      </View>
+
+      <View style={s.csNameRow}>
+        <Text style={s.csName}>{has(entry.name) ? entry.name : "Unnamed talent"}</Text>
+        {talentHasHold(entry) ? (
+          <View style={s.csHoldFlag}>
+            <View style={s.csHoldDot} />
+            <Text style={s.csHold}>Hold</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {entry.genderLabel || has(entry.agency) ? (
+        <View style={s.csMeta}>
+          {entry.genderLabel ? <Text style={s.genderBadge}>{entry.genderLabel}</Text> : null}
+          {has(entry.agency) ? <Text style={s.agency}>{entry.agency}</Text> : null}
+        </View>
+      ) : null}
+
+      <View style={s.csStat}>
+        <Text style={s.csCount}>{`${n} ${n === 1 ? "shot" : "shots"}`}</Text>
+      </View>
+    </View>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Document
 // ---------------------------------------------------------------------------
@@ -351,6 +521,7 @@ export function TalentPdfDocument(props: {
 }): JSX.Element {
   const { model, imageMap } = props
   const sheets = paginate(model)
+  const geom = geomFor(model.layout)
   const projectLine = has(model.project.client)
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
@@ -395,9 +566,20 @@ export function TalentPdfDocument(props: {
             ) : null}
 
             <View style={s.cards}>
-              {sheet.items.map((entry) => (
-                <Card key={entry.id} entry={entry} imageMap={imageMap} />
-              ))}
+              {sheet.items.map((entry) =>
+                model.layout === "contact-sheet" ? (
+                  <ContactCard
+                    key={entry.id}
+                    entry={entry}
+                    imageMap={imageMap}
+                    width={geom.cardWidth}
+                    frameWidth={geom.frameWidth}
+                    frameHeight={geom.frameHeight}
+                  />
+                ) : (
+                  <Card key={entry.id} entry={entry} imageMap={imageMap} />
+                ),
+              )}
             </View>
 
             <View style={s.footer} fixed>

--- a/src-vnext/features/export/lib/report/talentModel.ts
+++ b/src-vnext/features/export/lib/report/talentModel.ts
@@ -8,6 +8,7 @@ import type { ExportData } from "../../hooks/useExportData"
 import { buildStatusGroups, formatDateWindow, lookLabel, shotNumberSortKey, sortLooksByOrder, titleCaseSlug } from "./reportModel"
 import { compareText, sortItemsStable } from "./reportSort"
 import type {
+  HeadshotCrop,
   TalentAppearance,
   TalentConfig,
   TalentEntry,
@@ -16,6 +17,7 @@ import type {
   TalentModel,
   TalentSortField,
 } from "./talentTypes"
+import { DEFAULT_HEADSHOT_CROP } from "./talentTypes"
 
 // Pure derivation: ExportData + TalentConfig -> TalentModel. No async, no image
 // bytes (headshot is a path/URL candidate resolved later). The single source both
@@ -63,6 +65,7 @@ function toEntry(
   t: TalentRecord,
   shots: readonly Shot[],
   excluded: ReadonlySet<string>,
+  crops: Record<string, HeadshotCrop>,
 ): TalentEntry {
   const appears = buildAppearances(t.id, shots)
   const label = genderDisplayLabel(t.gender)
@@ -84,6 +87,9 @@ function toEntry(
     measurements,
     excluded: excluded.has(t.id),
     appears,
+    // R4 part 2: fold the per-talent crop from the (neutralized) config; absent ->
+    // the centered default (so flag-off, where crops is clamped to {}, is byte-identical).
+    crop: crops[t.id] ?? DEFAULT_HEADSHOT_CROP,
   }
 }
 
@@ -201,9 +207,11 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
     config.talentScope === "project-attached"
       ? projectAttachedTalent(data)
       : inShotsTalent(data)
+  // R4 part 2: per-talent crops from the (neutralized) config — {} flag-off.
+  const crops = config.headshotCrops ?? {}
 
   const built = records
-    .map((t) => toEntry(t, data.shots, excluded))
+    .map((t) => toEntry(t, data.shots, excluded, crops))
     // R3: drop a talent only when EVERY appearance is a hidden status. A project-attached
     // talent with no appearances (appears.length === 0) is kept — status can't hide what has no shots.
     .filter(
@@ -228,6 +236,9 @@ export function deriveTalentModel(data: ExportData, config: TalentConfig): Talen
       talentCount: items.length,
     },
     groups: groupEntries(items, config.groupBy),
+    // R4 density: fold the resolved layout onto the model so BOTH renderers read a
+    // pre-neutralized value (the page feeds the NEUTRALIZED config, so flag-off → "detail").
+    layout: config.layout ?? "detail",
   }
 }
 

--- a/src-vnext/features/export/lib/report/talentTypes.ts
+++ b/src-vnext/features/export/lib/report/talentTypes.ts
@@ -27,6 +27,53 @@ export const TALENT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: TalentSo
     label: TALENT_SORT_FIELD_LABEL[value],
   }))
 
+// R4 density variant. Exhaustive typed literal → the option list + label map
+// derive from it (mirror REPORT_LAYOUT_* / TALENT_SORT_FIELD_*). "detail" is the
+// shipped 2-up call-sheet card (DEFAULT — flag-off byte-identical); "contact-sheet"
+// is the compact casting board (denser grid; hides contact/measurements/per-shot list).
+export type TalentLayout = "detail" | "contact-sheet"
+export const TALENT_LAYOUT_LABEL: Record<TalentLayout, string> = {
+  detail: "Detail",
+  "contact-sheet": "Contact sheet",
+}
+export const TALENT_LAYOUT_OPTIONS: ReadonlyArray<{ readonly value: TalentLayout; readonly label: string }> =
+  (Object.keys(TALENT_LAYOUT_LABEL) as TalentLayout[]).map((value) => ({
+    value,
+    label: TALENT_LAYOUT_LABEL[value],
+  }))
+
+// R4 part 2 — adjustable headshot crop (contact-sheet only). Ted's requirement:
+// "adjust size/placement". A per-talent focal point + zoom into the fixed 4:5
+// contact-sheet frame. x,y ∈ 0–1 normalized focal point (0.5,0.5 = centered);
+// scale ≥ 1 zoom (1 = no zoom). Serializable; keyed by talentId on TalentConfig.
+export interface HeadshotCrop {
+  /** Zoom factor ≥ 1 (1 = fit the cover-cropped frame, no extra zoom). */
+  readonly scale: number
+  /** Horizontal focal point, 0 (left) – 1 (right). Default 0.5. */
+  readonly x: number
+  /** Vertical focal point, 0 (top) – 1 (bottom). Default 0.5. */
+  readonly y: number
+}
+
+export const DEFAULT_HEADSHOT_CROP: HeadshotCrop = { scale: 1, x: 0.5, y: 0.5 }
+
+// Format a 0–1 fraction as a CSS/@react-pdf percent, trimming float noise
+// (0.1 → "10%", not "10.000000000000002%"). Both renderers derive object-position
+// from this ONE helper so the DOM <img> and the @react-pdf <Image> can't drift.
+function toPercent(v: number): string {
+  return `${String(+(v * 100).toFixed(2))}%`
+}
+
+/** Focal point as percent strings — DOM `object-position` + @react-pdf `objectPositionX/Y`. */
+export function cropFocalPercents(crop: HeadshotCrop): { readonly x: string; readonly y: string } {
+  return { x: toPercent(crop.x), y: toPercent(crop.y) }
+}
+
+/** Zoom transform string, or undefined when scale is 1 (no transform on either surface). */
+export function cropZoomTransform(crop: HeadshotCrop): string | undefined {
+  return crop.scale === 1 ? undefined : `scale(${String(crop.scale)})`
+}
+
 /** Which talent surface: those slotted into shots, or every project-attached talent. */
 export type TalentScope = "in-shots" | "project-attached"
 
@@ -42,6 +89,11 @@ export interface TalentConfig {
   readonly sortBy?: TalentSortField
   /** R5 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
   readonly sortDir?: SortDir
+  /** R4 density variant. Absent → "detail" (the shipped call-sheet card, flag-off byte-identical). */
+  readonly layout?: TalentLayout
+  /** R4 part 2 — per-talent headshot crop (contact-sheet only), keyed by talentId.
+   *  Absent/empty → every headshot uses the centered default crop. */
+  readonly headshotCrops?: Record<string, HeadshotCrop>
 }
 
 export const DEFAULT_TALENT_CONFIG: TalentConfig = {
@@ -51,6 +103,8 @@ export const DEFAULT_TALENT_CONFIG: TalentConfig = {
   hiddenStatuses: [],
   sortBy: "name",
   sortDir: "asc",
+  layout: "detail",
+  headshotCrops: {},
 }
 
 /**
@@ -58,6 +112,13 @@ export const DEFAULT_TALENT_CONFIG: TalentConfig = {
  * Strips the gated-off sort/hidden fields AND clamps the O2-widened `groupBy`
  * back to its pre-O2 legal set, so a persisted "status" can't leak status-grouping
  * flag-off (byte-identity).
+ *
+ * ⚠ Divergence from the SHOT-report neutralizer: it leaves `layout` alone because
+ * shot `layout` shipped BEFORE the flag. Talent `layout` is NEW *behind* the flag
+ * (R4), so it MUST be stripped here — deriveTalentModel then folds it to the
+ * "detail" default, keeping flag-off byte-identical. Same reasoning for the
+ * headshot crop (R4 part 2): clamp it to {} so every headshot renders the default
+ * centered crop flag-off (and layout is forced to "detail" anyway, where crop is unused).
  */
 export function neutralizeTalentConfigForFlag(config: TalentConfig, flagOn: boolean): TalentConfig {
   if (flagOn) return config
@@ -66,6 +127,8 @@ export function neutralizeTalentConfigForFlag(config: TalentConfig, flagOn: bool
     hiddenStatuses: [],
     sortBy: undefined,
     sortDir: undefined,
+    layout: undefined,
+    headshotCrops: {},
     groupBy:
       config.groupBy === "none" || config.groupBy === "gender" || config.groupBy === "agency"
         ? config.groupBy
@@ -104,6 +167,9 @@ export interface TalentEntry {
   readonly measurements: readonly TalentMeasurement[]
   readonly excluded: boolean
   readonly appears: readonly TalentAppearance[]
+  /** R4 part 2 — resolved headshot crop folded from the (neutralized) config; both
+   *  renderers read this so screen + PDF can't drift. Contact-sheet layout only. */
+  readonly crop: HeadshotCrop
 }
 
 export interface TalentGroup {
@@ -122,4 +188,6 @@ export interface TalentModel {
     readonly talentCount: number
   }
   readonly groups: readonly TalentGroup[]
+  /** R4 density variant folded from the (neutralized) config — both renderers read this. */
+  readonly layout: TalentLayout
 }


### PR DESCRIPTION
## Report-config Phase C — layout/density parity for Product Info + Talent

Master-plan reports leg (report-config **Phase C**). Adds a per-type density layout to the two report types that lacked one, plus an adjustable headshot crop for the Talent contact sheet. Design + plan: `Projects/Shot Builder/outputs/2026-08-04-report-config-phaseC/`.

### What's new — behind `featureReportConfig` (LIVE); flag-off byte-identical; no rules change; no migration
- **Product Info — `gallery | index`** (default `gallery`). Index = compact 2-col spec/pull sheet (20/sheet). `imageSize` S/M/L stays an **orthogonal** gallery-only screen knob (dimmed under index). Index hero mark = canonical ink dot + uppercase tag (design-system fix; gallery keeps its shipped red, byte-identical).
- **Talent — `detail | contact-sheet`** (default `detail`). Contact sheet = 4-up casting grid; hides contact / measurements / per-shot list.
- **Talent adjustable headshot crop** (contact sheet only): per-talent `{scale, x, y}` on `TalentConfig`, honored identically in DOM (`object-fit: cover` + `object-position`) and @react-pdf (`objectFit: "cover"` + `objectPositionX/Y` + `transform: scale`). Editing = a draggable focal-point dot + zoom slider (screen-only, flag-gated). Full rect/rotation editor deferred to a follow-up.

### Architecture
Layout + crop fold onto the **pure models** from the **neutralized** config, so both renderers read a pre-clamped value → flag-off is byte-identical **by construction**. No new model logic; grouping / sort / filter untouched. Mirrors the shot report's `REPORT_LAYOUT_*` exhaustive-typed-literal (TS flags a missing label).

### Verification
- `typecheck:baseline` 160/160 · **107 report tests** · eslint 0 warnings · build green
- New **falsifiable** DOM-vs-PDF parity tests (mutating a hidden-block condition reddens a named test) + extended flag-off byte-identity + default-merge tests
- **Real-render gate:** gallery / index / detail / contact-sheet + a cropped contact sheet rendered to PDF and eyeballed. Crop confirmed honored in the PDF output; index calibrated to 20/sheet → 2 clean pages (was 3 stranded).

### Known pre-existing — NOT this PR (follow-up)
Product Info **gallery** (12/sheet) + Talent **detail** (6/sheet) strand a partial trailing page. These are the **shipped byte-identical dark defaults** (unchanged here). A follow-up recalibrates both against real data. Both report types are dark in prod → zero impact today.

### Flip
Ships **latent**: the report *types* (`VITE_PRODUCT_INFO_REPORT` / `VITE_TALENT_REPORT`) are still dark in prod, so nothing changes for users until those flags flip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01L7CeF25j7gGHbbyNYzVntn
