### PR TITLE
fix(export): recipe PDFs flow instead of silently clipping; honest balanced-rows caption

### DIFF
--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -14,6 +14,7 @@ import type {
   ReportProduct,
   ReportShot,
 } from "../../lib/report/reportTypes"
+import { formatOrderNote } from "../../lib/report/reportTypes"
 import { present, primaryLookImage, resolveSrc, statusMeta } from "./reportShared"
 import { sizeLabel } from "../../lib/report/reportModel"
 
@@ -159,12 +160,12 @@ function Band({
   )
 }
 
-function GroupHead({ group }: { readonly group: ReportGroup }): JSX.Element {
+function GroupHead({ group, note }: { readonly group: ReportGroup; readonly note: string }): JSX.Element {
   return (
     <div className="sb-br-group-head">
       <h2 className="sb-masthead sb-br-group-title">{group.label}</h2>
       <span className="sb-br-group-count">{group.count === 1 ? "1 shot" : `${group.count} shots`}</span>
-      <span className="sb-br-group-note">Grouped · sorted by shot no.</span>
+      <span className="sb-br-group-note">{note}</span>
     </div>
   )
 }
@@ -273,7 +274,8 @@ function PagedView({ model, imageMap, onToggleExclude }: BodyProps): JSX.Element
         <section className="sb-br-page" key={`br-page-${pi}`}>
           {items.map((item, ii) => {
             if (item.kind === "mast") return <Masthead key={`m-${pi}`} model={model} />
-            if (item.kind === "group") return <GroupHead key={`g-${pi}-${ii}`} group={item.group} />
+            if (item.kind === "group")
+              return <GroupHead key={`g-${pi}-${ii}`} group={item.group} note={formatOrderNote(model.order)} />
             return (
               <Band
                 key={item.shot.id}
@@ -322,7 +324,10 @@ export function BalancedRowsReport({ model, imageMap, onToggleExclude }: BodyPro
         {model.groups.map((group) => (
           <div className="sb-br-group" key={group.key}>
             {/* count = printable; excluded bands still shown struck below */}
-            <GroupHead group={{ ...group, count: group.shots.filter((s) => !s.excluded).length }} />
+            <GroupHead
+              group={{ ...group, count: group.shots.filter((s) => !s.excluded).length }}
+              note={formatOrderNote(model.order)}
+            />
             {group.shots.map((shot) => (
               <Band
                 key={shot.id}

--- a/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
@@ -42,6 +42,7 @@ function model(): ReportModel {
         ],
       },
     ],
+    order: { sortBy: "shot-number", sortDir: "asc" },
   }
 }
 
@@ -71,5 +72,15 @@ describe("BalancedRowsReport (comp-c)", () => {
     // first fact value ("Shots") = 2 printable
     expect(container.querySelector(".sb-br-fact-v")?.textContent).toBe("2")
     expect(getAllByText("Trail Crew").length).toBeGreaterThan(0)
+  })
+
+  it("renders the honest, config-driven order note — never a hardcoded 'shot no.' claim", () => {
+    const talentSorted: ReportModel = { ...model(), order: { sortBy: "talent", sortDir: "desc" } }
+    const { getAllByText, queryByText } = render(
+      <BalancedRowsReport model={talentSorted} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    // caption reflects the ACTUAL applied order (model.order), so it can't lie
+    expect(getAllByText("Sorted by talent, descending").length).toBeGreaterThan(0)
+    expect(queryByText(/sorted by shot/i)).toBeNull()
   })
 })

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
@@ -1,0 +1,94 @@
+// @vitest-environment node
+//
+// REAL @react-pdf render regression gate for the two shot-report recipes.
+// The parity/DOM tests mock @react-pdf, so they CANNOT see physical page
+// overflow. This suite renders the actual recipe Documents to a PDF buffer and
+// fails if @react-pdf reports the atomic-overflow condition that used to SILENTLY
+// CLIP content off a crew pull sheet: "Node of type VIEW can't wrap between pages
+// and it's bigger than available page height".
+//
+// Before the fix each shot was an atomic wrap={false} Row/Band with no height cap,
+// so a shot denser than one US-Letter-landscape page dropped its tail with no
+// marker. The fix makes the shot splittable (product rows flow; only a single
+// ProductRow stays atomic). Re-add wrap={false} to the Row/Band and BOTH cases
+// below go red — the property is falsifiable, not decorative.
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderToBuffer } from "@react-pdf/renderer"
+import { ProductionSheetPdfDocument } from "../../../lib/report/reportPdfProductionSheet"
+import { BalancedRowsPdfDocument } from "../../../lib/report/reportPdfBalancedRows"
+import type { ReportModel, ReportProduct, ReportShot } from "../../../lib/report/reportTypes"
+
+// @react-pdf emits the overflow condition via console.warn; match either phrasing.
+const OVERFLOW = /can't wrap between pages|bigger than available page height/i
+
+function product(i: number): ReportProduct {
+  return {
+    family: `Heavyweight Brushed Fleece Full-Zip Hoodie ${i}`,
+    style: `IMG-9${1000 + i}`,
+    colour: "Vintage Sun-Faded Indigo Wash Heather",
+    size: "XL",
+    sizeScope: "single",
+    qty: 2,
+    gender: "W",
+    isHero: i === 0,
+    img: null,
+  }
+}
+
+// One shot several times taller than a single US-Letter-landscape page (~530pt
+// usable): 50 products in the primary look + 2 alt looks + a long note. Sized to
+// exceed one page BY A WIDE MARGIN — a marginal fixture that merely fits masks the
+// bug (verified: 16–24 products still fit one page, so wrap={false} never fires).
+// Realistic shots never reach this; the guard proves the flow-vs-clip behavior.
+function overflowModel(): ReportModel {
+  const shot: ReportShot = {
+    id: "s1",
+    number: "01",
+    title: "Everything Shot",
+    colorway: "Charcoal / Bone",
+    status: "on_hold",
+    gender: "W",
+    notes: "Deliberately long styling note to add height. ".repeat(10),
+    talent: [{ id: "t1", name: "Alexandra Whitfield", img: null }],
+    excluded: false,
+    hasImage: false,
+    looks: [
+      { id: "l1", label: "Primary", isAlt: false, image: null, hasReference: false, products: Array.from({ length: 50 }, (_, i) => product(i)) },
+      { id: "l2", label: "Alt 1", isAlt: true, image: null, hasReference: false, products: Array.from({ length: 6 }, (_, i) => product(100 + i)) },
+      { id: "l3", label: "Alt 2", isAlt: true, image: null, hasReference: false, products: Array.from({ length: 6 }, (_, i) => product(200 + i)) },
+    ],
+  }
+  return {
+    project: { name: "Overflow Fixture", client: "unbound-merino", shotCount: 1, dateRange: null },
+    groups: [{ key: "W", label: "Women", count: 1, shots: [shot] }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+function overflowWarnings(warn: ReturnType<typeof vi.spyOn>): string[] {
+  return warn.mock.calls
+    .map((call) => call.map((a) => String(a)).join(" "))
+    .filter((line) => OVERFLOW.test(line))
+}
+
+describe("recipe PDF overflow — a page-busting shot must FLOW, never silently clip", () => {
+  let warn: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it("production-sheet renders the dense shot with NO can't-wrap warning", async () => {
+    const buf = await renderToBuffer(<ProductionSheetPdfDocument model={overflowModel()} imageMap={new Map()} />)
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+  })
+
+  it("balanced-rows renders the dense shot with NO can't-wrap warning", async () => {
+    const buf = await renderToBuffer(<BalancedRowsPdfDocument model={overflowModel()} imageMap={new Map()} />)
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+  })
+})

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest"
 import { deriveShotReportModel, formatDateWindow, mostOutstandingStatus, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
-import { DEFAULT_REPORT_CONFIG, neutralizeReportConfigForFlag, type ReportConfig } from "../reportTypes"
+import { DEFAULT_REPORT_CONFIG, formatOrderNote, neutralizeReportConfigForFlag, type ReportConfig, type ReportSortField } from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
 import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
 
@@ -560,5 +560,42 @@ describe("mostOutstandingStatus (O2 status-grouping reduction)", () => {
   })
   it("returns null for an item with no appearances", () => {
     expect(mostOutstandingStatus([])).toBeNull()
+  })
+})
+
+describe("model.order — the APPLIED order (so a recipe caption can never claim an order the shots don't have)", () => {
+  it("absent sortBy (flag-off / legacy) → order = {shot-number, asc}, matching the verbatim legacy sort", () => {
+    const model = deriveShotReportModel(data({}), { groupBy: "gender", excludedShotIds: [] })
+    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc" })
+  })
+  it("a chosen sortBy/sortDir flows into model.order verbatim", () => {
+    const model = deriveShotReportModel(data({}), { groupBy: "none", excludedShotIds: [], sortBy: "talent", sortDir: "desc" })
+    expect(model.order).toEqual({ sortBy: "talent", sortDir: "desc" })
+  })
+  it("neutralizing (flag off) a persisted talent/desc config resets order to legacy — the shots are re-sorted, and so is the caption", () => {
+    const raw: ReportConfig = { groupBy: "status", excludedShotIds: [], sortBy: "talent", sortDir: "desc" }
+    const model = deriveShotReportModel(data({}), neutralizeReportConfigForFlag(raw, false))
+    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc" })
+  })
+})
+
+describe("formatOrderNote — honest, config-driven recipe caption (replaces the hardcoded 'sorted by shot no.' lie)", () => {
+  it("default order reads 'Sorted by shot #'", () => {
+    expect(formatOrderNote({ sortBy: "shot-number", sortDir: "asc" })).toBe("Sorted by shot #")
+  })
+  it("a talent/descending order is described honestly and never says 'shot'", () => {
+    const note = formatOrderNote({ sortBy: "talent", sortDir: "desc" })
+    expect(note).toBe("Sorted by talent, descending")
+    expect(note).not.toMatch(/shot/i)
+  })
+  it("status ascending reads 'Sorted by status'", () => {
+    expect(formatOrderNote({ sortBy: "status", sortDir: "asc" })).toBe("Sorted by status")
+  })
+  it("falls back to shot # (never throws) on an out-of-union persisted sortBy", () => {
+    // exportReports is schemaless; a corrupted/legacy blob can carry an invalid
+    // sortBy. shotPrimaryFor sorts such shots by shot-number, so the caption
+    // honestly reads "shot #" rather than crashing on an undefined label.
+    const note = formatOrderNote({ sortBy: "retired-field" as ReportSortField, sortDir: "asc" })
+    expect(note).toBe("Sorted by shot #")
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
@@ -59,7 +59,11 @@ function group(label: string, shots: ReportShot[], over: Partial<ReportGroup> = 
   return { key: "W", label, count: shots.length, shots, ...over }
 }
 function model(groups: ReportGroup[]): ReportModel {
-  return { project: { name: "P", client: "C", shotCount: 0, dateRange: null }, groups }
+  return {
+    project: { name: "P", client: "C", shotCount: 0, dateRange: null },
+    groups,
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
 }
 
 /** A deliberately huge shot whose estimate exceeds a single column. */

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -365,6 +365,10 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
       dateRange: formatDateWindow(data.project?.shootDates),
     },
     groups,
+    // The applied order (absent sortBy → the legacy ascending shot-number sort
+    // above). Set here so a recipe caption can never claim an order the shots
+    // don't have; flag-off this is always {shot-number, asc}, matching legacy.
+    order: { sortBy: config.sortBy ?? "shot-number", sortDir: config.sortDir ?? "asc" },
   }
 }
 

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -6,7 +6,8 @@
 import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
 import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
-import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage } from "./reportPdfShared"
+import { formatOrderNote } from "./reportTypes"
+import { COLOR, FONT, PAGE, STATUS, breakLongToken, has, primaryLookImage } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
 
 const PAD_X = 34
@@ -99,7 +100,7 @@ function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
           {p.isHero ? <Text style={s.heroTag}>{"  HERO"}</Text> : null}
         </Text>
       </View>
-      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? p.style : "—"}</Text>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? breakLongToken(p.style) : "—"}</Text>
       <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "—"}</Text>
       <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizeText}</Text>
       <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>
@@ -111,7 +112,7 @@ function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
   const n = look.products.length
   return (
     <View style={[s.look, ...(look.isAlt ? [s.lookAlt] : [])]}>
-      <View style={s.lookLabel}>
+      <View style={s.lookLabel} minPresenceAhead={30}>
         <Text style={s.lookLabelTxt}>{look.label}</Text>
         <Text style={s.lkTag}>{n === 1 ? "1 piece" : `${n} pieces`}</Text>
       </View>
@@ -136,7 +137,7 @@ function Band({ shot, imageMap, zebra }: { readonly shot: ReportShot; readonly i
   const st = STATUS[shot.status]
   const talent = shot.talent.map((t) => t.name).filter((n) => has(n))
   return (
-    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]} wrap={false}>
+    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]}>
       <View style={s.imgCol}>
         {src ? <Image src={src} style={s.img} /> : <View style={s.noImg}><Text style={s.noImgTxt}>No image yet</Text></View>}
       </View>
@@ -176,12 +177,12 @@ function Band({ shot, imageMap, zebra }: { readonly shot: ReportShot; readonly i
   )
 }
 
-function GroupHead({ group }: { readonly group: ReportGroup }): JSX.Element {
+function GroupHead({ group, note }: { readonly group: ReportGroup; readonly note: string }): JSX.Element {
   return (
     <View style={s.groupHead} wrap={false} minPresenceAhead={60}>
       <Text style={s.groupTitle}>{group.label}</Text>
       <Text style={s.groupCount}>{group.count === 1 ? "1 shot" : `${group.count} shots`}</Text>
-      <Text style={s.groupNote}>Grouped · sorted by shot no.</Text>
+      <Text style={s.groupNote}>{note}</Text>
     </View>
   )
 }
@@ -233,7 +234,7 @@ export function BalancedRowsPdfDocument(props: {
           if (printable.length === 0) return null
           return (
             <View key={group.key}>
-              <GroupHead group={{ ...group, count: printable.length }} />
+              <GroupHead group={{ ...group, count: printable.length }} note={formatOrderNote(model.order)} />
               {printable.map((shot) => {
                 const zebra = z % 2 === 1
                 z += 1

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -5,7 +5,7 @@
 import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
 import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
-import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS, breakLongToken, has, primaryLookImage } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
 
 const PAD_X = 30
@@ -98,7 +98,7 @@ function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
     <View style={[s.prod, ...(p.isHero ? [s.prodHero] : [])]} wrap={false}>
       <View style={s.cHero}>{p.isHero ? <View style={s.heroDot} /> : null}</View>
       <Text style={[s.fam, s.cFam, ...(p.isHero ? [s.famHero] : [])]}>{has(p.family) ? p.family : "Unnamed product"}</Text>
-      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? p.style : "no style #"}</Text>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? breakLongToken(p.style) : "no style #"}</Text>
       <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "Unspecified"}</Text>
       <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizeText}</Text>
       <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>
@@ -109,8 +109,8 @@ function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
 function LookBlock({ look }: { readonly look: ReportLook }): JSX.Element {
   const n = look.products.length
   return (
-    <View style={[s.look, ...(look.isAlt ? [s.lookAlt] : [])]} wrap={false}>
-      <View style={s.lookHead}>
+    <View style={[s.look, ...(look.isAlt ? [s.lookAlt] : [])]}>
+      <View style={s.lookHead} minPresenceAhead={30}>
         <Text style={s.lookTag}>{look.label.toUpperCase()}</Text>
         <Text style={s.lookCount}>{n === 1 ? "1 piece" : `${n} pieces`}</Text>
       </View>
@@ -128,7 +128,7 @@ function Row({ shot, imageMap }: { readonly shot: ReportShot; readonly imageMap:
   const src = has(cand) ? imageMap.get(cand) : undefined
   const talent = shot.talent.filter((t) => has(t.name))
   return (
-    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]} wrap={false}>
+    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]}>
       <View style={s.spine}>
         <View style={[s.statusDot, { backgroundColor: st.color }]} />
         {flagged ? <Text style={s.holdTxt}>HOLD</Text> : null}

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -66,6 +66,27 @@ export const REPORT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: ReportSo
     label: REPORT_SORT_FIELD_LABEL[value],
   }))
 
+/** The order actually applied to the resolved model (set at derive time from the
+ *  applied config, so it can never drift from the shots' real order). Recipe
+ *  captions render this instead of a hardcoded "sorted by shot no." claim. */
+export interface ReportOrder {
+  readonly sortBy: ReportSortField
+  readonly sortDir: SortDir
+}
+
+/** Honest, config-driven order caption for the recipe group heads. Reads the
+ *  applied order off the model — NOT a persisted config field — so it always
+ *  describes the shots as actually sorted. */
+export function formatOrderNote(order: ReportOrder): string {
+  // Defensive lookup: exportReports persists schemaless (no rules validation),
+  // so a hand-edited/legacy blob can carry an out-of-union sortBy. shotPrimaryFor
+  // sorts such shots by shot-number, so falling back to that label keeps the
+  // caption HONEST (and never crashes on an undefined label — see reportModel.ts).
+  const label = REPORT_SORT_FIELD_LABEL[order.sortBy] ?? REPORT_SORT_FIELD_LABEL["shot-number"]
+  const field = label.toLowerCase()
+  return order.sortDir === "desc" ? `Sorted by ${field}, descending` : `Sorted by ${field}`
+}
+
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
 export interface ReportConfig {
   readonly groupBy: ReportGroupBy
@@ -183,4 +204,7 @@ export interface ReportModel {
     readonly dateRange: string | null
   }
   readonly groups: readonly ReportGroup[]
+  /** The order actually applied to the shots (from the applied config at derive
+   *  time). Recipe group heads render formatOrderNote(order) — never a static claim. */
+  readonly order: ReportOrder
 }


### PR DESCRIPTION
## What & why

Pre-work for the **`featureShotReportRecipes` flip (D3 rest)**. A comprehensive real-render verification workflow found the two DARK shot-report recipes were **not flip-ready**: each shot was an atomic `wrap={false}` unit with no height cap, so a shot denser than one US-Letter-landscape page **silently clipped** its overflow off the bottom — dropped SKUs on a crew pull sheet, no marker. The `@react-pdf` render gate measured **12 "can't wrap" warnings** across stress + falsify fixtures; realistic (12-shot) and real-scale (54-shot) render clean.

Second finding: balanced-rows hardcoded the caption `"Grouped · sorted by shot no."`, which **lies** the moment a user picks a non-default sort — reachable today since `featureReportConfig` is live.

## Changes (all behind `featureShotReportRecipes` — DARK; flag-off byte-identical)

- **Splittable shots** — drop `wrap={false}` from the outer `Row`/`Band` + production-sheet `LookBlock`; keep `ProductRow` atomic; pin look headers with `minPresenceAhead`. Content **flows** across pages (12 → 0 warnings, all products preserved); wasted blank trailing pages gone.
- **Honest caption** — `ReportModel.order` set at derive time from the *applied* config + pure `formatOrderNote()`, rendered by DOM + PDF group heads, so the caption can't drift from the shots' real order. Defensive against an out-of-union persisted `sortBy`.
- **SKU hardening** — `breakLongToken` on the style# column.
- **Tests** — a falsifiable **real `@react-pdf` render** regression test (mutation-verified on both recipes) + caption↔order binding tests + a DOM caption test.

## Verification
- typecheck:baseline 160/160 · 183 report tests · eslint clean · build ✓
- Real render: 12 → 0 "can't wrap" warnings; all falsify products preserved; realistic/real-scale unchanged-clean
- senior-code-reviewer pass (2 mediums, both addressed/accepted)

## Not in this PR
- **The flip itself** (`VITE_SHOT_REPORT_RECIPES=1` in `deploy-live.yml`) is a **separate env-line PR**, gated on a `:5174` eyeball of both recipes at real wedge-2 density.
- **Known trade (edge-case only):** a shot with ~40+ products in one look splits across pages; the continuation page keeps the product rows + (for held shots) the red rail, but not the identity strip (HOLD text / thumbnail / hero image). Realistic data never reaches that density. Restructuring the identity strip above the content would alter the approved image-left/table-right comp — deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L7CeF25j7gGHbbyNYzVntn