### PR TITLE
fix(shots): aria-labels on reorder chevrons

### DIFF
--- a/src-vnext/features/shots/components/ShotReorderControls.tsx
+++ b/src-vnext/features/shots/components/ShotReorderControls.tsx
@@ -51,6 +51,7 @@ export function ShotReorderControls({
         size="icon"
         className="h-6 w-6"
         disabled={isFirst}
+        aria-label="Move shot up"
         onClick={(e) => {
           e.stopPropagation()
           void move(-1)
@@ -63,6 +64,7 @@ export function ShotReorderControls({
         size="icon"
         className="h-6 w-6"
         disabled={isLast}
+        aria-label="Move shot down"
         onClick={(e) => {
           e.stopPropagation()
           void move(1)

--- a/src-vnext/features/shots/components/__tests__/ShotReorderControls.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotReorderControls.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { ShotReorderControls } from "../ShotReorderControls"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1" }),
+}))
+
+vi.mock("@/features/shots/lib/reorderShots", () => ({
+  persistShotOrder: vi.fn().mockResolvedValue(undefined),
+}))
+
+const shots = [
+  { id: "shot-1" },
+  { id: "shot-2" },
+  { id: "shot-3" },
+] as unknown as Shot[]
+
+describe("ShotReorderControls aria-labels", () => {
+  it("resolves the up chevron by its aria-label", () => {
+    render(
+      <ShotReorderControls
+        shot={shots[1]!}
+        shots={shots}
+        index={1}
+        onOptimisticReorder={vi.fn()}
+        onReorderComplete={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole("button", { name: /move shot up/i })).toBeInTheDocument()
+  })
+
+  it("resolves the down chevron by its aria-label", () => {
+    render(
+      <ShotReorderControls
+        shot={shots[1]!}
+        shots={shots}
+        index={1}
+        onOptimisticReorder={vi.fn()}
+        onReorderComplete={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole("button", { name: /move shot down/i })).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What
Adds `aria-label="Move shot up"` / `"Move shot down"` to the two icon-only chevron buttons in `ShotReorderControls`.

## Why
Shots surface build plan item 0.4 (G4 A6) — the reorder chevrons render as icon-only buttons with no accessible name, so a screen reader announces them as unlabeled "button". This is a self-contained a11y fix independent of the redesign.

## Mutation-test evidence
- `ShotReorderControls.test.tsx`, 2 tests, both green on the fix (`getByRole("button", { name: /move shot up|down/i })` resolves for each).
- Removed both `aria-label` attributes (mutation): both tests reddened — `getByRole` threw "Unable to find an accessible element" for each query.
- Restored the fix: both tests green again.

## Gates
- `CI=1 npx vitest --run src-vnext/features/shots/components/__tests__/ShotReorderControls.test.tsx` — 2/2 passed
- `npm run typecheck:baseline` — no new errors (161/161 baselined)
- `npx eslint --max-warnings=0 <changed files>` — clean
- `npm run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)