### PR TITLE
feat(export): report filters (status+tags), custom order, and Set grouping

### DIFF
--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -9,8 +9,12 @@ import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
 import { isFeatureEnabled } from "@/shared/lib/flags"
+import type { AvailableTag } from "@/features/shots/hooks/useAvailableTags"
 import type {
   ReportConfig,
+  ReportFilterCondition,
+  ReportFilterField,
+  ReportFilterOperator,
   ReportGroup,
   ReportGroupBy,
   ReportLayout,
@@ -19,7 +23,6 @@ import type {
   ReportModel,
   ReportProduct,
   ReportShot,
-  ReportShotStatus,
   ReportSortField,
   ReportTalent,
 } from "../../lib/report/reportTypes"
@@ -28,6 +31,7 @@ import {
   REPORT_LAYOUT_OPTIONS,
   REPORT_SORT_FIELD_OPTIONS,
   REPORT_STATUS_OPTIONS,
+  resolveReportFilters,
   resolveReportLayout,
 } from "../../lib/report/reportTypes"
 import type { SortDir } from "../../lib/report/reportSort"
@@ -46,6 +50,11 @@ export interface ReportViewProps {
   readonly onConfigChange: (next: ReportConfig) => void
   readonly onExportPdf: () => void
   readonly exporting?: boolean
+  /** Tag options for the Filters control — the SAME source the shot list uses
+   *  (useAvailableTags / computeAvailableTags), passed down rather than fetched
+   *  here so this stays a pure, data-fetching-free component (existing tests
+   *  render it directly with no Firestore/auth providers mounted). */
+  readonly availableTags: readonly AvailableTag[]
 }
 
 /** Primary look = first (image-led's whole-look accessor; distinct from the
@@ -429,6 +438,89 @@ function PagedView({
 }
 
 // ---------------------------------------------------------------------------
+// Filters control (replaces the old standalone "Hide statuses" toggle set) —
+// ONE unified vocabulary for status + tag, each with its own include/exclude
+// mode and a multi-select value seg. Two small local components (mirrors the
+// mode+values pairing in GroupSortControls' "Order by"/"Direction") rather
+// than one combined group, so each keeps its own role="group" + label, same
+// a11y shape as every other control in this bar.
+// ---------------------------------------------------------------------------
+const FILTER_OPERATOR_OPTIONS: ReadonlyArray<{ readonly value: ReportFilterOperator; readonly label: string }> = [
+  { value: "in", label: "Include" },
+  { value: "notIn", label: "Exclude" },
+]
+
+function FilterModeGroup({
+  label,
+  operator,
+  onSetOperator,
+}: {
+  readonly label: string
+  readonly operator: ReportFilterOperator
+  readonly onSetOperator: (op: ReportFilterOperator) => void
+}): JSX.Element {
+  const labelId = useId()
+  return (
+    <div className="sb-control-group" role="group" aria-labelledby={labelId}>
+      <span id={labelId} className="sb-control-label">
+        {label} mode
+      </span>
+      <div className="sb-seg">
+        {FILTER_OPERATOR_OPTIONS.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            className="sb-seg-btn"
+            aria-pressed={operator === opt.value}
+            onClick={() => onSetOperator(opt.value)}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FilterValuesGroup({
+  label,
+  options,
+  selected,
+  onToggleValue,
+}: {
+  readonly label: string
+  readonly options: ReadonlyArray<{ readonly value: string; readonly label: string }>
+  readonly selected: ReadonlySet<string>
+  readonly onToggleValue: (value: string) => void
+}): JSX.Element {
+  const labelId = useId()
+  return (
+    <div className="sb-control-group" role="group" aria-labelledby={labelId}>
+      <span id={labelId} className="sb-control-label">
+        {label}
+      </span>
+      {options.length === 0 ? (
+        <span className="sb-muted">None yet</span>
+      ) : (
+        <div className="sb-seg">
+          {options.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              className="sb-seg-btn"
+              aria-pressed={selected.has(opt.value)}
+              onClick={() => onToggleValue(opt.value)}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Sticky control bar (never prints): Screen/Print toggle, Group-by switch,
 // Export PDF button.
 // ---------------------------------------------------------------------------
@@ -442,14 +534,17 @@ function ControlBar({
   layout,
   onSetLayout,
   showLayout,
-  showStatusFilter,
+  showFilters,
   showSort,
   sortBy,
   onSetSortBy,
   sortDir,
   onSetSortDir,
-  hiddenStatuses,
-  onToggleStatus,
+  statusFilter,
+  tagFilter,
+  availableTagOptions,
+  onSetFilterOperator,
+  onToggleFilterValue,
   onExportPdf,
   exporting,
   canExport,
@@ -464,16 +559,19 @@ function ControlBar({
   readonly layout: ReportLayout
   readonly onSetLayout: (v: ReportLayout) => void
   readonly showLayout: boolean
-  readonly showStatusFilter: boolean
-  // showSort gates BOTH the flag-on "Status" group-by option and the order-by/
-  // direction controls (== featureReportConfig). Flag-off → neither appears.
+  readonly showFilters: boolean
+  // showSort gates BOTH the flag-on "Status"/"Set" group-by options and the
+  // order-by/direction controls (== featureReportConfig). Flag-off → neither appears.
   readonly showSort: boolean
   readonly sortBy: ReportSortField
   readonly onSetSortBy: (v: ReportSortField) => void
   readonly sortDir: SortDir
   readonly onSetSortDir: (v: SortDir) => void
-  readonly hiddenStatuses: readonly ReportShotStatus[]
-  readonly onToggleStatus: (v: ReportShotStatus) => void
+  readonly statusFilter: ReportFilterCondition | undefined
+  readonly tagFilter: ReportFilterCondition | undefined
+  readonly availableTagOptions: ReadonlyArray<{ readonly value: string; readonly label: string }>
+  readonly onSetFilterOperator: (field: ReportFilterField, op: ReportFilterOperator) => void
+  readonly onToggleFilterValue: (field: ReportFilterField, value: string) => void
   readonly onExportPdf: () => void
   readonly exporting: boolean
   readonly canExport: boolean
@@ -483,7 +581,8 @@ function ControlBar({
   const groupLabelId = useId()
   const looksLabelId = useId()
   const recipeLabelId = useId()
-  const statusLabelId = useId()
+  const statusSelected = useMemo(() => new Set(statusFilter?.value ?? []), [statusFilter])
+  const tagSelected = useMemo(() => new Set(tagFilter?.value ?? []), [tagFilter])
   return (
     <div className="sb-controlbar no-print" role="region" aria-label="Report controls">
       {showLayout ? (
@@ -562,6 +661,16 @@ function ControlBar({
               Status
             </button>
           )}
+          {showSort && (
+            <button
+              type="button"
+              className="sb-seg-btn"
+              aria-pressed={groupBy === "scene"}
+              onClick={() => onSetGroupBy("scene")}
+            >
+              Set
+            </button>
+          )}
         </div>
       </div>
 
@@ -600,25 +709,31 @@ function ControlBar({
         </div>
       </div>
 
-      {showStatusFilter && (
-        <div className="sb-control-group" role="group" aria-labelledby={statusLabelId}>
-          <span id={statusLabelId} className="sb-control-label">
-            Hide statuses
-          </span>
-          <div className="sb-seg">
-            {REPORT_STATUS_OPTIONS.map((opt) => (
-              <button
-                key={opt.value}
-                type="button"
-                className="sb-seg-btn"
-                aria-pressed={hiddenStatuses.includes(opt.value)}
-                onClick={() => onToggleStatus(opt.value)}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-        </div>
+      {showFilters && (
+        <>
+          <FilterModeGroup
+            label="Status"
+            operator={statusFilter?.operator ?? "notIn"}
+            onSetOperator={(op) => onSetFilterOperator("status", op)}
+          />
+          <FilterValuesGroup
+            label="Status"
+            options={REPORT_STATUS_OPTIONS}
+            selected={statusSelected}
+            onToggleValue={(v) => onToggleFilterValue("status", v)}
+          />
+          <FilterModeGroup
+            label="Tags"
+            operator={tagFilter?.operator ?? "in"}
+            onSetOperator={(op) => onSetFilterOperator("tag", op)}
+          />
+          <FilterValuesGroup
+            label="Tags"
+            options={availableTagOptions}
+            selected={tagSelected}
+            onToggleValue={(v) => onToggleFilterValue("tag", v)}
+          />
+        </>
       )}
 
       <button
@@ -646,7 +761,7 @@ function ControlBar({
 // Root.
 // ---------------------------------------------------------------------------
 export function ReportView(props: ReportViewProps): JSX.Element {
-  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false } = props
+  const { model, imageMap, config, onConfigChange, onExportPdf, exporting = false, availableTags } = props
   const [printMode, setPrintMode] = useState(false)
 
   // Recipes ride their own flag; flag-off forces image-led so prod is byte-identical
@@ -682,15 +797,53 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, layout: next })
   }
 
-  // R3 status filter — a multi-select toggle set (distinct from the single-select
-  // controls above). An absent field default-merges to [] at read.
-  const hiddenStatuses = config.hiddenStatuses ?? []
-  const toggleStatus = (status: ReportShotStatus): void => {
-    const set = new Set(hiddenStatuses)
-    if (set.has(status)) set.delete(status)
-    else set.add(status)
-    onConfigChange({ ...config, hiddenStatuses: [...set] })
+  // Unified filters (status + tag) — replaces the old standalone "Hide
+  // statuses" toggle set. resolveReportFilters reads the migrated view (so a
+  // legacy hiddenStatuses-only config still shows its prior selection as
+  // pre-checked "Exclude" chips) without requiring hydrateReportConfig to
+  // have run first. Every write here clears hiddenStatuses — once the user
+  // touches the new control, filters is authoritative and the legacy field
+  // stops being written (still tolerated on READ — see reportTypes.ts).
+  const filters = resolveReportFilters(config)
+  const statusFilter = filters.find((f) => f.field === "status")
+  const tagFilter = filters.find((f) => f.field === "tag")
+
+  const setFieldFilter = (
+    field: ReportFilterField,
+    operator: ReportFilterOperator,
+    value: readonly string[],
+  ): void => {
+    const rest = filters.filter((f) => f.field !== field)
+    onConfigChange({
+      ...config,
+      filters: [...rest, { id: field, field, operator, value }],
+      hiddenStatuses: [],
+    })
   }
+
+  const setFilterOperator = (field: ReportFilterField, operator: ReportFilterOperator): void => {
+    const existing = filters.find((f) => f.field === field)
+    setFieldFilter(field, operator, existing?.value ?? [])
+  }
+
+  // "Status" defaults to Exclude (matches the pre-existing "Hide statuses"
+  // behavior); "Tags" defaults to Include (the more natural "show only these"
+  // reading for a fresh tag pick) — only applied the FIRST time a value is
+  // toggled for that field, before any operator has been chosen.
+  const toggleFilterValue = (field: ReportFilterField, value: string): void => {
+    const existing = filters.find((f) => f.field === field)
+    const operator = existing?.operator ?? (field === "status" ? "notIn" : "in")
+    const currentValues = existing?.value ?? []
+    const nextValues = currentValues.includes(value)
+      ? currentValues.filter((v) => v !== value)
+      : [...currentValues, value]
+    setFieldFilter(field, operator, nextValues)
+  }
+
+  const availableTagOptions = useMemo(
+    () => availableTags.map((t) => ({ value: t.id, label: t.label })),
+    [availableTags],
+  )
 
   // R2 order-by — absent fields default-merge to the shipped legacy order.
   const sortBy: ReportSortField = config.sortBy ?? DEFAULT_REPORT_CONFIG.sortBy ?? "shot-number"
@@ -729,14 +882,17 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         layout={layout}
         onSetLayout={setLayout}
         showLayout={recipesEnabled}
-        showStatusFilter={reportConfigEnabled}
+        showFilters={reportConfigEnabled}
         showSort={reportConfigEnabled}
         sortBy={sortBy}
         onSetSortBy={setSortBy}
         sortDir={sortDir}
         onSetSortDir={setSortDir}
-        hiddenStatuses={hiddenStatuses}
-        onToggleStatus={toggleStatus}
+        statusFilter={statusFilter}
+        tagFilter={tagFilter}
+        availableTagOptions={availableTagOptions}
+        onSetFilterOperator={setFilterOperator}
+        onToggleFilterValue={toggleFilterValue}
         onExportPdf={onExportPdf}
         exporting={exporting}
         canExport={canExport}

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -9,7 +9,6 @@ import { useId, useMemo, useState } from "react"
 import type { JSX } from "react"
 import { Loader2 } from "lucide-react"
 import { isFeatureEnabled } from "@/shared/lib/flags"
-import type { AvailableTag } from "@/features/shots/hooks/useAvailableTags"
 import type {
   ReportConfig,
   ReportFilterCondition,
@@ -43,6 +42,15 @@ import { GroupSortControls } from "./GroupSortControls"
 import { ProductionSheetReport } from "./ProductionSheetReport"
 import { BalancedRowsReport } from "./BalancedRowsReport"
 
+/** A tag filter option: id actually present on a shot + its label. Deliberately
+ *  narrower than useAvailableTags' `AvailableTag` (no usageCount/isDefault) —
+ *  see computeUsedTagOptions (tagDedup.ts) for why the report's Filters
+ *  control needs a different source than the tag-ASSIGNMENT UI. */
+export interface ReportTagOption {
+  readonly id: string
+  readonly label: string
+}
+
 export interface ReportViewProps {
   readonly model: ReportModel
   readonly imageMap: ReadonlyMap<string, string>
@@ -50,11 +58,14 @@ export interface ReportViewProps {
   readonly onConfigChange: (next: ReportConfig) => void
   readonly onExportPdf: () => void
   readonly exporting?: boolean
-  /** Tag options for the Filters control — the SAME source the shot list uses
-   *  (useAvailableTags / computeAvailableTags), passed down rather than fetched
-   *  here so this stays a pure, data-fetching-free component (existing tests
-   *  render it directly with no Firestore/auth providers mounted). */
-  readonly availableTags: readonly AvailableTag[]
+  /** Tag options for the Filters control — the SAME source and semantics the
+   *  shot list's own tag FILTER uses (useShotListState.ts's tagLabelById /
+   *  tagOptions, mirrored by computeUsedTagOptions in tagDedup.ts): one option
+   *  per id actually present on a shot, no default-tag seeding, no
+   *  cross-shot label collapsing. Passed down rather than fetched here so
+   *  this stays a pure, data-fetching-free component (existing tests render
+   *  it directly with no Firestore/auth providers mounted). */
+  readonly availableTags: readonly ReportTagOption[]
 }
 
 /** Primary look = first (image-led's whole-look accessor; distinct from the

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -3,7 +3,7 @@ import { useParams, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { isFeatureEnabled } from "@/shared/lib/flags"
-import { computeAvailableTags } from "@/features/shots/hooks/useAvailableTags"
+import { computeUsedTagOptions } from "@/shared/lib/tagDedup"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
 import { deriveShotReportModel } from "../../lib/report/reportModel"
@@ -37,13 +37,19 @@ export default function ShotReportPage() {
   const [imagesLoading, setImagesLoading] = useState(false)
   const [exporting, setExporting] = useState(false)
 
-  // Tag options for the Filters control — the SAME aggregation the shot list's
-  // own tag picker uses (computeAvailableTags), run over the shots `data`
-  // already fetched above. Deliberately NOT a second useAvailableTags()/
-  // useShots() subscription: that would make ShotReportPage's data-fetching
-  // hook graph depend on Firestore/auth context that this page's own tests
-  // don't always mount, and it's the exact same shots list either way.
-  const availableTags = useMemo(() => computeAvailableTags(data.shots), [data.shots])
+  // Tag options for the Filters control — the SAME source and semantics as
+  // the shot list's own tag FILTER (useShotListState.ts's tagLabelById /
+  // tagOptions): one option per id actually present on a shot, run over the
+  // shots `data` already fetched above. Deliberately NOT computeAvailableTags
+  // (useAvailableTags.ts) — that seeds every DEFAULT_TAGS entry unconditionally
+  // and collapses same-labelled tags across shots to one canonical id, which
+  // is right for "what tag can I assign" but wrong for "what tag VALUE should
+  // this filter match" (filterEngine.ts matches the shot's own raw tag.id).
+  // Also deliberately NOT a second useAvailableTags()/useShots() subscription:
+  // that would make ShotReportPage's data-fetching hook graph depend on
+  // Firestore/auth context that this page's own tests don't always mount,
+  // and it's the exact same shots list either way.
+  const availableTags = useMemo(() => computeUsedTagOptions(data.shots), [data.shots])
 
   const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   // The reportId that has finished hydrating. Edits made while a report is still

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -3,6 +3,7 @@ import { useParams, useSearchParams } from "react-router-dom"
 import { toast } from "sonner"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { isFeatureEnabled } from "@/shared/lib/flags"
+import { computeAvailableTags } from "@/features/shots/hooks/useAvailableTags"
 import { useExportData } from "../../hooks/useExportData"
 import { useExportReports } from "../../hooks/useExportReports"
 import { deriveShotReportModel } from "../../lib/report/reportModel"
@@ -35,6 +36,14 @@ export default function ShotReportPage() {
   const [imageMap, setImageMap] = useState<ReadonlyMap<string, string>>(new Map())
   const [imagesLoading, setImagesLoading] = useState(false)
   const [exporting, setExporting] = useState(false)
+
+  // Tag options for the Filters control — the SAME aggregation the shot list's
+  // own tag picker uses (computeAvailableTags), run over the shots `data`
+  // already fetched above. Deliberately NOT a second useAvailableTags()/
+  // useShots() subscription: that would make ShotReportPage's data-fetching
+  // hook graph depend on Firestore/auth context that this page's own tests
+  // don't always mount, and it's the exact same shots list either way.
+  const availableTags = useMemo(() => computeAvailableTags(data.shots), [data.shots])
 
   const persistTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   // The reportId that has finished hydrating. Edits made while a report is still
@@ -186,6 +195,7 @@ export default function ShotReportPage() {
         model={model}
         imageMap={imageMap}
         config={config}
+        availableTags={availableTags}
         onConfigChange={handleConfigChange}
         onExportPdf={handleExportPdf}
         exporting={exporting}

--- a/src-vnext/features/export/components/report/__tests__/ReportView.filters.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/ReportView.filters.test.tsx
@@ -1,0 +1,148 @@
+/// <reference types="@testing-library/jest-dom" />
+// Coverage for the Filters control's WRITE path (setFieldFilter / setFilterOperator /
+// toggleFilterValue) and the tag-option id mapping — previously exercised by NO test:
+// the only test that rendered ReportView at all (reportRecipeFlagOffCallSites.test.tsx)
+// always passed `availableTags={[]}` and never clicked anything under `showFilters`.
+// That left the tag-id defect (report-tag-filter-values-are-canonicalized-tag-ids) and
+// the include/exclude default-operator rules completely unfalsifiable.
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, within, fireEvent } from "@testing-library/react"
+import { ReportView, type ReportTagOption } from "../ReportView"
+import { DEFAULT_REPORT_CONFIG, type ReportConfig, type ReportModel } from "../../../lib/report/reportTypes"
+
+// featureReportConfig gates showFilters/showSort — forced ON so the Filters
+// control actually renders. featureShotReportRecipes is deliberately left at
+// its real (OFF) test default: resolveReportLayout then clamps the layout to
+// "image-led" regardless of DEFAULT_REPORT_CONFIG.layout ("production-sheet"),
+// the same known-safe empty-model render path reportRecipeFlagOffCallSites.test.tsx
+// already exercises — these tests are about the Filters control, not the recipe body.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+      flag === "featureReportConfig" ? true : actual.isFeatureEnabled(flag),
+  }
+})
+
+function emptyModel(): ReportModel {
+  return {
+    project: { name: "Filters fixture", client: "unbound-merino", shotCount: 0, dateRange: null },
+    groups: [],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+function renderReportView(
+  config: ReportConfig,
+  availableTags: readonly ReportTagOption[],
+  onConfigChange: (next: ReportConfig) => void,
+) {
+  return render(
+    <ReportView
+      model={emptyModel()}
+      imageMap={new Map()}
+      config={config}
+      availableTags={availableTags}
+      onConfigChange={onConfigChange}
+      onExportPdf={vi.fn()}
+    />,
+  )
+}
+
+// Canonical shot-status vocabulary (statusMappings.ts, via REPORT_STATUS_LABEL):
+// complete -> "Shot", todo -> "Draft", in_progress -> "In Progress", on_hold -> "On Hold".
+
+describe("ReportView Filters control — Tags options are sourced from computeUsedTagOptions, not computeAvailableTags", () => {
+  it("offers exactly the ids passed in `availableTags` — a custom (non-default) tag renders as its OWN option", () => {
+    // 'Hero' is not a DEFAULT_TAGS label — this is exactly the id a real
+    // shot.tags[].id would carry, and exactly what filterEngine matches on.
+    const tags: ReportTagOption[] = [{ id: "cust-1", label: "Hero" }]
+    renderReportView(DEFAULT_REPORT_CONFIG, tags, vi.fn())
+    expect(screen.getByRole("button", { name: "Hero" })).toBeInTheDocument()
+  })
+
+  it("a project with NO tags in use offers ZERO tag options — never the 8 unused DEFAULT_TAGS", () => {
+    renderReportView(DEFAULT_REPORT_CONFIG, [], vi.fn())
+    const tagsValues = screen.getByRole("group", { name: "Tags" })
+    expect(within(tagsValues).getByText("None yet")).toBeInTheDocument()
+    expect(within(tagsValues).queryAllByRole("button")).toHaveLength(0)
+  })
+
+  it("two DIFFERENT ids sharing a label both render as separate, independently selectable options", () => {
+    // computeAvailableTags would collapse these to ONE option (label-keyed);
+    // computeUsedTagOptions (id-keyed) must keep both, matching the shot
+    // list's own tag filter — otherwise one of the two shots carrying
+    // "Hero" can never be matched by the report's filter at all.
+    const tags: ReportTagOption[] = [
+      { id: "cust-1", label: "Hero" },
+      { id: "cust-2", label: "Hero" },
+    ]
+    renderReportView(DEFAULT_REPORT_CONFIG, tags, vi.fn())
+    const buttons = screen.getAllByRole("button", { name: "Hero" })
+    expect(buttons).toHaveLength(2)
+  })
+})
+
+describe("ReportView Filters control — write path", () => {
+  it("toggling a Status value writes filters + clears hiddenStatuses, defaulting to Exclude on first touch", () => {
+    const onConfigChange = vi.fn()
+    renderReportView(DEFAULT_REPORT_CONFIG, [], onConfigChange)
+    const statusValues = screen.getByRole("group", { name: "Status" })
+    fireEvent.click(within(statusValues).getByRole("button", { name: "Shot" }))
+    expect(onConfigChange).toHaveBeenCalledTimes(1)
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.filters).toEqual([{ id: "status", field: "status", operator: "notIn", value: ["complete"] }])
+    expect(next.hiddenStatuses).toEqual([])
+  })
+
+  it("toggling a Tag value defaults to Include on first touch (the opposite default from Status)", () => {
+    const onConfigChange = vi.fn()
+    const tags: ReportTagOption[] = [{ id: "default-media-photo", label: "Photo" }]
+    renderReportView(DEFAULT_REPORT_CONFIG, tags, onConfigChange)
+    fireEvent.click(screen.getByRole("button", { name: "Photo" }))
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.filters).toEqual([{ id: "tag", field: "tag", operator: "in", value: ["default-media-photo"] }])
+  })
+
+  it("a second value toggle for the same field ADDS to the existing selection, not replaces it", () => {
+    const onConfigChange = vi.fn()
+    const config: ReportConfig = {
+      ...DEFAULT_REPORT_CONFIG,
+      filters: [{ id: "status", field: "status", operator: "notIn", value: ["complete"] }],
+    }
+    renderReportView(config, [], onConfigChange)
+    const statusValues = screen.getByRole("group", { name: "Status" })
+    fireEvent.click(within(statusValues).getByRole("button", { name: "Draft" }))
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.filters).toEqual([
+      { id: "status", field: "status", operator: "notIn", value: ["complete", "todo"] },
+    ])
+  })
+
+  it("re-clicking an already-selected value REMOVES it", () => {
+    const onConfigChange = vi.fn()
+    const config: ReportConfig = {
+      ...DEFAULT_REPORT_CONFIG,
+      filters: [{ id: "status", field: "status", operator: "notIn", value: ["complete", "todo"] }],
+    }
+    renderReportView(config, [], onConfigChange)
+    const statusValues = screen.getByRole("group", { name: "Status" })
+    fireEvent.click(within(statusValues).getByRole("button", { name: "Shot" }))
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.filters).toEqual([{ id: "status", field: "status", operator: "notIn", value: ["todo"] }])
+  })
+
+  it("switching the Status mode to Include changes the operator on the EXISTING selection", () => {
+    const onConfigChange = vi.fn()
+    const config: ReportConfig = {
+      ...DEFAULT_REPORT_CONFIG,
+      filters: [{ id: "status", field: "status", operator: "notIn", value: ["complete"] }],
+    }
+    renderReportView(config, [], onConfigChange)
+    const statusMode = screen.getByRole("group", { name: "Status mode" })
+    fireEvent.click(within(statusMode).getByRole("button", { name: "Include" }))
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.filters).toEqual([{ id: "status", field: "status", operator: "in", value: ["complete"] }])
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeFlagOffCallSites.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeFlagOffCallSites.test.tsx
@@ -43,6 +43,7 @@ describe("ReportView screen render — featureShotReportRecipes OFF clamps to im
         model={emptyModel()}
         imageMap={new Map()}
         config={config}
+        availableTags={[]}
         onConfigChange={vi.fn()}
         onExportPdf={vi.fn()}
       />,
@@ -59,6 +60,7 @@ describe("ReportView screen render — featureShotReportRecipes OFF clamps to im
         model={emptyModel()}
         imageMap={new Map()}
         config={config}
+        availableTags={[]}
         onConfigChange={vi.fn()}
         onExportPdf={vi.fn()}
       />,

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -311,7 +311,7 @@ export const REPORT_STYLES = `
   letter-spacing: 0.10em; text-transform: uppercase; color: var(--sb-ink-3);
 }
 .sb-seg {
-  display: inline-flex; align-items: stretch;
+  display: inline-flex; align-items: stretch; flex-wrap: wrap;
   border: 1px solid var(--sb-rule-strong); border-radius: 999px; overflow: hidden;
   background: var(--sb-paper);
 }

--- a/src-vnext/features/export/hooks/useExportData.ts
+++ b/src-vnext/features/export/hooks/useExportData.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react"
 import { useProjectScope } from "@/app/providers/ProjectScopeProvider"
 import { useProject } from "@/features/projects/hooks/useProject"
 import { useShots } from "@/features/shots/hooks/useShots"
+import { useLanes } from "@/features/shots/hooks/useLanes"
 import { useProductFamilies } from "@/features/products/hooks/useProducts"
 import { usePulls } from "@/features/pulls/hooks/usePulls"
 import { useCrewLibrary } from "@/features/library/hooks/useCrewLibrary"
@@ -9,6 +10,7 @@ import { useTalentLibrary } from "@/features/library/hooks/useTalentLibrary"
 import type {
   Project,
   Shot,
+  Lane,
   ProductFamily,
   Pull,
   CrewRecord,
@@ -18,6 +20,13 @@ import type {
 export interface ExportData {
   readonly project: Project | null
   readonly shots: readonly Shot[]
+  /**
+   * Project lanes ("Sets"). Optional so existing hand-built ExportData fixtures
+   * (tests that predate the groupBy:"scene" report grouping) keep compiling
+   * without updating — every reader treats an absent value as `[]`. The real
+   * hook always provides it, fetched the same way the shot list does (useLanes).
+   */
+  readonly lanes?: readonly Lane[]
   readonly productFamilies: readonly ProductFamily[]
   readonly pulls: readonly Pull[]
   readonly crew: readonly CrewRecord[]
@@ -27,7 +36,7 @@ export interface ExportData {
 
 /**
  * Aggregation hook that subscribes to all data the export builder needs.
- * Opens 6 concurrent Firestore subscriptions (project, shots, products,
+ * Opens 7 concurrent Firestore subscriptions (project, shots, lanes, products,
  * pulls, crew, talent). All use onSnapshot and auto-detach on unmount.
  * Firebase reuses the websocket and caches aggressively, so the overhead
  * is acceptable — matches the CallSheetBuilderPage pattern.
@@ -37,6 +46,10 @@ export function useExportData(): ExportData {
 
   const { data: project } = useProject(projectId)
   const { data: shots, loading: shotsLoading } = useShots()
+  // Mirrors how the shot list fetches lanes (useLanes) — same source, same
+  // ordering — so the report's groupBy:"scene" ("Set") grouping can't drift
+  // from what the list shows for the same project.
+  const { data: lanes, loading: lanesLoading } = useLanes()
   const { data: productFamilies, loading: productsLoading } =
     useProductFamilies()
   const { data: pulls, loading: pullsLoading } = usePulls()
@@ -44,18 +57,24 @@ export function useExportData(): ExportData {
   const { data: talent, loading: talentLoading } = useTalentLibrary()
 
   const loading =
-    shotsLoading || productsLoading || pullsLoading || crewLoading || talentLoading
+    shotsLoading ||
+    lanesLoading ||
+    productsLoading ||
+    pullsLoading ||
+    crewLoading ||
+    talentLoading
 
   return useMemo(
     () => ({
       project,
       shots,
+      lanes,
       productFamilies,
       pulls,
       crew,
       talent,
       loading,
     }),
-    [project, shots, productFamilies, pulls, crew, talent, loading],
+    [project, shots, lanes, productFamilies, pulls, crew, talent, loading],
   )
 }

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -605,7 +605,7 @@ describe("model.order — the APPLIED order (so a recipe caption can never claim
       data({ shots: [shot({ id: "s1", shotNumber: "01", status: "todo" })] }),
       { groupBy: "gender", excludedShotIds: [], filters: [{ id: "status", field: "status", operator: "notIn", value: ["on_hold"] }] },
     )
-    expect(model.order.filterSummary).toBe("filtered: status (1)")
+    expect(model.order.filterSummary).toBe("filtered: status excluded (1)")
   })
 })
 
@@ -645,9 +645,9 @@ describe("formatOrderNote — honest, config-driven recipe caption (replaces the
     const note = formatOrderNote({
       sortBy: "shot-number",
       sortDir: "asc",
-      filterSummary: "filtered: status (2), tags (3)",
+      filterSummary: "filtered: status excluded (2), tags included (3)",
     })
-    expect(note).toBe("Sorted by shot # · filtered: status (2), tags (3)")
+    expect(note).toBe("Sorted by shot # · filtered: status excluded (2), tags included (3)")
   })
   it("a null/absent filterSummary appends nothing", () => {
     expect(formatOrderNote({ sortBy: "shot-number", sortDir: "asc", filterSummary: null })).toBe(
@@ -659,9 +659,9 @@ describe("formatOrderNote — honest, config-driven recipe caption (replaces the
       sortBy: "custom",
       sortDir: "asc",
       groupBy: "scene",
-      filterSummary: "filtered: tags (1)",
+      filterSummary: "filtered: tags included (1)",
     })
-    expect(note).toBe("Custom order · grouped by Set · filtered: tags (1)")
+    expect(note).toBe("Custom order · grouped by Set · filtered: tags included (1)")
   })
 })
 
@@ -678,11 +678,19 @@ describe("formatFilterSummary — the 'filtered: ...' clause formatOrderNote app
       { id: "tag", field: "tag", operator: "in", value: ["t1", "t2", "t3"] },
       { id: "status", field: "status", operator: "notIn", value: ["on_hold", "todo"] },
     ]
-    expect(formatFilterSummary(filters)).toBe("filtered: status (2), tags (3)")
+    expect(formatFilterSummary(filters)).toBe("filtered: status excluded (2), tags included (3)")
   })
   it("a single active field omits the other from the summary", () => {
     const filters: ReportFilterCondition[] = [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }]
-    expect(formatFilterSummary(filters)).toBe("filtered: tags (1)")
+    expect(formatFilterSummary(filters)).toBe("filtered: tags included (1)")
+  })
+  it("names the OPERATOR, not just the count — 'include these 2' and 'exclude these 2' must read differently", () => {
+    // Same field, same value count, opposite arrangement of the actual shots.
+    const included: ReportFilterCondition[] = [{ id: "status", field: "status", operator: "in", value: ["complete", "todo"] }]
+    const excluded: ReportFilterCondition[] = [{ id: "status", field: "status", operator: "notIn", value: ["complete", "todo"] }]
+    expect(formatFilterSummary(included)).toBe("filtered: status included (2)")
+    expect(formatFilterSummary(excluded)).toBe("filtered: status excluded (2)")
+    expect(formatFilterSummary(included)).not.toBe(formatFilterSummary(excluded))
   })
 })
 
@@ -697,8 +705,14 @@ describe("resolveReportFilters — hiddenStatuses -> filters migration precedenc
     ])
   })
   it("filters present (even []) is authoritative — hiddenStatuses is ignored outright, never merged", () => {
+    // toEqual (content), not toBe (reference): resolveReportFilters now
+    // always routes `filters` through dedupeFiltersByField (see that fn's
+    // docstring), which allocates a fresh array even when there was nothing
+    // to dedupe. The load-bearing claim is unchanged — hiddenStatuses never
+    // appears — only the object identity, which was never a documented
+    // contract, changed.
     const filters: ReportFilterCondition[] = [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }]
-    expect(resolveReportFilters({ filters, hiddenStatuses: ["on_hold"] })).toBe(filters)
+    expect(resolveReportFilters({ filters, hiddenStatuses: ["on_hold"] })).toEqual(filters)
     expect(resolveReportFilters({ filters: [], hiddenStatuses: ["on_hold"] })).toEqual([])
   })
 })
@@ -811,17 +825,63 @@ describe("deriveShotReportModel — sortBy:'custom' respects Shot.sortOrder", ()
     expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["B", "A"])
   })
 
-  it("shots with no real sortOrder (0 / default) fall back to shot-number order, ordered LAST", () => {
+  it("a REAL sortOrder:0 (the shot dragged to the top) sorts FIRST, not last — persistShotOrder's shape", () => {
+    // Exactly what persistShotOrder's full-reindex writes after a drag
+    // (reorderShots.ts:55, called with no range from every drag-and-drop —
+    // DraggableShotList.tsx:89): the dragged-to-top shot gets sortOrder 0,
+    // everything else keeps its 1-based index. useShots.ts (the shot list
+    // itself) sorts this shot FIRST — the report must agree.
     const d = data({
       shots: [
-        shot({ id: "hasOrder", shotNumber: "05", sortOrder: 100 }),
-        shot({ id: "noOrderHi", shotNumber: "10", sortOrder: 0 }),
-        shot({ id: "noOrderLo", shotNumber: "02", sortOrder: 0 }),
+        shot({ id: "top", shotNumber: "09", sortOrder: 0 }),
+        shot({ id: "second", shotNumber: "01", sortOrder: 1 }),
+        shot({ id: "third", shotNumber: "02", sortOrder: 2 }),
       ],
     })
     const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "asc" })
-    // real sortOrder first, then the two missing-sortOrder shots by shot-number (02 < 10).
-    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["hasOrder", "noOrderLo", "noOrderHi"])
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["top", "second", "third"])
+  })
+
+  it("descending still keeps the real sortOrder:0 shot in its true rank (last when descending)", () => {
+    const d = data({
+      shots: [
+        shot({ id: "top", shotNumber: "09", sortOrder: 0 }),
+        shot({ id: "second", shotNumber: "01", sortOrder: 1 }),
+        shot({ id: "third", shotNumber: "02", sortOrder: 2 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "desc" })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["third", "second", "top"])
+  })
+
+  it("nobody has EVER reordered this project (every shot is 0/default) — falls back to shot-number order", () => {
+    // No shot carries a non-zero sortOrder anywhere in the project, matching
+    // useShots.ts's own "no real sortOrder" branch (useShots.ts:33) — the
+    // whole set has never been through persistShotOrder/renumberShots, so
+    // there's no real drag order to honour yet.
+    const d = data({
+      shots: [
+        shot({ id: "hi", shotNumber: "10", sortOrder: 0 }),
+        shot({ id: "lo", shotNumber: "02", sortOrder: 0 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "asc" })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["lo", "hi"])
+  })
+
+  it("a mix of real 0 and real non-zero sorts purely numerically — 0 is rank #1, not a sentinel", () => {
+    // Once hasCustomOrder is true, EVERY sortOrder (including 0) is a plain
+    // numeric rank with no special-cased value — this is what actually
+    // distinguishes the fix from the old "0 means missing" comparator.
+    const d = data({
+      shots: [
+        shot({ id: "middle", shotNumber: "05", sortOrder: 5 }),
+        shot({ id: "first", shotNumber: "01", sortOrder: 0 }),
+        shot({ id: "last", shotNumber: "09", sortOrder: 9 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "asc" })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["first", "middle", "last"])
   })
 })
 
@@ -878,6 +938,63 @@ describe("deriveShotReportModel — groupBy:'scene' (\"Set\")", () => {
     })
     const model = deriveShotReportModel(d, { groupBy: "scene", excludedShotIds: [] })
     expect(model.groups.map((g) => g.label)).toEqual(["Zebra Set", "No set"])
+  })
+
+  it("orders by Lane.sceneNumber even when it DISAGREES with Lane.sortOrder — proves sceneNumber is the primary key, not sortOrder", () => {
+    // sceneFixture() above always has sceneNumber and sortOrder increasing
+    // together, so a mutation that swapped the primary key for sortOrder
+    // could ship undetected. Here they deliberately disagree: laneHigh has
+    // the higher sceneNumber but the LOWER sortOrder.
+    const d = data({
+      shots: [
+        shot({ id: "inHigh", shotNumber: "01", laneId: "laneHigh" }),
+        shot({ id: "inLow", shotNumber: "02", laneId: "laneLow" }),
+      ],
+      lanes: [
+        lane({ id: "laneHigh", name: "Scene Two", sceneNumber: 2, sortOrder: 0 }),
+        lane({ id: "laneLow", name: "Scene One", sceneNumber: 1, sortOrder: 1 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "scene", excludedShotIds: [] })
+    // sceneNumber 1 ("Scene One") must lead despite its HIGHER sortOrder.
+    expect(model.groups.map((g) => g.label)).toEqual(["Scene One", "Scene Two"])
+  })
+
+  it("a real Lane with a blank/whitespace name gets 'Unnamed Set', sorted by its real sceneNumber — NOT mislabeled 'No set'", () => {
+    // Regression: `lane?.name || NO_SET_GROUP_LABEL` used to fall through on
+    // an empty string (mapLane defaults a nameless doc to ""), mislabeling a
+    // REAL Set "No set" while still sorting it by sceneNumber — producing
+    // two differently-positioned groups that both read "No set" on screen.
+    const d = data({
+      shots: [
+        shot({ id: "inBlank", shotNumber: "01", laneId: "blank" }),
+        shot({ id: "inNamed", shotNumber: "02", laneId: "named" }),
+        shot({ id: "trulyNoSet", shotNumber: "03" }),
+      ],
+      lanes: [
+        lane({ id: "blank", name: "", sceneNumber: 1, sortOrder: 0 }),
+        lane({ id: "named", name: "Kitchen", sceneNumber: 2, sortOrder: 1 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "scene", excludedShotIds: [] })
+    expect(model.groups.map((g) => g.label)).toEqual(["Unnamed Set", "Kitchen", "No set"])
+    expect(model.groups.map((g) => g.key)).toEqual(["blank", "named", "__no_set__"])
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["inBlank"])
+  })
+
+  it("lanes not yet loaded (empty laneById) does NOT collapse real Set membership into 'No set'", () => {
+    // Guard mirrors shotListFilters.ts's identical "only orphan-check once
+    // lanes have loaded" rule. Without it, a lanes read still in flight (or
+    // one that silently failed — useFirestoreCollection resolves
+    // loading:false/data:[] on a snapshot error) would misclassify every
+    // shot with a real laneId as "No set".
+    const d = data({
+      shots: [shot({ id: "s1", shotNumber: "01", laneId: "laneA" })],
+      lanes: [], // lanes not loaded / failed — laneById is empty
+    })
+    const model = deriveShotReportModel(d, { groupBy: "scene", excludedShotIds: [] })
+    expect(model.groups.map((g) => g.key)).toEqual(["laneA"])
+    expect(model.groups[0]?.key).not.toBe("__no_set__")
   })
 })
 

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect } from "vitest"
 import { deriveShotReportModel, formatDateWindow, mostOutstandingStatus, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
-import { DEFAULT_REPORT_CONFIG, formatOrderNote, neutralizeReportConfigForFlag, type ReportConfig, type ReportSortField } from "../reportTypes"
+import {
+  DEFAULT_REPORT_CONFIG,
+  formatFilterSummary,
+  formatOrderNote,
+  LEGACY_HIDDEN_STATUSES_FILTER_ID,
+  neutralizeReportConfigForFlag,
+  resolveReportFilters,
+  type ReportConfig,
+  type ReportFilterCondition,
+  type ReportSortField,
+} from "../reportTypes"
 import type { ExportData } from "../../../hooks/useExportData"
-import type { ProductFamily, Shot, TalentRecord } from "@/shared/types"
+import type { Lane, ProductFamily, Shot, TalentRecord } from "@/shared/types"
 
 // Minimal factories — cast past required audit fields the model never reads.
 function fam(id: string, styleNumber: string, gender: string | null): ProductFamily {
@@ -20,6 +30,15 @@ function shot(s: Partial<Shot> & { id: string }): Shot {
     sortOrder: 0,
     ...s,
   } as unknown as Shot
+}
+function lane(l: Partial<Lane> & { id: string }): Lane {
+  return {
+    name: l.id,
+    projectId: "p1",
+    clientId: "c1",
+    sortOrder: 0,
+    ...l,
+  } as unknown as Lane
 }
 
 function data(over: Partial<ExportData>): ExportData {
@@ -566,16 +585,27 @@ describe("mostOutstandingStatus (O2 status-grouping reduction)", () => {
 describe("model.order — the APPLIED order (so a recipe caption can never claim an order the shots don't have)", () => {
   it("absent sortBy (flag-off / legacy) → order = {shot-number, asc}, matching the verbatim legacy sort", () => {
     const model = deriveShotReportModel(data({}), { groupBy: "gender", excludedShotIds: [] })
-    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc" })
+    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc", groupBy: "gender", filterSummary: null })
   })
   it("a chosen sortBy/sortDir flows into model.order verbatim", () => {
     const model = deriveShotReportModel(data({}), { groupBy: "none", excludedShotIds: [], sortBy: "talent", sortDir: "desc" })
-    expect(model.order).toEqual({ sortBy: "talent", sortDir: "desc" })
+    expect(model.order).toEqual({ sortBy: "talent", sortDir: "desc", groupBy: "none", filterSummary: null })
   })
   it("neutralizing (flag off) a persisted talent/desc config resets order to legacy — the shots are re-sorted, and so is the caption", () => {
     const raw: ReportConfig = { groupBy: "status", excludedShotIds: [], sortBy: "talent", sortDir: "desc" }
     const model = deriveShotReportModel(data({}), neutralizeReportConfigForFlag(raw, false))
-    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc" })
+    expect(model.order).toEqual({ sortBy: "shot-number", sortDir: "asc", groupBy: "gender", filterSummary: null })
+  })
+  it("a chosen groupBy:'scene' flows into model.order verbatim", () => {
+    const model = deriveShotReportModel(data({}), { groupBy: "scene", excludedShotIds: [] })
+    expect(model.order.groupBy).toBe("scene")
+  })
+  it("active filters flow into model.order.filterSummary", () => {
+    const model = deriveShotReportModel(
+      data({ shots: [shot({ id: "s1", shotNumber: "01", status: "todo" })] }),
+      { groupBy: "gender", excludedShotIds: [], filters: [{ id: "status", field: "status", operator: "notIn", value: ["on_hold"] }] },
+    )
+    expect(model.order.filterSummary).toBe("filtered: status (1)")
   })
 })
 
@@ -597,5 +627,276 @@ describe("formatOrderNote — honest, config-driven recipe caption (replaces the
     // honestly reads "shot #" rather than crashing on an undefined label.
     const note = formatOrderNote({ sortBy: "retired-field" as ReportSortField, sortDir: "asc" })
     expect(note).toBe("Sorted by shot #")
+  })
+  it("sortBy:'custom' reads 'Custom order' — never 'Sorted by custom order'", () => {
+    expect(formatOrderNote({ sortBy: "custom", sortDir: "asc" })).toBe("Custom order")
+  })
+  it("sortBy:'custom' descending reads 'Custom order, descending'", () => {
+    expect(formatOrderNote({ sortBy: "custom", sortDir: "desc" })).toBe("Custom order, descending")
+  })
+  it("groupBy:'scene' appends 'grouped by Set' — mutation: omitting the groupBy field reddens", () => {
+    const note = formatOrderNote({ sortBy: "shot-number", sortDir: "asc", groupBy: "scene" })
+    expect(note).toBe("Sorted by shot # · grouped by Set")
+  })
+  it("groupBy other than 'scene' never mentions Set", () => {
+    expect(formatOrderNote({ sortBy: "shot-number", sortDir: "asc", groupBy: "status" })).toBe("Sorted by shot #")
+  })
+  it("a filterSummary appends its clause verbatim — mutation: dropping the append reddens", () => {
+    const note = formatOrderNote({
+      sortBy: "shot-number",
+      sortDir: "asc",
+      filterSummary: "filtered: status (2), tags (3)",
+    })
+    expect(note).toBe("Sorted by shot # · filtered: status (2), tags (3)")
+  })
+  it("a null/absent filterSummary appends nothing", () => {
+    expect(formatOrderNote({ sortBy: "shot-number", sortDir: "asc", filterSummary: null })).toBe(
+      "Sorted by shot #",
+    )
+  })
+  it("custom order + Set grouping + active filters all compose in one caption", () => {
+    const note = formatOrderNote({
+      sortBy: "custom",
+      sortDir: "asc",
+      groupBy: "scene",
+      filterSummary: "filtered: tags (1)",
+    })
+    expect(note).toBe("Custom order · grouped by Set · filtered: tags (1)")
+  })
+})
+
+describe("formatFilterSummary — the 'filtered: ...' clause formatOrderNote appends", () => {
+  it("returns null when no filters are active", () => {
+    expect(formatFilterSummary([])).toBeNull()
+  })
+  it("skips a field whose condition carries zero selected values (chosen mode, no values yet)", () => {
+    const filters: ReportFilterCondition[] = [{ id: "status", field: "status", operator: "in", value: [] }]
+    expect(formatFilterSummary(filters)).toBeNull()
+  })
+  it("counts each active field's selected-value count, status before tags regardless of array order", () => {
+    const filters: ReportFilterCondition[] = [
+      { id: "tag", field: "tag", operator: "in", value: ["t1", "t2", "t3"] },
+      { id: "status", field: "status", operator: "notIn", value: ["on_hold", "todo"] },
+    ]
+    expect(formatFilterSummary(filters)).toBe("filtered: status (2), tags (3)")
+  })
+  it("a single active field omits the other from the summary", () => {
+    const filters: ReportFilterCondition[] = [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }]
+    expect(formatFilterSummary(filters)).toBe("filtered: tags (1)")
+  })
+})
+
+describe("resolveReportFilters — hiddenStatuses -> filters migration precedence", () => {
+  it("absent filters + empty hiddenStatuses -> no filters", () => {
+    expect(resolveReportFilters({ hiddenStatuses: [] })).toEqual([])
+    expect(resolveReportFilters({})).toEqual([])
+  })
+  it("absent filters + non-empty hiddenStatuses -> a single synthetic status/notIn filter", () => {
+    expect(resolveReportFilters({ hiddenStatuses: ["on_hold", "todo"] })).toEqual([
+      { id: LEGACY_HIDDEN_STATUSES_FILTER_ID, field: "status", operator: "notIn", value: ["on_hold", "todo"] },
+    ])
+  })
+  it("filters present (even []) is authoritative — hiddenStatuses is ignored outright, never merged", () => {
+    const filters: ReportFilterCondition[] = [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }]
+    expect(resolveReportFilters({ filters, hiddenStatuses: ["on_hold"] })).toBe(filters)
+    expect(resolveReportFilters({ filters: [], hiddenStatuses: ["on_hold"] })).toEqual([])
+  })
+})
+
+describe("deriveShotReportModel — unified filters (status + tag), reusing filterEngine.ts verbatim", () => {
+  const filterFixture = () =>
+    data({
+      shots: [
+        shot({ id: "s1", shotNumber: "01", status: "todo", tags: [{ id: "hero", label: "Hero", color: "b", category: "other" }] }),
+        shot({ id: "s2", shotNumber: "02", status: "complete", tags: [{ id: "hero", label: "Hero", color: "b", category: "other" }] }),
+        shot({ id: "s3", shotNumber: "03", status: "complete", tags: [{ id: "flat", label: "Flat", color: "b", category: "other" }] }),
+        shot({ id: "s4", shotNumber: "04", status: "on_hold", tags: [] }),
+      ],
+    })
+
+  it("status field, operator 'in' — include mode keeps only matching statuses", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [{ id: "status", field: "status", operator: "in", value: ["complete"] }],
+    })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s2", "s3"])
+  })
+
+  it("status field, operator 'notIn' — exclude mode drops matching statuses", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [{ id: "status", field: "status", operator: "notIn", value: ["on_hold"] }],
+    })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+
+  it("tag field is OR-within-field: a shot matches if it carries ANY of the selected tags", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["hero", "flat"] }],
+    })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+
+  it("status + tag together is AND-across-fields — both conditions must pass", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [
+        { id: "status", field: "status", operator: "in", value: ["complete"] },
+        { id: "tag", field: "tag", operator: "in", value: ["hero"] },
+      ],
+    })
+    // s2 is complete AND hero; s3 is complete but flat (fails tag); s1 is hero but todo (fails status).
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s2"])
+  })
+
+  it("a filter that matches nothing empties the report (hasAnyIncludedShot false path)", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["no-such-tag"] }],
+    })
+    expect(model.groups[0]?.shots).toEqual([])
+    expect(model.project.shotCount).toBe(0)
+  })
+
+  it("legacy hiddenStatuses (no filters field) still filters — resolveReportFilters migrates it at derive time", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      hiddenStatuses: ["on_hold"],
+    })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+
+  it("filters present (even a tag-only filter) makes hiddenStatuses inert — no double-apply", () => {
+    const model = deriveShotReportModel(filterFixture(), {
+      groupBy: "none",
+      excludedShotIds: [],
+      hiddenStatuses: ["complete"], // would drop s2/s3 if it were still consulted
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["hero", "flat"] }],
+    })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["s1", "s2", "s3"])
+  })
+})
+
+describe("deriveShotReportModel — sortBy:'custom' respects Shot.sortOrder", () => {
+  it("exports in sortOrder, NOT shot-number order — a fixture where they deliberately disagree", () => {
+    // shot-number order would read A,B,C; sortOrder deliberately reverses it.
+    // If the "custom" case ever falls through to the shot-number default (the
+    // mutation this guards against), this assertion flips to ["A","B","C"].
+    const d = data({
+      shots: [
+        shot({ id: "A", shotNumber: "01", sortOrder: 300 }),
+        shot({ id: "B", shotNumber: "02", sortOrder: 200 }),
+        shot({ id: "C", shotNumber: "03", sortOrder: 100 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "asc" })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["C", "B", "A"])
+  })
+
+  it("descending flips the custom order too", () => {
+    const d = data({
+      shots: [
+        shot({ id: "A", shotNumber: "01", sortOrder: 100 }),
+        shot({ id: "B", shotNumber: "02", sortOrder: 200 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "desc" })
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["B", "A"])
+  })
+
+  it("shots with no real sortOrder (0 / default) fall back to shot-number order, ordered LAST", () => {
+    const d = data({
+      shots: [
+        shot({ id: "hasOrder", shotNumber: "05", sortOrder: 100 }),
+        shot({ id: "noOrderHi", shotNumber: "10", sortOrder: 0 }),
+        shot({ id: "noOrderLo", shotNumber: "02", sortOrder: 0 }),
+      ],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "none", excludedShotIds: [], sortBy: "custom", sortDir: "asc" })
+    // real sortOrder first, then the two missing-sortOrder shots by shot-number (02 < 10).
+    expect(model.groups[0]?.shots.map((s) => s.id)).toEqual(["hasOrder", "noOrderLo", "noOrderHi"])
+  })
+})
+
+describe("deriveShotReportModel — groupBy:'scene' (\"Set\")", () => {
+  const sceneFixture = () =>
+    data({
+      shots: [
+        shot({ id: "inLaneB", shotNumber: "01", laneId: "laneB" }),
+        shot({ id: "inLaneA", shotNumber: "02", laneId: "laneA" }),
+        shot({ id: "noLane", shotNumber: "03" }),
+        shot({ id: "orphanLane", shotNumber: "04", laneId: "deleted-lane" }),
+      ],
+      lanes: [
+        lane({ id: "laneA", name: "Kitchen", sceneNumber: 1, sortOrder: 0 }),
+        lane({ id: "laneB", name: "Bedroom", sceneNumber: 2, sortOrder: 1 }),
+      ],
+    })
+
+  it("groups by laneId, ordered by Lane.sceneNumber then Lane.sortOrder", () => {
+    const model = deriveShotReportModel(sceneFixture(), { groupBy: "scene", excludedShotIds: [] })
+    const named = model.groups.filter((g) => g.key !== "__no_set__")
+    expect(named.map((g) => g.label)).toEqual(["Kitchen", "Bedroom"])
+    expect(named[0]?.shots.map((s) => s.id)).toEqual(["inLaneA"])
+    expect(named[1]?.shots.map((s) => s.id)).toEqual(["inLaneB"])
+  })
+
+  it("a missing laneId AND an orphaned laneId (lane doc no longer exists) both land in 'No set', ordered LAST", () => {
+    const model = deriveShotReportModel(sceneFixture(), { groupBy: "scene", excludedShotIds: [] })
+    const last = model.groups[model.groups.length - 1]
+    expect(last?.label).toBe("No set")
+    expect(last?.shots.map((s) => s.id).sort()).toEqual(["noLane", "orphanLane"])
+    // "No set" is unconditionally last regardless of any sceneNumber comparison.
+    expect(model.groups[model.groups.length - 1]?.key).toBe("__no_set__")
+  })
+
+  it("an orphaned laneId never crashes the derive (guards a deleted Set out from under an open report)", () => {
+    expect(() => deriveShotReportModel(sceneFixture(), { groupBy: "scene", excludedShotIds: [] })).not.toThrow()
+  })
+
+  it("'No set' stays strictly LAST even against a real Set with no sceneNumber — proves the explicit last-place rule, not merely the Number.POSITIVE_INFINITY fallback, is load-bearing", () => {
+    // A real lane with NO sceneNumber (undefined) gets the SAME Infinity
+    // fallback "No set" gets, and the SAME sortOrder (0) — so only the
+    // explicit "NO_SET_GROUP_KEY sorts last" branch (not the Infinity
+    // fallback alone) stops "No set" (alphabetically "N") from sorting
+    // ahead of "Zebra Set" (alphabetically "Z") on the tie-break. Deleting
+    // the explicit branch reddens this while leaving the simpler
+    // missing-laneId-only scene test above green.
+    const d = data({
+      shots: [
+        shot({ id: "inZebra", shotNumber: "01", laneId: "zebra" }),
+        shot({ id: "noLane", shotNumber: "02" }),
+      ],
+      lanes: [lane({ id: "zebra", name: "Zebra Set", sortOrder: 0 })],
+    })
+    const model = deriveShotReportModel(d, { groupBy: "scene", excludedShotIds: [] })
+    expect(model.groups.map((g) => g.label)).toEqual(["Zebra Set", "No set"])
+  })
+})
+
+describe("DEFAULT_REPORT_CONFIG is a hard behavioral floor — a user who touches nothing gets byte-identical output", () => {
+  it("produces the same shot order/grouping and the exact pre-filters/custom/scene caption text", () => {
+    const d = data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({ id: "w1", shotNumber: "01", looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }] }),
+        shot({ id: "m1", shotNumber: "02", looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }] }),
+      ],
+    })
+    const model = deriveShotReportModel(d, DEFAULT_REPORT_CONFIG)
+    expect(model.groups.map((g) => g.key)).toEqual(["W", "M"])
+    expect(model.groups.flatMap((g) => g.shots).map((s) => s.id)).toEqual(["w1", "m1"])
+    // The caption text a screen/PDF actually renders is unchanged: no "grouped
+    // by Set", no "filtered: ..." clause leaks in from the new optional fields
+    // for a config that never touches filters/custom/scene.
+    expect(formatOrderNote(model.order)).toBe("Sorted by shot #")
+    expect(model.order.filterSummary).toBeNull()
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -5,8 +5,10 @@ import {
   LEGACY_REPORT_LAYOUT,
   REPORT_STATUS_LABEL,
   REPORT_STATUS_OPTIONS,
+  formatFilterSummary,
   hydrateReportConfig,
   neutralizeReportConfigForFlag,
+  resolveReportFilters,
   resolveReportLayout,
   type ReportConfig,
   type ReportFilterCondition,
@@ -106,8 +108,12 @@ describe("hydrateReportConfig — legacy hiddenStatuses -> filters migration (20
     expect(hydrated.filters).toEqual([
       { id: LEGACY_HIDDEN_STATUSES_FILTER_ID, field: "status", operator: "notIn", value: ["on_hold", "todo"] },
     ])
-    // Tolerated on read (the raw value survives on the hydrated object)...
-    expect(hydrated.hiddenStatuses).toEqual(["on_hold", "todo"])
+    // hiddenStatuses is READ once (to synthesize the filter above) then
+    // cleared on the returned object — it has done its only job, and page
+    // state (which this becomes) must never carry a non-empty legacy value
+    // forward into a future unrelated save. See "hydrateReportConfig clears
+    // hiddenStatuses" below for the write-back guarantee this protects.
+    expect(hydrated.hiddenStatuses).toEqual([])
   })
 
   it("a legacy blob with an EMPTY hiddenStatuses does not synthesize a filter", () => {
@@ -136,6 +142,66 @@ describe("hydrateReportConfig — legacy hiddenStatuses -> filters migration (20
       filters: [],
     }
     expect(hydrateReportConfig(stored).filters).toEqual([])
+  })
+
+  it("hydrateReportConfig clears hiddenStatuses on EVERY path — migrated, already-filters, and no-op — so a future save can never re-persist it", () => {
+    // The write-back guarantee this protects: the hydrated object becomes
+    // live page state, and every non-filter setter in ReportView.tsx spreads
+    // `{...config, X}` — so anything left in `hiddenStatuses` here would get
+    // silently re-saved to Firestore on the next unrelated edit, forever.
+    const migrated = hydrateReportConfig({
+      groupBy: "gender",
+      excludedShotIds: [],
+      hiddenStatuses: ["on_hold", "todo"],
+    })
+    expect(migrated.hiddenStatuses).toEqual([])
+
+    const alreadyFilters = hydrateReportConfig({
+      groupBy: "gender",
+      excludedShotIds: [],
+      hiddenStatuses: ["on_hold"],
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }],
+    })
+    expect(alreadyFilters.hiddenStatuses).toEqual([])
+
+    const brandNew = hydrateReportConfig({})
+    expect(brandNew.hiddenStatuses).toEqual([])
+  })
+})
+
+describe("resolveReportFilters — de-dupes a hand-edited blob to at most one condition per field", () => {
+  it("a hand-edited blob with TWO conditions on the same field collapses to ONE, last occurrence wins", () => {
+    // The Filters control itself can never produce this (setFieldFilter
+    // always replaces, never appends) — only a hand-edited/legacy blob can.
+    // Before this fix, the three readers of `filters` disagreed on what such
+    // a blob meant: ReportView's `.find()` read the FIRST condition,
+    // formatFilterSummary's Map read the LAST, and filterEngine ANDed BOTH.
+    const dup: ReportFilterCondition[] = [
+      { id: "status-1", field: "status", operator: "notIn", value: ["todo"] },
+      { id: "status-2", field: "status", operator: "in", value: ["complete", "on_hold"] },
+    ]
+    const resolved = resolveReportFilters({ filters: dup })
+    expect(resolved).toHaveLength(1)
+    expect(resolved[0]).toEqual(dup[1]) // last occurrence wins
+  })
+
+  it("the de-duped result is what formatFilterSummary and a ReportView-style .find() BOTH read — they can no longer disagree", () => {
+    const dup: ReportFilterCondition[] = [
+      { id: "status-1", field: "status", operator: "notIn", value: ["todo"] },
+      { id: "status-2", field: "status", operator: "in", value: ["complete", "on_hold"] },
+    ]
+    const resolved = resolveReportFilters({ filters: dup })
+    const foundFirst = resolved.find((f) => f.field === "status")
+    expect(foundFirst).toEqual(dup[1]) // .find() now sees the SAME (last) condition the summary counts
+    expect(formatFilterSummary(resolved)).toBe("filtered: status included (2)")
+  })
+
+  it("a normal single-condition-per-field blob is unaffected", () => {
+    const filters: ReportFilterCondition[] = [
+      { id: "status", field: "status", operator: "notIn", value: ["todo"] },
+      { id: "tag", field: "tag", operator: "in", value: ["t1"] },
+    ]
+    expect(resolveReportFilters({ filters })).toEqual(filters)
   })
 })
 

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -1,12 +1,15 @@
 import { describe, it, expect } from "vitest"
 import {
   DEFAULT_REPORT_CONFIG,
+  LEGACY_HIDDEN_STATUSES_FILTER_ID,
   LEGACY_REPORT_LAYOUT,
   REPORT_STATUS_LABEL,
   REPORT_STATUS_OPTIONS,
   hydrateReportConfig,
+  neutralizeReportConfigForFlag,
   resolveReportLayout,
   type ReportConfig,
+  type ReportFilterCondition,
 } from "../reportTypes"
 import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
 import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
@@ -71,6 +74,93 @@ describe("ReportConfig persistence round-trip", () => {
   it("round-trips sortBy/sortDir + the widened groupBy 'status' through JSON unchanged", () => {
     const config: ReportConfig = { groupBy: "status", excludedShotIds: [], sortBy: "talent", sortDir: "desc" }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+
+  it("round-trips groupBy 'scene' and sortBy 'custom' through JSON unchanged", () => {
+    const config: ReportConfig = { groupBy: "scene", excludedShotIds: [], sortBy: "custom", sortDir: "asc" }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+
+  it("round-trips a persisted filters array through JSON unchanged", () => {
+    const config: ReportConfig = {
+      groupBy: "none",
+      excludedShotIds: [],
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["t1", "t2"] }],
+    }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+describe("hydrateReportConfig — legacy hiddenStatuses -> filters migration (2026-08-11)", () => {
+  it("a genuinely pre-filters blob (no filters, no hiddenStatuses) hydrates with filters absent", () => {
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led"}')
+    const hydrated = hydrateReportConfig(stored)
+    expect(hydrated.filters).toBeUndefined()
+  })
+
+  it("a legacy blob with a non-empty hiddenStatuses migrates to an equivalent status/notIn filter", () => {
+    const stored = JSON.parse(
+      '{"groupBy":"gender","excludedShotIds":[],"looksMode":"all","layout":"image-led","hiddenStatuses":["on_hold","todo"]}',
+    )
+    const hydrated = hydrateReportConfig(stored)
+    expect(hydrated.filters).toEqual([
+      { id: LEGACY_HIDDEN_STATUSES_FILTER_ID, field: "status", operator: "notIn", value: ["on_hold", "todo"] },
+    ])
+    // Tolerated on read (the raw value survives on the hydrated object)...
+    expect(hydrated.hiddenStatuses).toEqual(["on_hold", "todo"])
+  })
+
+  it("a legacy blob with an EMPTY hiddenStatuses does not synthesize a filter", () => {
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"hiddenStatuses":[]}')
+    expect(hydrateReportConfig(stored).filters).toBeUndefined()
+  })
+
+  it("both present: a blob that already carries `filters` is left untouched — hiddenStatuses is never merged in (no double-apply)", () => {
+    const storedFilters: ReportFilterCondition[] = [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }]
+    const stored: Partial<ReportConfig> = {
+      groupBy: "gender",
+      excludedShotIds: [],
+      hiddenStatuses: ["on_hold"],
+      filters: storedFilters,
+    }
+    const hydrated = hydrateReportConfig(stored)
+    expect(hydrated.filters).toEqual(storedFilters)
+    expect(hydrated.filters).toHaveLength(1) // NOT 2 — the hiddenStatuses entry was never appended
+  })
+
+  it("both present with filters explicitly [] — the empty array wins, hiddenStatuses stays inert", () => {
+    const stored: Partial<ReportConfig> = {
+      groupBy: "gender",
+      excludedShotIds: [],
+      hiddenStatuses: ["on_hold"],
+      filters: [],
+    }
+    expect(hydrateReportConfig(stored).filters).toEqual([])
+  })
+})
+
+describe("neutralizeReportConfigForFlag — filters/custom/scene stripped the same way as sortBy/hiddenStatuses", () => {
+  it("flag off strips filters, clamps groupBy 'scene' back to 'gender', and blanks sortBy (so 'custom' can't leak through)", () => {
+    const config: ReportConfig = {
+      groupBy: "scene",
+      excludedShotIds: [],
+      sortBy: "custom",
+      sortDir: "asc",
+      filters: [{ id: "tag", field: "tag", operator: "in", value: ["t1"] }],
+    }
+    const neutralized = neutralizeReportConfigForFlag(config, false)
+    expect(neutralized.filters).toBeUndefined()
+    expect(neutralized.sortBy).toBeUndefined()
+    expect(neutralized.groupBy).toBe("gender")
+  })
+
+  it("flag on returns the config verbatim, filters and all", () => {
+    const config: ReportConfig = {
+      groupBy: "scene",
+      excludedShotIds: [],
+      filters: [{ id: "status", field: "status", operator: "in", value: ["todo"] }],
+    }
+    expect(neutralizeReportConfigForFlag(config, true)).toBe(config)
   })
 })
 

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -1,4 +1,5 @@
 import type {
+  Lane,
   ProductAssignment,
   ProductFamily,
   Shot,
@@ -9,8 +10,11 @@ import type {
 import type { ExportData } from "../../hooks/useExportData"
 import { humanizeLabel } from "@/shared/lib/textUtils"
 import { SHOT_STATUS_CYCLE } from "@/shared/lib/statusMappings"
+import { applyFilterConditions } from "@/features/shots/lib/filterEngine"
 import {
   REPORT_STATUS_LABEL,
+  formatFilterSummary,
+  resolveReportFilters,
   type GenderKey,
   type ReportConfig,
   type ReportGroup,
@@ -244,6 +248,13 @@ export function mostOutstandingStatus(
 export const NO_SHOTS_GROUP_KEY = "__no_shots__"
 export const NO_SHOTS_GROUP_LABEL = "No shots"
 
+/** Bucket key/label for groupBy:"scene" ("Set") shots with no laneId, or whose
+ *  laneId no longer resolves to a live Lane doc (an orphaned reference — same
+ *  treatment the shot list gives it: don't crash, don't drop the shot, show it
+ *  unset). Always sorts last (see buildSceneGroups). */
+export const NO_SET_GROUP_KEY = "__no_set__"
+export const NO_SET_GROUP_LABEL = "No set"
+
 /**
  * Group entries (products/talent) by their most-outstanding appearance status (O2).
  * One bucket per item; `statusesOf` extracts an item's appearance statuses. Buckets
@@ -269,6 +280,26 @@ export function buildStatusGroups<T>(
 const SHOT_TIEBREAK = (a: ReportShot, b: ReportShot): number =>
   compareShotNumber(a.number, b.number) || compareText(a.id, b.id)
 
+/**
+ * "custom" comparator: respects the shot's own drag order (Shot.sortOrder).
+ * A shot with NO real sortOrder (mapShot defaults a Firestore doc that's
+ * never carried the field to 0, and no writer ever mints a real 0 — every
+ * writer stamps `Date.now()` or a lane-relative offset) sorts to the END,
+ * ordered among itself by shot-number — never interleaved with real custom
+ * positions at the (arbitrary) value 0. Mirrors the "known ranks before
+ * unknown" shape of compareByOrder above, applied to a numeric key instead
+ * of a fixed literal order.
+ */
+function compareCustomOrder(a: ReportShot, b: ReportShot): number {
+  const aOrder = a.sortOrder ?? 0
+  const bOrder = b.sortOrder ?? 0
+  const aMissing = aOrder === 0
+  const bMissing = bOrder === 0
+  if (aMissing !== bMissing) return aMissing ? 1 : -1
+  if (!aMissing) return aOrder - bOrder
+  return compareShotNumber(a.number, b.number)
+}
+
 /** Primary comparator for a shot sort field (R2). Item-shape-local (needs GROUP_ORDER / STATUS_GROUP_ORDER). */
 function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot) => number {
   switch (sortBy) {
@@ -280,6 +311,8 @@ function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot)
       return (a, b) => compareByOrder(STATUS_GROUP_ORDER, a.status, b.status)
     case "gender":
       return (a, b) => compareByOrder(GROUP_ORDER, a.gender, b.gender)
+    case "custom":
+      return compareCustomOrder
     default:
       // Runtime safety: exportReports writes schemaless (no rules validation), so a
       // persisted/hand-edited config could carry an out-of-union sortBy. Fall back to
@@ -289,38 +322,95 @@ function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot)
   }
 }
 
