### PR TITLE
perf(shots): lazy/async hero thumbnails in table

### DIFF
--- a/src-vnext/features/shots/lib/__tests__/shotColumnRenderers.test.tsx
+++ b/src-vnext/features/shots/lib/__tests__/shotColumnRenderers.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import { computeShotRowContext, renderShotCell } from "../shotColumnRenderers"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/shared/hooks/useStorageUrl", () => ({
+  useStorageUrl: () => "https://example.test/hero.jpg",
+}))
+
+const shotWithHero = {
+  id: "shot-1",
+  projectId: "p1",
+  clientId: "c1",
+  title: "Test Shot",
+  status: "todo" as const,
+  talent: [],
+  products: [],
+  sortOrder: 1,
+  deleted: false,
+  heroImage: { path: "shots/shot-1/hero.jpg", downloadURL: "https://example.test/hero.jpg" },
+  createdAt: { toDate: () => new Date() },
+  updatedAt: { toDate: () => new Date() },
+} as unknown as Shot
+
+describe("shotColumnRenderers — hero thumb lazy loading", () => {
+  it("renders the hero thumb with loading=\"lazy\" decoding=\"async\"", () => {
+    const ctx = computeShotRowContext(shotWithHero, undefined, undefined, undefined, undefined, undefined)
+    render(<>{renderShotCell(shotWithHero, "heroThumb", ctx)}</>)
+    const img = screen.getByRole("img")
+    expect(img).toHaveAttribute("loading", "lazy")
+    expect(img).toHaveAttribute("decoding", "async")
+  })
+})

--- a/src-vnext/features/shots/lib/shotColumnRenderers.tsx
+++ b/src-vnext/features/shots/lib/shotColumnRenderers.tsx
@@ -120,6 +120,8 @@ function ShotHeroThumb({
     <img
       src={url}
       alt={alt}
+      loading="lazy"
+      decoding="async"
       className="h-9 w-9 rounded-[var(--radius-md)] border border-[var(--color-border)] object-cover"
       onError={() => setVisible(false)}
     />


### PR DESCRIPTION
## What
Adds `loading="lazy" decoding="async"` to the shots table's hero thumbnail `<img>` (`ShotHeroThumb`, rendered via `renderShotCell`'s `"heroThumb"` case). `object-cover` is untouched — the identification-thumb crop contract is unchanged.

## Why
Shots surface build plan item 0.6 (G4 A5) — the table row hero thumb was eagerly loading/decoding every image, including off-screen rows. This is a self-contained perf fix independent of the redesign.

## Mutation-test evidence
- `shotColumnRenderers.test.tsx`, 1 test, green on the fix (renders `renderShotCell(shot, "heroThumb", ctx)` for a shot with `heroImage` and asserts `loading="lazy"` + `decoding="async"`).
- Removed both attributes (mutation): test reddened — `toHaveAttribute("loading", "lazy")` failed with `Received: null`.
- Restored the fix: test green again.

## Gates
- `CI=1 npx vitest --run src-vnext/features/shots/lib/__tests__/shotColumnRenderers.test.tsx` — 1/1 passed
- `npm run typecheck:baseline` — no new errors (161/161 baselined)
- `npx eslint --max-warnings=0 <changed files>` — clean
- `npm run build` — succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)