### PR TITLE
fix(a11y): th scope=col on table headers

### DIFF
--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -577,9 +577,9 @@ export function ShotsTable({
 
             <thead className="border-b border-[var(--color-border)] bg-[var(--color-surface-subtle)] text-[var(--color-text-subtle)]">
               <tr>
-                {showDragColumn && <th className="w-9" />}
+                {showDragColumn && <th scope="col" className="w-9" />}
                 {selectionEnabled && (
-                  <th className="w-10 px-3 py-2 text-left">
+                  <th scope="col" className="w-10 px-3 py-2 text-left">
                     <Checkbox
                       checked={allSelected ? true : someSelected ? "indeterminate" : false}
                       onCheckedChange={(v) => {
@@ -612,9 +612,9 @@ export function ShotsTable({
                   </ResizableHeader>
                 ))}
                 {showLifecycleActions && (
-                  <th className="w-16 px-3 py-2 text-left font-medium">Actions</th>
+                  <th scope="col" className="w-16 px-3 py-2 text-left font-medium">Actions</th>
                 )}
-                <th className="w-28 px-3 py-2 text-left font-medium">Status</th>
+                <th scope="col" className="w-28 px-3 py-2 text-left font-medium">Status</th>
               </tr>
             </thead>
 

--- a/src-vnext/features/shots/components/__tests__/ShotsTable.thScope.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotsTable.thScope.test.tsx
@@ -1,0 +1,42 @@
+/// <reference types="@testing-library/jest-dom" />
+// 0.5 — th scope="col" (Phase 0 build plan, G4 A4).
+//
+// Every <th> in ShotsTable's <thead> — the resizable column headers (via the
+// shared ResizableHeader) and the static headers (drag handle, selection,
+// lifecycle actions, status) — must carry scope="col" for screen-reader table
+// navigation. Renders with an empty shots array so the <tbody> never mounts a
+// row (no ShotStatusSelect / AuthProvider dependency needed to exercise the
+// header row this fix touches).
+import { describe, it, expect } from "vitest"
+import { render } from "@testing-library/react"
+import { ShotsTable } from "../ShotsTable"
+
+describe("ShotsTable th scope=col", () => {
+  it("every rendered <th> (resizable columns + static headers) has scope=\"col\"", () => {
+    const { container } = render(
+      <ShotsTable
+        clientId="c1"
+        projectId="p1"
+        shots={[]}
+        onOpenShot={() => {}}
+        reorderEnabled
+        showLifecycleActions
+        selection={{
+          enabled: true,
+          selectedIds: new Set(),
+          onToggle: () => {},
+          onToggleAll: () => {},
+        }}
+      />,
+    )
+
+    const allHeaders = container.querySelectorAll("thead th")
+    const scopedHeaders = container.querySelectorAll("thead th[scope='col']")
+
+    // Sanity: this fixture actually exercises every static header branch —
+    // drag column (reorderEnabled) + selection + N visible columns +
+    // lifecycle actions + the always-on status column.
+    expect(allHeaders.length).toBeGreaterThanOrEqual(5)
+    expect(scopedHeaders.length).toBe(allHeaders.length)
+  })
+})

--- a/src-vnext/shared/components/ResizableHeader.tsx
+++ b/src-vnext/shared/components/ResizableHeader.tsx
@@ -22,6 +22,7 @@ export function ResizableHeader({
 }: ResizableHeaderProps) {
   return (
     <th
+      scope="col"
       style={{ width: `${width}px` }}
       className={cn("relative", className)}
     >


### PR DESCRIPTION
## What / why

Plan item 0.5 (Shots Premium Surface build plan, Phase 0). Adds `scope="col"` to every `<th>` ShotsTable renders:

- The shared `ResizableHeader.tsx` component (`<th>` at what is now line 25) — used for every resizable column header.
- The four static headers in `ShotsTable.tsx`: the drag-handle column, the selection checkbox column, the lifecycle-actions column, and the status column.

This lets screen readers correctly associate each header cell with its column when navigating the table.

**Note on cited line numbers:** the build plan cites `ShotsTable.tsx:580,582,615,617` for the static headers — verified by symbol in this checkout and all four line numbers matched exactly (zero drift). The `ResizableHeader.tsx:24` citation for the `<th>` also matched exactly.

## Blast radius / plan drift found

`ResizableHeader` is documented in the build plan as shared by **4** tables ("shots, products, library ×2 (NOT CallSheetCast)"). Verifying by grep in this checkout, that claim is **stale**: `CallSheetCastTable.tsx` also imports and renders `ResizableHeader` directly (2 usages, `<ResizableHeader>...</ResizableHeader>` around line 130). So the real blast radius for `ResizableHeader` is **5 tables**, not 4. Flagging this drift explicitly per the build plan's own instruction to verify every cited claim by symbol.

Ran the sibling test files (now including `CallSheetCastTable.test.tsx`) as the blast-radius gate:

- `src-vnext/features/schedules/components/CallSheetCastTable.test.tsx` — 8 tests, green
- `src-vnext/features/library/components/__tests__/TalentTable.test.tsx` — 10 tests, green
- `src-vnext/features/library/components/__tests__/LocationsTable.test.tsx` — 8 tests, green
- **`ProductFamiliesTable` has no test file** (confirmed via `find` — none exists in the repo). Not exercised by an automated gate; the change is additive-only (`scope="col"` never removes/alters existing markup or behavior), so no functional risk, but flagging per protocol.

## Test + mutation evidence

New file: `src-vnext/features/shots/components/__tests__/ShotsTable.thScope.test.tsx` (1 test). Renders `ShotsTable` with `shots={[]}` (so the `<tbody>` never mounts a row — no `ShotStatusSelect`/`AuthProvider` dependency needed to exercise the header row this fix touches) plus `reorderEnabled`, `showLifecycleActions`, and `selection` enabled to maximize the header count (drag column + selection + 11 default-visible columns + lifecycle actions + status = 15 `<th>` total). Asserts `thead th[scope='col']` count equals total `thead th` count.

**Mutation:** stripped `scope="col"` from both `ResizableHeader.tsx` and the four static `<th>`s in `ShotsTable.tsx`. Result: test failed — `expected +0 to be 15` (zero scoped headers found against 15 total). Reverted the mutation; test back to green.

## Gates (this branch)

- `CI=1 npx vitest --run` on the new test file + corrected blast-radius set — all green (see above)
- `npm run typecheck:baseline` — ✅ no new type errors (161/161 baselined)
- `npx eslint --max-warnings=0` on changed files — clean
- `npm run build` — succeeds

## Deviations

None to the fix itself. Documented the `ResizableHeader` blast-radius drift (4 → 5 tables) above rather than silently expanding scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)