+/**
+ * groupBy:"scene" ("Set" in the UI): one group per Lane, ordered by
+ * Lane.sceneNumber then Lane.sortOrder (the same two-key order the shot list
+ * itself sorts scene groups by — see shotListFilters.ts's "scene" groupKey),
+ * ties broken alphabetically on the lane name. A shot with no laneId, OR
+ * whose laneId no longer resolves to a live Lane doc (an orphaned reference —
+ * guards against a crash if a Set is deleted out from under an open report),
+ * lands in a trailing "No set" bucket — always LAST regardless of sceneNumber.
+ */
+function buildSceneGroups(
+  shots: readonly ReportShot[],
+  laneById: ReadonlyMap<string, Lane>,
+): ReportGroup[] {
+  const byLane = new Map<string, ReportShot[]>()
+  for (const shot of shots) {
+    const key = shot.laneId != null && laneById.has(shot.laneId) ? shot.laneId : NO_SET_GROUP_KEY
+    const bucket = byLane.get(key)
+    if (bucket) bucket.push(shot)
+    else byLane.set(key, [shot])
+  }
+
+  const groups = [...byLane.entries()].map(([key, groupShots]): ReportGroup => {
+    const lane = laneById.get(key)
+    return {
+      key,
+      label: lane?.name || NO_SET_GROUP_LABEL,
+      count: groupShots.length,
+      shots: groupShots,
+    }
+  })
+
+  groups.sort((a, b) => {
+    if (a.key === NO_SET_GROUP_KEY) return 1
+    if (b.key === NO_SET_GROUP_KEY) return -1
+    const laneA = laneById.get(a.key)
+    const laneB = laneById.get(b.key)
+    const sceneA = laneA?.sceneNumber ?? Number.POSITIVE_INFINITY
+    const sceneB = laneB?.sceneNumber ?? Number.POSITIVE_INFINITY
+    if (sceneA !== sceneB) return sceneA - sceneB
+    const orderA = laneA?.sortOrder ?? 0
+    const orderB = laneB?.sortOrder ?? 0
+    if (orderA !== orderB) return orderA - orderB
+    return compareText(a.label, b.label)
+  })
+
+  return groups
+}
+
 /** Derive the resolved report model from live export data + config. */
 export function deriveShotReportModel(data: ExportData, config: ReportConfig): ReportModel {
   const familyById = new Map(data.productFamilies.map((f) => [f.id, f]))
   const talentById = new Map(data.talent.map((t) => [t.id, t]))
+  const laneById = new Map((data.lanes ?? []).map((l) => [l.id, l]))
   const excluded = new Set(config.excludedShotIds)
-  // R3: statuses to hide entirely (undefined on pre-R3 blobs -> empty set -> no-op).
-  const hidden = new Set(config.hiddenStatuses ?? [])
   const primaryOnly = config.looksMode === "primary-only"
 
-  const built: ReportShot[] = data.shots
-    .filter((s) => !s.deleted && !hidden.has(s.status))
-    .map((shot): ReportShot => {
-      const looks = resolveLooks(shot, familyById)
-      // Gender resolves from ALL looks so grouping stays stable across looksMode.
-      const gender = resolveShotGender(shot, looks)
-      // primary-only is a display filter: keep only the primary look (looks[0]).
-      const visibleLooks = primaryOnly ? looks.slice(0, 1) : looks
-      return {
-        id: shot.id,
-        number: shot.shotNumber ?? "",
-        title: shot.title || "Untitled shot",
-        colorway: shot.description ?? null,
-        status: shot.status,
-        gender,
-        notes: shot.notesAddendum ?? shot.notes ?? null,
-        talent: resolveTalent(shot, talentById),
-        looks: visibleLooks,
-        excluded: excluded.has(shot.id),
-        // "References ready" = has a real uploaded reference, NOT the product-image plate fallback.
-        hasImage: visibleLooks.some((l) => l.hasReference),
-      }
-    })
+  // Unified filters (status + tag). resolveReportFilters folds a legacy
+  // hiddenStatuses list into an equivalent status/notIn filter when `filters`
+  // itself is absent (DEFAULT_REPORT_CONFIG and every pre-filters config take
+  // this path, so output stays byte-identical). applyFilterConditions is the
+  // SAME engine the shot list runs (filterEngine.ts) — AND-across-fields,
+  // OR-within-a-field's values — reused verbatim, not reimplemented.
+  const filters = resolveReportFilters(config)
+  const notDeleted = data.shots.filter((s) => !s.deleted)
+  const filteredShots = applyFilterConditions(notDeleted, filters, { familyById })
+
+  const built: ReportShot[] = filteredShots.map((shot): ReportShot => {
+    const looks = resolveLooks(shot, familyById)
+    // Gender resolves from ALL looks so grouping stays stable across looksMode.
+    const gender = resolveShotGender(shot, looks)
+    // primary-only is a display filter: keep only the primary look (looks[0]).
+    const visibleLooks = primaryOnly ? looks.slice(0, 1) : looks
+    return {
+      id: shot.id,
+      number: shot.shotNumber ?? "",
+      title: shot.title || "Untitled shot",
+      colorway: shot.description ?? null,
+      status: shot.status,
+      gender,
+      notes: shot.notesAddendum ?? shot.notes ?? null,
+      talent: resolveTalent(shot, talentById),
+      looks: visibleLooks,
+      excluded: excluded.has(shot.id),
+      // "References ready" = has a real uploaded reference, NOT the product-image plate fallback.
+      hasImage: visibleLooks.some((l) => l.hasReference),
+      sortOrder: shot.sortOrder,
+      laneId: shot.laneId ?? null,
+    }
+  })
 
   // R2 order-by. Absent sortBy → verbatim legacy comparator (flag-off byte-identical
   // by construction). Defined → the shared stable engine with the id tie-break.
@@ -350,10 +440,12 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
               shots: b.items,
             }),
           )
