### PR TITLE
feat(sets): flip featureSets live (Sets 2a visible in prod)

### DIFF
--- a/.github/workflows/deploy-live.yml
+++ b/.github/workflows/deploy-live.yml
@@ -53,6 +53,7 @@ jobs:
           VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
           VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
           VITE_SHOT_REPORT_RECIPES:         1   # D3 final: Production sheet + Balanced rows recipes LIVE (#508 splittable; Ted approved off real-data renders 2026-08-08)
+          VITE_SETS:                        1   # Sets Phase 2a: Set location + Apply-to-N LIVE (#499; Ted approved flip 2026-08-11)
         run: npm run build
 
       - name: Auth to Google Cloud (WIF)
@@ -99,6 +100,7 @@ jobs:
           VITE_PRODUCT_INFO_REPORT:         1   # D3: Product Info report type LIVE (2-up showcase; #505/#506 pagination fixed)
           VITE_TALENT_REPORT:               1   # D3: Talent report type LIVE (detail 2/sheet; #505/#506 pagination fixed)
           VITE_SHOT_REPORT_RECIPES:         1   # D3 final: Production sheet + Balanced rows recipes LIVE (#508 splittable; Ted approved off real-data renders 2026-08-08)
+          VITE_SETS:                        1   # Sets Phase 2a: Set location + Apply-to-N LIVE (#499; Ted approved flip 2026-08-11)
         run: npx firebase-tools deploy --only hosting --project um-shotbuilder --json > deploy-live.json
 
       - name: Output live URL


### PR DESCRIPTION
Two-line deploy-config change: `VITE_SETS: 1` in both deploy-live env blocks, making the Sets Phase 2a UI (#499: Set location + Apply-to-N) visible in prod.

- Ted approved the flip 2026-08-11 ("yes flip featureSets live after merge")
- Undo = revert this PR + redeploy; flag-off path is byte-identical to trunk
- Post-deploy: orchestrator does a read-only live eyeball of the Sets UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGon12ZeiVY8WtMg6LEV3d