### PR TITLE
feat(export): production sheet becomes the default shot-report recipe; style numbers render unbroken

### DIFF
--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -28,6 +28,7 @@ import {
   REPORT_LAYOUT_OPTIONS,
   REPORT_SORT_FIELD_OPTIONS,
   REPORT_STATUS_OPTIONS,
+  resolveReportLayout,
 } from "../../lib/report/reportTypes"
 import type { SortDir } from "../../lib/report/reportSort"
 import { hasAnyIncludedShot, sizeLabel } from "../../lib/report/reportModel"
@@ -649,10 +650,11 @@ export function ReportView(props: ReportViewProps): JSX.Element {
   const [printMode, setPrintMode] = useState(false)
 
   // Recipes ride their own flag; flag-off forces image-led so prod is byte-identical
-  // to the live R1/R2 report regardless of any persisted config.layout.
+  // to the live R1/R2 report regardless of any persisted config.layout (or of
+  // DEFAULT_REPORT_CONFIG.layout — resolveReportLayout ignores both when off).
   const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
   const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
-  const layout: ReportLayout = recipesEnabled ? (config.layout ?? "image-led") : "image-led"
+  const layout: ReportLayout = resolveReportLayout(config, recipesEnabled)
 
   const toggleExclude = (shotId: string): void => {
     const set = new Set(config.excludedShotIds)

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -59,7 +59,12 @@ export default function ShotReportListPage() {
   // Picker starts on the shipped default recipe (production-sheet as of the
   // 2026-08-09 decision) rather than a hardcoded "image-led" literal, so it
   // can't drift from DEFAULT_REPORT_CONFIG if the default changes again.
-  const [recipe, setRecipe] = useState<ReportLayout>(DEFAULT_REPORT_CONFIG.layout ?? "image-led")
+  // DEFAULT_REPORT_CONFIG.layout is always set at runtime — the interface
+  // types it optional (a persisted blob can lack it) but the shipped default
+  // constant always carries a value, so an "?? image-led" fallback here was
+  // dead code that quietly reintroduced the hardcoded literal this comment
+  // says to avoid.
+  const [recipe, setRecipe] = useState<ReportLayout>(DEFAULT_REPORT_CONFIG.layout!)
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
   const [pendingRename, setPendingRename] = useState<{ id: string; name: string } | null>(null)

--- a/src-vnext/features/export/components/report/ShotReportListPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportListPage.tsx
@@ -32,6 +32,7 @@ import {
   DEFAULT_REPORT_CONFIG,
   REPORT_LAYOUT_LABEL,
   REPORT_LAYOUT_OPTIONS,
+  resolveReportLayout,
   type ReportConfig,
   type ReportLayout,
 } from "../../lib/report/reportTypes"
@@ -55,7 +56,10 @@ export default function ShotReportListPage() {
   const recipesEnabled = isFeatureEnabled("featureShotReportRecipes")
   const reportConfigEnabled = isFeatureEnabled("featureReportConfig")
   const [newName, setNewName] = useState("")
-  const [recipe, setRecipe] = useState<ReportLayout>("image-led")
+  // Picker starts on the shipped default recipe (production-sheet as of the
+  // 2026-08-09 decision) rather than a hardcoded "image-led" literal, so it
+  // can't drift from DEFAULT_REPORT_CONFIG if the default changes again.
+  const [recipe, setRecipe] = useState<ReportLayout>(DEFAULT_REPORT_CONFIG.layout ?? "image-led")
   const [busy, setBusy] = useState(false)
   const [pendingDelete, setPendingDelete] = useState<{ id: string; name: string } | null>(null)
   const [pendingRename, setPendingRename] = useState<{ id: string; name: string } | null>(null)
@@ -69,11 +73,14 @@ export default function ShotReportListPage() {
   const handleCreate = useCallback(async () => {
     setBusy(true)
     try {
-      // Recipes flag-off => always image-led, so the create config can't smuggle
-      // an unreviewed layout into prod.
+      // Recipes flag-off => always image-led (via the shared clamp, NOT a raw
+      // DEFAULT_REPORT_CONFIG spread — DEFAULT_REPORT_CONFIG.layout is now
+      // production-sheet, so spreading it verbatim would persist the new
+      // default into a doc created while the flag is off: dev/preview, or a
+      // flag rollback, would then smuggle an unreviewed layout into prod).
       const config = recipesEnabled
         ? { ...DEFAULT_REPORT_CONFIG, layout: recipe }
-        : DEFAULT_REPORT_CONFIG
+        : { ...DEFAULT_REPORT_CONFIG, layout: resolveReportLayout(DEFAULT_REPORT_CONFIG, recipesEnabled) }
       const id = await createShotReport(newName.trim() || "Untitled report", config)
       setNewName("")
       openReport(id)
@@ -90,7 +97,13 @@ export default function ShotReportListPage() {
       try {
         const full = await loadReport(sourceId)
         // This list only handles shot-report docs; config narrows to ReportConfig.
-        const sourceConfig = (full?.config as ReportConfig | undefined) ?? DEFAULT_REPORT_CONFIG
+        // createShotReport always writes a config, so the fallback below is
+        // defensive-only (a malformed/legacy doc) — still clamp its layout so
+        // that edge case can't smuggle the new default past a flag-off create.
+        const sourceConfig = (full?.config as ReportConfig | undefined) ?? {
+          ...DEFAULT_REPORT_CONFIG,
+          layout: resolveReportLayout(DEFAULT_REPORT_CONFIG, recipesEnabled),
+        }
         const id = await createShotReport(`${sourceName} (copy)`, sourceConfig)
         openReport(id)
       } catch {
@@ -99,7 +112,7 @@ export default function ShotReportListPage() {
         setBusy(false)
       }
     },
-    [createShotReport, loadReport, openReport],
+    [createShotReport, loadReport, openReport, recipesEnabled],
   )
 
   const handleDelete = useCallback(

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -10,7 +10,13 @@ import {
   collectReportImageCandidates,
   resolveReportImages,
 } from "../../lib/report/reportImages"
-import { DEFAULT_REPORT_CONFIG, neutralizeReportConfigForFlag, type ReportConfig } from "../../lib/report/reportTypes"
+import {
+  DEFAULT_REPORT_CONFIG,
+  hydrateReportConfig,
+  neutralizeReportConfigForFlag,
+  resolveReportLayout,
+  type ReportConfig,
+} from "../../lib/report/reportTypes"
 import { ReportView } from "./ReportView"
 
 // Integration layer: live export data -> resolved model -> image sidecar ->
@@ -53,7 +59,12 @@ export default function ShotReportPage() {
         // Cross-type guard: a pasted cross-type reportId must not clobber that doc's config.
         if (full.reportType !== "shot-report") return
         const loaded = full.config as ReportConfig | undefined
-        setConfig(loaded ? { ...DEFAULT_REPORT_CONFIG, ...loaded } : DEFAULT_REPORT_CONFIG)
+        // hydrateReportConfig (not a raw {...DEFAULT_REPORT_CONFIG, ...loaded}
+        // spread) so a genuinely pre-R3 blob missing `layout` floors to
+        // "image-led" — the pre-recipes report it always rendered — instead of
+        // silently picking up DEFAULT_REPORT_CONFIG's current (production-sheet)
+        // default. A blob that DOES carry a persisted layout always wins.
+        setConfig(loaded ? hydrateReportConfig(loaded) : DEFAULT_REPORT_CONFIG)
         hydratedReportIdRef.current = reportId
       })
       .catch(() => {
@@ -133,10 +144,9 @@ export default function ShotReportPage() {
     void (async () => {
       const { generateShotReportPdf } = await import("../../lib/report/reportPdf")
       // Recipes ride their own flag; flag-off forces image-led so the PDF matches
-      // the on-screen layout (which ReportView also forces to image-led).
-      const layout = isFeatureEnabled("featureShotReportRecipes")
-        ? (config.layout ?? "image-led")
-        : "image-led"
+      // the on-screen layout (which ReportView also forces to image-led via the
+      // same resolveReportLayout — single source, can't drift).
+      const layout = resolveReportLayout(config, isFeatureEnabled("featureShotReportRecipes"))
       await generateShotReportPdf(
         model,
         imageMap,

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -60,11 +60,15 @@ export default function ShotReportPage() {
         if (full.reportType !== "shot-report") return
         const loaded = full.config as ReportConfig | undefined
         // hydrateReportConfig (not a raw {...DEFAULT_REPORT_CONFIG, ...loaded}
-        // spread) so a genuinely pre-R3 blob missing `layout` floors to
-        // "image-led" — the pre-recipes report it always rendered — instead of
-        // silently picking up DEFAULT_REPORT_CONFIG's current (production-sheet)
-        // default. A blob that DOES carry a persisted layout always wins.
-        setConfig(loaded ? hydrateReportConfig(loaded) : DEFAULT_REPORT_CONFIG)
+        // spread, and NOT a bare DEFAULT_REPORT_CONFIG when `loaded` is
+        // undefined) so a genuinely pre-R3 blob missing `config` entirely — or
+        // missing just `layout` — floors to "image-led", the pre-recipes report
+        // it always rendered, instead of silently picking up
+        // DEFAULT_REPORT_CONFIG's current (production-sheet) default. `loaded ??
+        // {}` matters: a bare `DEFAULT_REPORT_CONFIG` fallback here would hand a
+        // no-config legacy doc the NEW default, and the next save would persist
+        // it. A blob that DOES carry a persisted layout always wins.
+        setConfig(hydrateReportConfig(loaded ?? {}))
         hydratedReportIdRef.current = reportId
       })
       .catch(() => {

--- a/src-vnext/features/export/components/report/__tests__/ShotReportListPage.recipeDefault.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/ShotReportListPage.recipeDefault.test.tsx
@@ -1,0 +1,83 @@
+/// <reference types="@testing-library/jest-dom" />
+// H2b — the flag-off clamp on the CREATE path. ShotReportListPage.handleCreate
+// picks between `{ ...DEFAULT_REPORT_CONFIG, layout: recipe }` (recipes ON) and
+// the shared `resolveReportLayout` clamp (recipes OFF). Nothing exercised the
+// OFF branch end-to-end: this renders the real page, clicks Create with the
+// flag off, and asserts the write handed to createShotReport carries
+// layout:"image-led" — never DEFAULT_REPORT_CONFIG's current "production-sheet"
+// default. Mutation check: swapping the OFF branch for a raw
+// `{ ...DEFAULT_REPORT_CONFIG }` spread must redden this test.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import ShotReportListPage from "../ShotReportListPage"
+
+const createShotReportMock = vi.hoisted(() => vi.fn().mockResolvedValue("report-new"))
+// Stable stubs (module-level, not recreated per-render) — see the identity
+// note in ShotReportPage.legacyHydrate.test.tsx for why a fresh vi.fn() per
+// render is a hazard elsewhere in this page family.
+const loadReportMock = vi.hoisted(() => vi.fn())
+const deleteReportMock = vi.hoisted(() => vi.fn())
+const renameReportMock = vi.hoisted(() => vi.fn())
+
+vi.mock("../../../hooks/useExportReports", () => ({
+  useExportReports: () => ({
+    reports: [],
+    loading: false,
+    createShotReport: createShotReportMock,
+    loadReport: loadReportMock,
+    deleteReport: deleteReportMock,
+    renameReport: renameReportMock,
+  }),
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "client-1", role: "producer" }),
+}))
+
+// featureShotReportRecipes pinned OFF for this file (the contract under test);
+// everything else falls through to the real flag module.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureShotReportRecipes" ? false : actual.isFeatureEnabled(flag),
+  }
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/proj-1/export/reports"]}>
+      <Routes>
+        <Route path="/projects/:id/export/reports" element={<ShotReportListPage />} />
+        {/* openReport() navigates here after create — route it to avoid a
+            "no routes matched" router warning; the test asserts on the
+            create write, not the destination page. */}
+        <Route path="/projects/:id/export/report" element={<div>Report route</div>} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ShotReportListPage create — featureShotReportRecipes OFF (H2b)", () => {
+  beforeEach(() => {
+    createShotReportMock.mockClear()
+  })
+
+  it("the create write's layout is image-led, not DEFAULT_REPORT_CONFIG's production-sheet default", async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    // Recipe picker is hidden while the flag is off (showLayout=recipesEnabled).
+    expect(screen.queryByLabelText("Report recipe")).not.toBeInTheDocument()
+
+    await user.type(screen.getByLabelText("New report name"), "Q3 warehouse sheet")
+    await user.click(screen.getByRole("button", { name: /create report/i }))
+
+    expect(createShotReportMock).toHaveBeenCalledTimes(1)
+    const [, config] = createShotReportMock.mock.calls[0] as [string, { layout?: string }]
+    expect(config.layout).toBe("image-led")
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/ShotReportPage.legacyHydrate.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/ShotReportPage.legacyHydrate.test.tsx
@@ -1,0 +1,117 @@
+/// <reference types="@testing-library/jest-dom" />
+// H3 — a saved shot-report doc with NO `config` field at all (a genuinely
+// pre-R3 doc) must hydrate to LEGACY_REPORT_LAYOUT ("image-led"), never to
+// DEFAULT_REPORT_CONFIG's current "production-sheet" default, and the NEXT
+// save must persist that floor. The no-config branch previously called
+// `setConfig(DEFAULT_REPORT_CONFIG)` directly (bypassing hydrateReportConfig's
+// layout floor), so a legacy doc opened after the 2026-08-09 default-recipe
+// change would silently pick up production-sheet and re-persist it on the
+// next edit. Mutation check: reverting the no-config branch to
+// `DEFAULT_REPORT_CONFIG` (instead of `hydrateReportConfig(loaded ?? {})`)
+// must redden this test.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { MemoryRouter, Routes, Route } from "react-router-dom"
+import ShotReportPage from "../ShotReportPage"
+import type { ExportReportFull } from "../../../hooks/useExportReports"
+
+// IMPORTANT: every value handed back by these two mocked hooks must be
+// REFERENTIALLY STABLE across renders (module-level, not a fresh object/fn
+// literal inside the mock factory's returned closure). ShotReportPage's
+// hydrate effect depends on `[reportId, loadReport]` and its image-resolve
+// effect depends on `[model]` (derived from `data`) — a `loadReport` or
+// `data` that changes identity every render re-fires those effects, which
+// call setState, which re-renders, which produces a new identity: an
+// infinite loop that OOMs the test worker rather than failing loudly. Caught
+// empirically (heap exhaustion) before landing this file.
+const loadReportMock = vi.hoisted(() => vi.fn())
+const saveReportConfigMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined))
+const exportDataStub = vi.hoisted(() => ({
+  project: { id: "p1", name: "Legacy Project", client: "unbound-merino" },
+  shots: [],
+  productFamilies: [],
+  pulls: [],
+  crew: [],
+  talent: [],
+  loading: false,
+}))
+
+// A genuinely pre-R3 doc: reportType is "shot-report" but `config` is entirely
+// absent (never written by the pre-recipes builder).
+const legacyDoc: ExportReportFull = {
+  id: "r1",
+  name: "Legacy report",
+  reportType: "shot-report",
+  layout: "image-led",
+  schemaVersion: 1,
+  updatedAt: null,
+  createdBy: "u1",
+  pages: [],
+  settings: { layout: "portrait", size: "letter", fontFamily: "Inter" },
+  customVariables: [],
+  config: undefined,
+}
+loadReportMock.mockResolvedValue(legacyDoc)
+
+vi.mock("../../../hooks/useExportReports", () => ({
+  useExportReports: () => ({
+    loadReport: loadReportMock,
+    saveReportConfig: saveReportConfigMock,
+  }),
+}))
+
+vi.mock("../../../hooks/useExportData", () => ({
+  useExportData: () => exportDataStub,
+}))
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "client-1", role: "producer" }),
+}))
+
+// featureShotReportRecipes OFF for this file (the H3 contract as specified);
+// everything else falls through to the real flag module.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureShotReportRecipes" ? false : actual.isFeatureEnabled(flag),
+  }
+})
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/projects/proj-1/export/report?reportId=r1"]}>
+      <Routes>
+        <Route path="/projects/:id/export/report" element={<ShotReportPage />} />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe("ShotReportPage — legacy no-config doc hydrates to image-led (H3)", () => {
+  beforeEach(() => {
+    saveReportConfigMock.mockClear()
+  })
+
+  it("persists layout:image-led on the next save, never production-sheet", async () => {
+    const user = userEvent.setup()
+    renderPage()
+
+    // Wait for the hydrate effect's loadReport().then(...) to resolve and for
+    // the control bar (screen render) to mount.
+    const noneButton = await screen.findByRole("button", { name: "None" })
+    await user.click(noneButton)
+
+    await waitFor(() => expect(saveReportConfigMock).toHaveBeenCalledTimes(1), {
+      timeout: 2000,
+    })
+    const [, savedConfig] = saveReportConfigMock.mock.calls[0] as [
+      string,
+      { layout?: string; groupBy?: string },
+    ]
+    expect(savedConfig.layout).toBe("image-led")
+    expect(savedConfig.groupBy).toBe("none")
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeFlagOffCallSites.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeFlagOffCallSites.test.tsx
@@ -1,0 +1,70 @@
+/// <reference types="@testing-library/jest-dom" />
+// H2 — the clamp that keeps `featureShotReportRecipes` OFF byte-identical to
+// the pre-recipes report was only proven at the `resolveReportLayout` helper
+// (reportTypes.test.ts). Nothing exercised the two real CALL SITES that
+// actually decide what a user sees/persists. Mutation check: reverting either
+// call site to a raw `config.layout ?? "image-led"` (i.e. NOT routing through
+// resolveReportLayout with the live flag) must redden its test here, because
+// production-sheet becoming DEFAULT_REPORT_CONFIG.layout (2026-08-09) means a
+// bypassed clamp would render/persist "production-sheet" instead.
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import { render } from "@testing-library/react"
+import { ReportView } from "../ReportView"
+import { DEFAULT_REPORT_CONFIG, type ReportConfig, type ReportModel } from "../../../lib/report/reportTypes"
+
+// Only featureShotReportRecipes is pinned; everything else falls through to
+// the real flag module so unrelated flags keep their normal behavior.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureShotReportRecipes" ? false : actual.isFeatureEnabled(flag),
+  }
+})
+
+function emptyModel(): ReportModel {
+  return {
+    project: { name: "Flag-off clamp fixture", client: "unbound-merino", shotCount: 0, dateRange: null },
+    groups: [],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+describe("ReportView screen render — featureShotReportRecipes OFF clamps to image-led (H2a)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("renders data-layout=image-led even when the persisted config carries production-sheet", () => {
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout: "production-sheet" }
+    const { container } = render(
+      <ReportView
+        model={emptyModel()}
+        imageMap={new Map()}
+        config={config}
+        onConfigChange={vi.fn()}
+        onExportPdf={vi.fn()}
+      />,
+    )
+    expect(container.querySelector(".sb-report-root")?.getAttribute("data-layout")).toBe(
+      "image-led",
+    )
+  })
+
+  it("renders data-layout=image-led when config.layout is absent (brand-new-report shape)", () => {
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout: undefined }
+    const { container } = render(
+      <ReportView
+        model={emptyModel()}
+        imageMap={new Map()}
+        config={config}
+        onConfigChange={vi.fn()}
+        onExportPdf={vi.fn()}
+      />,
+    )
+    expect(container.querySelector(".sb-report-root")?.getAttribute("data-layout")).toBe(
+      "image-led",
+    )
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeStyleTokenSpacing.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeStyleTokenSpacing.test.tsx
@@ -22,12 +22,15 @@
 // contiguous run. Comment out the `hyphenationCallback` prop + restore
 // `breakLongToken(p.style)` in reportPdfProductionSheet.tsx to mutation-check:
 // the assertion goes red.
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, afterEach } from "vitest"
 import { inflateSync } from "node:zlib"
 import { renderToBuffer } from "@react-pdf/renderer"
 import { ProductionSheetPdfDocument } from "../../../lib/report/reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "../../../lib/report/reportPdfBalancedRows"
+import { TalentPdfDocument } from "../../../lib/report/reportPdfTalent"
 import type { ReportModel, ReportShot } from "../../../lib/report/reportTypes"
+import { DEFAULT_HEADSHOT_CROP } from "../../../lib/report/talentTypes"
+import type { TalentModel } from "../../../lib/report/talentTypes"
 
 /**
  * Minimal PDF text-showing extractor for a base-14 (non-embedded, WinAnsi)
@@ -169,6 +172,14 @@ function modelWithStyle(style: string): ReportModel {
 const STYLE = "W-TP-LS-1066"
 
 describe("recipe PDF style-number spacing — a typical style # must render as ONE unbroken token", () => {
+  // console.warn is spied per-test (not module-level) so each `it` restores its
+  // own spy — but the restore must run AFTER the assertions read warn.mock.calls,
+  // never before (mockRestore clears recorded calls, same as mockReset). Mirrors
+  // reportRecipeOverflow.test.tsx's beforeEach/afterEach shape.
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("production-sheet: extracted PDF text contains the style number contiguously, no inserted space", async () => {
     const buf = await renderToBuffer(
       <ProductionSheetPdfDocument model={modelWithStyle(STYLE)} imageMap={new Map()} />,
@@ -196,8 +207,11 @@ describe("recipe PDF style-number spacing — a typical style # must render as O
     const buf = await renderToBuffer(
       <ProductionSheetPdfDocument model={modelWithStyle(long)} imageMap={new Map()} />,
     )
-    warn.mockRestore()
     expect(buf.length).toBeGreaterThan(0)
+    // Read warn.mock.calls BEFORE any restore — vi.restoreAllMocks() in
+    // afterEach clears recorded calls (mockRestore ≡ mockReset + restore), so
+    // reading them here (not after an inline mockRestore()) is what makes this
+    // assertion falsifiable at all.
     const overflowWarning = warn.mock.calls
       .map((call) => call.map((a) => String(a)).join(" "))
       .some((line) => /can't wrap between pages|bigger than available page height/i.test(line))
@@ -208,5 +222,133 @@ describe("recipe PDF style-number spacing — a typical style # must render as O
     for (const chunk of long.split("-")) {
       expect(text).toContain(chunk)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// M2 — long-token coverage for the other two hyphenationCallback call sites
+// (BalancedRowsPdfDocument's style column, TalentPdfDocument's contact-value
+// email). The style-number cases above only exercised production-sheet's long
+// token; the M1 doubled-hyphen fix lives in the SHARED hyphenateToken, so a
+// wrap anywhere it's wired must never draw "--" or an unencodable U+000B.
+// Mutation check: reverting hyphenateToken's head-emission to the old
+// tail-emission (break char stays at the END of the preceding syllable)
+// reddens both — a wrap lands on a syllable already ending in "-", drawing a
+// second "-" right after it.
+// ---------------------------------------------------------------------------
+
+function talentModelWithEmail(email: string): TalentModel {
+  return {
+    project: { name: "Talent Contact Fixture", client: "unbound-merino", dateRange: null, talentCount: 1 },
+    groups: [
+      {
+        key: "W",
+        label: "Women",
+        count: 1,
+        items: [
+          {
+            id: "t1",
+            name: "Contact Value Talent",
+            gender: "W",
+            genderLabel: "Women",
+            agency: "Long Agency Co.",
+            email,
+            phone: null,
+            web: null,
+            headshot: null,
+            measurements: [],
+            excluded: false,
+            appears: [],
+            crop: DEFAULT_HEADSHOT_CROP,
+          },
+        ],
+      },
+    ],
+    layout: "detail",
+  }
+}
+
+describe("recipe PDF style-number spacing — M2 coverage for the other two hyphenationCallback call sites", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it("balanced-rows: a pathologically long style number still renders with no can't-wrap warning, no reintroduced U+000B, and every chunk reaches the page", async () => {
+    // NOTE on what this can and can't prove: this token is intentionally long
+    // enough to wrap across SEVERAL physical lines in the style column. Once
+    // a wrap happens, @react-pdf/textkit draws its own "-" glyph as a
+    // SEPARATE text-showing op that closes that physical line, and the next
+    // line opens with the following syllable's own leading "-" — two
+    // genuinely different glyphs on two different lines, correct output. Our
+    // extractor only concatenates Tj/TJ operators in STREAM order with no
+    // line-boundary awareness (see its docstring: "NOT a general PDF
+    // parser"), so it flattens those two lines together and reports a
+    // same-string "--" for EVERY multi-line-wrapped token regardless of
+    // whether the fix is applied or reverted (verified empirically against
+    // both the fixed and pre-fix production-sheet renders — 5 "--" hits
+    // either way) — a `not.toContain("--")` assertion here would be a false
+    // positive on the extractor, not a real check. The unit-level "never
+    // draws two adjacent hyphens across a wrap point" test in
+    // reportPdfShared.test.ts covers the SAME-LINE doubling property
+    // directly, is genuinely falsifiable by reverting M1's head-emission,
+    // and doesn't share this blind spot. What real-render coverage on the
+    // wide/pathological case for THIS layout can still prove — and is worth
+    // proving, since balanced-rows wasn't exercised by the #508 overflow
+    // suite: no page-overflow warning, no reintroduced U+000B, no content lost.
+    const long = "PATHOLOGICALLY-LONG-STYLE-NUMBER-THAT-EXCEEDS-THE-COLUMN-WIDTH-1234567890"
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={modelWithStyle(long)} imageMap={new Map()} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    const overflowWarning = warn.mock.calls
+      .map((call) => call.map((a) => String(a)).join(" "))
+      .some((line) => /can't wrap between pages|bigger than available page height/i.test(line))
+    expect(overflowWarning).toBe(false)
+    const text = extractPdfText(buf)
+    // The OLD U+200B-injection bug's signature glyph (truncated to 0x0B) is a
+    // real character inserted INTO the string, independent of line wrapping —
+    // this check has no cross-line blind spot and would catch a regression
+    // to the pre-fix breakLongToken path.
+    expect(text).not.toContain("\u000B")
+    for (const chunk of long.split("-")) {
+      expect(text).toContain(chunk)
+    }
+  })
+
+  it("balanced-rows: a realistic long style number that still fits on one line round-trips byte-identical (no drawn hyphen at all)", async () => {
+    // Longer than the file's existing STYLE fixture ("W-TP-LS-1066", 12
+    // chars) but still under the style column's empirically-measured
+    // single-line budget (~20 chars of Helvetica-Bold at this column width —
+    // verified: a run of 20 "A"s still fits, 22 wraps), so unlike the
+    // pathological case above, a flattened-text "--" check here IS valid: no
+    // wrap means no drawn glyph, so the extracted text must equal the input
+    // exactly.
+    const long = "W-TP-LS-BLACK-1066"
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={modelWithStyle(long)} imageMap={new Map()} />,
+    )
+    const text = extractPdfText(buf)
+    expect(text).toContain(long)
+    expect(text).not.toContain("--")
+    expect(text).not.toContain("\u000B")
+  })
+
+  it("talent: a long agency email in a contact value renders with no '--' and no U+000B", async () => {
+    const long = "alexandra.whitfield-representation@a-very-long-talent-agency-domain-name.example.com"
+    const buf = await renderToBuffer(
+      <TalentPdfDocument model={talentModelWithEmail(long)} imageMap={new Map()} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    const text = extractPdfText(buf)
+    expect(text).not.toContain("--")
+    expect(text).not.toContain("\u000B")
+    // A short email (well under the column width) must still round-trip
+    // contiguously — the byte-identity guarantee for a fitting token.
+    const shortBuf = await renderToBuffer(
+      <TalentPdfDocument model={talentModelWithEmail("a@b.com")} imageMap={new Map()} />,
+    )
+    const shortText = extractPdfText(shortBuf)
+    expect(shortText).toContain("a@b.com")
   })
 })

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeStyleTokenSpacing.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeStyleTokenSpacing.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment node
+//
+// REAL @react-pdf render regression gate for the style-number spacing bug
+// (2026-08-09). breakLongToken used to inject a literal U+200B between every
+// breakable character (/ . ? & = _ - @ + : % # , ;) so @react-pdf could wrap a
+// long SKU/URL. On real data every style number came out with stray VISIBLE
+// spaces — "W- TP- BU- 1045" — because @react-pdf's non-embedded base-14
+// Helvetica/WinAnsi path can't encode U+200B: it silently truncates the
+// codepoint to its low byte (0x200B & 0xFF = 0x0B) and draws the WinAnsi glyph
+// at 0x0B, which carries the SAME advance width as a real space (verified by
+// rendering a real PDF and reading glyph bboxes with PyMuPDF: each inserted
+// glyph measured 1.807pt at 6.5pt Helvetica — exactly the space-glyph width).
+//
+// The fix (reportPdfShared.ts: hyphenateToken / tokenHyphenation) drives
+// @react-pdf's `hyphenationCallback` prop instead of pre-processing the
+// string. @react-pdf rejoins the callback's parts byte-for-byte when a line
+// doesn't need to break, so no glyph is ever inserted for a token that fits.
+//
+// This test extracts the ACTUAL text-showing operators from the rendered PDF's
+// content stream (not the React tree/props — a prop-level test can't see a
+// font-encoding bug like this one) and asserts the style number appears as one
+// contiguous run. Comment out the `hyphenationCallback` prop + restore
+// `breakLongToken(p.style)` in reportPdfProductionSheet.tsx to mutation-check:
+// the assertion goes red.
+import { describe, it, expect, vi } from "vitest"
+import { inflateSync } from "node:zlib"
+import { renderToBuffer } from "@react-pdf/renderer"
+import { ProductionSheetPdfDocument } from "../../../lib/report/reportPdfProductionSheet"
+import { BalancedRowsPdfDocument } from "../../../lib/report/reportPdfBalancedRows"
+import type { ReportModel, ReportShot } from "../../../lib/report/reportTypes"
+
+/**
+ * Minimal PDF text-showing extractor for a base-14 (non-embedded, WinAnsi)
+ * @react-pdf render: inflates every FlateDecode stream and runs a tiny
+ * token-at-a-time state machine over Tj/TJ operators, concatenating their
+ * string operands IN STREAM ORDER (kerning-adjustment numbers inside a TJ
+ * array are simply not matched by the tokenizer, so they fall out for free).
+ * @react-pdf emits per-glyph HEX strings ("<41>") inside TJ arrays for
+ * justified/kerned text — not parenthesized literals — so hex decoding is
+ * the primary path; literal-string decoding is kept for any Tj usage.
+ * Good enough to prove two adjacent syllables of one style number were
+ * drawn with no stray glyph between them — NOT a general PDF parser.
+ */
+function extractPdfText(buf: Buffer): string {
+  const raw = buf.toString("latin1")
+  let out = ""
+  let searchFrom = 0
+  for (;;) {
+    const streamAt = raw.indexOf("stream", searchFrom)
+    if (streamAt === -1) break
+    // Only decode FlateDecode content streams — skip anything else (there are
+    // none in these fixtures; imageMap is empty, so no image XObjects).
+    const dictStart = raw.lastIndexOf("<<", streamAt)
+    const dict = raw.slice(dictStart, streamAt)
+    const endAt = raw.indexOf("endstream", streamAt)
+    if (endAt === -1) break
+    if (dict.includes("/FlateDecode")) {
+      // Skip "stream" + EOL (\r\n or \n) to the first data byte.
+      let dataStart = streamAt + "stream".length
+      if (raw[dataStart] === "\r") dataStart += 1
+      if (raw[dataStart] === "\n") dataStart += 1
+      let dataEnd = endAt
+      if (raw[dataEnd - 1] === "\n") dataEnd -= 1
+      if (raw[dataEnd - 1] === "\r") dataEnd -= 1
+      const compressed = buf.subarray(dataStart, dataEnd)
+      try {
+        const content = inflateSync(compressed).toString("latin1")
+        out += extractShowTextOps(content)
+      } catch {
+        /* not a real FlateDecode stream (e.g. a false-positive dict match) — skip */
+      }
+    }
+    searchFrom = endAt + "endstream".length
+  }
+  return out
+}
+
+/** Unescape a PDF literal-string body: \( \) \\ and octal \ddd (ASCII-only fixtures). */
+function unescapePdfString(body: string): string {
+  return body.replace(/\\([()\\]|[0-7]{1,3})/g, (_m, esc: string) => {
+    if (esc === "(" || esc === ")" || esc === "\\") return esc
+    return String.fromCharCode(parseInt(esc, 8))
+  })
+}
+
+/** Decode a PDF hex-string body ("41 52" style bytes, no separators) via WinAnsi≈ASCII. */
+function decodeHexString(hex: string): string {
+  let s = ""
+  for (let i = 0; i < hex.length; i += 2) {
+    s += String.fromCharCode(parseInt(hex.slice(i, i + 2), 16))
+  }
+  return s
+}
+
+/**
+ * Pull the string operands of every Tj / TJ operator, in stream order. A
+ * single flat token regex (no nested repeated groups) avoids catastrophic
+ * backtracking; numbers/whitespace inside a TJ array simply don't match any
+ * alternative, so `exec` skips past them for free.
+ */
+function extractShowTextOps(content: string): string {
+  let out = ""
+  const tokenRe = /<([0-9A-Fa-f]+)>|\(((?:\\.|[^\\()])*)\)|\[|\]|\bTJ\b|\bTj\b/g
+  let inArray = false
+  let arrayBuf = ""
+  let pendingSingle: string | null = null
+  let m: RegExpExecArray | null
+  while ((m = tokenRe.exec(content)) !== null) {
+    const tok = m[0]
+    if (m[1] !== undefined) {
+      const s = decodeHexString(m[1])
+      if (inArray) arrayBuf += s
+      else pendingSingle = s
+    } else if (m[2] !== undefined) {
+      const s = unescapePdfString(m[2])
+      if (inArray) arrayBuf += s
+      else pendingSingle = s
+    } else if (tok === "[") {
+      inArray = true
+      arrayBuf = ""
+    } else if (tok === "]") {
+      inArray = false
+    } else if (tok === "TJ") {
+      out += arrayBuf
+      arrayBuf = ""
+    } else if (tok === "Tj") {
+      if (pendingSingle !== null) out += pendingSingle
+      pendingSingle = null
+    }
+  }
+  return out
+}
+
+function shotWithStyle(style: string): ReportShot {
+  return {
+    id: "s1",
+    number: "01",
+    title: "Style Token Shot",
+    colorway: null,
+    status: "complete",
+    gender: "W",
+    notes: null,
+    talent: [],
+    excluded: false,
+    hasImage: false,
+    looks: [
+      {
+        id: "l1",
+        label: "Primary",
+        isAlt: false,
+        image: null,
+        hasReference: false,
+        products: [
+          { family: "Crew", style, colour: "Black", size: "M", sizeScope: "single", qty: 1, gender: "W", isHero: true, img: null },
+        ],
+      },
+    ],
+  }
+}
+
+function modelWithStyle(style: string): ReportModel {
+  return {
+    project: { name: "Style Token Fixture", client: "unbound-merino", shotCount: 1, dateRange: null },
+    groups: [{ key: "W", label: "Women", count: 1, shots: [shotWithStyle(style)] }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+const STYLE = "W-TP-LS-1066"
+
+describe("recipe PDF style-number spacing — a typical style # must render as ONE unbroken token", () => {
+  it("production-sheet: extracted PDF text contains the style number contiguously, no inserted space", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={modelWithStyle(STYLE)} imageMap={new Map()} />,
+    )
+    const text = extractPdfText(buf)
+    // toContain requires an EXACT contiguous substring match. The pre-fix
+    // breakLongToken broke this: it drew "W-" then a stray glyph then "TP-"
+    // etc as separate runs, so the joined content-stream text read
+    // "W-\x0bTP-\x0bLS-\x0b1066" — this assertion goes red on that code
+    // (mutation-verified: reverting to breakLongToken(p.style) fails here).
+    expect(text).toContain(STYLE)
+  })
+
+  it("balanced-rows: extracted PDF text contains the style number contiguously, no inserted space", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={modelWithStyle(STYLE)} imageMap={new Map()} />,
+    )
+    const text = extractPdfText(buf)
+    expect(text).toContain(STYLE)
+  })
+
+  it("a pathologically long style number (the #508 overflow scenario) still renders with no can't-wrap warning", async () => {
+    const long = "PATHOLOGICALLY-LONG-STYLE-NUMBER-THAT-EXCEEDS-THE-COLUMN-WIDTH-1234567890"
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={modelWithStyle(long)} imageMap={new Map()} />,
+    )
+    warn.mockRestore()
+    expect(buf.length).toBeGreaterThan(0)
+    const overflowWarning = warn.mock.calls
+      .map((call) => call.map((a) => String(a)).join(" "))
+      .some((line) => /can't wrap between pages|bigger than available page height/i.test(line))
+    expect(overflowWarning).toBe(false)
+    // Every character of the long token must still reach the page (flowed
+    // across wrapped lines within its column), not silently dropped.
+    const text = extractPdfText(buf)
+    for (const chunk of long.split("-")) {
+      expect(text).toContain(chunk)
+    }
+  })
+})

--- a/src-vnext/features/export/hooks/useExportReports.ts
+++ b/src-vnext/features/export/hooks/useExportReports.ts
@@ -21,7 +21,7 @@ import type {
   PageSettings,
   CustomVariable,
 } from "../types/exportBuilder"
-import type { ReportConfig, ReportLayout } from "../lib/report/reportTypes"
+import { LEGACY_REPORT_LAYOUT, type ReportConfig, type ReportLayout } from "../lib/report/reportTypes"
 import type { ProductInfoConfig } from "../lib/report/productInfoTypes"
 import type { TalentConfig } from "../lib/report/talentTypes"
 
@@ -106,7 +106,7 @@ export function mapReport(
     // Missing reportType => a legacy block-canvas doc (no migration).
     reportType: (data.reportType as ExportReportType) ?? "block-canvas",
     // Missing layout => image-led (the shipped recipe; pre-R3 docs render unchanged).
-    layout: config?.layout ?? "image-led",
+    layout: config?.layout ?? LEGACY_REPORT_LAYOUT,
     schemaVersion: (data.schemaVersion as number) ?? 1,
     updatedAt: ts?.toDate?.() ?? null,
     createdBy: (data.createdBy as string) ?? "",

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfShared.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfShared.test.ts
@@ -13,13 +13,13 @@ describe("hyphenateToken", () => {
     expect(hyphenateToken(token).join("")).toBe(token)
   })
 
-  it("splits at every breakable character, keeping it attached to the preceding syllable", () => {
-    expect(hyphenateToken("W-TP-LS-1066")).toEqual(["W-", "TP-", "LS-", "1066"])
+  it("splits at every breakable character, keeping it attached to the FOLLOWING syllable (M1 fix — see reportPdfShared.ts docstring: @react-pdf/textkit draws an unconditional real hyphen at any syllable-boundary wrap, so a break char left at the tail of a syllable would double up with it)", () => {
+    expect(hyphenateToken("W-TP-LS-1066")).toEqual(["W", "-TP", "-LS", "-1066"])
   })
 
   it("splits at each of the / . ? & = _ - @ + : % # , ; break characters", () => {
     expect(hyphenateToken("a/b.c?d&e=f_g@h+i:j%k#l,m;n")).toEqual([
-      "a/", "b.", "c?", "d&", "e=", "f_", "g@", "h+", "i:", "j%", "k#", "l,", "m;", "n",
+      "a", "/b", ".c", "?d", "&e", "=f", "_g", "@h", "+i", ":j", "%k", "#l", ",m", ";n",
     ])
   })
 
@@ -42,6 +42,26 @@ describe("hyphenateToken", () => {
   })
 
   it("tokenHyphenation exposes hyphenateToken as a mutable string[] (the @react-pdf HyphenationCallback contract)", () => {
-    expect(tokenHyphenation("W-TP-LS-1066")).toEqual(["W-", "TP-", "LS-", "1066"])
+    expect(tokenHyphenation("W-TP-LS-1066")).toEqual(["W", "-TP", "-LS", "-1066"])
+  })
+
+  it("never draws two adjacent hyphens across a wrap point (M1): no syllable both ends AND the next syllable starts with a breakable char", () => {
+    // The doubling bug required a syllable ending in a breakable char
+    // immediately followed by @react-pdf's own drawn hyphen. Head-emission
+    // means only the FIRST syllable can lack a leading breakable char; every
+    // other syllable starts with one and none end with one, so a wrap can
+    // never produce "--".
+    const parts = hyphenateToken("W-TP-LS-1066")
+    for (let i = 0; i < parts.length; i++) {
+      const p = parts[i]!
+      if (i > 0) expect(BREAKABLE_FOR_TEST.has(p[0]!)).toBe(true)
+      expect(BREAKABLE_FOR_TEST.has(p[p.length - 1]!)).toBe(false)
+    }
   })
 })
+
+// Mirrors reportPdfShared.ts's private BREAKABLE set for the assertion above
+// (not exported — small enough to duplicate rather than export test-only surface).
+const BREAKABLE_FOR_TEST = new Set([
+  "/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%", "#", ",", ";",
+])

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfShared.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfShared.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest"
+import { hyphenateToken, tokenHyphenation } from "../reportPdfShared"
+
+// hyphenateToken feeds @react-pdf's hyphenationCallback (see reportPdfShared.ts
+// for the full root-cause writeup). The property that matters: rejoining the
+// returned parts must reproduce the INPUT BYTE-FOR-BYTE — @react-pdf only uses
+// the parts to decide where a real line break MAY fall; it never inserts a
+// separator of its own. That's what makes this approach immune to the old
+// U+200B bug (a real, non-representable glyph injected into the string).
+describe("hyphenateToken", () => {
+  it("rejoins to the exact original string for a typical style number (no inserted characters)", () => {
+    const token = "W-TP-LS-1066"
+    expect(hyphenateToken(token).join("")).toBe(token)
+  })
+
+  it("splits at every breakable character, keeping it attached to the preceding syllable", () => {
+    expect(hyphenateToken("W-TP-LS-1066")).toEqual(["W-", "TP-", "LS-", "1066"])
+  })
+
+  it("splits at each of the / . ? & = _ - @ + : % # , ; break characters", () => {
+    expect(hyphenateToken("a/b.c?d&e=f_g@h+i:j%k#l,m;n")).toEqual([
+      "a/", "b.", "c?", "d&", "e=", "f_", "g@", "h+", "i:", "j%", "k#", "l,", "m;", "n",
+    ])
+  })
+
+  it("falls back to a hard chunk break for a run with no breakable character at all", () => {
+    const parts = hyphenateToken("12345678901234567890", 14)
+    expect(parts.join("")).toBe("12345678901234567890")
+    expect(parts.length).toBeGreaterThan(1)
+    for (const p of parts) expect(p.length).toBeLessThanOrEqual(14)
+  })
+
+  it("a pathologically long token (the #508 overflow scenario) still yields multiple syllables", () => {
+    const long = "PATHOLOGICALLY-LONG-STYLE-NUMBER-THAT-EXCEEDS-THE-COLUMN-WIDTH-1234567890"
+    const parts = hyphenateToken(long)
+    expect(parts.join("")).toBe(long)
+    expect(parts.length).toBeGreaterThan(5)
+  })
+
+  it("never returns an empty syllable list (the Knuth-Plass engine requires at least one)", () => {
+    expect(hyphenateToken("")).toEqual([""])
+  })
+
+  it("tokenHyphenation exposes hyphenateToken as a mutable string[] (the @react-pdf HyphenationCallback contract)", () => {
+    expect(tokenHyphenation("W-TP-LS-1066")).toEqual(["W-", "TP-", "LS-", "1066"])
+  })
+})

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest"
-import { DEFAULT_REPORT_CONFIG, type ReportConfig } from "../reportTypes"
+import {
+  DEFAULT_REPORT_CONFIG,
+  LEGACY_REPORT_LAYOUT,
+  hydrateReportConfig,
+  resolveReportLayout,
+  type ReportConfig,
+} from "../reportTypes"
 import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
 import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
 
@@ -10,33 +16,52 @@ describe("ReportConfig persistence round-trip", () => {
   })
 
   it("default-merges a pre-looksMode blob, filling looksMode from the default", () => {
-    // How ShotReportPage hydrates a persisted config; forward-compatible by design.
-    // An older blob written before looksMode existed must hydrate to looksMode "all".
+    // hydrateReportConfig is the REAL fn ShotReportPage calls to hydrate a
+    // persisted config — not a copy of its merge logic — so this breaks if
+    // that code path ever diverges. An older blob written before looksMode
+    // existed must hydrate to looksMode "all".
     const stored = JSON.parse('{"groupBy":"none","excludedShotIds":["x"]}')
-    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    const hydrated = hydrateReportConfig(stored)
     expect(hydrated.groupBy).toBe("none")
     expect(hydrated.excludedShotIds).toEqual(["x"])
     expect(hydrated.looksMode).toBe("all")
   })
 
-  it("default-merges a pre-layout blob to layout 'image-led' (R3 forward-compat)", () => {
-    // A pre-R3 shot-report doc has no layout — it must hydrate to the shipped image-led layout.
+  it("default-merges a pre-layout blob to LEGACY_REPORT_LAYOUT 'image-led' (R3 forward-compat) — even though DEFAULT_REPORT_CONFIG.layout is now a different value", () => {
+    // A pre-R3 shot-report doc has no layout at all — it must hydrate to the
+    // shipped image-led layout it always rendered, NOT to whatever NEW
+    // reports currently default to. Pin both sides of the decoupling so a
+    // future "just re-point the floor at the default" edit goes red here.
+    expect(DEFAULT_REPORT_CONFIG.layout).not.toBe("image-led")
+    expect(DEFAULT_REPORT_CONFIG.layout).toBe("production-sheet")
     const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all"}')
-    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    const hydrated = hydrateReportConfig(stored)
+    expect(hydrated.layout).toBe(LEGACY_REPORT_LAYOUT)
     expect(hydrated.layout).toBe("image-led")
+  })
+
+  it("a persisted layout ALWAYS wins over both the legacy floor and the current default", () => {
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"layout":"balanced-rows"}')
+    expect(hydrateReportConfig(stored).layout).toBe("balanced-rows")
+    const storedImageLed = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"layout":"image-led"}')
+    expect(hydrateReportConfig(storedImageLed).layout).toBe("image-led")
+  })
+
+  it("a brand-new report (no persisted doc) defaults to layout 'production-sheet' (2026-08-09 decision)", () => {
+    expect(DEFAULT_REPORT_CONFIG.layout).toBe("production-sheet")
   })
 
   it("default-merges a pre-hiddenStatuses blob to hiddenStatuses [] (R3-filter forward-compat)", () => {
     // A blob written before the status filter existed must hydrate to [] -> nothing hidden.
     const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led"}')
-    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    const hydrated = hydrateReportConfig(stored)
     expect(hydrated.hiddenStatuses).toEqual([])
   })
 
   it("default-merges a pre-Phase-B blob to sortBy 'shot-number' / sortDir 'asc' (R2 forward-compat)", () => {
     // A blob written before order-by existed must hydrate to the shipped legacy order.
     const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led","hiddenStatuses":[]}')
-    const hydrated: ReportConfig = { ...DEFAULT_REPORT_CONFIG, ...stored }
+    const hydrated = hydrateReportConfig(stored)
     expect(hydrated.sortBy).toBe("shot-number")
     expect(hydrated.sortDir).toBe("asc")
   })
@@ -44,6 +69,37 @@ describe("ReportConfig persistence round-trip", () => {
   it("round-trips sortBy/sortDir + the widened groupBy 'status' through JSON unchanged", () => {
     const config: ReportConfig = { groupBy: "status", excludedShotIds: [], sortBy: "talent", sortDir: "desc" }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("resolveReportLayout — featureShotReportRecipes flag-off clamp", () => {
+  it("flag OFF always resolves to image-led, even for a fresh DEFAULT_REPORT_CONFIG (the mutation-check the 2026-08-09 default-recipe change must survive)", () => {
+    // DEFAULT_REPORT_CONFIG.layout is production-sheet — a naive
+    // `config.layout ?? "image-led"` with no flag branch would leak it
+    // through here. This is exactly the ShotReportListPage.handleCreate
+    // flag-off create path: a fresh default config, flag off.
+    expect(resolveReportLayout(DEFAULT_REPORT_CONFIG, false)).toBe("image-led")
+  })
+
+  it("flag OFF clamps to image-led even when config.layout explicitly carries a different recipe", () => {
+    const config: ReportConfig = { groupBy: "gender", excludedShotIds: [], layout: "balanced-rows" }
+    expect(resolveReportLayout(config, false)).toBe("image-led")
+  })
+
+  it("flag ON resolves DEFAULT_REPORT_CONFIG.layout (production-sheet) for a fresh config", () => {
+    expect(resolveReportLayout(DEFAULT_REPORT_CONFIG, true)).toBe("production-sheet")
+  })
+
+  it("flag ON respects an explicit persisted choice of any recipe", () => {
+    const imageLed: ReportConfig = { groupBy: "gender", excludedShotIds: [], layout: "image-led" }
+    const balanced: ReportConfig = { groupBy: "gender", excludedShotIds: [], layout: "balanced-rows" }
+    expect(resolveReportLayout(imageLed, true)).toBe("image-led")
+    expect(resolveReportLayout(balanced, true)).toBe("balanced-rows")
+  })
+
+  it("flag ON with layout absent falls back to image-led (matches the pre-R3-blob hydrate floor)", () => {
+    const config = { groupBy: "gender", excludedShotIds: [] } as ReportConfig
+    expect(resolveReportLayout(config, true)).toBe("image-led")
   })
 })
 

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -7,7 +7,7 @@ import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
 import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
 import { formatOrderNote } from "./reportTypes"
-import { COLOR, FONT, PAGE, STATUS, breakLongToken, has, primaryLookImage } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage, tokenHyphenation } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
 
 const PAD_X = 34
@@ -100,7 +100,7 @@ function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
           {p.isHero ? <Text style={s.heroTag}>{"  HERO"}</Text> : null}
         </Text>
       </View>
-      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? breakLongToken(p.style) : "—"}</Text>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]} hyphenationCallback={tokenHyphenation}>{has(p.style) ? p.style : "—"}</Text>
       <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "—"}</Text>
       <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizeText}</Text>
       <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -5,7 +5,7 @@
 import type { JSX } from "react"
 import { Document, Page, Text, View, Image, StyleSheet } from "@react-pdf/renderer"
 import type { ReportGroup, ReportLook, ReportModel, ReportProduct, ReportShot } from "./reportTypes"
-import { COLOR, FONT, PAGE, STATUS, breakLongToken, has, primaryLookImage } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS, has, primaryLookImage, tokenHyphenation } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
 
 const PAD_X = 30
@@ -98,7 +98,7 @@ function ProductRow({ p }: { readonly p: ReportProduct }): JSX.Element {
     <View style={[s.prod, ...(p.isHero ? [s.prodHero] : [])]} wrap={false}>
       <View style={s.cHero}>{p.isHero ? <View style={s.heroDot} /> : null}</View>
       <Text style={[s.fam, s.cFam, ...(p.isHero ? [s.famHero] : [])]}>{has(p.family) ? p.family : "Unnamed product"}</Text>
-      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]}>{has(p.style) ? breakLongToken(p.style) : "no style #"}</Text>
+      <Text style={[s.style, s.cStyle, ...(has(p.style) ? [] : [s.muted])]} hyphenationCallback={tokenHyphenation}>{has(p.style) ? p.style : "no style #"}</Text>
       <Text style={[s.colour, s.cColour, ...(has(p.colour) ? [] : [s.muted])]}>{has(p.colour) ? p.colour : "Unspecified"}</Text>
       <Text style={[s.size, s.cSize, ...(sizePending ? [s.muted] : [])]}>{sizeText}</Text>
       <Text style={[s.qty, s.cQty]}>{p.qty != null ? `×${p.qty}` : "—"}</Text>

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -4,6 +4,7 @@
 // built-ins, so the editorial serif maps to Helvetica (matches the rest of the
 // export PDFs); the type intentionally differs from screen.
 