-        : GROUP_ORDER.map((key): ReportGroup => {
-            const inGroup = shots.filter((s) => s.gender === key)
-            return { key, label: GROUP_LABEL[key], count: inGroup.length, shots: inGroup }
-          }).filter((g) => g.count > 0)
+        : config.groupBy === "scene"
+          ? buildSceneGroups(shots, laneById)
+          : GROUP_ORDER.map((key): ReportGroup => {
+              const inGroup = shots.filter((s) => s.gender === key)
+              return { key, label: GROUP_LABEL[key], count: inGroup.length, shots: inGroup }
+            }).filter((g) => g.count > 0)
 
   return {
     project: {
@@ -363,10 +455,16 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
       dateRange: formatDateWindow(data.project?.shootDates),
     },
     groups,
-    // The applied order (absent sortBy → the legacy ascending shot-number sort
-    // above). Set here so a recipe caption can never claim an order the shots
-    // don't have; flag-off this is always {shot-number, asc}, matching legacy.
-    order: { sortBy: config.sortBy ?? "shot-number", sortDir: config.sortDir ?? "asc" },
+    // The applied order/group/filters (absent sortBy → the legacy ascending
+    // shot-number sort above). Set here so a recipe caption can never claim an
+    // arrangement the shots don't actually have; flag-off this is always
+    // {shot-number, asc, gender/none, no filters}, matching legacy exactly.
+    order: {
+      sortBy: config.sortBy ?? "shot-number",
+      sortDir: config.sortDir ?? "asc",
+      groupBy: config.groupBy,
+      filterSummary: formatFilterSummary(filters),
+    },
   }
 }
 

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -282,26 +282,41 @@ const SHOT_TIEBREAK = (a: ReportShot, b: ReportShot): number =>
 
 /**
  * "custom" comparator: respects the shot's own drag order (Shot.sortOrder).
- * A shot with NO real sortOrder (mapShot defaults a Firestore doc that's
- * never carried the field to 0, and no writer ever mints a real 0 — every
- * writer stamps `Date.now()` or a lane-relative offset) sorts to the END,
- * ordered among itself by shot-number — never interleaved with real custom
- * positions at the (arbitrary) value 0. Mirrors the "known ranks before
- * unknown" shape of compareByOrder above, applied to a numeric key instead
- * of a fixed literal order.
+ *
+ * `sortOrder: 0` is AMBIGUOUS at the per-shot level: mapShot defaults a
+ * Firestore doc that's never carried the field to 0, but the app's own
+ * reorder writers ALSO mint a real, meaningful 0 for the FIRST shot —
+ * persistShotOrder's full-reindex (`sortOrder: start + i` from index 0,
+ * reorderShots.ts) and range branches (`start = min(from, to)`, which is 0
+ * whenever the moved range includes the top of the list), and
+ * renumberShots/renumberShotsWithScenes (`newSortOrder = i` /
+ * `offsets[gIdx] + i`, first shot of the first scene = 0). Every drag
+ * reorder in the shot list goes through persistShotOrder with NO range
+ * (DraggableShotList.tsx), so it ALWAYS produces exactly one shot with a
+ * real sortOrder of 0. Treating that 0 as "missing" banished the shot the
+ * user just dragged to the top to the BOTTOM of the custom-order report.
+ *
+ * There is no way to tell "real 0" from "never touched" on a single shot —
+ * so, like useShots.ts's own client sort (useShots.ts:33), this decides at
+ * the SET level: if ANY shot in scope carries a non-zero sortOrder, a real
+ * custom order has been established for this project, and every sortOrder
+ * (0 included — it's simply rank #1) is trusted as-is. Only when EVERY shot
+ * is 0 (nobody has ever reordered) does the whole set fall back to
+ * shot-number order, matching useShots.ts's own "no real sortOrder" branch.
  */
