### PR TITLE
ci(deploy): flip Product Info + Talent report types ON in prod (D3)

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -50,6 +50,8 @@ jobs:
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
           VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
           VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
+          VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
+          VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -93,6 +95,8 @@ jobs:
           VITE_TALENT_LAZY:                  1   # Talent redesign: lazy portfolio/casting images
           VITE_SHOT_REPORT:                  1   # Export reimagine: image-led Shot Report + reports list/recipe/looksMode live
           VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
+          VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
+          VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
Flips **D3** (Product Info + Talent report types) live in prod. Ted-authorized, scope = the two report types verified this session (recipes flag deliberately excluded).

## Change
`VITE_PRODUCT_INFO_REPORT=1` + `VITE_TALENT_REPORT=1` in **both** `deploy-live.yml` build blocks (byte-identical, YAML-validated).

## Why it's ready
- The report-config layer (`featureReportConfig`) is already live (rename / group×order / status filter / layout-density / talent crop).
- **#505/#506 fixed the PDF pagination** for exactly these two types: Product Info gallery → 2-up showcase, Talent detail → 2/sheet. Real-render verified, no stranding.
- The render-pack PDFs Ted reviewed are what this flip turns on.

## Scope note
`VITE_SHOT_REPORT_RECIPES` (the 3rd D3 flag — on-set production-sheet + balanced-rows shot-report layouts) is **NOT** flipped here — not eyeballed this session (Ted's call).

## Rollback
Revert this one commit + redeploy. Code stays byte-identical dark; no rules/migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)