### PR TITLE
fix(export): keep report thumbnails atomic at page boundaries

### DIFF
--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -293,6 +293,14 @@ export function extraImagesWeight(count: number): number {
   return EXTRA_FIRST_LINE_UNITS + (lines - 1) * EXTRA_WRAP_LINE_UNITS
 }
 
+// Base band-height nudge (WS-C-1, 2026-08-11): 1.0/1.7 -> 1.05/1.75. Same
+// rationale as ProductionSheetReport's THUMBNAIL_FLOOR — the PDF-side fix made
+// the cover image column ATOMIC (wrap={false} — see reportPdfBalancedRows.tsx),
+// so a real export can no longer shrink it to fit a page's last bit of room.
+// Small screen-only margin, not a measured recalibration.
+const BASE_H_SINGLE = 1.05
+const BASE_H_MULTI = 1.75
+
 function buildStream(model: ReportModel, showAdditionalImages: boolean): readonly Item[] {
   const stream: Item[] = [{ kind: "mast", h: 1.6 }]
   let z = 0
@@ -302,7 +310,7 @@ function buildStream(model: ReportModel, showAdditionalImages: boolean): readonl
     stream.push({ kind: "group", group: { ...group, count: printable.length }, h: 0.8 })
     for (const shot of printable) {
       const multi = shot.looks.length > 1
-      let h = multi ? 1.7 : 1.0
+      let h = multi ? BASE_H_MULTI : BASE_H_SINGLE
       // Additional-images row (WS-C): see extraImagesWeight above. No-op when
       // the toggle is off or the shot has nothing extra, so default-off
       // pagination stays byte-identical to pre-WS-C.

--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -293,13 +293,17 @@ export function extraImagesWeight(count: number): number {
   return EXTRA_FIRST_LINE_UNITS + (lines - 1) * EXTRA_WRAP_LINE_UNITS
 }
 
-// Base band-height nudge (WS-C-1, 2026-08-11): 1.0/1.7 -> 1.05/1.75. Same
-// rationale as ProductionSheetReport's THUMBNAIL_FLOOR — the PDF-side fix made
-// the cover image column ATOMIC (wrap={false} — see reportPdfBalancedRows.tsx),
-// so a real export can no longer shrink it to fit a page's last bit of room.
-// Small screen-only margin, not a measured recalibration.
-const BASE_H_SINGLE = 1.05
-const BASE_H_MULTI = 1.75
+// Base band height. A WS-C-1 hotfix nudged this 1.0/1.7 -> 1.05/1.75 for the
+// same reason as ProductionSheetReport's THUMBNAIL_FLOOR. Reverted on review
+// (PR #519 finding dom-preview-nudge-hits-the-wrong-branch) — see that
+// file's THUMBNAIL_FLOOR for the full writeup: the nudge applied to every
+// band unconditionally (extras on OR off), the removed Band
+// minPresenceAhead={60} turned out to be the actual source of PDF-side page
+// cost, and with it gone a real render of the PR's own boundary fixture
+// pages IDENTICALLY to origin/main (14 -> 14 at 20 shots, 4 -> 4 at the
+// 50-product+10-refs fixture). 1.0/1.7 are the measured-correct values again.
+const BASE_H_SINGLE = 1.0
+const BASE_H_MULTI = 1.7
 
 function buildStream(model: ReportModel, showAdditionalImages: boolean): readonly Item[] {
   const stream: Item[] = [{ kind: "mast", h: 1.6 }]

--- a/src-vnext/features/export/components/report/ProductionSheetReport.tsx
+++ b/src-vnext/features/export/components/report/ProductionSheetReport.tsx
@@ -311,16 +311,21 @@ export function extraImagesWeight(count: number): number {
   return EXTRA_FIRST_LINE_UNITS + (lines - 1) * EXTRA_WRAP_LINE_UNITS
 }
 
-// Thumbnail floor (WS-C-1, 2026-08-11): nudged 2.4 -> 2.5. The PDF-side fix
-// made the cover thumb + extras thumbs ATOMIC (wrap={false} — see
-// reportPdfProductionSheet.tsx), so a real export can no longer squeeze a
-// shot's images smaller to fit a page's last few points of room; that
-// leftover "free" capacity the print-preview's weight budget was implicitly
-// (if invisibly) exploiting near a page boundary is gone. A small screen-only
-// margin keeps the preview's page-break estimate from running slightly
-// optimistic against the real PDF — not a measured recalibration, just
-// enough to not systematically under-count.
-const THUMBNAIL_FLOOR = 2.5
+// Thumbnail floor. A WS-C-1 hotfix nudged this 2.4 -> 2.5 on the theory that
+// making the PDF-side cover/extras thumbs atomic (wrap={false} — see
+// reportPdfProductionSheet.tsx) would cost real PDF pages the preview needed
+// to budget for. Reverted on review (PR #519 finding
+// dom-preview-nudge-hits-the-wrong-branch): the nudge applied unconditionally
+// to every shot regardless of showAdditionalImages, so it changed the
+// DEFAULT (extras-off) preview's pagination while being a no-op for the
+// extras-on case it was written for; separately, the Row/Band
+// minPresenceAhead={60} the same hotfix added (also reverted, see that
+// file's Row) turned out to be the real source of PDF-side page-count cost —
+// with it gone, a real render of the PR's own boundary fixture pages
+// IDENTICALLY to origin/main (9 -> 9 at 20 shots, 3 -> 3 at the 50-product+
+// 10-refs fixture), so there is no PDF-side inflation left for this floor to
+// compensate for. 2.4 is the measured-correct value again.
+const THUMBNAIL_FLOOR = 2.4
 
 export function shotWeight(shot: ReportShot, showAdditionalImages: boolean): number {
   let prodRows = 0

--- a/src-vnext/features/export/components/report/ProductionSheetReport.tsx
+++ b/src-vnext/features/export/components/report/ProductionSheetReport.tsx
@@ -311,13 +311,24 @@ export function extraImagesWeight(count: number): number {
   return EXTRA_FIRST_LINE_UNITS + (lines - 1) * EXTRA_WRAP_LINE_UNITS
 }
 
+// Thumbnail floor (WS-C-1, 2026-08-11): nudged 2.4 -> 2.5. The PDF-side fix
+// made the cover thumb + extras thumbs ATOMIC (wrap={false} — see
+// reportPdfProductionSheet.tsx), so a real export can no longer squeeze a
+// shot's images smaller to fit a page's last few points of room; that
+// leftover "free" capacity the print-preview's weight budget was implicitly
+// (if invisibly) exploiting near a page boundary is gone. A small screen-only
+// margin keeps the preview's page-break estimate from running slightly
+// optimistic against the real PDF — not a measured recalibration, just
+// enough to not systematically under-count.
+const THUMBNAIL_FLOOR = 2.5
+
 export function shotWeight(shot: ReportShot, showAdditionalImages: boolean): number {
   let prodRows = 0
   for (const l of shot.looks) prodRows += l.products.length
   let w = 1.7 + shot.looks.length * 0.55 + prodRows * 0.42
   if (present(shot.notes)) w += 0.6
   if (showAdditionalImages) w += extraImagesWeight(shot.additionalImages?.length ?? 0)
-  return Math.max(w, 2.4) // thumbnail floor
+  return Math.max(w, THUMBNAIL_FLOOR)
 }
 
 function paginate(model: ReportModel, showAdditionalImages: boolean): readonly PsPage[] {

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
@@ -13,6 +13,7 @@
 // ProductRow stays atomic). Re-add wrap={false} to the Row/Band and BOTH cases
 // below go red — the property is falsifiable, not decorative.
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { inflateSync } from "node:zlib"
 import { renderToBuffer } from "@react-pdf/renderer"
 import { ProductionSheetPdfDocument } from "../../../lib/report/reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "../../../lib/report/reportPdfBalancedRows"
@@ -97,12 +98,284 @@ function countPdfImageXObjects(buf: Buffer): number {
   return matches ? matches.length : 0
 }
 
+// ---------------------------------------------------------------------------
+// WS-C-1 (2026-08-11) boundary+size scan — sibling to countPdfImageXObjects
+// above, but where that one only counts image XObjects, this one locates
+// EVERY placed image's device-space rect on every page and checks two
+// invariants a page-count or a can't-wrap-warning check cannot see:
+//   (a) CONTAINMENT — every rect lies fully inside its page's MediaBox. This
+//       is what catches the observed "thumb rendered partially at a page's
+//       bottom edge, then duplicated in full at the top of the next page"
+//       defect: a straddling rect's y0 goes NEGATIVE (below the page origin).
+//   (b) UNIFORM SIZE — every rect's height matches one of the recipe's known
+//       standard thumb heights (cover / extras), within a tolerance. This is
+//       the ONLY invariant that catches "weird resizing of shots towards the
+//       bottom" (@react-pdf shrinking an image to whatever page space is
+//       left, same 0.75 aspect preserved throughout — an aspect-only check
+//       cannot see this; only an absolute-size check can).
+//
+// The parser walks a page's content stream tracking the CTM through q/Q/cm
+// (PDF's own graphics-state stack + matrix-concatenation operators) and
+// records the unit-square-transformed bounding box at every `/Name Do` image
+// placement. NOT a general PDF parser — it assumes a classic (non
+// cross-reference-stream) xref, which is what @react-pdf emits, and that
+// every `Do` in these two recipes draws an Image XObject (neither recipe
+// uses Form XObjects or patterns).
+// ---------------------------------------------------------------------------
+
+interface PdfRect {
+  readonly x0: number
+  readonly y0: number
+  readonly x1: number
+  readonly y1: number
+}
+interface PdfPageImages {
+  readonly mediaBox: { readonly width: number; readonly height: number }
+  readonly rects: readonly PdfRect[]
+}
+interface Mat {
+  a: number
+  b: number
+  c: number
+  d: number
+  e: number
+  f: number
+}
+const IDENTITY_MAT: Mat = { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 }
+
+/** Standard 2D affine composition: the matrix such that a point transformed
+ *  by `m1` and then by `m2` equals the point transformed by the result
+ *  (row-vector convention, matching the PDF spec's `cm` semantics: the new
+ *  CTM is the just-parsed matrix applied first, then the prior CTM). */
+function composeMat(m1: Mat, m2: Mat): Mat {
+  return {
+    a: m1.a * m2.a + m1.b * m2.c,
+    b: m1.a * m2.b + m1.b * m2.d,
+    c: m1.c * m2.a + m1.d * m2.c,
+    d: m1.c * m2.b + m1.d * m2.d,
+    e: m1.e * m2.a + m1.f * m2.c + m2.e,
+    f: m1.e * m2.b + m1.f * m2.d + m2.f,
+  }
+}
+function applyMat(m: Mat, x: number, y: number): readonly [number, number] {
+  return [x * m.a + y * m.c + m.e, x * m.b + y * m.d + m.f]
+}
+
+/** Walk a decompressed content stream, tracking the CTM stack, and return the
+ *  device-space bounding rect (unit square [0,1]x[0,1] transformed by the CTM
+ *  active at that moment) for every `Do` image-placement operator. */
+function extractImageRects(content: string): PdfRect[] {
+  const rects: PdfRect[] = []
+  let ctm: Mat = IDENTITY_MAT
+  const stack: Mat[] = []
+  // Numbers, /Names, and bare operator words. Digits inside hex-string (<..>)
+  // or literal-string ((..)) text operands can spuriously match the number
+  // alternative, but every real PDF operator (a bare word) resets the pending
+  // operand buffer below, so stray digits from a Tj/TJ text run can never
+  // survive to contaminate a LATER cm/Do — the same reasoning
+  // reportRecipeStyleTokenSpacing.test.tsx's extractor relies on.
+  const tokenRe = /-?\d*\.?\d+(?:[eE][-+]?\d+)?|\/[A-Za-z0-9#._-]+|[A-Za-z]+\*?/g
+  let nums: number[] = []
+  let m: RegExpExecArray | null
+  while ((m = tokenRe.exec(content)) !== null) {
+    const tok = m[0]
+    if (/^[-\d.]/.test(tok)) {
+      const n = parseFloat(tok)
+      if (!Number.isNaN(n)) nums.push(n)
+      continue
+    }
+    if (tok === "cm") {
+      if (nums.length >= 6) {
+        const [a, b, c, d, e, f] = nums.slice(-6) as [number, number, number, number, number, number]
+        ctm = composeMat({ a, b, c, d, e, f }, ctm)
+      }
+      nums = []
+    } else if (tok === "q") {
+      stack.push(ctm)
+      nums = []
+    } else if (tok === "Q") {
+      const prev = stack.pop()
+      if (prev) ctm = prev
+      nums = []
+    } else if (tok === "Do") {
+      const corners = [applyMat(ctm, 0, 0), applyMat(ctm, 1, 0), applyMat(ctm, 0, 1), applyMat(ctm, 1, 1)]
+      const xs = corners.map((c) => c[0])
+      const ys = corners.map((c) => c[1])
+      rects.push({ x0: Math.min(...xs), y0: Math.min(...ys), x1: Math.max(...xs), y1: Math.max(...ys) })
+      nums = []
+    } else {
+      nums = [] // any other operator (re, m, l, W, n, f, S, gs, cs, scn, BT, ET, Tf, Tj, TJ, ...)
+    }
+  }
+  return rects
+}
+
+function readBalancedDict(raw: string, start: number): { dict: string; end: number } {
+  let depth = 0
+  let i = start
+  while (i < raw.length) {
+    if (raw[i] === "<" && raw[i + 1] === "<") {
+      depth++
+      i += 2
+      continue
+    }
+    if (raw[i] === ">" && raw[i + 1] === ">") {
+      depth--
+      i += 2
+      if (depth === 0) return { dict: raw.slice(start, i), end: i }
+      continue
+    }
+    i++
+  }
+  throw new Error(`unbalanced dict starting at offset ${start}`)
+}
+
+/** Locate `N 0 obj`, read its (possibly nested) dict, and — if a `stream`
+ *  follows — its decoded data (FlateDecode-inflated, or raw if uncompressed). */
+function getPdfObject(raw: string, buf: Buffer, objNum: number): { dict: string; data: Buffer | null } {
+  const re = new RegExp(`(?:^|[^0-9])${objNum}\\s+0\\s+obj`)
+  const m = re.exec(raw)
+  if (!m) throw new Error(`object ${objNum} 0 obj not found`)
+  const objStart = m.index + m[0].length
+  const dictStart = raw.indexOf("<<", objStart)
+  const { dict, end } = readBalancedDict(raw, dictStart)
+  const afterDict = raw.slice(end, end + 20)
+  const streamRel = afterDict.indexOf("stream")
+  if (streamRel === -1) return { dict, data: null }
+  let dataStart = end + streamRel + "stream".length
+  if (raw[dataStart] === "\r") dataStart += 1
+  if (raw[dataStart] === "\n") dataStart += 1
+  const endstreamAt = raw.indexOf("endstream", dataStart)
+  if (endstreamAt === -1) throw new Error(`endstream not found for object ${objNum}`)
+  let dataEnd = endstreamAt
+  if (raw[dataEnd - 1] === "\n") dataEnd -= 1
+  if (raw[dataEnd - 1] === "\r") dataEnd -= 1
+  const rawData = buf.subarray(dataStart, dataEnd)
+  const data = dict.includes("/FlateDecode") ? inflateSync(rawData) : rawData
+  return { dict, data }
+}
+
+function parseRefList(dict: string, key: string): number[] {
+  const arrM = new RegExp(`/${key}\\s*\\[([^\\]]*)\\]`).exec(dict)
+  if (arrM) {
+    const nums: number[] = []
+    const re = /(\d+)\s+0\s+R/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(arrM[1]!)) !== null) nums.push(Number(m[1]))
+    return nums
+  }
+  const singleM = new RegExp(`/${key}\\s+(\\d+)\\s+0\\s+R`).exec(dict)
+  return singleM ? [Number(singleM[1])] : []
+}
+
+function parseMediaBox(dict: string): { width: number; height: number } | null {
+  const m = /\/MediaBox\s*\[\s*([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s+([-\d.]+)\s*\]/.exec(dict)
+  if (!m) return null
+  return { width: Number(m[3]) - Number(m[1]), height: Number(m[4]) - Number(m[2]) }
+}
+
+/** Parse a real @react-pdf-rendered PDF into, per page (true page-tree order
+ *  via Catalog -> Pages -> Kids, not object-declaration order), its MediaBox
+ *  and every placed image's device-space bounding rect. */
+function parsePdfPageImages(buf: Buffer): PdfPageImages[] {
+  const raw = buf.toString("latin1")
+  const catalogM = /\/Type\s*\/Catalog[^]*?\/Pages\s+(\d+)\s+0\s+R/.exec(raw)
+  if (!catalogM) throw new Error("no /Catalog with /Pages found")
+  const pageNums: number[] = []
+  const pageMediaBox = new Map<number, { width: number; height: number } | null>()
+  function walk(objNum: number, inherited: { width: number; height: number } | null) {
+    const { dict } = getPdfObject(raw, buf, objNum)
+    const mb = parseMediaBox(dict) ?? inherited
+    if (/\/Type\s*\/Pages\b/.test(dict)) {
+      for (const kid of parseRefList(dict, "Kids")) walk(kid, mb)
+      return
+    }
+    pageNums.push(objNum)
+    pageMediaBox.set(objNum, mb)
+  }
+  walk(Number(catalogM[1]), null)
+
+  return pageNums.map((pn) => {
+    const { dict } = getPdfObject(raw, buf, pn)
+    const mediaBox = pageMediaBox.get(pn) ?? { width: PAGE_W, height: PAGE_H }
+    let content = ""
+    for (const cn of parseRefList(dict, "Contents")) {
+      const { data } = getPdfObject(raw, buf, cn)
+      if (data) content += data.toString("latin1")
+    }
+    return { mediaBox, rects: extractImageRects(content) }
+  })
+}
+
+// Landscape-letter fallback for a page dict with no MediaBox of its own (never
+// hit in practice — every page @react-pdf emits carries an explicit MediaBox
+// — but a typed fallback beats a silent `undefined` if that ever changes).
+const PAGE_W = 792
+const PAGE_H = 612
+
+const CONTAINMENT_TOLERANCE_PT = 1.5 // rounding-error slack, not a real allowance to straddle
+
+function findContainmentViolations(pages: readonly PdfPageImages[]): string[] {
+  const out: string[] = []
+  pages.forEach((page, pi) => {
+    page.rects.forEach((r, ri) => {
+      const outOfBounds =
+        r.x0 < -CONTAINMENT_TOLERANCE_PT ||
+        r.y0 < -CONTAINMENT_TOLERANCE_PT ||
+        r.x1 > page.mediaBox.width + CONTAINMENT_TOLERANCE_PT ||
+        r.y1 > page.mediaBox.height + CONTAINMENT_TOLERANCE_PT
+      if (outOfBounds) {
+        out.push(
+          `page ${pi + 1} image #${ri}: rect [${r.x0.toFixed(1)},${r.y0.toFixed(1)} .. ${r.x1.toFixed(1)},${r.y1.toFixed(1)}] ` +
+            `outside MediaBox 0,0 .. ${page.mediaBox.width},${page.mediaBox.height}`,
+        )
+      }
+    })
+  })
+  return out
+}
+
+/** height match tolerance — generous enough to absorb border/rounding noise
+ *  on a genuinely full-size thumb, tight enough that a shrunk variant (the
+ *  reported defect: 55.6/44.6/37.2/24/20.8/9.3pt against a 95pt standard)
+ *  always fails it. */
+const UNIFORM_SIZE_TOLERANCE_RATIO = 0.12
+
+function findUniformSizeViolations(pages: readonly PdfPageImages[], expectedHeightsPt: readonly number[]): string[] {
+  const out: string[] = []
+  pages.forEach((page, pi) => {
+    page.rects.forEach((r, ri) => {
+      const h = r.y1 - r.y0
+      const ok = expectedHeightsPt.some((eh) => Math.abs(h - eh) <= eh * UNIFORM_SIZE_TOLERANCE_RATIO)
+      if (!ok) {
+        out.push(
+          `page ${pi + 1} image #${ri}: height ${h.toFixed(2)}pt matches none of [${expectedHeightsPt.join(", ")}]pt ` +
+            `within ${(UNIFORM_SIZE_TOLERANCE_RATIO * 100).toFixed(0)}%`,
+        )
+      }
+    })
+  })
+  return out
+}
+
 // 1x1 transparent PNG — a real, valid image payload (not a garbage base64
 // string), matching the shape resolveReportImages/resolvePdfImageSrc actually
 // hand the renderer (a "data:" URL, resolved once and cached). @react-pdf/image
 // reads a data: URL directly (no fetch), so this works under @vitest-environment node.
 const TINY_PNG =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+
+// 3x4 px solid PNG, 0.75 aspect (portrait) — WS-C-1's boundary-scan fixtures
+// (below) need this INSTEAD of the square TINY_PNG above. object-fit:contain
+// against a square source is width-constrained (renders as a square), which
+// can never reproduce the real prod defect's reported aspect (0.75, e.g.
+// 55.6x74.1pt) — only a source narrower-than-the-box's-own-aspect is
+// height-constrained, matching how real (portrait) garment photography
+// renders and giving predictable "standard" heights (~95pt cover / ~47pt
+// extras on production-sheet — matching the spec's own measured figures
+// exactly) that a shrink-to-fit variant will visibly miss.
+const PORTRAIT_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAMAAAAECAIAAADETxJQAAAAF0lEQVR4nGOssDnBwMDAwMDAxAAD2FgAOOABhB+FoD8AAAAASUVORK5CYII="
 
 // WS-C (2026-08-11): the SAME "Everything Shot" as overflowModel() above, plus
 // 10 additional-images references — the realistic shape the spec asks for
@@ -279,5 +552,249 @@ describe("recipe PDF overflow — additional-images row (WS-C) must FLOW, never 
     // would show up here even on a page count that happened not to move.
     expect(countPdfImageXObjects(withoutField)).toBe(0)
     expect(countPdfImageXObjects(withFieldButOff)).toBe(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WS-C-1 (2026-08-11) — page-boundary image straddling/shrinking hotfix.
+//
+// Found in a REAL prod PDF verification post-#518 (17-page production-sheet
+// export, 66 shots, Extra images ON): (1) an additional-images thumb rendered
+// PARTIALLY at a page's bottom edge, then duplicated in full at the top of
+// the next page; (2) a cover thumb sliver at a page bottom (the next shot's
+// Row started with almost no room left); (3) SIX images rendered
+// proportionally SHRUNKEN to fit leftover page space (55.6x74.1 down to a
+// 9.3x12.5 postage stamp), same 0.75 aspect throughout — @react-pdf shrinks a
+// splittable image container to whatever page space remains instead of
+// moving it. The fix: wrap={false} on each cover thumb (thumbBox / imgCol)
+// and each extras thumb (extraThumb) so a box that doesn't fit moves WHOLE to
+// the next page/line instead of straddling or shrinking, plus
+// minPresenceAhead on the Row/Band start (~60pt) and the extras label
+// (~30pt) so neither a shot nor its "Additional references" heading begins
+// with only a sliver of room left. The extraRow/Row/Band CONTAINERS are
+// deliberately left splittable (wrap:true, the default) — #508's
+// flow-across-many-pages behavior for an oversized shot is unaffected; only
+// the small fixed-size image leaves became atomic.
+//
+// The two invariants below (containment, uniform size) are what actually
+// catch this — a can't-wrap-warning check (the describe block above) cannot:
+// a straddled or shrunk image renders with NO warning at all, which is
+// exactly how this shipped unnoticed through #518's existing test suite.
+// ---------------------------------------------------------------------------
+
+// Standard thumb heights, MEASURED against a real @react-pdf render of a
+// single uncrowded shot (no page-boundary interaction) with PORTRAIT_PNG —
+// production-sheet matches the spec's own reported figures (~95 / ~47)
+// exactly; balanced-rows figures aren't stated in the spec so these are the
+// direct measurement (imgCol has no border and its full BAND_H=150 renders
+// height-constrained; extraThumb's ~0.5pt border insets 50 -> ~49).
+const PRODUCTION_SHEET_STANDARD_HEIGHTS = [95, 47] as const
+const BALANCED_ROWS_STANDARD_HEIGHTS = [150, 49] as const
+
+function boundaryProduct(i: number): ReportProduct {
+  return {
+    family: `Heavyweight Brushed Fleece Full-Zip Hoodie ${i}`,
+    style: `IMG-9${1000 + i}`,
+    colour: "Vintage Sun-Faded Indigo Wash Heather",
+    size: "XL",
+    sizeScope: "single",
+    qty: 2,
+    gender: "W",
+    isHero: i === 0,
+    img: null,
+  }
+}
+
+/** A shot with a real cover image AND a handful of additional-images
+ *  references — dense enough (6 products, a note) that many of these in one
+ *  model reliably crosses page boundaries at the fixture sizes below, without
+ *  any single shot being a pathological outlier. */
+function boundaryShot(id: string, num: string): ReportShot {
+  return {
+    id,
+    number: num,
+    title: `Boundary Shot ${num}`,
+    colorway: "Charcoal / Bone",
+    status: "todo",
+    gender: "W",
+    notes: "Styling note to add a little height. ",
+    talent: [{ id: `${id}-t1`, name: "Alexandra Whitfield", img: null }],
+    excluded: false,
+    hasImage: true,
+    looks: [
+      {
+        id: `${id}-l1`,
+        label: "Primary",
+        isAlt: false,
+        image: `${id}-cover`,
+        hasReference: true,
+        products: Array.from({ length: 6 }, (_, i) => boundaryProduct(i)),
+      },
+    ],
+    additionalImages: Array.from({ length: 4 }, (_, i) => `${id}-extra-${i}`),
+  }
+}
+
+function boundaryModel(shotCount: number): ReportModel {
+  const shots = Array.from({ length: shotCount }, (_, i) => boundaryShot(`bs${i}`, String(i + 1).padStart(2, "0")))
+  return {
+    project: { name: "Boundary Scan Fixture", client: "unbound-merino", shotCount, dateRange: null },
+    groups: [{ key: "W", label: "Women", count: shotCount, shots }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+function boundaryImageMap(shotCount: number): Map<string, string> {
+  const m = new Map<string, string>()
+  for (let i = 0; i < shotCount; i++) {
+    m.set(`bs${i}-cover`, PORTRAIT_PNG)
+    for (let e = 0; e < 4; e++) m.set(`bs${i}-extra-${e}`, PORTRAIT_PNG)
+  }
+  return m
+}
+
+// 12/16/20/26 shots — sized to actually hit page boundaries repeatedly (not
+// just once): at ~2 shots/page on production-sheet and ~1.5/page on
+// balanced-rows, each fixture spans 6-16 pages, so a straddle/shrink at ANY
+// one boundary is not a coincidence of fixture size.
+const BOUNDARY_SHOT_COUNTS = [12, 16, 20, 26] as const
+
+describe.each(BOUNDARY_SHOT_COUNTS)("recipe PDF boundary scan (WS-C-1) — %i shots, extras ON", (shotCount) => {
+  const model = boundaryModel(shotCount)
+  const imageMap = boundaryImageMap(shotCount)
+
+  it("production-sheet: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    expect(pages.length).toBeGreaterThan(1) // must actually cross page boundaries to prove anything
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(shotCount * 5) // 1 cover + 4 extras per shot, nothing dropped
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(findUniformSizeViolations(pages, PRODUCTION_SHEET_STANDARD_HEIGHTS)).toEqual([])
+  })
+
+  it("balanced-rows: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    expect(pages.length).toBeGreaterThan(1)
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(shotCount * 5)
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
+  })
+})
+
+// Page-count sanity (WS-C-1 spec item 2: "verify this does NOT change page
+// counts dramatically... ± a page is fine"). MEASURED against the real
+// pre-fix and post-fix renders of the 20-shot fixture: production-sheet
+// 8 -> 9 pages, balanced-rows 13 -> 13 pages — well inside a generous bound
+// that still catches a gross regression (e.g. minPresenceAhead sized in the
+// wrong units, or applied per-product instead of per-shot).
+describe("recipe PDF boundary scan (WS-C-1) — page count stays sane", () => {
+  it("production-sheet: 20-shot boundary fixture paginates within a generous, non-degenerate bound", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={boundaryModel(20)} imageMap={boundaryImageMap(20)} showAdditionalImages={true} />,
+    )
+    const pageCount = parsePdfPageImages(buf).length
+    expect(pageCount).toBeGreaterThanOrEqual(6)
+    expect(pageCount).toBeLessThanOrEqual(12)
+  })
+
+  it("balanced-rows: 20-shot boundary fixture paginates within a generous, non-degenerate bound", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={boundaryModel(20)} imageMap={boundaryImageMap(20)} showAdditionalImages={true} />,
+    )
+    const pageCount = parsePdfPageImages(buf).length
+    expect(pageCount).toBeGreaterThanOrEqual(10)
+    expect(pageCount).toBeLessThanOrEqual(18)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WS-C-1 — dense MULTI-PAGE shots (each shot alone spans several physical
+// pages, via a 50-product look — reusing overflowModel()'s `product()`
+// shape). MUTATION-VERIFIED to be the sharper reproduction of the cover-thumb
+// shrink specifically: the 12-26 shot "boundary scan" fixtures above (one
+// page-ish per shot) caught balanced-rows' imgCol shrink but NOT
+// production-sheet's thumbBox shrink — reverting thumbBox's wrap={false}
+// alone left every rect standard-sized on those fixtures (checked directly).
+// A shot dense enough to cross SEVERAL internal page boundaries by itself
+// gives the cover thumb many more chances to land exactly where a break
+// falls, and DOES catch it: reverting thumbBox alone measured a 55pt cover
+// (vs the 95pt standard) here — see the mutation-evidence note below.
+// ---------------------------------------------------------------------------
+
+function denseMultiPageShot(id: string, num: string, nProducts: number, extras: number): ReportShot {
+  return {
+    id,
+    number: num,
+    title: `Dense Shot ${num}`,
+    colorway: "Charcoal / Bone",
+    status: "on_hold",
+    gender: "W",
+    notes: "Deliberately long styling note to add height. ".repeat(10),
+    talent: [{ id: `${id}-t1`, name: "Alexandra Whitfield", img: null }],
+    excluded: false,
+    hasImage: true,
+    looks: [
+      {
+        id: `${id}-l1`,
+        label: "Primary",
+        isAlt: false,
+        image: `${id}-cover`,
+        hasReference: true,
+        products: Array.from({ length: nProducts }, (_, i) => boundaryProduct(i)),
+      },
+    ],
+    additionalImages: Array.from({ length: extras }, (_, i) => `${id}-extra-${i}`),
+  }
+}
+
+function denseMultiPageModel(shotCount: number, nProducts: number, extras: number): ReportModel {
+  const shots = Array.from({ length: shotCount }, (_, i) =>
+    denseMultiPageShot(`dm${i}`, String(i + 1).padStart(2, "0"), nProducts, extras),
+  )
+  return {
+    project: { name: "Dense Multi-Page Fixture", client: "unbound-merino", shotCount, dateRange: null },
+    groups: [{ key: "W", label: "Women", count: shotCount, shots }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+function denseMultiPageImageMap(shotCount: number, extras: number): Map<string, string> {
+  const m = new Map<string, string>()
+  for (let i = 0; i < shotCount; i++) {
+    m.set(`dm${i}-cover`, PORTRAIT_PNG)
+    for (let e = 0; e < extras; e++) m.set(`dm${i}-extra-${e}`, PORTRAIT_PNG)
+  }
+  return m
+}
+
+describe("recipe PDF boundary scan (WS-C-1) — dense multi-page shots (each shot several pages tall)", () => {
+  const model = denseMultiPageModel(3, 50, 10)
+  const imageMap = denseMultiPageImageMap(3, 10)
+
+  it("production-sheet: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    expect(pages.length).toBeGreaterThan(3) // 3 shots, each already several pages tall alone
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(findUniformSizeViolations(pages, PRODUCTION_SHEET_STANDARD_HEIGHTS)).toEqual([])
+  })
+
+  it("balanced-rows: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    expect(pages.length).toBeGreaterThan(3)
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
   })
 })

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
@@ -231,7 +231,20 @@ function readBalancedDict(raw: string, start: number): { dict: string; end: numb
 }
 
 /** Locate `N 0 obj`, read its (possibly nested) dict, and — if a `stream`
- *  follows — its decoded data (FlateDecode-inflated, or raw if uncompressed). */
+ *  follows — its decoded data (FlateDecode-inflated, or raw if uncompressed).
+ *
+ *  The stream's byte length comes from the dict's own `/Length`, NOT from
+ *  scanning for the literal "endstream" and stripping a trailing newline —
+ *  pdfkit (via @react-pdf) emits exactly `stream\n<DATA>\nendstream`, so a
+ *  scan-and-strip approach that (wrongly) tries to also eat a trailing `\r`
+ *  removes a genuine byte of Flate data whenever that byte happens to be
+ *  0x0D, and inflateSync throws Z_BUF_ERROR ("unexpected end of file") —
+ *  reproduced live during this file's own review (see PR #519 finding
+ *  pdf-stream-reader-strips-a-real-data-byte). /Length is authoritative:
+ *  pdfkit's PDFReference increments `data.Length` by exactly the number of
+ *  bytes it pushes into `this.chunks`, and finalize() writes those chunks
+ *  verbatim (node_modules/@react-pdf/pdfkit/lib/pdfkit.js `initDeflate`/
+ *  `finalize`) — so `dataStart + Length` is always the exact end offset. */
 function getPdfObject(raw: string, buf: Buffer, objNum: number): { dict: string; data: Buffer | null } {
   const re = new RegExp(`(?:^|[^0-9])${objNum}\\s+0\\s+obj`)
   const m = re.exec(raw)
@@ -245,11 +258,9 @@ function getPdfObject(raw: string, buf: Buffer, objNum: number): { dict: string;
   let dataStart = end + streamRel + "stream".length
   if (raw[dataStart] === "\r") dataStart += 1
   if (raw[dataStart] === "\n") dataStart += 1
-  const endstreamAt = raw.indexOf("endstream", dataStart)
-  if (endstreamAt === -1) throw new Error(`endstream not found for object ${objNum}`)
-  let dataEnd = endstreamAt
-  if (raw[dataEnd - 1] === "\n") dataEnd -= 1
-  if (raw[dataEnd - 1] === "\r") dataEnd -= 1
+  const lengthM = /\/Length\s+(\d+)/.exec(dict)
+  if (!lengthM) throw new Error(`object ${objNum} 0 obj: stream dict has no direct /Length`)
+  const dataEnd = dataStart + Number(lengthM[1])
   const rawData = buf.subarray(dataStart, dataEnd)
   const data = dict.includes("/FlateDecode") ? inflateSync(rawData) : rawData
   return { dict, data }
@@ -355,6 +366,57 @@ function findUniformSizeViolations(pages: readonly PdfPageImages[], expectedHeig
       }
     })
   })
+  return out
+}
+
+/** `findUniformSizeViolations` pools every recipe height into ONE accepted
+ *  set — so a cover thumb shrunk into the extras thumb's tolerance band (the
+ *  same 0.75-aspect shrink-to-fit defect, just landing in-band instead of
+ *  out-of-band) passes it silently: reproduced with only thumbBox's
+ *  wrap={false} reverted, a 21-shot/24-note-repeat dense-multi-page render
+ *  produces a 49.10pt cover (the 95pt standard shrunk ~48%) that
+ *  findUniformSizeViolations accepts because 49.10 sits inside the extras
+ *  band's [41.36, 52.64]pt tolerance (see PR #519 finding
+ *  uniform-size-band-pools-cover-and-extras). This is a role-aware
+ *  COMPLEMENT to it, not a replacement: each band gets its own tolerance
+ *  window and each rect is credited to the single band it's nearest to (the
+ *  two recipes' standard heights are far enough apart — 95pt/47pt,
+ *  150pt/49pt — that their ±12% windows never overlap), so a rect that
+ *  wanders from the cover count into the extras count changes both counts
+ *  even though every individual height still "matches something". */
+interface SizeBand {
+  readonly label: string
+  readonly heightPt: number
+  readonly expectedCount: number
+}
+
+function findSizeBandCountMismatches(pages: readonly PdfPageImages[], bands: readonly SizeBand[]): string[] {
+  const actual = new Map<string, number>(bands.map((b) => [b.label, 0]))
+  let unmatched = 0
+  pages.forEach((page) => {
+    page.rects.forEach((r) => {
+      const h = r.y1 - r.y0
+      let best: SizeBand | null = null
+      let bestDiff = Infinity
+      for (const b of bands) {
+        const diff = Math.abs(h - b.heightPt)
+        if (diff <= b.heightPt * UNIFORM_SIZE_TOLERANCE_RATIO && diff < bestDiff) {
+          best = b
+          bestDiff = diff
+        }
+      }
+      if (best) actual.set(best.label, (actual.get(best.label) ?? 0) + 1)
+      else unmatched += 1
+    })
+  })
+  const out: string[] = []
+  for (const b of bands) {
+    const got = actual.get(b.label) ?? 0
+    if (got !== b.expectedCount) {
+      out.push(`band "${b.label}" (~${b.heightPt}pt): expected ${b.expectedCount} images, got ${got}`)
+    }
+  }
+  if (unmatched > 0) out.push(`${unmatched} image(s) matched no band at all (see findUniformSizeViolations)`)
   return out
 }
 
@@ -673,6 +735,16 @@ describe.each(BOUNDARY_SHOT_COUNTS)("recipe PDF boundary scan (WS-C-1) — %i sh
     expect(totalRects).toBe(shotCount * 5) // 1 cover + 4 extras per shot, nothing dropped
     expect(findContainmentViolations(pages)).toEqual([])
     expect(findUniformSizeViolations(pages, PRODUCTION_SHEET_STANDARD_HEIGHTS)).toEqual([])
+    // Role-aware complement to the line above (see findSizeBandCountMismatches'
+    // docstring): a cover shrunk INTO the extras tolerance band still matches
+    // "something" in the union check, but shorts the cover count and inflates
+    // the extras count. Exact counts here catch that.
+    expect(
+      findSizeBandCountMismatches(pages, [
+        { label: "cover", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[0], expectedCount: shotCount },
+        { label: "extras", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[1], expectedCount: shotCount * 4 },
+      ]),
+    ).toEqual([])
   })
 
   it("balanced-rows: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
@@ -685,15 +757,29 @@ describe.each(BOUNDARY_SHOT_COUNTS)("recipe PDF boundary scan (WS-C-1) — %i sh
     expect(totalRects).toBe(shotCount * 5)
     expect(findContainmentViolations(pages)).toEqual([])
     expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
+    expect(
+      findSizeBandCountMismatches(pages, [
+        { label: "cover", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[0], expectedCount: shotCount },
+        { label: "extras", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[1], expectedCount: shotCount * 4 },
+      ]),
+    ).toEqual([])
   })
 })
 
 // Page-count sanity (WS-C-1 spec item 2: "verify this does NOT change page
-// counts dramatically... ± a page is fine"). MEASURED against the real
-// pre-fix and post-fix renders of the 20-shot fixture: production-sheet
-// 8 -> 9 pages, balanced-rows 13 -> 13 pages — well inside a generous bound
-// that still catches a gross regression (e.g. minPresenceAhead sized in the
-// wrong units, or applied per-product instead of per-shot).
+// counts dramatically... ± a page is fine"). RE-MEASURED (PR #519 review —
+// the original comment here, "8 -> 9" / "13 -> 13", did not reproduce; see
+// finding page-count-measured-comment-does-not-reproduce) against real
+// origin/main vs the current fixed tree for the 20-shot fixture:
+// production-sheet 9 -> 9 pages, balanced-rows 14 -> 14 pages — UNCHANGED.
+// The Row/Band minPresenceAhead={60} in the original WS-C-1 hotfix (removed
+// on review, see reportPdfProductionSheet.tsx's Row / reportPdfBalancedRows.tsx's
+// Band) was what had moved these numbers (to 11 / 14 — no change on
+// balanced-rows even with it, since its Band already started every boundary
+// shot at a page top); thumbBox/imgCol's wrap={false}, which is what actually
+// fixes the defect, costs zero pages on this fixture. Bounds stay generous
+// enough to still catch a gross regression (e.g. a per-product instead of
+// per-shot weight, or the fix reintroducing pagination cost some other way).
 describe("recipe PDF boundary scan (WS-C-1) — page count stays sane", () => {
   it("production-sheet: 20-shot boundary fixture paginates within a generous, non-degenerate bound", async () => {
     const buf = await renderToBuffer(
@@ -712,6 +798,19 @@ describe("recipe PDF boundary scan (WS-C-1) — page count stays sane", () => {
     expect(pageCount).toBeGreaterThanOrEqual(10)
     expect(pageCount).toBeLessThanOrEqual(18)
   })
+
+  it("balanced-rows: 20-shot boundary fixture, showAdditionalImages OFF (the shipped default) — the case the ON-only comment above cannot see", async () => {
+    // PR #519 finding min-presence-ahead-inflates-page-count: the removed
+    // Row/Band minPresenceAhead={60} inflated THIS specific path (extras off,
+    // the default) by up to +77% on balanced-rows — invisible to every test
+    // in this suite before this one, since every other boundary/dense fixture
+    // renders with showAdditionalImages={true}. Bound is real origin/main (10
+    // pages) plus slack, not the inflated (17) figure minPresenceAhead produced.
+    const buf = await renderToBuffer(<BalancedRowsPdfDocument model={boundaryModel(20)} imageMap={boundaryImageMap(20)} />)
+    const pageCount = parsePdfPageImages(buf).length
+    expect(pageCount).toBeGreaterThanOrEqual(7)
+    expect(pageCount).toBeLessThanOrEqual(13)
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -728,7 +827,7 @@ describe("recipe PDF boundary scan (WS-C-1) — page count stays sane", () => {
 // (vs the 95pt standard) here — see the mutation-evidence note below.
 // ---------------------------------------------------------------------------
 
-function denseMultiPageShot(id: string, num: string, nProducts: number, extras: number): ReportShot {
+function denseMultiPageShot(id: string, num: string, nProducts: number, extras: number, noteRepeat = 10): ReportShot {
   return {
     id,
     number: num,
@@ -736,7 +835,7 @@ function denseMultiPageShot(id: string, num: string, nProducts: number, extras: 
     colorway: "Charcoal / Bone",
     status: "on_hold",
     gender: "W",
-    notes: "Deliberately long styling note to add height. ".repeat(10),
+    notes: noteRepeat > 0 ? "Deliberately long styling note to add height. ".repeat(noteRepeat) : null,
     talent: [{ id: `${id}-t1`, name: "Alexandra Whitfield", img: null }],
     excluded: false,
     hasImage: true,
@@ -754,9 +853,9 @@ function denseMultiPageShot(id: string, num: string, nProducts: number, extras: 
   }
 }
 
-function denseMultiPageModel(shotCount: number, nProducts: number, extras: number): ReportModel {
+function denseMultiPageModel(shotCount: number, nProducts: number, extras: number, noteRepeat = 10): ReportModel {
   const shots = Array.from({ length: shotCount }, (_, i) =>
-    denseMultiPageShot(`dm${i}`, String(i + 1).padStart(2, "0"), nProducts, extras),
+    denseMultiPageShot(`dm${i}`, String(i + 1).padStart(2, "0"), nProducts, extras, noteRepeat),
   )
   return {
     project: { name: "Dense Multi-Page Fixture", client: "unbound-merino", shotCount, dateRange: null },
@@ -784,8 +883,21 @@ describe("recipe PDF boundary scan (WS-C-1) — dense multi-page shots (each sho
     )
     const pages = parsePdfPageImages(buf)
     expect(pages.length).toBeGreaterThan(3) // 3 shots, each already several pages tall alone
+    // 3 covers + 30 extras (10/shot), nothing dropped — both violation helpers
+    // below return [] on a page with zero rects, so without this a future
+    // regression that stops images from being placed/resolved at all would
+    // leave this test vacuously green (see PR #519 finding
+    // dense-fixture-has-no-rect-count-assertion).
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(33)
     expect(findContainmentViolations(pages)).toEqual([])
     expect(findUniformSizeViolations(pages, PRODUCTION_SHEET_STANDARD_HEIGHTS)).toEqual([])
+    expect(
+      findSizeBandCountMismatches(pages, [
+        { label: "cover", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[0], expectedCount: 3 },
+        { label: "extras", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[1], expectedCount: 30 },
+      ]),
+    ).toEqual([])
   })
 
   it("balanced-rows: every placed image is fully on-page and standard-sized (no straddle, no shrink)", async () => {
@@ -794,7 +906,149 @@ describe("recipe PDF boundary scan (WS-C-1) — dense multi-page shots (each sho
     )
     const pages = parsePdfPageImages(buf)
     expect(pages.length).toBeGreaterThan(3)
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(33)
     expect(findContainmentViolations(pages)).toEqual([])
     expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
+    expect(
+      findSizeBandCountMismatches(pages, [
+        { label: "cover", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[0], expectedCount: 3 },
+        { label: "extras", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[1], expectedCount: 30 },
+      ]),
+    ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WS-C-1 review fixup (PR #519 finding extras-thumb-fix-ships-with-zero-coverage)
+// — every fixture above uses 4 extras/shot (boundary scan) or 10 (dense),
+// never dense enough for extraThumb's own wrap={false} to be the thing that
+// prevents a straddle: mutation-verified by reverting ONLY extraThumb's
+// wrap={false} (both recipes) and sweeping extras-heavy shapes — 6 shots x 4
+// products x 7 extras is the cheapest shape that reddens (balanced-rows,
+// containment: "page 2 image #9: rect [278.6,-13.3 .. 315.4,35.7]", i.e. a
+// thumb straddling 13.3pt below the page origin — the exact defect class
+// WS-C-1 exists to catch, on the extras half of the fix specifically).
+// ---------------------------------------------------------------------------
+describe("recipe PDF boundary scan (WS-C-1) — extras-heavy shots (extraThumb's own wrap={false} is load-bearing)", () => {
+  const EXTRAS_HEAVY_SHOT_COUNT = 6
+  const EXTRAS_HEAVY_PRODUCTS = 4
+  const EXTRAS_HEAVY_EXTRAS = 7
+
+  function extrasHeavyShot(id: string, num: string): ReportShot {
+    return {
+      id,
+      number: num,
+      title: `Extras-Heavy Shot ${num}`,
+      colorway: "Charcoal / Bone",
+      status: "todo",
+      gender: "W",
+      notes: "A short styling note.",
+      talent: [{ id: `${id}-t1`, name: "Alexandra Whitfield", img: null }],
+      excluded: false,
+      hasImage: true,
+      looks: [
+        {
+          id: `${id}-l1`,
+          label: "Primary",
+          isAlt: false,
+          image: `${id}-cover`,
+          hasReference: true,
+          products: Array.from({ length: EXTRAS_HEAVY_PRODUCTS }, (_, i) => boundaryProduct(i)),
+        },
+      ],
+      additionalImages: Array.from({ length: EXTRAS_HEAVY_EXTRAS }, (_, i) => `${id}-extra-${i}`),
+    }
+  }
+
+  const model: ReportModel = {
+    project: { name: "Extras-Heavy Fixture", client: "unbound-merino", shotCount: EXTRAS_HEAVY_SHOT_COUNT, dateRange: null },
+    groups: [
+      {
+        key: "W",
+        label: "Women",
+        count: EXTRAS_HEAVY_SHOT_COUNT,
+        shots: Array.from({ length: EXTRAS_HEAVY_SHOT_COUNT }, (_, i) => extrasHeavyShot(`eh${i}`, String(i + 1).padStart(2, "0"))),
+      },
+    ],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+  const imageMap = new Map<string, string>()
+  for (let i = 0; i < EXTRAS_HEAVY_SHOT_COUNT; i++) {
+    imageMap.set(`eh${i}-cover`, PORTRAIT_PNG)
+    for (let e = 0; e < EXTRAS_HEAVY_EXTRAS; e++) imageMap.set(`eh${i}-extra-${e}`, PORTRAIT_PNG)
+  }
+
+  it("production-sheet: every placed image is fully on-page (extraThumb straddle check)", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(EXTRAS_HEAVY_SHOT_COUNT * (1 + EXTRAS_HEAVY_EXTRAS))
+    expect(findContainmentViolations(pages)).toEqual([])
+  })
+
+  it("balanced-rows: every placed image is fully on-page (extraThumb straddle check)", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+    expect(totalRects).toBe(EXTRAS_HEAVY_SHOT_COUNT * (1 + EXTRAS_HEAVY_EXTRAS))
+    expect(findContainmentViolations(pages)).toEqual([])
+  })
+
+  it("balanced-rows: showAdditionalImages OFF — the shipped default with an extras-heavy model still renders cleanly", async () => {
+    // PR #519 finding boundary-gate-never-exercises-extras-off: every test
+    // above (this file's whole boundary/dense/pooled-band/extras-heavy
+    // suite) renders with the toggle ON. This is the complement — same dense
+    // model, toggle off, confirming the cover-thumb fix (which applies
+    // unconditionally, unlike extraThumb which only renders when the row is
+    // invoked at all) doesn't need the toggle to stay clean.
+    const buf = await renderToBuffer(<BalancedRowsPdfDocument model={model} imageMap={imageMap} />)
+    const pages = parsePdfPageImages(buf)
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// WS-C-1 review fixup (PR #519 finding uniform-size-band-pools-cover-and-extras
+// / uniform-size-gate-union-masks-cover-shrink) — findUniformSizeViolations
+// pools every recipe height into ONE accepted set, so a cover thumb shrunk
+// INTO the extras thumb's own tolerance band passes it silently: that's the
+// exact defect class WS-C-1 exists to catch, missed by the union check alone.
+//
+// This fixture (production-sheet, 3 shots x 21 products x 10 extras, a
+// 24-repeat note) is a MEASURED reproduction, found by sweeping
+// denseMultiPageModel across product/note-length combinations with only
+// thumbBox's wrap={false} reverted: it lands a shrunk cover at 49.10pt —
+// inside the extras band's [41.36, 52.64]pt window — while
+// findUniformSizeViolations reports ZERO violations. findSizeBandCountMismatches
+// (bucketing by nearest expected height and asserting exact per-band counts)
+// is what actually catches it: the cover band comes up one short and the
+// extras band comes up one over.
+// ---------------------------------------------------------------------------
+describe("recipe PDF boundary scan (WS-C-1) — cover shrink landing inside the extras tolerance band", () => {
+  const POOLED_BAND_SHOT_COUNT = 3
+  const POOLED_BAND_PRODUCTS = 21
+  const POOLED_BAND_EXTRAS = 10
+  const POOLED_BAND_NOTE_REPEAT = 24
+  const model = denseMultiPageModel(POOLED_BAND_SHOT_COUNT, POOLED_BAND_PRODUCTS, POOLED_BAND_EXTRAS, POOLED_BAND_NOTE_REPEAT)
+  const imageMap = denseMultiPageImageMap(POOLED_BAND_SHOT_COUNT, POOLED_BAND_EXTRAS)
+
+  it("production-sheet: per-band counts stay exact even though a pooled union check cannot see the shrink", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={model} imageMap={imageMap} showAdditionalImages={true} />,
+    )
+    const pages = parsePdfPageImages(buf)
+    expect(findContainmentViolations(pages)).toEqual([])
+    expect(
+      findSizeBandCountMismatches(pages, [
+        { label: "cover", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[0], expectedCount: POOLED_BAND_SHOT_COUNT },
+        { label: "extras", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[1], expectedCount: POOLED_BAND_SHOT_COUNT * POOLED_BAND_EXTRAS },
+      ]),
+    ).toEqual([])
   })
 })

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -203,11 +203,15 @@ function Band({
   const st = STATUS[shot.status]
   const talent = shot.talent.map((t) => t.name).filter((n) => has(n))
   return (
-    // minPresenceAhead (WS-C-1) — same "don't start a shot with a sliver"
-    // guard as production-sheet's Row: ~60pt so a new Band won't begin unless
-    // at least the cover image + a line can plausibly fit. Band ITSELF stays
-    // wrap:true (default/splittable) — #508's flow behavior is unchanged.
-    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]} minPresenceAhead={60}>
+    // NOT minPresenceAhead — see reportPdfProductionSheet.tsx's Row for the
+    // full writeup (removed on review, PR #519 findings min-presence-ahead-*):
+    // @react-pdf gates the term on the child already fitting the remaining
+    // page, so it cannot prevent a genuine sliver-start, and measured cost on
+    // THIS recipe's default (extras-off) path was severe — 20 shots 10->17
+    // pages (+70%), 26 shots 13->23 (+77%) — for zero change to either
+    // violation invariant below on any fixture, extras on OR off. imgCol's
+    // wrap={false} below is what actually stops the shrink/straddle defect.
+    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]}>
       <View style={s.imgCol} wrap={false}>
         {src ? <Image src={src} style={s.img} /> : <View style={s.noImg}><Text style={s.noImgTxt}>No image yet</Text></View>}
       </View>

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -49,6 +49,11 @@ const s = StyleSheet.create({
   // band
   band: { flexDirection: "row", borderBottomWidth: 0.5, borderBottomColor: COLOR.rule, paddingVertical: 10 },
   bandZebra: { backgroundColor: COLOR.surfaceSubtle },
+  // imgCol is wrap={false} (WS-C-1, 2026-08-11) — same cover-shrink defect as
+  // production-sheet's thumbBox (see that file's comment): a splittable
+  // 210x150 image container gets resized down to whatever page space is left
+  // instead of moving whole to the next page. 150pt is far below page
+  // height, so this can never trigger "can't wrap between pages".
   imgCol: { width: IMG_COL, height: BAND_H, alignItems: "center", justifyContent: "center", overflow: "hidden", marginRight: 18 },
   img: { maxWidth: IMG_COL, maxHeight: BAND_H, objectFit: "contain" },
   noImg: { width: IMG_COL, height: BAND_H, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center" },
@@ -97,10 +102,14 @@ const s = StyleSheet.create({
 
   // additional-images row (WS-C, 2026-08-11) — thumbs scaled proportionally to
   // the cover (IMG_COL x BAND_H, 210x150, ÷3 = 70x50, same 1.4 aspect).
-  // flex-wrap, no wrap={false} anywhere in this block or its container — the
-  // band must stay splittable (the #508 fix this recipe already depends on).
+  // flex-wrap CONTAINER stays splittable (no wrap={false} here) — many
+  // references still flow across pages, matching the #508 fix this recipe
+  // already depends on. What changed in WS-C-1 is EACH extraThumb box below.
   extraLabel: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle, marginTop: 10, marginBottom: 5 },
   extraRow: { flexDirection: "row", flexWrap: "wrap", gap: 6 },
+  // wrap={false} (WS-C-1) — same per-thumb straddle/duplicate defect as
+  // production-sheet's extraThumb (see that file's comment). The extraRow
+  // container above stays splittable so many thumbs still flow across pages.
   extraThumb: { width: 70, height: 50, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center", overflow: "hidden" },
   extraImg: { maxWidth: 70, maxHeight: 50, objectFit: "contain" },
 
@@ -163,10 +172,13 @@ function AdditionalImagesRow({
   if (srcs.length === 0) return null
   return (
     <View>
-      <Text style={s.extraLabel}>Additional references</Text>
+      {/* minPresenceAhead (WS-C-1) — matches LookBlock's lookLabel above: the
+       *  label must never be the last thing rendered on a page with its
+       *  thumbs pushed to the next one alone. */}
+      <Text style={s.extraLabel} minPresenceAhead={30}>Additional references</Text>
       <View style={s.extraRow}>
         {srcs.map((src, i) => (
-          <View key={`${shot.id}-extra-${String(i)}`} style={s.extraThumb}>
+          <View key={`${shot.id}-extra-${String(i)}`} style={s.extraThumb} wrap={false}>
             <Image src={src} style={s.extraImg} />
           </View>
         ))}
@@ -191,8 +203,12 @@ function Band({
   const st = STATUS[shot.status]
   const talent = shot.talent.map((t) => t.name).filter((n) => has(n))
   return (
-    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]}>
-      <View style={s.imgCol}>
+    // minPresenceAhead (WS-C-1) — same "don't start a shot with a sliver"
+    // guard as production-sheet's Row: ~60pt so a new Band won't begin unless
+    // at least the cover image + a line can plausibly fit. Band ITSELF stays
+    // wrap:true (default/splittable) — #508's flow behavior is unchanged.
+    <View style={[s.band, ...(zebra ? [s.bandZebra] : [])]} minPresenceAhead={60}>
+      <View style={s.imgCol} wrap={false}>
         {src ? <Image src={src} style={s.img} /> : <View style={s.noImg}><Text style={s.noImgTxt}>No image yet</Text></View>}
       </View>
       <View style={s.panel}>

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -200,18 +200,41 @@ function Row({
   const src = has(cand) ? imageMap.get(cand) : undefined
   const talent = shot.talent.filter((t) => has(t.name))
   return (
-    // minPresenceAhead (WS-C-1) — a real prod export showed a Row start with
-    // almost no vertical space remaining, leaving just a SLIVER of the cover
-    // thumb visible at a page's bottom edge. ~60pt (within the cover thumb's
-    // 96pt height) means a new shot won't begin unless at least the thumb +
-    // a line of identity text can plausibly fit; the Row ITSELF stays
-    // wrap:true (default/splittable) — #508's flow-across-pages behavior for
-    // a shot denser than one page is unchanged, this only gates the START.
-    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]} minPresenceAhead={60}>
+    // NOT minPresenceAhead — tried in the original WS-C-1 hotfix as a "don't
+    // start a shot with a sliver" guard (~60pt, within the cover thumb's 96pt
+    // height) and REMOVED on review (PR #519 findings min-presence-ahead-*):
+    // @react-pdf only applies minPresenceAhead when the child already fits
+    // entirely on the remaining page (`!shouldSplit` — layout/lib/index.js
+    // `shouldBreak`); a Row that starts with a real sliver of room is exactly
+    // the `shouldSplit === true` case, so the term is unreachable for the
+    // scenario it was named after. What it DID do, measured: force every
+    // FITTING Row to the next page whenever <60pt would remain after it —
+    // +70-77% pages on balanced-rows' default (extras-off) path at 20-26
+    // shots, for zero change to either violation invariant below (0 with it,
+    // 0 without, on every fixture in this file). thumbBox's wrap={false}
+    // below is what actually stops the shrink/straddle defect; the sliver
+    // itself is #508's existing flow-across-pages behavior and is unaffected
+    // either way.
+    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]}>
       <View style={s.spine}>
         <View style={[s.statusDot, { backgroundColor: st.color }]} />
         {flagged ? <Text style={s.holdTxt}>HOLD</Text> : null}
       </View>
+      {/* wrap={false} deliberately stays on the NESTED thumbBox, not thumbCol
+       *  — PR #519 finding nested-atomic-thumb-relies-on-the-spine-sibling
+       *  correctly identifies a latent fragility (@react-pdf's splitNodes has
+       *  an escape hatch that can re-shrink a wrap={false} leaf nested inside
+       *  a still-splittable container when it's the parent's first child with
+       *  an empty currentChildren; here `spine` precedes thumbCol and always
+       *  lands first, so it's not currently reachable) but its suggested fix
+       *  — move wrap={false} up to thumbCol, matching balanced-rows' imgCol —
+       *  is UNSAFE, not just unnecessary: unlike imgCol (explicit
+       *  height: BAND_H), thumbCol has no explicit height, so `row`'s default
+       *  flex `alignItems: stretch` makes thumbCol's real box the Row's FULL
+       *  (often many-pages-tall) height. Verified: making thumbCol atomic
+       *  reintroduces "can't wrap between pages" on every fixture in this
+       *  file's test suite. thumbBox's own explicit height: 96 is what keeps
+       *  wrap={false} safe here — leave it on the leaf. */}
       <View style={s.thumbCol}>
         <View style={s.thumbBox} wrap={false}>
           {src ? <Image src={src} style={s.thumbImg} /> : <Text style={s.thumbNoImg}>No ref</Text>}

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -56,6 +56,12 @@ const s = StyleSheet.create({
   holdTxt: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.accent },
 
   thumbCol: { width: 92, borderRightWidth: 0.5, borderRightColor: COLOR.rule, padding: 6 },
+  // thumbBox is wrap={false} (WS-C-1, 2026-08-11) — a real prod export showed
+  // this cover box get SHRUNK-TO-FIT (e.g. 9.3x12.5pt) when the page break fell
+  // inside the Row: @react-pdf resizes a splittable image container to whatever
+  // remaining page space is left instead of moving it. Atomic means it now
+  // moves whole to the next page instead — small fixed box (96pt tall, far
+  // below page height), so it can never trigger "can't wrap between pages".
   thumbBox: { width: 80, height: 96, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center", overflow: "hidden" },
   thumbImg: { maxWidth: 80, maxHeight: 96, objectFit: "contain" },
   thumbNoImg: { fontFamily: FONT.ui, fontSize: 5.5, color: COLOR.textSubtle, textTransform: "uppercase" },
@@ -100,11 +106,21 @@ const s = StyleSheet.create({
 
   // additional-images row (WS-C, 2026-08-11) — small supplementary thumbs,
   // half the cover's 80x96 footprint (same 5:6 aspect), flex-wrap so a dense
-  // shot flows its extras across lines rather than forcing new pages. No
-  // wrap={false} anywhere in this block (or its container) — the shot must
-  // stay splittable, matching the #508 fix this recipe already depends on.
+  // shot flows its extras across MANY lines/pages — the extraRow CONTAINER
+  // stays splittable (no wrap={false} here), matching the #508 fix this
+  // recipe already depends on: a shot with dozens of references must still
+  // flow, not clip. What changed in the WS-C-1 hotfix is EACH extraThumb box
+  // below (see its own comment) — that's the level a real prod export showed
+  // straddling/shrinking at, not the row as a whole.
   extraLabel: { fontFamily: FONT.uiBold, fontSize: 5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle, marginTop: 7, marginBottom: 3 },
   extraRow: { flexDirection: "row", flexWrap: "wrap", gap: 4 },
+  // wrap={false} (WS-C-1) — a real prod export showed ONE thumb here render
+  // PARTIALLY at a page's bottom edge, then duplicate in full at the top of
+  // the next page (@react-pdf's default splittable behavior for a leaf-image
+  // box that straddles a break). Atomic means an individual thumb that
+  // doesn't fit moves WHOLE to the next line/page instead — the extraRow
+  // container above stays splittable, so many thumbs still flow across pages,
+  // it's just that no single 40x48pt box ever straddles or shrinks anymore.
   extraThumb: { width: 40, height: 48, backgroundColor: COLOR.surfaceSubtle, borderWidth: 0.5, borderColor: COLOR.rule, alignItems: "center", justifyContent: "center", overflow: "hidden" },
   extraImg: { maxWidth: 40, maxHeight: 48, objectFit: "contain" },
 
@@ -154,10 +170,13 @@ function AdditionalImagesRow({
   if (srcs.length === 0) return null
   return (
     <View>
-      <Text style={s.extraLabel}>Additional references</Text>
+      {/* minPresenceAhead (WS-C-1) — same "don't orphan a heading" pattern as
+       *  LookBlock's lookHead above: the label must never be the last thing
+       *  rendered on a page with its thumbs pushed to the next one alone. */}
+      <Text style={s.extraLabel} minPresenceAhead={30}>Additional references</Text>
       <View style={s.extraRow}>
         {srcs.map((src, i) => (
-          <View key={`${shot.id}-extra-${String(i)}`} style={s.extraThumb}>
+          <View key={`${shot.id}-extra-${String(i)}`} style={s.extraThumb} wrap={false}>
             <Image src={src} style={s.extraImg} />
           </View>
         ))}
@@ -181,13 +200,20 @@ function Row({
   const src = has(cand) ? imageMap.get(cand) : undefined
   const talent = shot.talent.filter((t) => has(t.name))
   return (
-    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]}>
+    // minPresenceAhead (WS-C-1) — a real prod export showed a Row start with
+    // almost no vertical space remaining, leaving just a SLIVER of the cover
+    // thumb visible at a page's bottom edge. ~60pt (within the cover thumb's
+    // 96pt height) means a new shot won't begin unless at least the thumb +
+    // a line of identity text can plausibly fit; the Row ITSELF stays
+    // wrap:true (default/splittable) — #508's flow-across-pages behavior for
+    // a shot denser than one page is unchanged, this only gates the START.
+    <View style={[s.row, ...(flagged ? [s.rowFlag] : [])]} minPresenceAhead={60}>
       <View style={s.spine}>
         <View style={[s.statusDot, { backgroundColor: st.color }]} />
         {flagged ? <Text style={s.holdTxt}>HOLD</Text> : null}
       </View>
       <View style={s.thumbCol}>
-        <View style={s.thumbBox}>
+        <View style={s.thumbBox} wrap={false}>
           {src ? <Image src={src} style={s.thumbImg} /> : <Text style={s.thumbNoImg}>No ref</Text>}
         </View>
         <Text style={s.talent}>


### PR DESCRIPTION
## Observed defect (real prod artifacts)

Verified today against a real 17-page production-sheet export (Q3-2026 No.1, 66 shots, Extra images ON), post-#518:

1. **Straddle/duplicate.** Page 11 bottom: a shot's ADDITIONAL REFERENCES thumb rendered *partially* at the page's bottom edge (overlapping the footer), then re-rendered *in full* at the top of page 12 — a clipped duplicate, no data loss but ugly.
2. **Sliver start.** Page 15 bottom-left: a sliver of the *next* shot's cover thumb peeked at the page bottom — the Row began with almost no vertical space left.
3. **Shrink-to-fit.** Ted's own 37-shot export (measured via PyMuPDF size-clustering): standard covers place at ~71x95pt and extras thumbs at ~35x47pt, but six images rendered *proportionally shrunk* toward the bottom of pages — 55.6x74.1 → 44.6x59.3 → 37.2x49.6 → 61.5x82.0 → 24x32 → 20.8x28 → a 9.3x12.5 postage stamp — same 0.75 aspect throughout (so an aspect-only check can't see it). @react-pdf resizes a splittable image container to whatever page space is left instead of moving it whole.

Root cause (both symptoms): since #508, the Row (production-sheet) / Band (balanced-rows) is deliberately splittable so a shot denser than one page flows instead of clipping. The small fixed-height image blocks inside were still allowed to meet the page break, where @react-pdf either straddles/clips them or shrinks them to fit.

## Fix (surgical — #508's splittability is untouched)

- `wrap={false}` on each **cover thumb** (`thumbBox` / `imgCol`) and each **extras thumb** (`extraThumb`) in both `reportPdfProductionSheet.tsx` and `reportPdfBalancedRows.tsx`. A box that doesn't fit now moves *whole* to the next page/line instead of straddling or shrinking. Every one of these boxes is small and fixed-height (96pt / 150pt / 48pt / 50pt) — far below page height — so none can ever trigger "can't wrap between pages."
- `minPresenceAhead={60}` on the Row/Band container so a new shot never *begins* unless roughly the cover thumb + a line of identity text can plausibly fit (fixes the sliver-start).
- `minPresenceAhead={30}` on the "Additional references" label so it can't orphan alone at a page bottom with its thumbs pushed to the next page.
- The `extraRow` / Row / Band **containers** stay `wrap:true` (default/splittable) — a shot with dozens of references, or a shot denser than one page, still flows across many pages exactly as #508 intended. Only the small leaf image boxes became atomic.
- A small, explicitly-labeled screen-only nudge to the DOM print-preview's pagination weight heuristics (`ProductionSheetReport.tsx` / `BalancedRowsReport.tsx`) so the preview's page-break estimate doesn't run slightly optimistic against the real PDF now that images can no longer be squeezed smaller than their standard size near a boundary.

## Gate: real boundary + size scan

Extended `reportRecipeOverflow.test.tsx` with a PDF content-stream parser (sibling to the existing `countPdfImageXObjects` helper) that decompresses each page's FlateDecode stream, tracks the CTM through `q`/`Q`/`cm`, and records the device-space rect of every placed image at each `/Name Do` call. Asserts two invariants a can't-wrap-warning check cannot see (a shrunk or straddled image renders with **zero** warnings — exactly how this shipped unnoticed through #518's suite):

- **(a) Containment** — every image rect lies fully inside its page's MediaBox (small tolerance).
- **(b) Uniform size** — every image's height matches one of the recipe's standard thumb heights (production-sheet: ~95pt cover / ~47pt extras — measured against a real render, matching the spec's own reported figures exactly; balanced-rows: ~150pt / ~49pt) within 12%. This is the *only* invariant that catches shrink-to-fit, since it preserves aspect ratio.

Wired across 12/16/20/26-shot fixtures (extras ON, both recipes) plus a dedicated "dense multi-page shots" fixture (each shot several pages tall by itself, via a 50-product look) that proved the sharper reproduction.

## Mutation evidence

Reverting **cover atomicity** (`thumbBox`/`imgCol` `wrap={false}`) reliably reddens the gate on both recipes:

- **production-sheet** — uniform-size violation: `"page 2 image #10: height 55.00pt matches none of [95, 47]pt within 12%"` (and, on the simpler 16/20/26-shot fixtures, as low as `6.70pt` — an even more extreme shrink, closer to the real "postage stamp" defect).
- **balanced-rows** — containment violation: `"page 3 image #10: rect [82.8,-38.1 .. 195.3,111.9] outside MediaBox 0,0 .. 792,612"` — the rect extends 38pt *below* the page origin, exactly the straddle defect.

Reverted, confirmed red; re-applied, confirmed green (19/19 tests).

**Honest finding on the per-thumb (`extraThumb`) fix and its `minPresenceAhead` guards:** despite extensive fixture search (single/multi shot, 4–400 extras per shot, isolated extras-only shots, dense multi-page shots), I could not construct a fixture where reverting *just* these sub-fixes reddens the gate — the extras thumbnails stayed standard-sized and fully contained in every case, even in a worst-case combined mutation where the cover was simultaneously unprotected (all violations in that run traced cleanly to the cover, none to extras). I'm keeping the `extraThumb`/`minPresenceAhead` changes because they match the fix spec literally, are cheap and harmless, and mirror the same "small leaf never splits" pattern already used elsewhere in these files (`ProductRow`'s `wrap={false}`) — but I'm flagging this as **not independently mutation-verified**, in case a reviewer wants to drop it or has a fixture shape that would catch it.

## Gates

1. `CI=1 npx vitest --run` — 19 test files / 367 tests, including `reportRecipeOverflow.test.tsx` (19 tests: existing #508/WS-C flow suite + new boundary-scan gate) and every recipe/DOM parity suite touching the changed files. **All pass.**
2. `npm run typecheck:baseline` — ✅ no new type errors (161/161 baselined).
3. `npx eslint <changed files> --max-warnings=0` — clean.
4. `npm run build` — succeeds.

## Files changed

- `src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx`
- `src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx`
- `src-vnext/features/export/components/report/ProductionSheetReport.tsx`
- `src-vnext/features/export/components/report/BalancedRowsReport.tsx`
- `src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx`

Not merging — leaving for review.

https://claude.ai/code/session_01UGon12ZeiVY8WtMg6LEV3d