### PR TITLE
ci(deploy): flip Shot Report recipes ON in prod (D3 final)

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -52,6 +52,7 @@ jobs:
           VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
           VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
           VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
+          VITE_SHOT_REPORT_RECIPES:         1   # D3 final: Production sheet + Balanced rows recipes LIVE (#508 splittable; Ted approved off real-data renders 2026-08-08)
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -97,6 +98,7 @@ jobs:
           VITE_REPORT_CONFIG:               1   # Report config Phase A: rename-after-create + hide-by-status controls (featureReportConfig)
           VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
           VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
+          VITE_SHOT_REPORT_RECIPES:         1   # D3 final: Production sheet + Balanced rows recipes LIVE (#508 splittable; Ted approved off real-data renders 2026-08-08)
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
One-line-per-block env flip: `VITE_SHOT_REPORT_RECIPES: 1` in both deploy-live blocks. Code is byte-identical — the recipes shipped dark in #508 (splittable, real-render regression-tested, mutation-verified).

**Ted's call (2026-08-09):** flip immediately (explicit freeze exception — flag-only, trivially reversible), off the real-data side-by-side renders of Q2-26 No. 3. Production sheet is slated to become the default recipe in a follow-up after a design-perfection audit (tracked; includes the style-number stray-space nit).

Undo = revert this PR + redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)