### PR TITLE
fix(export): recalibrate Product Info gallery (2-up showcase) + Talent detail PDF pagination (#505)

### DIFF
--- a/src-vnext/features/export/components/report/TalentReportView.tsx
+++ b/src-vnext/features/export/components/report/TalentReportView.tsx
@@ -430,13 +430,16 @@ function GroupSection({
 // (non-excluded) entries are paginated.
 // ---------------------------------------------------------------------------
 // Per-layout print geometry, kept in LOCKSTEP with reportPdfTalent's paginate().
-// detail = the shipped 2×3 (6/sheet) call-sheet grid; contact-sheet = a denser
+// detail = the 2-up (2/sheet) call-sheet grid; contact-sheet = a denser
 // 4-up casting board with a fixed 4:5 COVER crop (part 2). The 4:5 crop is much
 // taller than part-1's native-cap headshot, so the sheet packs 4×2 = 8 (not 12).
 // perSheet drives pagination; cols drives the paged grid var so a card never
 // straddles a break. EYEBALL-GATE the perSheet vs the real rendered sheet height.
+// Calibrated against a real @react-pdf render for issue #505 (2026-08-05): a
+// detail card is ~half a landscape sheet tall, so exactly ONE row (2 cards) fits;
+// 3 overflow to a stranded 2nd page. Hence detail perSheet = 2 (1 row × 2 cols).
 const LAYOUT_PRINT: Record<TalentLayout, { readonly cols: number; readonly perSheet: number }> = {
-  detail: { cols: 2, perSheet: 6 },
+  detail: { cols: 2, perSheet: 2 },
   "contact-sheet": { cols: 4, perSheet: 8 },
 }
 

--- a/src-vnext/features/export/components/report/__tests__/productInfoLayouts.parity.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/productInfoLayouts.parity.test.tsx
@@ -56,7 +56,7 @@ import {
 } from "../../../lib/report/productInfoTypes"
 
 // A single group (Women) with enough families that BOTH densities fill their
-// first sheet/page (gallery 12, index 20 — both < 26), so first-sheet count ==
+// first sheet/page (gallery 2, index 20 — both < 26), so first-sheet count ==
 // cardsPerSheet on each surface.
 const N = 26
 

--- a/src-vnext/features/export/components/report/productInfoStyles.ts
+++ b/src-vnext/features/export/components/report/productInfoStyles.ts
@@ -343,7 +343,9 @@ export const PRODUCT_INFO_STYLES = `
 }
 .sb-pir-sheet .sb-pir-card { break-inside: avoid; page-break-inside: avoid; }
 .sb-pir-sheet .sb-pir-card-name { font-size: var(--sb-t-sm); }
-.sb-pir-sheet .sb-pir-card-frame img { max-height: 2.3in; width: auto; max-width: 100%; object-fit: contain; }
+/* 2-up SHOWCASE (issue #505): match the PDF gallery image cap (IMAGE_MAX_HEIGHT 330pt ≈ 4.58in)
+   so the on-screen print preview and the @react-pdf export don't drift. Was 2.3in for the old 4×3. */
+.sb-pir-sheet .sb-pir-card-frame img { max-height: 4.58in; width: auto; max-width: 100%; object-fit: contain; }
 
 @media print {
   @page { size: letter landscape; margin: 0; }

--- a/src-vnext/features/export/lib/report/productInfoTypes.ts
+++ b/src-vnext/features/export/lib/report/productInfoTypes.ts
@@ -69,10 +69,13 @@ export interface ProductInfoLayoutGeometry {
   readonly cardsPerSheet: number
 }
 export const PRODUCT_INFO_LAYOUT_GEOMETRY: Record<ProductInfoLayout, ProductInfoLayoutGeometry> = {
-  // gallery = the shipped pre-Phase-C packing (4×3). NOTE: a real render shows only ~8 fit a
-  // landscape sheet, so gallery strands a partial page — a PRE-EXISTING defect kept byte-identical
-  // here; recalibration is a separate follow-up (see Phase C notes).
-  gallery: { printCols: 4, cardsPerSheet: 12 },
+  // gallery = image-forward SHOWCASE (issue #505, real-render calibrated 2026-08-05): 2 large
+  // cards side-by-side, one row per landscape sheet. The prior pre-Phase-C packing was 4×3=12,
+  // which stranded partial trailing pages — a real render fits only ONE card row (the card is tall:
+  // image + colours/sizes/appears), and a 2nd row strands the moment a card grows (3+ colourways
+  // wrap a chip row). So gallery is a 2-up showcase (printCols 2) rather than a fragile dense grid;
+  // fewer columns also means larger images. cardsPerSheet 2 = the row, robust for any product.
+  gallery: { printCols: 2, cardsPerSheet: 2 },
   // index = new Phase-C variant. Calibrated against a real render (Q2-26 data): exactly 10 rows × 2
   // fit one landscape sheet (22 stranded 2; 20 packs clean). Page-wrap is the safety net.
   index: { printCols: 2, cardsPerSheet: 20 },

--- a/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductInfo.tsx
@@ -7,9 +7,11 @@
 //
 // PDF typography differs from screen by design: @react-pdf ships only the
 // Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
-// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — 12
-// cards (4×3) per landscape sheet, never spanning a group, each card wrap={false} so
-// a card NEVER straddles or clips a page break.
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — the
+// gallery packs 2 large cards (2×1, a showcase spread) per landscape sheet, never
+// spanning a group, each card wrap={false} so a card NEVER straddles or clips a
+// page break. (2-up, issue #505 2026-08-05: the prior 4×3=12 stranded partial
+// pages on real product data — 2 rows never fit; see IMAGE_MAX_HEIGHT below.)
 
 import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
@@ -31,18 +33,20 @@ const ROW_GAP = 18
 // Gallery packing derives from the SHARED geometry so screen + PDF can't drift.
 const PRINT_COLS = PRODUCT_INFO_LAYOUT_GEOMETRY.gallery.printCols
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
-// Card width derives from the COLUMN count (not cards-per-sheet): a 4-up card is
-// (content - 3 col gaps) / 4. Matches the on-screen PagedView's 4-col grid.
+// Card width derives from the COLUMN count (not cards-per-sheet): a 2-up card is
+// (content - 1 col gap) / 2. Matches the on-screen PagedView's --sb-pir-print-cols grid.
 const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // Image is width-only so its height follows the photo's native aspect; the cap
-// bounds an unusually tall portrait so the card body always fits the sheet. At
-// 4×3 (12/page) three card rows stack on one landscape sheet, so the cap is far
-// tighter than the old 3-up (1 row) value of 232. EYEBALL-GATE this number.
-const IMAGE_MAX_HEIGHT = 96
+// bounds an unusually tall portrait so the card body always fits the sheet.
+// 2-up SHOWCASE (issue #505, real-render calibrated 2026-08-05): only ONE card row
+// fits a landscape sheet, so with 2 big cards the cap can be large — a real render
+// holds 2 cards on one page up to ~340 (360 overflows); 330 fills the page with a
+// stress-case (5 colours / 6 sizes / 3 appearances) margin. EYEBALL-GATE this number.
+const IMAGE_MAX_HEIGHT = 330
 
-// INDEX density (R4): compact 2-up spec-sheet rows, ~22 per landscape sheet. A
+// INDEX density (R4): compact 2-up spec-sheet rows, ~20 per landscape sheet. A
 // small fixed thumb + name + one meta line + shot count. RED-FREE (ink hero mark).
-// EYEBALL-GATE the row height: 11 rows × 2 cols must fit the usable landscape body.
+// EYEBALL-GATE the row height: 10 rows × 2 cols must fit the usable landscape body.
 const IDX_COLS = PRODUCT_INFO_LAYOUT_GEOMETRY.index.printCols
 const IDX_CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (IDX_COLS - 1)) / IDX_COLS
 const IDX_THUMB_W = 26
@@ -113,7 +117,7 @@ const s = StyleSheet.create({
   noImage: {
     width: CARD_WIDTH,
     // Match the image cap so a missing-image card is no taller than an imaged one
-    // (else the denser 4×3 grid overflows on incomplete libraries).
+    // (else the 2-up showcase row could overflow on incomplete libraries).
     height: IMAGE_MAX_HEIGHT,
     backgroundColor: COLOR.surfaceSubtle,
     alignItems: "center",

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -8,8 +8,8 @@
 //
 // PDF typography differs from screen by design: @react-pdf ships only the
 // Helvetica / Courier / Times built-ins, so the Ivy Presto serif maps to
-// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — six
-// cards (2×3) per landscape sheet, never spanning a group, each card wrap={false} so
+// Helvetica (via reportPdfShared's FONT map). Pagination is explicit — two
+// cards (1×2) per landscape sheet, never spanning a group, each card wrap={false} so
 // a card NEVER straddles or clips a page break.
 
 import type { JSX } from "react"
@@ -32,7 +32,7 @@ const PAD_BOTTOM = 30
 const COL_GAP = 22
 const ROW_GAP = 18
 const PRINT_COLS = 2
-const PRINT_ROWS = 3
+const PRINT_ROWS = 1
 const CARDS_PER_SHEET = PRINT_COLS * PRINT_ROWS
 const CONTENT_WIDTH = PAGE.width - PAD_X * 2
 // Card width derives from the COLUMN count (not cards-per-sheet): a 2-up card is
@@ -40,8 +40,10 @@ const CONTENT_WIDTH = PAGE.width - PAD_X * 2
 const CARD_WIDTH = (CONTENT_WIDTH - COL_GAP * (PRINT_COLS - 1)) / PRINT_COLS
 // Headshot is width-only so its height follows the photo's native aspect; the
 // cap bounds an unusually tall portrait so the card body always fits the sheet.
-// At 2×3 (6/page) three card rows stack on one landscape sheet, so the cap is
-// tighter than the old 3-up (1 row) value of 168. EYEBALL-GATE this number.
+// At 1×2 (2/page) a single card row occupies the landscape sheet — calibrated
+// against a real render for issue #505 (2026-08-05): a detail card is ~half a
+// sheet tall, so exactly ONE row (2 cards) fits and 3 overflow. The cap is
+// unchanged from the prior 6/page build. EYEBALL-GATE this number.
 const HEADSHOT_MAX_HEIGHT = 120
 
 // contact-sheet (R4 density) — a denser casting board with a FIXED 4:5 COVER crop
@@ -181,7 +183,7 @@ const s = StyleSheet.create({
   initials: {
     width: "100%",
     // Match the headshot cap so a no-headshot card is no taller than one with a
-    // photo (else the denser 2×3 grid overflows).
+    // photo (else the detail 1×2 row could overflow the sheet).
     height: HEADSHOT_MAX_HEIGHT,
     backgroundColor: COLOR.surfaceSubtle,
     alignItems: "center",


### PR DESCRIPTION
Closes #505.

## What & why
Both report types are **DARK** in prod (`VITE_PRODUCT_INFO_REPORT` / `VITE_TALENT_REPORT` unset in `deploy-live.yml`) → this ships **latent, zero prod impact**. Flag-independent (gallery/detail are the layout defaults). **No rules change, no migration.**

The two shipped defaults stranded a partial trailing PDF page. Fixed by calibrating the per-sheet packing against a **real `@react-pdf` render** (the parity unit tests read the constants, so they can't see physical overflow — the render is the only gate that can).

### Product Info gallery → 2-up showcase
The shipped `4×3 = 12`/sheet stranded partial pages on real product data. A real render fits only **one card row** (the card is tall: image + colours/sizes/appears), and a 2nd row strands the moment a card grows — 3+ colourways wrap a chip row. Image-cap trims don't help: the **text block, not the image**, is the tall part.

So gallery becomes a **2-up showcase** (`printCols 4→2`, `cardsPerSheet 12→2`, `IMAGE_MAX_HEIGHT 96→330`, real-render calibrated: 2 large cards fill one landscape page up to ~340; 360 overflows). One row **never strands** for any product, and fewer columns means larger images. The **DOM** print image cap is matched (`2.3in → 4.58in`) so the on-screen preview and the PDF don't drift.

> Ted picked the 2-up direction from rendered layout comps (2-up vs 3-up vs 4-up).

### Talent detail → 2/sheet
`perSheet 6→2` (`PRINT_ROWS 3→1`). A detail card is ~half a landscape sheet (headshot + contact + measurements + shot list), so only 2 fit; 6 stranded to 3 pages. The "tighten to 4" idea was measured and rejected — the card height is dominated by the contact/measurements block, not the headshot.

## Verification
- **Real-render gate** (`renderToFile` + `pdfinfo`): a mixed-density **6-product gallery → 2/page across 3 pages, no stranding** (incl. a 5-colour/3-appearance product); detail **4-talent → 2 pages**. Confirmed against pixels (heavy-product page renders clean, no clipping).
- Swept stale geometry comments (`12`/`4×3`, `6`/`2×3`, and pre-existing #504 index `22`/`11-row`).
- **84 report tests green** (incl. the gallery DOM/PDF cards-per-sheet parity test) · `typecheck:baseline` 160/160 · eslint clean · build green.

Only 5 code lines change (the rest are comments): gallery `printCols`/`cardsPerSheet`, `IMAGE_MAX_HEIGHT`, DOM image cap, and talent `PRINT_ROWS`.

Render-pack evidence: `Projects/Shot Builder/outputs/2026-08-05-issue-505-pagination/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)