-function compareCustomOrder(a: ReportShot, b: ReportShot): number {
-  const aOrder = a.sortOrder ?? 0
-  const bOrder = b.sortOrder ?? 0
-  const aMissing = aOrder === 0
-  const bMissing = bOrder === 0
-  if (aMissing !== bMissing) return aMissing ? 1 : -1
-  if (!aMissing) return aOrder - bOrder
-  return compareShotNumber(a.number, b.number)
+function compareCustomOrder(hasCustomOrder: boolean): (a: ReportShot, b: ReportShot) => number {
+  return (a, b) => {
+    if (!hasCustomOrder) return compareShotNumber(a.number, b.number)
+    return (a.sortOrder ?? 0) - (b.sortOrder ?? 0)
+  }
 }
 
-/** Primary comparator for a shot sort field (R2). Item-shape-local (needs GROUP_ORDER / STATUS_GROUP_ORDER). */
-function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot) => number {
+/** Primary comparator for a shot sort field (R2). Item-shape-local (needs GROUP_ORDER / STATUS_GROUP_ORDER).
+ *  `hasCustomOrder` only matters for sortBy:"custom" — see compareCustomOrder. */
+function shotPrimaryFor(
+  sortBy: ReportSortField,
+  hasCustomOrder: boolean,
+): (a: ReportShot, b: ReportShot) => number {
   switch (sortBy) {
     case "shot-number":
       return (a, b) => compareShotNumber(a.number, b.number)
@@ -312,7 +327,7 @@ function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot)
     case "gender":
       return (a, b) => compareByOrder(GROUP_ORDER, a.gender, b.gender)
     case "custom":
-      return compareCustomOrder
+      return compareCustomOrder(hasCustomOrder)
     default:
       // Runtime safety: exportReports writes schemaless (no rules validation), so a
       // persisted/hand-edited config could carry an out-of-union sortBy. Fall back to
@@ -322,6 +337,12 @@ function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot)
   }
 }
 