+import type { HyphenationCallback } from "@react-pdf/types"
 import { getPageDimensionsPt } from "../pageDimensions"
 import { mapFontFamilyToPdf } from "../pdf/fontMapping"
 import { getShotStatusLabel } from "@/shared/lib/statusMappings"
@@ -69,27 +70,50 @@ export function has(v: string | null | undefined): v is string {
 }
 
 const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%", "#", ",", ";"])
-/** Inject U+200B break opportunities so @react-pdf (which ignores overflow-wrap) can wrap a long URL/token. */
-export function breakLongToken(value: string, chunk = 14): string {
-  let out = ""
+
+/**
+ * Split a long token (SKU/URL) into hyphenation "syllables" at natural break
+ * characters (/ . ? & = _ - @ + : % # , ;), plus a hard chunk fallback for a
+ * run with no breakable character at all (e.g. a bare numeric ID). Feeds
+ * @react-pdf's hyphenationCallback (see tokenHyphenation below) — NOT string
+ * injection. @react-pdf rejoins these parts byte-for-byte when a line doesn't
+ * need to break, so a typical token (up to ~16 chars) always renders as one
+ * contiguous run; only a token that's actually too wide for its column gets a
+ * real line break (with a drawn hyphen, same as dictionary hyphenation).
+ *
+ * Previously this injected a literal U+200B between every breakable character.
+ * That broke on real data: @react-pdf's non-embedded base-14 Helvetica path
+ * (WinAnsiEncoding, no ToUnicode/embedded glyphs) can't encode U+200B, so it
+ * silently truncated the codepoint to its low byte (0x200B & 0xFF = 0x0B) and
+ * rendered the WinAnsi glyph living at 0x0B — which carries the SAME advance
+ * width as a real space (~278/1000 em; measured via a real renderToBuffer PDF
+ * inspected with PyMuPDF: 1.807pt at 6.5pt Helvetica, matching the space
+ * glyph exactly). Every breakable character printed a visible gap, e.g.
+ * "W-TP-LS-1066" rendered as "W- TP- LS- 1066". hyphenationCallback never
+ * inserts a glyph into the unbroken case, so it can't reproduce that bug.
+ */
+export function hyphenateToken(word: string, chunk = 14): readonly string[] {
+  const parts: string[] = []
+  let current = ""
   let run = 0
-  for (const ch of value) {
-    out += ch
-    if (ch === " " || ch === "\n" || ch === "\t") {
-      run = 0
-      continue
-    }
+  for (const ch of word) {
+    current += ch
     run += 1
-    if (BREAKABLE.has(ch)) {
-      out += "​"
-      run = 0
-    } else if (run >= chunk) {
-      out += "​"
+    if (BREAKABLE.has(ch) || run >= chunk) {
+      parts.push(current)
+      current = ""
       run = 0
     }
   }
-  return out
+  if (current) parts.push(current)
+  // linebreak's Knuth–Plass engine requires at least one syllable.
+  return parts.length > 0 ? parts : [word]
 }
+
+/** @react-pdf hyphenationCallback for a Text element that renders a raw
+ *  SKU/URL/token (style numbers, talent contact values). Pass as the
+ *  `hyphenationCallback` prop on that Text — do NOT pre-process the string. */
+export const tokenHyphenation: HyphenationCallback = (word) => [...hyphenateToken(word)]
 
 /** The shot's primary image candidate (looks[0] — the canonical primary, as image-led uses). */
 export function primaryLookImage(shot: ReportShot): string | null {

--- a/src-vnext/features/export/lib/report/reportPdfShared.ts
+++ b/src-vnext/features/export/lib/report/reportPdfShared.ts
@@ -79,7 +79,34 @@ const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%"
  * injection. @react-pdf rejoins these parts byte-for-byte when a line doesn't
  * need to break, so a typical token (up to ~16 chars) always renders as one
  * contiguous run; only a token that's actually too wide for its column gets a
- * real line break (with a drawn hyphen, same as dictionary hyphenation).
+ * real line break.
+ *
+ * IMPORTANT — @react-pdf/textkit draws a REAL "-" (U+002D) glyph at every
+ * wrap it takes at a syllable boundary. This is unconditional: `breakLines`
+ * (textkit's line-break executor) calls `insertGlyph(line.length, HYPHEN,
+ * line)` for any break whose preceding syllable isn't followed by a literal
+ * space, with no way to opt a specific break out of it. So the break
+ * character MUST be the first character of the FOLLOWING syllable, never the
+ * last character of the preceding one — otherwise the natural break char
+ * (already present in the token) collides with textkit's own drawn hyphen and
+ * doubles: syllables ending "...W-", "TP-", ... would render
+ * "W--TP--LS--1066" wherever a wrap actually lands. Emitting the break char
+ * at the head of the next part instead — "W", "-TP", "-LS", "-1066" — means a
+ * wrap after "W" draws its hyphen there ("W-") and the following line starts
+ * clean with the token's own "-TP..."; no double hyphen ON THE SAME LINE, and
+ * no spurious "-" gets inserted next to a "@" or "." in a talent email/URL
+ * either. Verified two ways (see reportPdfShared.test.ts + the render suite
+ * reportRecipeStyleTokenSpacing.test.tsx): a unit-level check that no
+ * syllable both ends AND the next syllable starts with a breakable char
+ * (so a same-line "--" is structurally impossible), and a real
+ * renderToBuffer + content-stream text extraction confirming a token that
+ * FITS on one line (no wrap at all) round-trips byte-for-byte with no "--".
+ * A token forced to wrap across MULTIPLE physical lines is not checked this
+ * way — the flattened extractor concatenates separate lines' text runs with
+ * no line-boundary awareness, so it reports a same-string "--" at every wrap
+ * regardless of whether this fix is applied (that's an extractor blind spot,
+ * not a rendering defect — the unit-level check above is what actually
+ * proves the same-line property for that case).
  *
  * Previously this injected a literal U+200B between every breakable character.
  * That broke on real data: @react-pdf's non-embedded base-14 Helvetica path
@@ -95,14 +122,20 @@ const BREAKABLE = new Set(["/", ".", "?", "&", "=", "_", "-", "@", "+", ":", "%"
 export function hyphenateToken(word: string, chunk = 14): readonly string[] {
   const parts: string[] = []
   let current = ""
-  let run = 0
   for (const ch of word) {
+    // A breakable char starts the NEXT syllable (not ends this one) — see the
+    // doubled-hyphen note above. Guard current.length>0 so a token that opens
+    // with a breakable char (rare; e.g. a leading "-") doesn't emit a
+    // leading empty syllable.
+    if (BREAKABLE.has(ch) && current.length > 0) {
+      parts.push(current)
+      current = ch
+      continue
+    }
     current += ch
-    run += 1
-    if (BREAKABLE.has(ch) || run >= chunk) {
+    if (current.length >= chunk) {
       parts.push(current)
       current = ""
-      run = 0
     }
   }
   if (current) parts.push(current)

--- a/src-vnext/features/export/lib/report/reportPdfTalent.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfTalent.tsx
@@ -24,7 +24,7 @@ import type {
 } from "./talentTypes"
 import { cropFocalPercents, cropZoomTransform } from "./talentTypes"
 import { initials } from "@/features/library/components/talentUtils"
-import { COLOR, FONT, PAGE, STATUS, has, breakLongToken } from "./reportPdfShared"
+import { COLOR, FONT, PAGE, STATUS, has, tokenHyphenation } from "./reportPdfShared"
 
 const PAD_X = 36
 const PAD_TOP = 34
@@ -384,7 +384,7 @@ function ContactItem({ k, value }: { readonly k: string; readonly value: string 
   return (
     <View style={s.contactItem}>
       <Text style={s.contactKey}>{k}</Text>
-      <Text style={s.contactValue}>{breakLongToken(value)}</Text>
+      <Text style={s.contactValue} hyphenationCallback={tokenHyphenation}>{value}</Text>
     </View>
   )
 }

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -94,7 +94,15 @@ export interface ReportConfig {
   readonly excludedShotIds: readonly string[]
   /** "primary-only" shows just each shot's primary look. Defaults to "all". */
   readonly looksMode?: ReportLooksMode
-  /** Layout recipe. Defaults to "image-led" so pre-R3 blobs render unchanged. */
+  /**
+   * Layout recipe. Absent on a legacy (pre-R3) blob — `hydrateReportConfig`
+   * floors that case to `LEGACY_REPORT_LAYOUT` ("image-led"), NOT
+   * `DEFAULT_REPORT_CONFIG.layout`, so an old saved report keeps rendering
+   * exactly what it always has. A BRAND-NEW report gets
+   * `DEFAULT_REPORT_CONFIG.layout` (production-sheet as of the 2026-08-09
+   * default-recipe decision — see resolveReportLayout for the
+   * featureShotReportRecipes flag-off clamp).
+   */
   readonly layout?: ReportLayout
   /** Shot statuses to HIDE entirely (screen + PDF). Defaults to [] (nothing hidden); an absent field default-merges to []. */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
@@ -104,14 +112,67 @@ export interface ReportConfig {
   readonly sortDir?: SortDir
 }
 
+/**
+ * Default config for a BRAND-NEW shot report (no persisted doc yet, and no
+ * ?reportId= in the URL). `layout: "production-sheet"` is Ted's 2026-08-09
+ * decision (production-sheet becomes the default shot-report recipe, landing
+ * alongside PR #513 flipping `featureShotReportRecipes` ON in prod) — see
+ * `resolveReportLayout` for how the flag-off case still clamps to
+ * "image-led" regardless of this default, and `hydrateReportConfig` /
+ * `LEGACY_REPORT_LAYOUT` for why an EXISTING pre-R3 saved report does NOT
+ * inherit this value just because it's read after this change ships.
+ */
 export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   groupBy: "gender",
   excludedShotIds: [],
   looksMode: "all",
-  layout: "image-led",
+  layout: "production-sheet",
   hiddenStatuses: [],
   sortBy: "shot-number",
   sortDir: "asc",
+}
+
+/**
+ * Forward-compat floor for a persisted config with NO `layout` field at all
+ * (a genuinely pre-R3 doc, written before recipes existed). Frozen — this
+ * must stay "image-led" even after `DEFAULT_REPORT_CONFIG.layout` changes
+ * for NEW reports, or opening an old report silently "migrates" its layout
+ * the day the default flips. See reportTypes.test.ts "keeps a pre-R3 blob on
+ * image-led even after the shipped default changes".
+ */
+export const LEGACY_REPORT_LAYOUT: ReportLayout = "image-led"
+
+/**
+ * Hydrate a persisted (possibly legacy) ReportConfig for editing: fill every
+ * absent field from `DEFAULT_REPORT_CONFIG` EXCEPT `layout`, whose
+ * forward-compat floor is `LEGACY_REPORT_LAYOUT` — so a blob that has never
+ * carried a `layout` field keeps rendering the pre-recipes report it always
+ * has, independent of what NEW reports now default to. A blob that DOES
+ * carry a persisted `layout` (any value, including a past "image-led"
+ * choice) always wins over both floors — existing saved reports keep their
+ * persisted layout, full stop. This is what ShotReportPage's hydrate effect
+ * calls; kept here (not inlined) so the persistence-round-trip tests exercise
+ * the real function, not a copy of its logic.
+ */
+export function hydrateReportConfig(stored: Partial<ReportConfig>): ReportConfig {
+  return { ...DEFAULT_REPORT_CONFIG, layout: LEGACY_REPORT_LAYOUT, ...stored }
+}
+
+/**
+ * Recipes-flag rollback safety (independent of `neutralizeReportConfigForFlag`
+ * below, which gates the separate `featureReportConfig` flag). When
+ * `featureShotReportRecipes` is OFF, the resolved layout is ALWAYS
+ * "image-led" — regardless of `config.layout` or `DEFAULT_REPORT_CONFIG.layout`
+ * — so dev/preview (no env var) and any flag rollback render, export, AND
+ * persist exactly like the pre-recipes report. Single source for the 3 call
+ * sites (ReportView's screen render, ShotReportPage's PDF export, and
+ * ShotReportListPage's create-report persist path) so they can't drift from
+ * each other or silently pick up a future default-layout change while the
+ * flag is off.
+ */
+export function resolveReportLayout(config: ReportConfig, recipesEnabled: boolean): ReportLayout {
+  if (!recipesEnabled) return "image-led"
+  return config.layout ?? "image-led"
 }
 
 /**


### PR DESCRIPTION
## ⚠️ DO NOT MERGE until #513 is deployed and Ted gives the word

This PR is the code half of a two-part rollout. #513 (env-only) flips
`featureShotReportRecipes` ON in prod. Once that's live and confirmed, Ted
decides when this one merges — it changes the shot-report DEFAULT and needs
that flag live first, or the new default is invisible (flag-off always
clamps to image-led, by design — see below).

## Summary

**1. Default recipe (Ted's 2026-08-09 decision).** `DEFAULT_REPORT_CONFIG.layout`
is now `"production-sheet"` for brand-new shot reports (was `"image-led"`).
Two forward-compat floors keep this from leaking where it shouldn't:

- `resolveReportLayout(config, recipesEnabled)` — single source for all 3
  places layout gets resolved (ReportView's screen render, ShotReportPage's
  PDF export, ShotReportListPage's create/duplicate persist paths). When
  `featureShotReportRecipes` is OFF it **always** returns `"image-led"`,
  regardless of `config.layout` or the new default — so dev/preview (no env
  var) and any flag rollback keep the old behavior, and a report created
  while the flag is off can never persist the new default into a saved doc.
- `hydrateReportConfig(stored)` — floors an **absent** `layout` field to a
  frozen `LEGACY_REPORT_LAYOUT` ("image-led"), not the current default. A
  genuinely pre-R3 saved report (written before recipes existed) keeps
  rendering exactly what it always has; it does not silently "migrate" the
  day this ships. Existing saved reports that DO carry a persisted layout
  keep it, full stop — nothing migrates them.
- **Duplicate-report is a documented exception, by design**: `handleDuplicate`
  in `ShotReportListPage` copies the SOURCE report's `config` verbatim
  (layout included), even while `featureShotReportRecipes` is OFF — cloning a
  saved production-sheet report while the flag is off still writes
  `layout: "production-sheet"` into the new doc. This is intentional (a
  "duplicate" that silently downgraded the source's own recipe would be
  surprising), and it's safe: the *render* stays clamped to image-led by
  `resolveReportLayout` regardless of what's persisted, so nothing ships the
  new layout to a viewer while the flag is off — only the saved doc's config
  field carries it forward, ready to resume once the flag is on.

**2. Style numbers render unbroken.** Real-data renders showed every style
number with stray visible spaces — `"W- TP- BU- 1045"`, `"UM2025- 252"`.

Root cause (verified by rendering a real PDF via `renderToBuffer` and
inspecting it with PyMuPDF, not guessed): `breakLongToken` injected a literal
U+200B (zero-width space) between breakable characters (`/ . ? & = _ - @ + :
% # , ;`) so `@react-pdf` could wrap long SKUs/URLs. `@react-pdf`'s
non-embedded base-14 Helvetica/WinAnsi path can't encode U+200B — it silently
truncates the codepoint to its low byte (`0x200B & 0xFF = 0x0B`) and draws
the WinAnsi glyph living at `0x0B`, which carries the **same advance width as
a real space** (measured 1.807pt at 6.5pt Helvetica — exactly the space
glyph). Every breakable character printed a visible gap.

Fix: `hyphenateToken` / `tokenHyphenation` in `reportPdfShared.ts` now drive
`@react-pdf`'s `hyphenationCallback` prop instead of pre-processing the
string. `@react-pdf` rejoins the callback's returned parts byte-for-byte when
a line doesn't need to break, so **no glyph is ever inserted** for a typical
token (up to ~16 chars) — while a pathologically long token (the #508
overflow scenario) still gets real line breaks and doesn't blow its column.
Fixed at the shared root so production-sheet, balanced-rows, and the talent
report's contact values all pick it up.

## Review-pass fixes (this update)

An adversarial review of the above surfaced 3 HIGH, 2 MEDIUM, and 3 LOW
findings, all verified against the code and fixed:

- **H1** — `reportRecipeStyleTokenSpacing.test.tsx`'s "no can't-wrap warning"
  assertion was unfalsifiable: `warn.mockRestore()` ran *before*
  `warn.mock.calls` was read, and `mockRestore` clears recorded calls (same
  as `mockReset`), so the assertion passed unconditionally regardless of
  whether the warning fired. Fixed by moving the restore to `afterEach`,
  mirroring the existing `reportRecipeOverflow.test.tsx` pattern.
- **H2** — the flag-off clamp was only proven at the `resolveReportLayout`
  helper level, never at a real call site. Added: (a) a `ReportView` render
  test asserting `data-layout="image-led"` with the flag off even when
  `config.layout` carries `"production-sheet"`; (b) a `ShotReportListPage`
  create-flow test (real render + click) asserting the Firestore write's
  `config.layout` is `"image-led"`, not the new default.
- **H3** — `ShotReportPage`'s hydrate effect had an unclamped branch: a
  legacy doc with **no `config` field at all** (`full.config === undefined`)
  fell through to `setConfig(DEFAULT_REPORT_CONFIG)` directly, handing it the
  NEW `"production-sheet"` default; the next debounced save would persist
  that into what was previously an image-led-only doc. Fixed:
  `setConfig(hydrateReportConfig(loaded ?? {}))`, so the no-config case floors
  to `LEGACY_REPORT_LAYOUT` exactly like the missing-layout-field case
  already did. Added a real-render test: a no-config doc, flag off, click a
  config control, assert the persisted write's layout is `"image-led"`.
- **M1** — `hyphenateToken` kept the break character at the *end* of each
  syllable (`"W-"`, `"TP-"`, `"LS-"`, `"1066"`). `@react-pdf/textkit` draws an
  **unconditional** real `"-"` glyph at every syllable-boundary wrap
  (`breakLines` → `insertGlyph(..., HYPHEN, ...)`, no way to opt out) — so a
  wrap landing on a syllable that already ends in `"-"` doubles it
  (`"W--TP--LS--1066"` wherever a wrap actually falls), and the same
  mechanism inserts a spurious `"-"` right after an `"@"` or `"."` in a
  talent email/URL. Fixed by emitting the break character at the **head** of
  the *next* syllable instead (`"W"`, `"-TP"`, `"-LS"`, `"-1066"`), so a
  drawn hyphen and the token's own hyphen never land on the same physical
  line. Unit-tested directly (no syllable both ends AND the next starts with
  a breakable char) and falsifiable: reverting to tail-emission reddens it.
- **M2** — extended the real-render spacing suite with long-token coverage
  for `BalancedRowsPdfDocument` and `TalentPdfDocument` (a long agency email
  in a contact value). Also documented — empirically, not by assumption — why
  a blanket "no `--` anywhere in the flattened extracted text" check is a
  **false-positive trap** for any token that wraps across multiple physical
  lines: the extractor concatenates every line's text runs in stream order
  with no line-boundary awareness (by its own docstring, "NOT a general PDF
  parser"), so it reports a same-string `"--"` at *every* wrap regardless of
  whether the fix is applied or reverted (verified against both states: 5
  hits either way on the pathological fixture). The suite now uses that
  check only where it's actually valid — a token long enough to matter but
  still fitting on one line — and covers the wrapping case with what real
  rendering *can* prove (no overflow warning, no reintroduced U+000B, no
  content lost).
- **L1** — `useExportReports.ts`'s `"image-led"` fallback literal now imports
  `LEGACY_REPORT_LAYOUT` instead of duplicating the string.
- **L3** — removed the dead `?? "image-led"` fallback arm on
  `DEFAULT_REPORT_CONFIG.layout` in `ShotReportListPage` (the constant always
  carries a value at runtime; the interface just types the field optional
  for persisted blobs, which was making the fallback look load-bearing when
  it wasn't).

## Mutation-verified (not just green — proven falsifiable)

- Reverted `resolveReportLayout`'s flag branch → both flag-off clamp tests
  (including the new H2 call-site tests) went red; restored → green.
- Reverted `hydrateReportConfig`'s legacy floor → the pre-R3-blob test went
  red; restored → green.
- Reverted the two production-sheet/balanced-rows `Text` elements to the old
  `breakLongToken` string-injection + removed `hyphenationCallback` → all
  real-render regression tests in `reportRecipeStyleTokenSpacing.test.tsx`
  went red (confirmed via extracting the actual PDF content-stream text, not
  React props); restored → green.
- Reverted `hyphenateToken`'s head-emission back to tail-emission → the new
  unit test ("never draws two adjacent hyphens across a wrap point") went
  red; restored → green.
- Reverted the H3 fix to a bare `DEFAULT_REPORT_CONFIG` fallback → the new
  no-config-doc test went red; restored → green.

## Gate results

- `npm run typecheck:baseline` — ✅ no new type errors (160/160 baselined)
- `CI=1 npx vitest --run <touched + related test files>` — ✅ all green
  (full `src-vnext/features/export` suite also run for extra safety: 43
  files / 478 tests passed, 9 pre-existing skips, 0 failures)
- `npx eslint <touched files> --max-warnings=0` — ✅ clean
- `npm run build` — ✅ succeeds

## Test plan

- [ ] After #513 deploys and the flag is confirmed ON in prod, create a new
      shot report and confirm it defaults to the "On-set sheet"
      (production-sheet) recipe.
- [ ] Open an existing pre-recipes shot report and confirm it still renders
      image-led (unchanged).
- [ ] Export a production-sheet or balanced-rows PDF with a real style number
      (e.g. `W-TP-LS-1066`) and confirm it prints as one unbroken token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
