### PR TITLE
perf(shots): memoize table rows

### DIFF
--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react"
+import { memo, useCallback, useMemo, useRef, useState, type ReactNode } from "react"
 import {
   DndContext,
   closestCenter,
@@ -122,7 +122,12 @@ type RowCellsProps = {
   readonly visibleColumns: readonly TableColumnConfig[]
   readonly selectionEnabled: boolean
   readonly isSelected: boolean
-  readonly onToggle?: () => void
+  /**
+   * Stable across renders (it's `selection.onToggle`, forwarded as-is — never
+   * a per-row closure built by the caller). RowCells curries it with `shot.id`
+   * internally, which only happens when RowCells itself actually re-renders.
+   */
+  readonly onToggleShot?: (shotId: string) => void
   readonly showLifecycleActions: boolean
   readonly renderLifecycleAction?: (shot: Shot) => ReactNode
   readonly onOpenShot: (shotId: string) => void
@@ -133,12 +138,32 @@ type RowCellsProps = {
   readonly onAssignScene?: (shotId: string, laneId: string | null) => void
 }
 
-function RowCells({
+/**
+ * Only these four props determine whether a row's cells need to re-render.
+ * Everything else (onOpenShot, stopPropagation, reorderDragHandle, lanes,
+ * onAssignScene, showLifecycleActions, renderLifecycleAction, onToggleShot)
+ * is table-wide config or a stable/curried callback that doesn't vary
+ * independently of a data or selection change — see React.memo(RowCells) below.
+ */
+function rowCellsPropsAreEqual(prev: RowCellsProps, next: RowCellsProps): boolean {
+  return (
+    prev.shot === next.shot &&
+    prev.visibleColumns === next.visibleColumns &&
+    prev.isSelected === next.isSelected &&
+    prev.ctx === next.ctx
+  )
+}
+
+// Memoized: with N shots, a single unrelated re-render (e.g. toggling one
+// row's selection) would otherwise re-render every row's cells. The
+// comparator above lets React skip rows whose own data/selection/columns
+// haven't changed.
+const RowCells = memo(function RowCells({
   shot,
   visibleColumns,
   selectionEnabled,
   isSelected,
-  onToggle,
+  onToggleShot,
   showLifecycleActions,
   renderLifecycleAction,
   ctx,
@@ -160,7 +185,7 @@ function RowCells({
             checked={isSelected}
             onCheckedChange={(v) => {
               if (v === "indeterminate") return
-              onToggle?.()
+              onToggleShot?.(shot.id)
             }}
             aria-label={isSelected ? "Deselect shot" : "Select shot"}
           />
@@ -224,7 +249,7 @@ function RowCells({
       </td>
     </>
   )
-}
+}, rowCellsPropsAreEqual)
 
 // ---------------------------------------------------------------------------
 // Sortable row (DnD)
@@ -234,7 +259,23 @@ type SortableRowProps = Omit<RowCellsProps, "reorderDragHandle"> & {
   readonly onOpenShot: (shotId: string) => void
 }
 
-function SortableRow(props: SortableRowProps) {
+/**
+ * Same comparator scope as RowCells (shot, visibleColumns, isSelected, ctx).
+ * Note this only gates re-renders triggered by a PARENT prop change — the
+ * useSortable() hook below subscribes to dnd-kit's DndContext directly, so
+ * live drag transforms for OTHER rows still update via that context
+ * subscription, independent of this memo boundary.
+ */
+function sortableRowPropsAreEqual(prev: SortableRowProps, next: SortableRowProps): boolean {
+  return (
+    prev.shot === next.shot &&
+    prev.visibleColumns === next.visibleColumns &&
+    prev.isSelected === next.isSelected &&
+    prev.ctx === next.ctx
+  )
+}
+
+const SortableRow = memo(function SortableRow(props: SortableRowProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: props.shot.id,
   })
@@ -261,7 +302,7 @@ function SortableRow(props: SortableRowProps) {
       <RowCells {...props} reorderDragHandle={dragHandle} />
     </tr>
   )
-}
+}, sortableRowPropsAreEqual)
 
 // ---------------------------------------------------------------------------
 // DnD context wrapper
@@ -359,7 +400,6 @@ function GroupRows({
           const ctx = contextById.get(shot.id)
           if (!ctx) return null
           const isSelected = selectionEnabled ? selection!.selectedIds.has(shot.id) : false
-          const onToggle = selectionEnabled ? () => selection!.onToggle(shot.id) : undefined
 
           return (
             <tr
@@ -372,7 +412,7 @@ function GroupRows({
                 visibleColumns={visibleColumns}
                 selectionEnabled={selectionEnabled}
                 isSelected={isSelected}
-                onToggle={onToggle}
+                onToggleShot={selectionEnabled ? selection?.onToggle : undefined}
                 showLifecycleActions={showLifecycleActions}
                 renderLifecycleAction={renderLifecycleAction}
                 onOpenShot={onOpenShot}
@@ -459,6 +499,21 @@ export function ShotsTable({
   // -- Column management via useTableColumns --
   const { columns, visibleColumns, setColumnWidth, toggleVisibility, reorderColumns, resetToDefaults } =
     useTableColumns(storageKey, SHOT_TABLE_COLUMNS)
+
+  // useTableColumns derives `visibleColumns` via `.filter().toSorted()` on every
+  // call, so it's a NEW array reference every render even when nothing about the
+  // columns actually changed — that breaks RowCells/SortableRow's React.memo
+  // comparator (which compares visibleColumns by reference) for every row on
+  // every unrelated re-render (e.g. a selection toggle). Row cells only care
+  // WHICH columns are visible and in what order — never their pixel width (that's
+  // colgroup/header-only, below) — so key the memo on the column-key sequence and
+  // pass this stable reference to rows; the raw `visibleColumns` (with live
+  // widths) still drives the colgroup/thead below.
+  const visibleColumnKeySequence = visibleColumns.map((c) => c.key).join(",")
+  const stableVisibleColumns = useMemo(
+    () => visibleColumns,
+    [visibleColumnKeySequence],
+  )
 
   // -- Column resize: hold the live width in local state during the drag and
   // only persist (localStorage write, via setColumnWidth) once on mouseup.
@@ -662,7 +717,7 @@ export function ShotsTable({
                       isUngrouped={isUngrouped}
                       colSpan={sceneColSpan}
                       contextById={contextById}
-                      visibleColumns={visibleColumns}
+                      visibleColumns={stableVisibleColumns}
                       selectionEnabled={selectionEnabled}
                       selection={selection}
                       showLifecycleActions={showLifecycleActions}
@@ -683,14 +738,17 @@ export function ShotsTable({
                 shots.map((shot, index) => {
                   const ctx = rowContexts[index]!
                   const isSelected = selectionEnabled ? selection!.selectedIds.has(shot.id) : false
-                  const onToggle = selectionEnabled ? () => selection!.onToggle(shot.id) : undefined
 
+                  // onToggleShot is `selection.onToggle` forwarded as-is (never a new
+                  // per-row closure here) — see RowCells' React.memo comparator above,
+                  // which deliberately doesn't compare it: RowCells curries it with
+                  // shot.id internally, only when RowCells itself actually re-renders.
                   const commonCellProps = {
                     shot,
-                    visibleColumns,
+                    visibleColumns: stableVisibleColumns,
                     selectionEnabled,
                     isSelected,
-                    onToggle,
+                    onToggleShot: selectionEnabled ? selection?.onToggle : undefined,
                     showLifecycleActions,
                     renderLifecycleAction,
                     onOpenShot,

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -139,18 +139,27 @@ type RowCellsProps = {
 }
 
 /**
- * Only these four props determine whether a row's cells need to re-render.
- * Everything else (onOpenShot, stopPropagation, reorderDragHandle, lanes,
- * onAssignScene, showLifecycleActions, renderLifecycleAction, onToggleShot)
- * is table-wide config or a stable/curried callback that doesn't vary
- * independently of a data or selection change — see React.memo(RowCells) below.
+ * These props determine whether a row's cells need to re-render.
+ * `selectionEnabled`, `showLifecycleActions`, and whether `reorderDragHandle`
+ * is present each gate an entire <td> in the output above — omitting any of
+ * them from this comparator lets a row skip a re-render across a toggle that
+ * changes its own column count, misaligning it against the unmemoized
+ * thead/colgroup. `lanes` is safe to exclude: scene reassignment goes through
+ * `rowContexts`' `laneById`, which is carried on `ctx` (already compared).
+ * `renderLifecycleAction`/`onAssignScene`/`onOpenShot`/`stopPropagation`/
+ * `onToggleShot` are stable callbacks the row curries with `shot.id`
+ * internally — comparing them by reference would defeat the memo for no
+ * correctness benefit.
  */
 function rowCellsPropsAreEqual(prev: RowCellsProps, next: RowCellsProps): boolean {
   return (
     prev.shot === next.shot &&
     prev.visibleColumns === next.visibleColumns &&
     prev.isSelected === next.isSelected &&
-    prev.ctx === next.ctx
+    prev.ctx === next.ctx &&
+    prev.selectionEnabled === next.selectionEnabled &&
+    prev.showLifecycleActions === next.showLifecycleActions &&
+    (prev.reorderDragHandle !== undefined) === (next.reorderDragHandle !== undefined)
   )
 }
 
@@ -260,7 +269,11 @@ type SortableRowProps = Omit<RowCellsProps, "reorderDragHandle"> & {
 }
 
 /**
- * Same comparator scope as RowCells (shot, visibleColumns, isSelected, ctx).
+ * Same comparator scope as RowCells (shot, visibleColumns, isSelected, ctx,
+ * selectionEnabled, showLifecycleActions) — see the rationale above.
+ * `reorderDragHandle` isn't part of `SortableRowProps` (it's omitted from the
+ * type; SortableRow always builds its own via `useSortable` below and passes
+ * it to `RowCells` directly), so there's nothing to compare here for it.
  * Note this only gates re-renders triggered by a PARENT prop change — the
  * useSortable() hook below subscribes to dnd-kit's DndContext directly, so
  * live drag transforms for OTHER rows still update via that context
@@ -271,7 +284,9 @@ function sortableRowPropsAreEqual(prev: SortableRowProps, next: SortableRowProps
     prev.shot === next.shot &&
     prev.visibleColumns === next.visibleColumns &&
     prev.isSelected === next.isSelected &&
-    prev.ctx === next.ctx
+    prev.ctx === next.ctx &&
+    prev.selectionEnabled === next.selectionEnabled &&
+    prev.showLifecycleActions === next.showLifecycleActions
   )
 }
 

--- a/src-vnext/features/shots/components/__tests__/ShotsTable.rowMemo.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotsTable.rowMemo.test.tsx
@@ -103,7 +103,63 @@ function SelectableTable({ reorderEnabled }: { readonly reorderEnabled: boolean 
   )
 }
 
+// Toggles a boolean that changes the row's own <td> count (selectionEnabled
+// or showLifecycleActions) via a button, without touching `shots` — isolates
+// the memo-comparator bug from any data/ctx change that would legitimately
+// force a re-render on its own.
+function ToggleColumnCountTable({
+  toggle,
+}: {
+  readonly toggle: "selectionEnabled" | "showLifecycleActions"
+}) {
+  const [on, setOn] = useState(true)
+  return (
+    <>
+      <button type="button" onClick={() => setOn((v) => !v)}>
+        toggle
+      </button>
+      <ShotsTable
+        clientId="c1"
+        projectId="p1"
+        shots={SHOTS}
+        onOpenShot={() => {}}
+        reorderEnabled={false}
+        selection={
+          toggle === "selectionEnabled"
+            ? { enabled: on, selectedIds: new Set(), onToggle: () => {}, onToggleAll: () => {} }
+            : { enabled: true, selectedIds: new Set(), onToggle: () => {}, onToggleAll: () => {} }
+        }
+        showLifecycleActions={toggle === "showLifecycleActions" ? on : false}
+        renderLifecycleAction={() => <button type="button">Actions</button>}
+      />
+    </>
+  )
+}
+
+function expectEveryRowTdCountMatchesTheadThCount() {
+  const theadThCount = document.querySelectorAll("thead th").length
+  const rows = document.querySelectorAll("tbody tr")
+  expect(rows.length).toBeGreaterThan(0)
+  rows.forEach((row, i) => {
+    expect(row.querySelectorAll(":scope > td").length, `row ${i} <td> count`).toBe(theadThCount)
+  })
+}
+
 describe("ShotsTable row memoization", () => {
+  it("keeps every row's <td> count in sync with <thead> after selectionEnabled toggles off", () => {
+    render(<ToggleColumnCountTable toggle="selectionEnabled" />)
+    expectEveryRowTdCountMatchesTheadThCount()
+    fireEvent.click(screen.getByText("toggle"))
+    expectEveryRowTdCountMatchesTheadThCount()
+  })
+
+  it("keeps every row's <td> count in sync with <thead> after showLifecycleActions toggles on", () => {
+    render(<ToggleColumnCountTable toggle="showLifecycleActions" />)
+    expectEveryRowTdCountMatchesTheadThCount()
+    fireEvent.click(screen.getByText("toggle"))
+    expectEveryRowTdCountMatchesTheadThCount()
+  })
+
   it("toggling one row's selection does not re-render other rows' cells (plain <tr> path)", () => {
     render(<SelectableTable reorderEnabled={false} />)
     renderShotCellCalls.ids = [] // discard the initial-mount render

--- a/src-vnext/features/shots/components/__tests__/ShotsTable.rowMemo.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotsTable.rowMemo.test.tsx
@@ -1,0 +1,132 @@
+/// <reference types="@testing-library/jest-dom" />
+// 0.3 — row memoization (Phase 0 build plan, G4 A3).
+//
+// RowCells and SortableRow are wrapped in React.memo with a comparator over
+// {shot, visibleColumns, isSelected, ctx} so that toggling ONE row's
+// selection doesn't force every row's cells to re-render. This test proves
+// it by spying on renderShotCell (called once per visible column per row)
+// and confirming only the toggled row re-invokes it.
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent } from "@testing-library/react"
+import { useState } from "react"
+import { Timestamp } from "firebase/firestore"
+import { ShotsTable } from "../ShotsTable"
+import type { Shot } from "@/shared/types"
+
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => ({ clientId: "c1", user: { uid: "u1" }, role: "producer" }),
+}))
+
+vi.mock("@/features/shots/lib/updateShotWithVersion", () => ({
+  updateShotWithVersion: vi.fn().mockResolvedValue(undefined),
+}))
+
+// Render-counter: records which shot id renderShotCell was invoked for on
+// each render pass, so the test can assert unaffected rows never re-invoke
+// it after an unrelated selection toggle.
+const renderShotCellCalls = vi.hoisted(() => ({ ids: [] as string[] }))
+
+vi.mock("@/features/shots/lib/shotColumnRenderers", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/features/shots/lib/shotColumnRenderers")>()
+  return {
+    ...actual,
+    renderShotCell: (
+      shot: Shot,
+      columnKey: string,
+      ctx: Parameters<typeof actual.renderShotCell>[2],
+    ) => {
+      renderShotCellCalls.ids.push(shot.id)
+      return actual.renderShotCell(shot, columnKey, ctx)
+    },
+  }
+})
+
+function makeShot(overrides: Partial<Shot>): Shot {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "s1",
+    title: overrides.title ?? "Shot",
+    projectId: overrides.projectId ?? "p1",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "todo",
+    talent: overrides.talent ?? [],
+    talentIds: overrides.talentIds,
+    products: overrides.products ?? [],
+    locationId: overrides.locationId,
+    locationName: overrides.locationName,
+    laneId: overrides.laneId,
+    sortOrder: overrides.sortOrder ?? 0,
+    shotNumber: overrides.shotNumber,
+    notes: overrides.notes,
+    notesAddendum: overrides.notesAddendum,
+    referenceLinks: overrides.referenceLinks,
+    date: overrides.date,
+    heroImage: overrides.heroImage,
+    tags: overrides.tags,
+    deleted: overrides.deleted,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+    createdBy: overrides.createdBy ?? "u1",
+  }
+}
+
+const SHOTS: readonly Shot[] = [
+  makeShot({ id: "a", title: "Alpha", shotNumber: "1", sortOrder: 0 }),
+  makeShot({ id: "b", title: "Bravo", shotNumber: "2", sortOrder: 1 }),
+  makeShot({ id: "c", title: "Charlie", shotNumber: "3", sortOrder: 2 }),
+]
+
+function SelectableTable({ reorderEnabled }: { readonly reorderEnabled: boolean }) {
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set())
+  return (
+    <ShotsTable
+      clientId="c1"
+      projectId="p1"
+      shots={SHOTS}
+      onOpenShot={() => {}}
+      reorderEnabled={reorderEnabled}
+      selection={{
+        enabled: true,
+        selectedIds,
+        onToggle: (id) => {
+          setSelectedIds((prev) => {
+            const next = new Set(prev)
+            if (next.has(id)) next.delete(id)
+            else next.add(id)
+            return next
+          })
+        },
+        onToggleAll: () => {},
+      }}
+    />
+  )
+}
+
+describe("ShotsTable row memoization", () => {
+  it("toggling one row's selection does not re-render other rows' cells (plain <tr> path)", () => {
+    render(<SelectableTable reorderEnabled={false} />)
+    renderShotCellCalls.ids = [] // discard the initial-mount render
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: /select shot/i })
+    expect(checkboxes).toHaveLength(3)
+    fireEvent.click(checkboxes[0]!) // toggle row "a"
+
+    expect(renderShotCellCalls.ids).toContain("a")
+    expect(renderShotCellCalls.ids).not.toContain("b")
+    expect(renderShotCellCalls.ids).not.toContain("c")
+  })
+
+  it("toggling one row's selection does not re-render other rows' cells (SortableRow/DnD path)", () => {
+    render(<SelectableTable reorderEnabled={true} />)
+    renderShotCellCalls.ids = [] // discard the initial-mount render
+
+    const checkboxes = screen.getAllByRole("checkbox", { name: /select shot/i })
+    expect(checkboxes).toHaveLength(3)
+    fireEvent.click(checkboxes[1]!) // toggle row "b" this time
+
+    expect(renderShotCellCalls.ids).toContain("b")
+    expect(renderShotCellCalls.ids).not.toContain("a")
+    expect(renderShotCellCalls.ids).not.toContain("c")
+  })
+})


### PR DESCRIPTION
## What / why

Plan item 0.3 (Shots Premium Surface build plan, Phase 0). `RowCells` and `SortableRow` in `ShotsTable.tsx` are wrapped in `React.memo` with a comparator scoped to `{shot, visibleColumns, isSelected, ctx}` — the only props that actually determine a row's rendered output. Everything else (`onOpenShot`, `stopPropagation`, `reorderDragHandle`, `lanes`, `onAssignScene`, `showLifecycleActions`, `renderLifecycleAction`) is table-wide config or a stable/curried callback, deliberately excluded from the comparator.

Without this, toggling ONE row's selection (or any other unrelated state change) re-renders every row's cells.

### Two supporting changes needed for the memoization to actually work

1. **`useTableColumns.visibleColumns` is a fresh array reference every call** — it's derived via `.filter().toSorted()`, uncached, so it's a brand-new array even when nothing about the columns changed. That silently broke the row comparator for every row on every unrelated re-render (confirmed empirically — first test pass showed all 33 cells across all 3 rows re-rendering, not just the toggled row). Row cells only care WHICH columns are visible and in what ORDER — never pixel width (that's colgroup/header-only) — so a local `stableVisibleColumns` is memoized off the column-key sequence and passed to rows; the live `visibleColumns` (with current widths) still drives the colgroup/thead directly.
2. **The per-row `onToggle` closure was built inline in ShotsTable's render loop** (`() => selection.onToggle(shot.id)`), a fresh closure every render for every row regardless of memoization. Replaced with `onToggleShot`, `selection.onToggle` forwarded as-is (unchanged reference); `RowCells` curries it with `shot.id` internally — which only happens when `RowCells` itself actually re-renders. `GroupRows` (grouped-view rendering, not memoized, out of scope for this fix) was updated to match since it shares `RowCellsProps`.

## Blast radius

**Local.** `RowCells`, `SortableRow`, `RowCellsProps`, `SortableRowProps` are all module-private to `ShotsTable.tsx`. No shared hook or component (`useTableColumns.ts`, `useColumnResize.ts`, `ResizableHeader.tsx`, etc.) is touched — `useTableColumns` is only *consumed* here, not modified. No blast-radius gate applies per the build plan's classification of this item.

Ran the broader shots suite anyway as a sanity check (not required, but cheap): `ShotListPage.test.tsx` (35), `ShotListPage.unifiedEditorFork.test.tsx` (2), `ShootShotList.test.tsx` (10) — 47/47 green, confirming the `onToggle` → `onToggleShot` prop rename didn't regress selection/toggle behavior anywhere else that renders `ShotsTable`.

## Test + mutation evidence

New file: `src-vnext/features/shots/components/__tests__/ShotsTable.rowMemo.test.tsx` (2 tests, one for the plain `<tr>` path and one for the `SortableRow`/DnD path). Spies on `renderShotCell` (called once per visible column per row) to record which shot id's cells actually re-rendered, then toggles one row's selection checkbox and asserts only that row's id appears in the post-toggle call list.

**Mutation:** unwrapped `React.memo(...)` from both `RowCells` and `SortableRow` (reverting to plain function components). Result: both tests failed — all 3 rows re-rendered (33 `renderShotCell` calls across ids `a`/`b`/`c` instead of just the toggled row's ~11). Reverted the mutation; suite back to 2/2 green.

## Gates (this branch)

- `CI=1 npx vitest --run` on the new test file — 2/2 green
- `npm run typecheck:baseline` — ✅ no new type errors (161/161 baselined)
- `npx eslint --max-warnings=0` on changed files — clean
- `npm run build` — succeeds

## Deviations

- `GroupRows` (grouped-view rendering) required a matching `onToggleShot` prop-wiring update since it shares `RowCellsProps` with the primary row path — it is NOT memoized itself (out of scope; grouped-view row unification is Phase 2 per the build plan) and its behavior is unchanged, just re-wired to the renamed prop.
- Added a `stableVisibleColumns` local memo (see above) to make the row comparator actually effective — this wasn't explicitly called out in the plan's 0.3 description but was necessary for the mutation-verified test to pass; without it, `visibleColumns`'s per-render fresh-array identity defeated memoization for every row, every render. Confined to `ShotsTable.tsx`; `useTableColumns.ts` itself is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)