+/** Fallback label for a real Lane doc whose `name` is empty/blank — distinct
+ *  from NO_SET_GROUP_LABEL so a genuinely-named-but-blank Set never collides
+ *  with (or gets mistaken for) the "no Set membership" bucket. Mirrors the
+ *  shot list's own wording for the identical case (shotListFilters.ts). */
+const UNNAMED_SET_LABEL = "Unnamed Set"
+
 /**
  * groupBy:"scene" ("Set" in the UI): one group per Lane, ordered by
  * Lane.sceneNumber then Lane.sortOrder (the same two-key order the shot list
@@ -330,24 +351,39 @@ function shotPrimaryFor(sortBy: ReportSortField): (a: ReportShot, b: ReportShot)
  * whose laneId no longer resolves to a live Lane doc (an orphaned reference —
  * guards against a crash if a Set is deleted out from under an open report),
  * lands in a trailing "No set" bucket — always LAST regardless of sceneNumber.
+ *
+ * Guard: only treat a laneId as orphaned when lanes have actually loaded
+ * (`laneById.size > 0`) — mirrors shotListFilters.ts's identical guard for
+ * the shot list's own "scene" grouping. Without it, a lanes read that's
+ * still loading (or that silently failed — useFirestoreCollection resolves
+ * `loading:false`/`data:[]` on a snapshot error) would present an EMPTY
+ * laneById, and every shot with a real laneId would incorrectly collapse
+ * into "No set" instead of keeping its real Set grouping.
  */
 function buildSceneGroups(
   shots: readonly ReportShot[],
   laneById: ReadonlyMap<string, Lane>,
 ): ReportGroup[] {
+  const lanesLoaded = laneById.size > 0
   const byLane = new Map<string, ReportShot[]>()
   for (const shot of shots) {
-    const key = shot.laneId != null && laneById.has(shot.laneId) ? shot.laneId : NO_SET_GROUP_KEY
+    const isOrphan = lanesLoaded && shot.laneId != null && !laneById.has(shot.laneId)
+    const key = shot.laneId != null && !isOrphan ? shot.laneId : NO_SET_GROUP_KEY
     const bucket = byLane.get(key)
     if (bucket) bucket.push(shot)
     else byLane.set(key, [shot])
   }
 
   const groups = [...byLane.entries()].map(([key, groupShots]): ReportGroup => {
-    const lane = laneById.get(key)
+    const lane = key === NO_SET_GROUP_KEY ? undefined : laneById.get(key)
+    // A real (non-orphaned, non-"No set") lane ALWAYS gets a real label —
+    // "Unnamed Set" for a blank `name`, never NO_SET_GROUP_LABEL, so it can't
+    // be mistaken for (or sort like) the trailing "No set" bucket below.
+    const label =
+      key === NO_SET_GROUP_KEY ? NO_SET_GROUP_LABEL : lane?.name || UNNAMED_SET_LABEL
     return {
       key,
-      label: lane?.name || NO_SET_GROUP_LABEL,
+      label,
       count: groupShots.length,
       shots: groupShots,
     }
@@ -412,6 +448,13 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
     }
   })
 
