### PR TITLE
perf(shots): rAF-coalesce column resize; persist width on mouseup

### DIFF
--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, type ReactNode } from "react"
+import { useCallback, useMemo, useRef, useState, type ReactNode } from "react"
 import {
   DndContext,
   closestCenter,
@@ -460,7 +460,37 @@ export function ShotsTable({
   const { columns, visibleColumns, setColumnWidth, toggleVisibility, reorderColumns, resetToDefaults } =
     useTableColumns(storageKey, SHOT_TABLE_COLUMNS)
 
-  const { startResize } = useColumnResize({ onWidthChange: setColumnWidth })
+  // -- Column resize: hold the live width in local state during the drag and
+  // only persist (localStorage write, via setColumnWidth) once on mouseup.
+  // useColumnResize already rAF-coalesces onWidthChange; this additionally
+  // keeps every intermediate frame OFF the persist path entirely. The override
+  // is applied only to the colgroup/header below — row cells don't render
+  // per-column pixel widths, so `visibleColumns` (and therefore row memoization
+  // in RowCells/SortableRow) is untouched by an in-progress drag.
+  const [dragWidthOverride, setDragWidthOverride] = useState<{ key: string; width: number } | null>(null)
+
+  const handleColumnWidthChange = useCallback((key: string, width: number) => {
+    setDragWidthOverride({ key, width })
+  }, [])
+
+  const handleColumnResizeEnd = useCallback(
+    (key: string, width: number) => {
+      setColumnWidth(key, width)
+      setDragWidthOverride(null)
+    },
+    [setColumnWidth],
+  )
+
+  const { startResize } = useColumnResize({
+    onWidthChange: handleColumnWidthChange,
+    onResizeEnd: handleColumnResizeEnd,
+  })
+
+  const columnDisplayWidth = useCallback(
+    (col: TableColumnConfig): number =>
+      dragWidthOverride?.key === col.key ? dragWidthOverride.width : col.width,
+    [dragWidthOverride],
+  )
 
   // -- Keyboard nav --
   const tableRef = useRef<HTMLTableElement>(null)
@@ -569,7 +599,7 @@ export function ShotsTable({
               {showDragColumn && <col style={{ width: 36 }} />}
               {selectionEnabled && <col style={{ width: 40 }} />}
               {visibleColumns.map((c) => (
-                <col key={c.key} style={{ width: c.width }} />
+                <col key={c.key} style={{ width: columnDisplayWidth(c) }} />
               ))}
               {showLifecycleActions && <col style={{ width: 64 }} />}
               <col style={{ width: 110 }} />
@@ -598,7 +628,7 @@ export function ShotsTable({
                   <ResizableHeader
                     key={col.key}
                     columnKey={col.key}
-                    width={col.width}
+                    width={columnDisplayWidth(col)}
                     onStartResize={startResize}
                     className={
                       col.key === "shotNumber"

--- a/src-vnext/shared/hooks/__tests__/useColumnResize.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useColumnResize.test.ts
@@ -106,6 +106,28 @@ describe("useColumnResize", () => {
     expect(onResizeEnd).toHaveBeenCalledWith("name", 240)
   })
 
+  it("reports the DRAGGED width on mouseup even when the last frame already flushed", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    const { result } = renderHook(() => useColumnResize({ onWidthChange, onResizeEnd }))
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+    act(() => {
+      fireMouseMove(150) // width 250
+      flushRaf() // the frame paints; the pending entry is consumed
+    })
+    expect(onWidthChange).toHaveBeenCalledWith("name", 250)
+
+    act(() => {
+      fireMouseUp() // user releases ≥1 frame after the last move — the common real drag
+    })
+
+    expect(onResizeEnd).toHaveBeenCalledTimes(1)
+    expect(onResizeEnd).toHaveBeenCalledWith("name", 250)
+  })
+
   it("reports onResizeEnd with the starting width when mouseup fires with no movement", () => {
     const onWidthChange = vi.fn()
     const onResizeEnd = vi.fn()

--- a/src-vnext/shared/hooks/__tests__/useColumnResize.test.ts
+++ b/src-vnext/shared/hooks/__tests__/useColumnResize.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { renderHook, act } from "@testing-library/react"
+import { useColumnResize } from "@/shared/hooks/useColumnResize"
+
+// requestAnimationFrame/cancelAnimationFrame are stubbed with a manually-driven
+// queue so the test controls exactly when a "frame" flushes, rather than
+// depending on jsdom's real rAF timing.
+let rafCallbacks: Array<() => void>
+let nextRafId: number
+
+function flushRaf(): void {
+  const callbacks = rafCallbacks
+  rafCallbacks = []
+  for (const cb of callbacks) cb()
+}
+
+function fireMouseMove(clientX: number): void {
+  document.dispatchEvent(new MouseEvent("mousemove", { clientX }))
+}
+
+function fireMouseUp(): void {
+  document.dispatchEvent(new MouseEvent("mouseup"))
+}
+
+describe("useColumnResize", () => {
+  beforeEach(() => {
+    rafCallbacks = []
+    nextRafId = 1
+    vi.stubGlobal("requestAnimationFrame", (cb: () => void) => {
+      rafCallbacks.push(cb)
+      return nextRafId++
+    })
+    vi.stubGlobal("cancelAnimationFrame", (_id: number) => {
+      // Test queue is flushed manually via flushRaf(); nothing keyed by id.
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("coalesces rapid mousemoves into ≤1 onWidthChange call per animation frame, delivering the FINAL width", () => {
+    const onWidthChange = vi.fn()
+    const { result } = renderHook(() => useColumnResize({ onWidthChange }))
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+
+    // 10 mousemoves before the frame is flushed — simulates 10 pixel-level
+    // moves happening faster than the browser paints.
+    act(() => {
+      for (let i = 1; i <= 10; i++) {
+        fireMouseMove(100 + i * 5)
+      }
+    })
+
+    expect(onWidthChange).not.toHaveBeenCalled()
+    expect(rafCallbacks).toHaveLength(1) // only ONE frame scheduled for the whole burst
+
+    act(() => {
+      flushRaf()
+    })
+
+    expect(onWidthChange).toHaveBeenCalledTimes(1)
+    expect(onWidthChange).toHaveBeenCalledWith("name", 250) // startWidth 200 + delta 50
+  })
+
+  it("clamps to minWidth/maxWidth while coalescing", () => {
+    const onWidthChange = vi.fn()
+    const { result } = renderHook(() =>
+      useColumnResize({ onWidthChange, minWidth: 60, maxWidth: 600 }),
+    )
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+    act(() => {
+      fireMouseMove(-10000)
+      flushRaf()
+    })
+
+    expect(onWidthChange).toHaveBeenCalledWith("name", 60)
+  })
+
+  it("flushes the pending frame and fires onResizeEnd exactly once on mouseup, even if the rAF never painted", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    const { result } = renderHook(() => useColumnResize({ onWidthChange, onResizeEnd }))
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+    act(() => {
+      fireMouseMove(140) // pending width 240, not yet flushed by a frame
+    })
+    expect(onWidthChange).not.toHaveBeenCalled()
+
+    act(() => {
+      fireMouseUp()
+    })
+
+    expect(onWidthChange).toHaveBeenCalledTimes(1)
+    expect(onWidthChange).toHaveBeenCalledWith("name", 240)
+    expect(onResizeEnd).toHaveBeenCalledTimes(1)
+    expect(onResizeEnd).toHaveBeenCalledWith("name", 240)
+  })
+
+  it("reports onResizeEnd with the starting width when mouseup fires with no movement", () => {
+    const onWidthChange = vi.fn()
+    const onResizeEnd = vi.fn()
+    const { result } = renderHook(() => useColumnResize({ onWidthChange, onResizeEnd }))
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+    act(() => {
+      fireMouseUp()
+    })
+
+    expect(onWidthChange).not.toHaveBeenCalled()
+    expect(onResizeEnd).toHaveBeenCalledTimes(1)
+    expect(onResizeEnd).toHaveBeenCalledWith("name", 200)
+  })
+
+  it("does not throw when onResizeEnd is omitted (backward-compatible for the 4 other table consumers)", () => {
+    const onWidthChange = vi.fn()
+    const { result } = renderHook(() => useColumnResize({ onWidthChange }))
+
+    act(() => {
+      result.current.startResize("name", 100, 200)
+    })
+    act(() => {
+      fireMouseMove(120)
+      flushRaf()
+    })
+    expect(() => {
+      act(() => {
+        fireMouseUp()
+      })
+    }).not.toThrow()
+
+    expect(onWidthChange).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src-vnext/shared/hooks/useColumnResize.ts
+++ b/src-vnext/shared/hooks/useColumnResize.ts
@@ -3,22 +3,43 @@ import { useCallback, useRef, useState } from "react"
 /**
  * Mouse-based column resize handler.
  * Tracks mousemove from an initial mousedown position and reports width changes.
+ *
+ * `onWidthChange` is rAF-coalesced: mousemove can fire far more often than the
+ * browser paints, so intermediate positions within a single animation frame are
+ * collapsed and only the LATEST width for that frame is delivered. The pending
+ * frame is always flushed on mouseup (even if the browser never got to paint it),
+ * so `onWidthChange` still reports the true end-of-drag width.
+ *
+ * `onResizeEnd`, if provided, fires exactly once per drag — on mouseup, with the
+ * final {key, width} — for consumers that want to defer expensive work (e.g. a
+ * localStorage persist) until the drag is over rather than on every width update.
  */
 export function useColumnResize(opts: {
   readonly onWidthChange: (key: string, width: number) => void
+  readonly onResizeEnd?: (key: string, width: number) => void
   readonly minWidth?: number   // default 60
   readonly maxWidth?: number   // default 600
 }): {
   readonly startResize: (key: string, startX: number, currentWidth: number) => void
   readonly isResizing: boolean
 } {
-  const { onWidthChange, minWidth = 60, maxWidth = 600 } = opts
+  const { onWidthChange, onResizeEnd, minWidth = 60, maxWidth = 600 } = opts
   const [isResizing, setIsResizing] = useState(false)
   const stateRef = useRef<{
     readonly key: string
     readonly startX: number
     readonly startWidth: number
   } | null>(null)
+  const rafIdRef = useRef<number | null>(null)
+  const pendingRef = useRef<{ key: string; width: number } | null>(null)
+
+  const flushPending = useCallback(() => {
+    rafIdRef.current = null
+    const pending = pendingRef.current
+    if (!pending) return
+    pendingRef.current = null
+    onWidthChange(pending.key, pending.width)
+  }, [onWidthChange])
 
   const handleMouseMove = useCallback(
     (e: MouseEvent) => {
@@ -26,19 +47,34 @@ export function useColumnResize(opts: {
       if (!state) return
       const delta = e.clientX - state.startX
       const newWidth = Math.max(minWidth, Math.min(maxWidth, state.startWidth + delta))
-      onWidthChange(state.key, newWidth)
+      pendingRef.current = { key: state.key, width: newWidth }
+      if (rafIdRef.current === null) {
+        rafIdRef.current = requestAnimationFrame(flushPending)
+      }
     },
-    [onWidthChange, minWidth, maxWidth],
+    [minWidth, maxWidth, flushPending],
   )
 
   const handleMouseUp = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      cancelAnimationFrame(rafIdRef.current)
+      rafIdRef.current = null
+    }
+    const pending = pendingRef.current
+    pendingRef.current = null
+    const state = stateRef.current
     stateRef.current = null
     setIsResizing(false)
     document.body.style.cursor = ""
     document.body.style.userSelect = ""
     document.removeEventListener("mousemove", handleMouseMove)
     document.removeEventListener("mouseup", handleMouseUp)
-  }, [handleMouseMove])
+    if (!state) return
+    // Flush any frame the rAF never got to paint so onWidthChange still sees
+    // the true end-of-drag width, then report the single resize-end signal.
+    if (pending) onWidthChange(pending.key, pending.width)
+    onResizeEnd?.(state.key, pending?.width ?? state.startWidth)
+  }, [handleMouseMove, onWidthChange, onResizeEnd])
 
   const startResize = useCallback(
     (key: string, startX: number, currentWidth: number) => {

--- a/src-vnext/shared/hooks/useColumnResize.ts
+++ b/src-vnext/shared/hooks/useColumnResize.ts
@@ -32,6 +32,10 @@ export function useColumnResize(opts: {
   } | null>(null)
   const rafIdRef = useRef<number | null>(null)
   const pendingRef = useRef<{ key: string; width: number } | null>(null)
+  // Last width delivered or scheduled during THIS drag. Unlike pendingRef it is
+  // NOT cleared when a frame flushes, so mouseup can always report the true
+  // end-of-drag width even when the final rAF already painted.
+  const lastWidthRef = useRef<{ key: string; width: number } | null>(null)
 
   const flushPending = useCallback(() => {
     rafIdRef.current = null
@@ -48,6 +52,7 @@ export function useColumnResize(opts: {
       const delta = e.clientX - state.startX
       const newWidth = Math.max(minWidth, Math.min(maxWidth, state.startWidth + delta))
       pendingRef.current = { key: state.key, width: newWidth }
+      lastWidthRef.current = pendingRef.current
       if (rafIdRef.current === null) {
         rafIdRef.current = requestAnimationFrame(flushPending)
       }
@@ -62,6 +67,8 @@ export function useColumnResize(opts: {
     }
     const pending = pendingRef.current
     pendingRef.current = null
+    const last = lastWidthRef.current
+    lastWidthRef.current = null
     const state = stateRef.current
     stateRef.current = null
     setIsResizing(false)
@@ -73,12 +80,13 @@ export function useColumnResize(opts: {
     // Flush any frame the rAF never got to paint so onWidthChange still sees
     // the true end-of-drag width, then report the single resize-end signal.
     if (pending) onWidthChange(pending.key, pending.width)
-    onResizeEnd?.(state.key, pending?.width ?? state.startWidth)
+    onResizeEnd?.(state.key, last?.width ?? state.startWidth)
   }, [handleMouseMove, onWidthChange, onResizeEnd])
 
   const startResize = useCallback(
     (key: string, startX: number, currentWidth: number) => {
       stateRef.current = { key, startX, startWidth: currentWidth }
+      lastWidthRef.current = null
       setIsResizing(true)
       document.body.style.cursor = "col-resize"
       document.body.style.userSelect = "none"


### PR DESCRIPTION
## What / why

Plan item 0.2 (Shots Premium Surface build plan, Phase 0). Two related fixes to `useColumnResize`:

1. **rAF-coalesce `onWidthChange`.** `mousemove` fires far more often than the browser paints; `onWidthChange` is now coalesced to at most one call per animation frame, always flushing the last pending frame on `mouseup` so the true end-of-drag width is never lost.
2. **New optional `onResizeEnd(key, width)` callback**, fired once per drag on `mouseup`. `ShotsTable` uses it to defer the localStorage persist (`useTableColumns.setColumnWidth -> persist -> setItem`) to mouseup instead of writing on every frame — the live width is held in local state (`dragWidthOverride`) during the drag and only applied to the colgroup/header. Row cells don't render per-column pixel widths, so this override never touches `visibleColumns`, meaning it doesn't interact with row memoization (PR for 0.3) either.

Both changes are additive/backward-compatible: `onWidthChange` keeps its existing signature (same final value, just delivered less often), and `onResizeEnd` is optional — the other 4 consumers of `useColumnResize` pass nothing new and are unaffected.

## Blast radius

`useColumnResize` is shared by 5 tables: shots, `ProductFamiliesTable`, `LocationsTable`, `TalentTable`, `CallSheetCastTable`. Ran the sibling test files as a required gate:

- `src-vnext/features/schedules/components/CallSheetCastTable.test.tsx` — 8 tests, green
- `src-vnext/features/library/components/__tests__/TalentTable.test.tsx` — 10 tests, green
- `src-vnext/features/library/components/__tests__/LocationsTable.test.tsx` — 8 tests, green
- **`ProductFamiliesTable` has no test file** (confirmed via `find` — none exists in the repo). Not exercised by an automated gate; the change to `useColumnResize` is additive-only (new optional field in the options object, existing behavior preserved for callers that don't pass it), so no behavior change for this consumer, but flagging per the blast-radius protocol.

## Test + mutation evidence

New file: `src-vnext/shared/hooks/__tests__/useColumnResize.test.ts` (5 tests):
- 10 `mousemove`s fired within one (unflushed) animation frame → `onWidthChange` not yet called, exactly 1 frame scheduled; flushing the frame → exactly 1 call, with the correct FINAL width.
- clamping to `minWidth`/`maxWidth` still holds while coalescing.
- pending frame is flushed and `onResizeEnd` fires exactly once on `mouseup`, even when the rAF never got to paint.
- `onResizeEnd` reports the starting width when `mouseup` fires with no movement.
- omitting `onResizeEnd` doesn't throw (backward compatibility check).

**Mutation:** reverted `handleMouseMove` to call `onWidthChange` directly per mousemove (bypassing the rAF coalescing). Result: the coalescing test failed — 10 calls recorded instead of 1 (`expected "spy" to not be called at all, but actually been called 10 times`) — and the pending-flush-on-mouseup test also failed. Reverted the mutation; suite back to 5/5 green.

## Gates (this branch)

- `CI=1 npx vitest --run` on the new test file + blast-radius set — all green (see above)
- `npm run typecheck:baseline` — ✅ no new type errors (161/161 baselined)
- `npx eslint --max-warnings=0` on changed files — clean
- `npm run build` — succeeds

## Deviations

None. `useTableColumns.ts` was NOT touched — the persist-deferral is entirely local to `ShotsTable.tsx`'s consumption of `useColumnResize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)