+  // Project-level "has a real custom order ever been established" — see
+  // compareCustomOrder's docstring. Scoped to ALL non-deleted shots (not just
+  // the report's own filtered subset), mirroring useShots.ts:33 exactly, so a
+  // report's own Status/Tags filters can never flip this decision by
+  // coincidentally excluding the shot that happens to carry the differentiator.
+  const hasCustomOrder = notDeleted.some((s) => s.sortOrder !== 0)
+
   // R2 order-by. Absent sortBy → verbatim legacy comparator (flag-off byte-identical
   // by construction). Defined → the shared stable engine with the id tie-break.
   const shots: ReportShot[] =
@@ -421,7 +464,12 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
           const [bk, bn, bs] = shotNumberSortKey(b.number)
           return ak - bk || an - bn || as.localeCompare(bs)
         })
-      : sortItemsStable(built, shotPrimaryFor(config.sortBy), SHOT_TIEBREAK, config.sortDir ?? "asc")
+      : sortItemsStable(
+          built,
+          shotPrimaryFor(config.sortBy, hasCustomOrder),
+          SHOT_TIEBREAK,
+          config.sortDir ?? "asc",
+        )
 
   const groups: ReportGroup[] =
     config.groupBy === "none"

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -161,10 +161,16 @@ export interface ReportConfig {
   /**
    * LEGACY status-hide list, superseded by `filters` below (2026-08-11 — the
    * unified filters control replaced the standalone "Hide statuses" toggle
-   * set). Tolerated on READ ONLY: `hydrateReportConfig` migrates a non-empty
-   * value into an equivalent `filters` entry exactly once, and no code path
-   * writes this field anymore. See `resolveReportFilters` for the precedence
-   * rule when a blob somehow carries both.
+   * set). Tolerated on READ from a raw/un-hydrated persisted blob only:
+   * `resolveReportFilters` reads it (when `filters` is absent) to synthesize
+   * an equivalent migrated filter. `hydrateReportConfig` clears it to `[]`
+   * on the object it RETURNS the moment migration has run (or was never
+   * needed) — so page state, and therefore every SAVE from then on (every
+   * non-filter setter spreads the current config wholesale), never carries a
+   * non-empty value forward. See `resolveReportFilters` for the precedence
+   * rule when a raw blob somehow carries both, and reportTypes.test.ts
+   * "hydrateReportConfig clears hiddenStatuses once resolved" for the
+   * write-back guarantee this depends on.
    */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
   /**
@@ -187,6 +193,28 @@ export interface ReportConfig {
 export const LEGACY_HIDDEN_STATUSES_FILTER_ID = "legacy-hidden-statuses"
 
 /**
+ * De-dupe a filter list to AT MOST ONE condition per field, last occurrence
+ * wins. The Filters control itself can never produce two conditions on the
+ * same field (setFieldFilter always replaces, never appends — ReportView.tsx),
+ * so this only ever matters for a hand-edited/legacy blob — the exact class
+ * of input reportTypes.ts already defends against elsewhere (an out-of-union
+ * sortBy, reportModel.ts's shotPrimaryFor default). Without this, the THREE
+ * readers of `filters` disagreed on what a duplicate-field blob even means:
+ * ReportView's `.find()` read the FIRST condition, formatFilterSummary's Map
+ * read the LAST, and filterEngine's applyFilterConditions ANDed BOTH. Calling
+ * this from the single canonical resolveReportFilters below makes it
+ * impossible for those three to diverge — there is only ever one condition
+ * per field for any of them to read.
+ */
+function dedupeFiltersByField(
+  filters: readonly ReportFilterCondition[],
+): readonly ReportFilterCondition[] {
+  const byField = new Map<ReportFilterField, ReportFilterCondition>()
+  for (const f of filters) byField.set(f.field, f)
+  return [...byField.values()]
+}
+
+/**
  * The filters actually in force for a config, resolving the hiddenStatuses ->
  * filters migration's precedence. `filters` (even an explicit []) is always
  * authoritative once present — `hiddenStatuses` is never merged into it, so a
@@ -198,13 +226,14 @@ export const LEGACY_HIDDEN_STATUSES_FILTER_ID = "legacy-hidden-statuses"
  * `filters` and stop writing `hiddenStatuses`) and derive time
  * (deriveShotReportModel — so a raw/hand-built config that skips hydrate,
  * e.g. every existing hiddenStatuses-only test fixture, still filters
- * correctly without updating).
+ * correctly without updating). Always returns at most one condition per
+ * field — see dedupeFiltersByField.
  */
 export function resolveReportFilters(config: {
   readonly filters?: readonly ReportFilterCondition[]
   readonly hiddenStatuses?: readonly ReportShotStatus[]
 }): readonly ReportFilterCondition[] {
-  if (config.filters !== undefined) return config.filters
+  if (config.filters !== undefined) return dedupeFiltersByField(config.filters)
   const hidden = config.hiddenStatuses ?? []
   if (hidden.length === 0) return []
   return [{ id: LEGACY_HIDDEN_STATUSES_FILTER_ID, field: "status", operator: "notIn", value: hidden }]
@@ -215,14 +244,32 @@ const FILTER_FIELD_SUMMARY_LABEL: Record<ReportFilterField, string> = {
   tag: "tags",
 }
 
+// Mirrors FILTER_OPERATOR_OPTIONS' own Include/Exclude vocabulary (ReportView.tsx)
+// so the caption never describes an "in" filter and its exact opposite "notIn"
+// filter over the same field/value-count with identical text.
+const FILTER_OPERATOR_SUMMARY_WORD: Record<ReportFilterOperator, string> = {
+  in: "included",
+  notIn: "excluded",
+}
+
 /**
  * Honest "N active filters" clause appended to the recipe caption by
- * formatOrderNote, e.g. "filtered: status (2), tags (3)". A field with zero
+ * formatOrderNote, e.g. "filtered: status excluded (2), tags included (3)".
+ * Names the operator (included/excluded), NOT just a value count — "show
+ * only these two statuses" and "hide these two statuses" are opposite
+ * arrangements of the shots and must read differently. A field with zero
  * selected values is skipped (an operator chosen before any value is picked
  * isn't "active" yet). Field order is always status-then-tag regardless of
  * array order, so the caption reads identically no matter which the user
  * touched first. Returns null when nothing is active (formatOrderNote then
  * omits the clause entirely rather than printing "filtered: ").
+ *
+ * De-dupes by field first (resolveReportFilters below is the only producer
+ * of `filters` this ever sees on a normal path and already guarantees at
+ * most one condition per field, but a hand-edited/legacy blob could still
+ * carry two — see reportTypes.test.ts "a hand-edited blob with two
+ * conditions on the same field"). Last-write-wins, matching the field's own
+ * de-dupe order.
  */
 export function formatFilterSummary(filters: readonly ReportFilterCondition[]): string | null {
   const byField = new Map(filters.map((f) => [f.field, f]))
@@ -230,7 +277,8 @@ export function formatFilterSummary(filters: readonly ReportFilterCondition[]): 
   for (const field of ["status", "tag"] as const) {
     const condition = byField.get(field)
     if (condition && condition.value.length > 0) {
-      parts.push(`${FILTER_FIELD_SUMMARY_LABEL[field]} (${condition.value.length})`)
+      const word = FILTER_OPERATOR_SUMMARY_WORD[condition.operator]
+      parts.push(`${FILTER_FIELD_SUMMARY_LABEL[field]} ${word} (${condition.value.length})`)
     }
   }
   return parts.length === 0 ? null : `filtered: ${parts.join(", ")}`
@@ -289,11 +337,22 @@ export const LEGACY_REPORT_LAYOUT: ReportLayout = "image-led"
  * `DEFAULT_REPORT_CONFIG` alone, no `stored` at all) has an empty
  * `hiddenStatuses` too, so it resolves to `[]` and stays untouched — no
  * gratuitous `filters: []` gets written onto a config that never had one.
+ *
+ * The RETURNED object always has `hiddenStatuses: []`, regardless of what
+ * `stored.hiddenStatuses` carried: its only job was feeding
+ * `resolveReportFilters` above, and once that's run (migrated or not needed)
+ * the legacy field is spent. This is what makes `ReportConfig.hiddenStatuses`'s
+ * "no code path writes this field anymore" docstring actually true — the
+ * hydrated object becomes live page state, and every subsequent setConfig
+ * spreads the CURRENT config (ReportView.tsx's setGroupBy/setSortBy/etc.), so
+ * anything still sitting in `hiddenStatuses` here would otherwise get
+ * re-persisted to Firestore on the next unrelated edit, forever.
  */
 export function hydrateReportConfig(stored: Partial<ReportConfig>): ReportConfig {
   const merged = { ...DEFAULT_REPORT_CONFIG, layout: LEGACY_REPORT_LAYOUT, ...stored }
   const filters = resolveReportFilters(merged)
-  return filters.length === 0 ? merged : { ...merged, filters }
+  const withoutLegacyHiddenStatuses = { ...merged, hiddenStatuses: [] as readonly ReportShotStatus[] }
+  return filters.length === 0 ? withoutLegacyHiddenStatuses : { ...withoutLegacyHiddenStatuses, filters }
 }
 
 /**

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -7,7 +7,7 @@
 import type { SortDir } from "./reportSort"
 import { getShotStatusLabel } from "@/shared/lib/statusMappings"
 
-export type ReportGroupBy = "gender" | "none" | "status"
+export type ReportGroupBy = "gender" | "none" | "status" | "scene"
 
 /** Which looks each shot shows: every look, or only the primary (alts hidden). */
 export type ReportLooksMode = "all" | "primary-only"
@@ -59,12 +59,15 @@ export const REPORT_STATUS_OPTIONS: ReadonlyArray<{ readonly value: ReportShotSt
 // Shot-report order-by (R2) field vocabulary. Exhaustive typed literal → the
 // option list derives from it (same pattern as REPORT_LAYOUT_*). Sort is applied
 // WITHIN each group at derive time via the shared sortItemsStable engine.
-export type ReportSortField = "shot-number" | "talent" | "status" | "gender"
+// "custom" respects the shot's own drag order (Shot.sortOrder) instead of a
+// computed comparator — see shotPrimaryFor in reportModel.ts.
+export type ReportSortField = "shot-number" | "talent" | "status" | "gender" | "custom"
 export const REPORT_SORT_FIELD_LABEL: Record<ReportSortField, string> = {
   "shot-number": "Shot #",
   talent: "Talent",
   status: "Status",
   gender: "Gender",
+  custom: "Custom order",
 }
 export const REPORT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: ReportSortField; readonly label: string }> =
   (Object.keys(REPORT_SORT_FIELD_LABEL) as ReportSortField[]).map((value) => ({
@@ -74,16 +77,33 @@ export const REPORT_SORT_FIELD_OPTIONS: ReadonlyArray<{ readonly value: ReportSo
 
 /** The order actually applied to the resolved model (set at derive time from the
  *  applied config, so it can never drift from the shots' real order). Recipe
- *  captions render this instead of a hardcoded "sorted by shot no." claim. */
+ *  captions render this instead of a hardcoded "sorted by shot no." claim.
+ *  `groupBy` and `filterSummary` are OPTIONAL — they extend the caption to also
+ *  name Set grouping and active filters honestly, but stay optional so the many
+ *  pre-existing fixtures that build a bare `{sortBy, sortDir}` ReportOrder (PDF
+ *  pagination tests, recipe smoke tests) keep compiling unchanged; a real
+ *  deriveShotReportModel run always populates both. */
 export interface ReportOrder {
   readonly sortBy: ReportSortField
   readonly sortDir: SortDir
+  /** The applied groupBy at derive time. Only "scene" changes the caption
+   *  (it names the Set grouping) — every other value is left unmentioned,
+   *  matching the pre-existing caption's silence on gender/status grouping. */
+  readonly groupBy?: ReportGroupBy
+  /** Pre-formatted "filtered: status (2), tags (3)" clause (formatFilterSummary),
+   *  or null/absent when no filter is active. Carried on the order (not
+   *  recomputed in the caption) so formatOrderNote stays a pure string-join. */
+  readonly filterSummary?: string | null
 }
 
-/** Honest, config-driven order caption for the recipe group heads. Reads the
- *  applied order off the model — NOT a persisted config field — so it always
- *  describes the shots as actually sorted. */
-export function formatOrderNote(order: ReportOrder): string {
+/** The sort-only clause of the caption ("Sorted by X[, descending]", or the
+ *  distinct "Custom order[, descending]" phrasing for sortBy:"custom" — a
+ *  drag order isn't "sorted BY" anything, so it gets its own wording rather
+ *  than forcing REPORT_SORT_FIELD_LABEL's noun through the generic template). */
+function orderClause(order: Pick<ReportOrder, "sortBy" | "sortDir">): string {
+  if (order.sortBy === "custom") {
+    return order.sortDir === "desc" ? "Custom order, descending" : "Custom order"
+  }
   // Defensive lookup: exportReports persists schemaless (no rules validation),
   // so a hand-edited/legacy blob can carry an out-of-union sortBy. shotPrimaryFor
   // sorts such shots by shot-number, so falling back to that label keeps the
@@ -91,6 +111,34 @@ export function formatOrderNote(order: ReportOrder): string {
   const label = REPORT_SORT_FIELD_LABEL[order.sortBy] ?? REPORT_SORT_FIELD_LABEL["shot-number"]
   const field = label.toLowerCase()
   return order.sortDir === "desc" ? `Sorted by ${field}, descending` : `Sorted by ${field}`
+}
+
+/** Honest, config-driven order caption for the recipe group heads. Reads the
+ *  applied order off the model — NOT a persisted config field — so it always
+ *  describes the shots as actually sorted, grouped, and filtered. Appends a
+ *  "grouped by Set" clause when the applied groupBy is "scene", and a
+ *  pre-formatted filter clause when one or more filters are active — so the
+ *  caption never lies by omission about either. */
+export function formatOrderNote(order: ReportOrder): string {
+  const parts = [orderClause(order)]
+  if (order.groupBy === "scene") parts.push("grouped by Set")
+  if (order.filterSummary) parts.push(order.filterSummary)
+  return parts.join(" · ")
+}
+
+// Unified report filter vocabulary (status + tag, v1). Deliberately the SAME
+// shape as features/shots/lib/filterConditions.ts's FilterCondition (a
+// structural subtype: narrower `field`/`operator` unions, `value` always a
+// string array) so a ReportFilterCondition can be handed straight to the shot
+// list's own evaluateCondition/applyFilterConditions (filterEngine.ts) with no
+// adapter — one engine, one semantics, for both surfaces. Reuse, don't reinvent.
+export type ReportFilterField = "status" | "tag"
+export type ReportFilterOperator = "in" | "notIn"
+export interface ReportFilterCondition {
+  readonly id: string
+  readonly field: ReportFilterField
+  readonly operator: ReportFilterOperator
+  readonly value: readonly string[]
 }
 
 /** Persisted report config — serializable (strings + string[] only); optional fields enable default-merge from older blobs. */
@@ -110,12 +158,82 @@ export interface ReportConfig {
    * featureShotReportRecipes flag-off clamp).
    */
   readonly layout?: ReportLayout
-  /** Shot statuses to HIDE entirely (screen + PDF). Defaults to [] (nothing hidden); an absent field default-merges to []. */
+  /**
+   * LEGACY status-hide list, superseded by `filters` below (2026-08-11 — the
+   * unified filters control replaced the standalone "Hide statuses" toggle
+   * set). Tolerated on READ ONLY: `hydrateReportConfig` migrates a non-empty
+   * value into an equivalent `filters` entry exactly once, and no code path
+   * writes this field anymore. See `resolveReportFilters` for the precedence
+   * rule when a blob somehow carries both.
+   */
   readonly hiddenStatuses?: readonly ReportShotStatus[]
+  /**
+   * Unified filters (status + tag, multi-value, AND-across-fields /
+   * OR-within-field — see filterEngine.ts's applyFilterConditions, which this
+   * reuses verbatim at derive time). Absent → `resolveReportFilters` falls
+   * back to migrating `hiddenStatuses`; present (even []) is authoritative and
+   * `hiddenStatuses` is ignored outright, so the two can never double-apply.
+   */
+  readonly filters?: readonly ReportFilterCondition[]
   /** R2 order-by: primary sort key applied within each group. Absent → legacy shot-number order (flag-off byte-identical). */
   readonly sortBy?: ReportSortField
   /** R2 order-by direction. Absent → "asc". Flips the PRIMARY key only; tie-break stays ascending. */
   readonly sortDir?: SortDir
+}
+
+/** Stable id for the single synthetic filter `resolveReportFilters` folds a
+ *  legacy `hiddenStatuses` list into — never minted by the Filters control
+ *  itself (which keys its own entries by field name), so it can't collide. */
+export const LEGACY_HIDDEN_STATUSES_FILTER_ID = "legacy-hidden-statuses"
+
+/**
+ * The filters actually in force for a config, resolving the hiddenStatuses ->
+ * filters migration's precedence. `filters` (even an explicit []) is always
+ * authoritative once present — `hiddenStatuses` is never merged into it, so a
+ * blob that somehow carries both never double-applies. Only when `filters` is
+ * entirely ABSENT does a non-empty `hiddenStatuses` get folded into a single
+ * synthetic status/notIn filter, reproducing the exact pre-migration "hide
+ * these statuses" behavior. Called at BOTH hydrate time (hydrateReportConfig
+ * migrates a legacy blob once, so its ongoing edits/persistence carry
+ * `filters` and stop writing `hiddenStatuses`) and derive time
+ * (deriveShotReportModel — so a raw/hand-built config that skips hydrate,
+ * e.g. every existing hiddenStatuses-only test fixture, still filters
+ * correctly without updating).
+ */
+export function resolveReportFilters(config: {
+  readonly filters?: readonly ReportFilterCondition[]
+  readonly hiddenStatuses?: readonly ReportShotStatus[]
+}): readonly ReportFilterCondition[] {
+  if (config.filters !== undefined) return config.filters
+  const hidden = config.hiddenStatuses ?? []
+  if (hidden.length === 0) return []
+  return [{ id: LEGACY_HIDDEN_STATUSES_FILTER_ID, field: "status", operator: "notIn", value: hidden }]
+}
+
+const FILTER_FIELD_SUMMARY_LABEL: Record<ReportFilterField, string> = {
+  status: "status",
+  tag: "tags",
+}
+
+/**
+ * Honest "N active filters" clause appended to the recipe caption by
+ * formatOrderNote, e.g. "filtered: status (2), tags (3)". A field with zero
+ * selected values is skipped (an operator chosen before any value is picked
+ * isn't "active" yet). Field order is always status-then-tag regardless of
+ * array order, so the caption reads identically no matter which the user
+ * touched first. Returns null when nothing is active (formatOrderNote then
+ * omits the clause entirely rather than printing "filtered: ").
+ */
+export function formatFilterSummary(filters: readonly ReportFilterCondition[]): string | null {
+  const byField = new Map(filters.map((f) => [f.field, f]))
+  const parts: string[] = []
+  for (const field of ["status", "tag"] as const) {
+    const condition = byField.get(field)
+    if (condition && condition.value.length > 0) {
+      parts.push(`${FILTER_FIELD_SUMMARY_LABEL[field]} (${condition.value.length})`)
+    }
+  }
+  return parts.length === 0 ? null : `filtered: ${parts.join(", ")}`
 }
 
 /**
@@ -159,9 +277,23 @@ export const LEGACY_REPORT_LAYOUT: ReportLayout = "image-led"
  * persisted layout, full stop. This is what ShotReportPage's hydrate effect
  * calls; kept here (not inlined) so the persistence-round-trip tests exercise
  * the real function, not a copy of its logic.
+ *
+ * Also migrates a legacy `hiddenStatuses` list into the unified `filters`
+ * vocabulary EXACTLY ONCE, by delegating the precedence decision to
+ * `resolveReportFilters` (the single source of truth for it — see that
+ * function's docstring): a `merged` that already carries `filters` (from
+ * `stored`, spread last) round-trips through unchanged, since
+ * `resolveReportFilters` returns an already-present `filters` verbatim; only
+ * a genuinely pre-filters blob with a non-empty `hiddenStatuses` gets the
+ * synthetic filter written on. A brand-new config (`merged` from
+ * `DEFAULT_REPORT_CONFIG` alone, no `stored` at all) has an empty
+ * `hiddenStatuses` too, so it resolves to `[]` and stays untouched — no
+ * gratuitous `filters: []` gets written onto a config that never had one.
  */
 export function hydrateReportConfig(stored: Partial<ReportConfig>): ReportConfig {
-  return { ...DEFAULT_REPORT_CONFIG, layout: LEGACY_REPORT_LAYOUT, ...stored }
+  const merged = { ...DEFAULT_REPORT_CONFIG, layout: LEGACY_REPORT_LAYOUT, ...stored }
+  const filters = resolveReportFilters(merged)
+  return filters.length === 0 ? merged : { ...merged, filters }
 }
 
 /**
@@ -183,21 +315,23 @@ export function resolveReportLayout(config: ReportConfig, recipesEnabled: boolea
 
 /**
  * Flag-off rollback safety. When `featureReportConfig` is OFF, strip every
- * Phase-A/B config field whose control is gated off (so a user can no longer
- * clear it) and clamp the widened `groupBy` back to its pre-Phase-B values —
- * so the derive runs its verbatim legacy path and output stays byte-identical.
- * Exported (not inlined in the page) so the flag-off byte-identity test exercises
- * the REAL code the page runs, not a copy — see reportModel flag-off test.
+ * Phase-A/B/filters config field whose control is gated off (so a user can no
+ * longer clear it) and clamp the widened `groupBy` back to its pre-Phase-B
+ * values — so the derive runs its verbatim legacy path and output stays
+ * byte-identical. Exported (not inlined in the page) so the flag-off
+ * byte-identity test exercises the REAL code the page runs, not a copy — see
+ * reportModel flag-off test.
  */
 export function neutralizeReportConfigForFlag(config: ReportConfig, flagOn: boolean): ReportConfig {
   if (flagOn) return config
   return {
     ...config,
     hiddenStatuses: [],
+    filters: undefined,
     sortBy: undefined,
     sortDir: undefined,
-    // A persisted "status" would otherwise render as gender flag-off (not
-    // byte-identical). The two legacy values were always user-settable.
+    // A persisted "status" or "scene" would otherwise render past flag-off
+    // (not byte-identical). The two legacy values were always user-settable.
     groupBy: config.groupBy === "gender" || config.groupBy === "none" ? config.groupBy : "gender",
   }
 }
@@ -253,10 +387,32 @@ export interface ReportShot {
   /** True when the user excluded this shot (struck on screen, omitted from PDF). */
   readonly excluded: boolean
   readonly hasImage: boolean
+  /**
+   * Raw Shot.sortOrder, threaded through for sortBy:"custom". OPTIONAL so the
+   * pre-existing hand-built ReportShot fixtures (PDF pagination + style-token
+   * regression suites, which never touch sort/group config) keep compiling
+   * without updating — every reader treats an absent value as 0 ("no custom
+   * order set"), matching mapShot's own `?? 0` default for a Firestore doc
+   * that has never carried the field. See shotPrimaryFor in reportModel.ts.
+   */
+  readonly sortOrder?: number
+  /**
+   * Shot.laneId (Set membership), threaded through for groupBy:"scene" ("Set").
+   * OPTIONAL for the same reason as sortOrder above. Absent/null groups under
+   * "No set", same as an id that no longer resolves to a live Lane doc.
+   */
+  readonly laneId?: string | null
 }
 
 export interface ReportGroup {
-  readonly key: GenderKey | "all" | ReportShotStatus
+  /**
+   * A gender/status/"all" literal for the pre-existing groupings, OR an
+   * arbitrary Lane doc id (or the "No set" sentinel) for groupBy:"scene" —
+   * lane ids can't be a closed literal union, so this widens to `string`.
+   * Only ever consumed as a React list key / equality check, never switched
+   * on exhaustively, so the widening is safe.
+   */
+  readonly key: GenderKey | "all" | ReportShotStatus | string
   readonly label: string
   readonly count: number
   readonly shots: readonly ReportShot[]

--- a/src-vnext/features/shots/hooks/useAvailableTags.ts
+++ b/src-vnext/features/shots/hooks/useAvailableTags.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 import { useShots } from "@/features/shots/hooks/useShots"
 import { DEFAULT_TAGS } from "@/shared/lib/defaultTags"
-import type { ShotTag } from "@/shared/types"
+import type { Shot, ShotTag } from "@/shared/types"
 import { resolveShotTagCategory } from "@/shared/lib/tagCategories"
 import { normalizeTagLabel, findCanonicalTag } from "@/shared/lib/tagDedup"
 
@@ -26,52 +26,60 @@ function normalizeTag(raw: unknown): ShotTag | null {
   }
 }
 
-export function useAvailableTags() {
-  const { data: shots, loading, error } = useShots()
+/**
+ * Pure aggregation: every tag in use across `shots`, deduped against the
+ * canonical default set, ranked by usage. Extracted from the `useAvailableTags`
+ * hook body so a consumer that ALREADY has a shots array in hand (e.g. the
+ * export report, which fetches shots once via useExportData) can reuse the
+ * exact same aggregation without opening a second Firestore subscription —
+ * "same source the list uses" without a second `useShots()`.
+ */
+export function computeAvailableTags(shots: readonly Shot[]): readonly AvailableTag[] {
+  const tagMap = new Map<string, AvailableTag>()
 
-  const tags = useMemo<readonly AvailableTag[]>(() => {
-    const tagMap = new Map<string, AvailableTag>()
+  for (const t of DEFAULT_TAGS) {
+    tagMap.set(normalizeTagLabel(t.label), { ...t, usageCount: 0, isDefault: true })
+  }
 
-    for (const t of DEFAULT_TAGS) {
-      tagMap.set(normalizeTagLabel(t.label), { ...t, usageCount: 0, isDefault: true })
-    }
+  for (const shot of shots) {
+    const raw = shot.tags
+    if (!Array.isArray(raw)) continue
 
-    for (const shot of shots) {
-      const raw = shot.tags
-      if (!Array.isArray(raw)) continue
+    for (const maybeTag of raw) {
+      const normalized = normalizeTag(maybeTag)
+      if (!normalized) continue
 
-      for (const maybeTag of raw) {
-        const normalized = normalizeTag(maybeTag)
-        if (!normalized) continue
+      const labelKey = normalizeTagLabel(normalized.label)
+      const canonical = findCanonicalTag(normalized.label)
+      const next: AvailableTag = {
+        id: canonical?.id ?? normalized.id,
+        label: canonical?.label ?? normalized.label,
+        color: canonical?.color ?? normalized.color,
+        category: canonical?.category ?? normalized.category ?? "other",
+        usageCount: 1,
+        isDefault: Boolean(canonical),
+      }
 
-        const labelKey = normalizeTagLabel(normalized.label)
-        const canonical = findCanonicalTag(normalized.label)
-        const next: AvailableTag = {
-          id: canonical?.id ?? normalized.id,
-          label: canonical?.label ?? normalized.label,
-          color: canonical?.color ?? normalized.color,
-          category: canonical?.category ?? normalized.category ?? "other",
-          usageCount: 1,
-          isDefault: Boolean(canonical),
-        }
-
-        const existing = tagMap.get(labelKey)
-        if (existing) {
-          tagMap.set(labelKey, {
-            ...existing,
-            usageCount: existing.usageCount + 1,
-            isDefault: existing.isDefault || next.isDefault,
-          })
-        } else {
-          tagMap.set(labelKey, next)
-        }
+      const existing = tagMap.get(labelKey)
+      if (existing) {
+        tagMap.set(labelKey, {
+          ...existing,
+          usageCount: existing.usageCount + 1,
+          isDefault: existing.isDefault || next.isDefault,
+        })
+      } else {
+        tagMap.set(labelKey, next)
       }
     }
+  }
 
-    return [...tagMap.values()].sort(
-      (a, b) => b.usageCount - a.usageCount || a.label.localeCompare(b.label),
-    )
-  }, [shots])
+  return [...tagMap.values()].sort(
+    (a, b) => b.usageCount - a.usageCount || a.label.localeCompare(b.label),
+  )
+}
 
+export function useAvailableTags() {
+  const { data: shots, loading, error } = useShots()
+  const tags = useMemo<readonly AvailableTag[]>(() => computeAvailableTags(shots), [shots])
   return { tags, loading, error }
 }

--- a/src-vnext/shared/lib/tagDedup.ts
+++ b/src-vnext/shared/lib/tagDedup.ts
@@ -1,6 +1,6 @@
 import { DEFAULT_TAGS } from "@/shared/lib/defaultTags"
 import { resolveShotTagCategory } from "@/shared/lib/tagCategories"
-import type { ShotTag, ShotTagCategory } from "@/shared/types"
+import type { Shot, ShotTag, ShotTagCategory } from "@/shared/types"
 
 /**
  * Normalize a tag label for comparison: trim, collapse whitespace, lowercase.
@@ -56,4 +56,36 @@ export function deduplicateTags(tags: readonly ShotTag[]): readonly ShotTag[] {
     }
   }
   return [...seen.values()]
+}
+
+/**
+ * Tag-filter option list actually reachable by matching against `shot.tags`:
+ * one option per DISTINCT id currently on a shot, keyed by that raw id
+ * (first-seen label wins), NO default-tag seeding. This is deliberately the
+ * SAME shape and semantics as the shot list's own tag-filter options
+ * (useShotListState.ts's tagLabelById/tagOptions) — and deliberately
+ * DIFFERENT from computeAvailableTags (useAvailableTags.ts), which seeds
+ * every DEFAULT_TAGS entry unconditionally and collapses same-labelled tags
+ * across different shots down to ONE canonical id. That collapsing is
+ * correct for "what tag can I assign to a shot" (computeAvailableTags' job)
+ * but wrong for "what tag VALUE should a filter match": filterEngine.ts's
+ * evalSetArray matches a filter's selected value against the shot's own
+ * stored `tag.id` verbatim, so a filter option must carry an id that
+ * actually appears on a shot — never a canonicalized/collapsed stand-in for
+ * one, and never a default tag nobody has used yet (which would just filter
+ * the report to zero shots with no indication why).
+ */
+export function computeUsedTagOptions(
+  shots: readonly Shot[],
+): ReadonlyArray<{ readonly id: string; readonly label: string }> {
+  const byId = new Map<string, string>()
+  for (const shot of shots) {
+    for (const tag of shot.tags ?? []) {
+      if (!byId.has(tag.id)) byId.set(tag.id, tag.label)
+    }
+  }
+  const collator = new Intl.Collator(undefined, { sensitivity: "base", numeric: true })
+  return Array.from(byId.entries())
+    .map(([id, label]) => ({ id, label }))
+    .sort((a, b) => collator.compare(a.label, b.label))
 }


### PR DESCRIPTION
## What was decoupled before

The Comprehensive Shot Report's export config had three previously-fixed
behaviors:

- **Filtering** was exclude-only (`hiddenStatuses`) and status-only — no
  tag filtering, no include mode, no unified vocabulary.
- **Grouping** never touched Set (Lane) membership — gender/none/status only.
- **Custom order** — `Shot.sortOrder` was fetched (`useShots`) but
  unconditionally discarded at derive time by a re-sort. Drag order never
  reached the report.

## New config fields (`ReportConfig`, `reportTypes.ts`)

- `filters?: ReportFilterCondition[]` — status + tag, multi-value,
  `in`/`notIn` per field. Applied via `features/shots/lib/filterEngine.ts`'s
  real `applyFilterConditions`/`evaluateCondition` (reused verbatim from the
  shot list, not reimplemented) — AND-across-fields, OR-within-a-field's
  values, exactly matching list-engine semantics.
- `sortBy` gains `"custom"` — respects `Shot.sortOrder`; shots with no real
  order (0/default) fall back to shot-number, ordered **last**.
- `groupBy` gains `"scene"` (UI label **"Set"**) — one group per Lane,
  ordered by `sceneNumber` then `Lane.sortOrder`, "No set" bucket always
  **last** (orphaned `laneId` — a deleted Set — lands there too, never
  crashes). `useExportData` now also fetches lanes (mirrors `useLanes`, same
  source the shot list uses).

## Back-compat / hydrate story

`hydrateReportConfig` migrates a legacy `hiddenStatuses` list into an
equivalent `filters` entry **exactly once**. `resolveReportFilters` is the
single precedence rule — `filters` present (even `[]`) is authoritative;
`hiddenStatuses` is tolerated on read only, never written going forward,
and can never double-apply. Called at both hydrate time and derive time, so
a raw/hand-built config that skips hydrate (every pre-existing
`hiddenStatuses`-only test fixture) still filters correctly without
updating. `neutralizeReportConfigForFlag` strips `filters`/custom/scene the
same way it already stripped `sortBy`/`hiddenStatuses` when
`featureReportConfig` is off, so flag-off stays byte-identical.
`DEFAULT_REPORT_CONFIG` is **unchanged** — proven by a dedicated test
comparing shot order/grouping and the exact pre-change caption text against
`DEFAULT_REPORT_CONFIG`.

## Caption honesty

`formatOrderNote` now:
- names `"Custom order"` distinctly from `"Sorted by X"` (a drag order isn't
  "sorted by" anything),
- appends `"grouped by Set"` when `groupBy` is `"scene"`,
- appends a `"filtered: status (2), tags (3)"` summary when filters are
  active,

so the recipe caption can never describe an arrangement the shots don't
actually have. `ReportOrder`'s new `groupBy`/`filterSummary` fields are
**optional** so the many pre-existing hand-built `ReportOrder`/`ReportShot`/
`ReportModel` fixtures (PDF pagination, style-token spacing, recipe smoke
tests) keep compiling unchanged.

## UI

`ControlBar` (`ReportView.tsx`) **replaces** the standalone "Hide statuses"
toggle set with **one** Filters control: Status and Tags each get their own
Include/Exclude mode toggle plus a multi-select value seg, matching the
bar's existing segmented-control look (no second competing status
mechanism). Tag options come from `computeAvailableTags` — extracted as a
pure function from `useAvailableTags.ts` — run over `ShotReportPage`'s
already-fetched shots, so there's no second Firestore subscription and
`ReportView` itself stays data-fetching-free (existing tests render it
directly with no providers mounted).

Out of scope (per spec): product-info/talent report types, recipe
layout/rendering, Firestore writes.

## Gate results

- `typecheck:baseline`: **161/161 baselined, zero new errors**, none in any
  touched file (verified directly against raw `tsc` output too).
- `eslint --max-warnings=0` on all 9 changed files: **clean**.
- `npm run build`: **succeeds**.
- Vitest, 13 files / **210 tests passing**: `reportModel.test.ts` (78),
  `reportTypes.test.ts` (34), `reportSort`, `filterEngine`,
  `filterConditions`, `ReportView`/`ControlBar` (`reportRecipeFlagOffCallSites`,
  `reportLayouts`, `reportRecipeOverflow`, `reportRecipeStyleTokenSpacing`),
  `ShotReportPage.legacyHydrate`, `ShotReportListPage.recipeDefault`,
  `TagEditor`, `BulkActionBar`.
- **Mutation-verified by hand** (not just "a test exists"): removed the
  `"custom"` comparator case, removed the "No set always last" branch,
  removed the "grouped by Set" caption clause, disabled filter application,
  and removed a redundant guard in `hydrateReportConfig` (which turned out
  to be provably dead code once `resolveReportFilters` already owns the
  precedence — simplified rather than left unfalsifiable). Each mutation
  reddened exactly the tests it should and nothing else, then was restored.
  One test was strengthened mid-review: the initial "No set sorts last"
  fixture passed even with the explicit last-place branch deleted, because
  `Number.POSITIVE_INFINITY` already achieved the same ordering for that
  fixture — added a case where a real Set has no `sceneNumber` (an
  Infinity-vs-Infinity tie) to make the explicit branch actually
  load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGon12ZeiVY8WtMg6LEV3d