### PR TITLE
feat(shots): bulk copy/move shots to another project + duplicate project

### DIFF
--- a/src-vnext/features/projects/components/DuplicateProjectDialog.tsx
+++ b/src-vnext/features/projects/components/DuplicateProjectDialog.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react"
+import { useNavigate } from "react-router-dom"
+import { collection, getCountFromServer, query, where } from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { useAuth } from "@/app/providers/AuthProvider"
+import { lanesPath, shotsPath } from "@/shared/lib/paths"
+import { duplicateProject, DuplicateProjectPartialFailureError } from "@/features/projects/lib/duplicateProject"
+import type { Project } from "@/shared/types"
+import { toast } from "sonner"
+import { ResponsiveDialog } from "@/shared/components/ResponsiveDialog"
+import { Button } from "@/ui/button"
+import { Input } from "@/ui/input"
+import { Label } from "@/ui/label"
+
+interface DuplicateProjectDialogProps {
+  readonly project: Project
+  readonly open: boolean
+  readonly onOpenChange: (open: boolean) => void
+}
+
+interface SourceCounts {
+  readonly laneCount: number
+  readonly shotCount: number
+}
+
+async function loadSourceCounts(clientId: string, projectId: string): Promise<SourceCounts> {
+  const lanesSegs = lanesPath(projectId, clientId)
+  const shotsSegs = shotsPath(clientId)
+
+  const [lanesSnap, shotsSnap] = await Promise.all([
+    getCountFromServer(collection(db, lanesSegs[0]!, ...lanesSegs.slice(1))),
+    getCountFromServer(
+      query(
+        collection(db, shotsSegs[0]!, ...shotsSegs.slice(1)),
+        where("projectId", "==", projectId),
+        where("deleted", "==", false),
+      ),
+    ),
+  ])
+
+  return { laneCount: lanesSnap.data().count, shotCount: shotsSnap.data().count }
+}
+
+export function DuplicateProjectDialog({ project, open, onOpenChange }: DuplicateProjectDialogProps) {
+  const { clientId, role, user } = useAuth()
+  const navigate = useNavigate()
+
+  const [name, setName] = useState(`${project.name} (Copy)`)
+  const [counts, setCounts] = useState<SourceCounts | null>(null)
+  const [countsLoading, setCountsLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!open) return
+    setName(`${project.name} (Copy)`)
+    setError(null)
+    if (!clientId) return
+    setCountsLoading(true)
+    setCounts(null)
+    loadSourceCounts(clientId, project.id)
+      .then(setCounts)
+      .catch((err) => {
+        console.error("[DuplicateProjectDialog] Failed to load source counts:", err)
+      })
+      .finally(() => setCountsLoading(false))
+  }, [open, project.id, project.name, clientId])
+
+  const handleDuplicate = async () => {
+    const trimmedName = name.trim()
+    if (!trimmedName || !clientId || saving) return
+
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await duplicateProject({
+        clientId,
+        sourceProjectId: project.id,
+        newName: trimmedName,
+        role,
+        user,
+      })
+      toast.success("Project duplicated", {
+        description: `${result.shotCount} shot${result.shotCount === 1 ? "" : "s"} across ${result.laneCount} set${result.laneCount === 1 ? "" : "s"}.`,
+      })
+      onOpenChange(false)
+      navigate(`/projects/${result.newProjectId}/shots`)
+    } catch (err) {
+      if (err instanceof DuplicateProjectPartialFailureError) {
+        setError(err.message)
+        toast.error("Project duplicated partially", { description: err.message })
+      } else {
+        const message = err instanceof Error ? err.message : "Failed to duplicate project"
+        setError(message)
+        toast.error("Failed to duplicate project", { description: message })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const countsLabel = countsLoading
+    ? "Counting sets and shots…"
+    : counts
+      ? `${counts.laneCount} set${counts.laneCount === 1 ? "" : "s"}, ${counts.shotCount} shot${counts.shotCount === 1 ? "" : "s"} will be copied.`
+      : null
+
+  return (
+    <ResponsiveDialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!saving) onOpenChange(next)
+      }}
+      title="Duplicate project"
+      description={`Create a copy of "${project.name}" with all its sets and shots.`}
+      footer={
+        <>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={() => void handleDuplicate()} disabled={!name.trim() || saving}>
+            {saving ? "Duplicating…" : "Duplicate"}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4 py-4">
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="duplicate-project-name">New project name</Label>
+          <Input
+            id="duplicate-project-name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            disabled={saving}
+          />
+        </div>
+
+        {countsLabel && (
+          <p className="text-xs text-[var(--color-text-muted)]">{countsLabel}</p>
+        )}
+
+        <p className="text-xs text-[var(--color-text-subtle)]">
+          Status, dates, shot numbers, and order are preserved exactly. Pulls, schedules, and
+          casting are not copied.
+        </p>
+
+        {error && (
+          <p className="text-xs text-[var(--color-error)]" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
+    </ResponsiveDialog>
+  )
+}

--- a/src-vnext/features/projects/components/ProjectActionsMenu.tsx
+++ b/src-vnext/features/projects/components/ProjectActionsMenu.tsx
@@ -13,6 +13,7 @@ import {
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
 import { ConfirmDialog } from "@/shared/components/ConfirmDialog"
+import { DuplicateProjectDialog } from "@/features/projects/components/DuplicateProjectDialog"
 import { MoreHorizontal } from "lucide-react"
 
 interface ProjectActionsMenuProps {
@@ -34,6 +35,7 @@ export function ProjectActionsMenu({ project, onEdit, onActionInteraction }: Pro
   const [busy, setBusy] = useState(false)
   const [confirmArchiveOpen, setConfirmArchiveOpen] = useState(false)
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
+  const [duplicateOpen, setDuplicateOpen] = useState(false)
 
   const status = project.status ?? "active"
   const markActionInteraction = () => onActionInteraction?.()
@@ -155,6 +157,16 @@ export function ProjectActionsMenu({ project, onEdit, onActionInteraction }: Pro
           >
             Edit details…
           </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.stopPropagation()
+              markActionInteraction()
+              setDuplicateOpen(true)
+            }}
+            disabled={busy}
+          >
+            Duplicate project…
+          </DropdownMenuItem>
           <DropdownMenuSeparator />
           <DropdownMenuItem
             onSelect={(e) => {
@@ -223,6 +235,15 @@ export function ProjectActionsMenu({ project, onEdit, onActionInteraction }: Pro
         onConfirm={() => {
           markActionInteraction()
           void deleteProject()
+        }}
+      />
+
+      <DuplicateProjectDialog
+        project={project}
+        open={duplicateOpen}
+        onOpenChange={(next) => {
+          setDuplicateOpen(next)
+          markActionInteraction()
         }}
       />
     </>

--- a/src-vnext/features/projects/components/__tests__/DuplicateProjectDialog.test.tsx
+++ b/src-vnext/features/projects/components/__tests__/DuplicateProjectDialog.test.tsx
@@ -1,6 +1,6 @@
 /// <reference types="@testing-library/jest-dom" />
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, act } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import { Timestamp } from "firebase/firestore"
 import type { Project } from "@/shared/types"
@@ -130,6 +130,39 @@ describe("DuplicateProjectDialog", () => {
     })
     expect(mockNavigate).not.toHaveBeenCalled()
     expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it("guards against double-submit: re-entering handleDuplicate while a submit is in flight calls duplicateProject once", async () => {
+    let resolveDuplicate!: (val: unknown) => void
+    mockDuplicateProject.mockReturnValue(new Promise((r) => { resolveDuplicate = r }))
+    renderDialog(makeProject({ id: "src-1", name: "Q4 Shoot" }))
+
+    const button = screen.getByRole("button", { name: "Duplicate" })
+    // A second `fireEvent.click`/`.click()` on the SAME button cannot
+    // falsify the internal `saving` check: React reads `disabled` off the
+    // fiber's own memoized props at event-dispatch time (not the live DOM
+    // attribute), and setSaving(true) commits synchronously on discrete
+    // click events — so a disabled button never re-dispatches to the
+    // handler at all, guard or no guard (verified empirically). To test
+    // the guard actually WRITTEN in handleDuplicate, invoke its onClick
+    // prop directly a second time — exactly the scenario the internal
+    // check defends: a re-entrant call while a submit is already in
+    // flight, bypassing the disabled button entirely.
+    const getOnClick = (): (() => void) => {
+      const propsKey = Object.keys(button).find((k) => k.startsWith("__reactProps$"))!
+      return (button as unknown as Record<string, { onClick: () => void }>)[propsKey]!.onClick
+    }
+
+    act(() => getOnClick()())
+    await waitFor(() => expect(mockDuplicateProject).toHaveBeenCalledTimes(1))
+
+    // Re-query onClick: the closure now reflects the COMMITTED saving=true
+    // from the first call.
+    act(() => getOnClick()())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(mockDuplicateProject).toHaveBeenCalledTimes(1)
+    resolveDuplicate({ newProjectId: "new-p1", laneCount: 0, shotCount: 0 })
   })
 
   it("disables Duplicate when the name is blank", async () => {

--- a/src-vnext/features/projects/components/__tests__/DuplicateProjectDialog.test.tsx
+++ b/src-vnext/features/projects/components/__tests__/DuplicateProjectDialog.test.tsx
@@ -1,0 +1,145 @@
+/// <reference types="@testing-library/jest-dom" />
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { render, screen, waitFor } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import { Timestamp } from "firebase/firestore"
+import type { Project } from "@/shared/types"
+
+const mockGetCountFromServer = vi.fn()
+const mockNavigate = vi.fn()
+
+vi.mock("firebase/firestore", async () => {
+  const actual = await vi.importActual<typeof import("firebase/firestore")>("firebase/firestore")
+  return {
+    ...actual,
+    collection: vi.fn((...args: unknown[]) => ({ __col: args.join("/") })),
+    query: vi.fn((...args: unknown[]) => ({ __query: args })),
+    where: vi.fn((field: string, op: string, value: unknown) => ({ field, op, value })),
+    getCountFromServer: (...args: unknown[]) => mockGetCountFromServer(...args),
+  }
+})
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom")
+  return { ...actual, useNavigate: () => mockNavigate }
+})
+
+let mockAuth = { clientId: "c1", role: "producer" as const, user: { uid: "u1", email: null, displayName: null, photoURL: null } }
+vi.mock("@/app/providers/AuthProvider", () => ({
+  useAuth: () => mockAuth,
+}))
+
+const mockDuplicateProject = vi.fn()
+vi.mock("@/features/projects/lib/duplicateProject", async () => {
+  const actual = await vi.importActual<typeof import("@/features/projects/lib/duplicateProject")>(
+    "@/features/projects/lib/duplicateProject",
+  )
+  return {
+    ...actual,
+    duplicateProject: (...args: unknown[]) => mockDuplicateProject(...args),
+  }
+})
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { DuplicateProjectDialog } from "@/features/projects/components/DuplicateProjectDialog"
+import { DuplicateProjectPartialFailureError } from "@/features/projects/lib/duplicateProject"
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "p1",
+    name: overrides.name ?? "Q4 Shoot",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "active",
+    shootDates: overrides.shootDates ?? [],
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  }
+}
+
+describe("DuplicateProjectDialog", () => {
+  const onOpenChange = vi.fn()
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockAuth = { clientId: "c1", role: "producer", user: { uid: "u1", email: null, displayName: null, photoURL: null } }
+    mockGetCountFromServer.mockResolvedValue({ data: () => ({ count: 3 }) })
+  })
+
+  function renderDialog(project: Project = makeProject()) {
+    return render(
+      <MemoryRouter>
+        <DuplicateProjectDialog project={project} open={true} onOpenChange={onOpenChange} />
+      </MemoryRouter>,
+    )
+  }
+
+  it("prefills the name as «{name} (Copy)»", () => {
+    renderDialog(makeProject({ name: "Q4 Shoot" }))
+    expect(screen.getByLabelText("New project name")).toHaveValue("Q4 Shoot (Copy)")
+  })
+
+  it("shows source counts once loaded", async () => {
+    renderDialog()
+    await waitFor(() => {
+      expect(screen.getByText(/3 sets, 3 shots will be copied\./)).toBeInTheDocument()
+    })
+  })
+
+  it("calls duplicateProject with the trimmed name and navigates to the new project on success", async () => {
+    mockDuplicateProject.mockResolvedValue({ newProjectId: "new-p1", laneCount: 2, shotCount: 5 })
+    renderDialog(makeProject({ id: "src-1", name: "Q4 Shoot" }))
+
+    screen.getByRole("button", { name: "Duplicate" }).click()
+
+    await waitFor(() => {
+      expect(mockDuplicateProject).toHaveBeenCalledWith(
+        expect.objectContaining({
+          clientId: "c1",
+          sourceProjectId: "src-1",
+          newName: "Q4 Shoot (Copy)",
+          role: "producer",
+        }),
+      )
+    })
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith("/projects/new-p1/shots")
+    })
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("surfaces a DuplicateProjectPartialFailureError message inline and does NOT navigate", async () => {
+    mockDuplicateProject.mockRejectedValue(
+      new DuplicateProjectPartialFailureError("Only 3 of 10 shots landed.", {
+        newProjectId: "partial-p1",
+        lanesWritten: 1,
+        shotsWritten: 3,
+      }),
+    )
+    renderDialog()
+
+    screen.getByRole("button", { name: "Duplicate" }).click()
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("Only 3 of 10 shots landed.")
+    })
+    expect(mockNavigate).not.toHaveBeenCalled()
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+  })
+
+  it("disables Duplicate when the name is blank", async () => {
+    renderDialog()
+    const input = screen.getByLabelText("New project name")
+    const button = screen.getByRole("button", { name: "Duplicate" }) as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+
+    const user = await import("@testing-library/user-event")
+    await user.default.clear(input)
+    expect((screen.getByRole("button", { name: "Duplicate" }) as HTMLButtonElement).disabled).toBe(true)
+  })
+})

--- a/src-vnext/features/projects/components/__tests__/ProjectActionsMenu.test.tsx
+++ b/src-vnext/features/projects/components/__tests__/ProjectActionsMenu.test.tsx
@@ -23,6 +23,14 @@ vi.mock("sonner", () => ({
   },
 }))
 
+// Stubbed — DuplicateProjectDialog has its own test file
+// (DuplicateProjectDialog.test.tsx) covering its Firestore/navigate
+// behavior. Here we only assert the menu wires it up correctly.
+vi.mock("@/features/projects/components/DuplicateProjectDialog", () => ({
+  DuplicateProjectDialog: ({ open }: { readonly open: boolean }) =>
+    open ? <div data-testid="duplicate-project-dialog-stub" /> : null,
+}))
+
 import { ProjectActionsMenu } from "@/features/projects/components/ProjectActionsMenu"
 
 function makeProject(overrides: Partial<Project> = {}): Project {
@@ -62,5 +70,28 @@ describe("ProjectActionsMenu", () => {
     render(<ProjectActionsMenu project={makeProject()} onEdit={() => undefined} />)
 
     expect(screen.queryByTitle("Project actions")).not.toBeInTheDocument()
+  })
+
+  it("shows 'Duplicate project…' for producer (same predicate that gates project creation UI)", async () => {
+    mockRole = "producer"
+    const user = userEvent.setup()
+
+    render(<ProjectActionsMenu project={makeProject()} onEdit={() => undefined} />)
+    await user.click(screen.getByTitle("Project actions"))
+
+    expect(screen.getByText("Duplicate project…")).toBeInTheDocument()
+  })
+
+  it("clicking 'Duplicate project…' opens DuplicateProjectDialog", async () => {
+    mockRole = "admin"
+    const user = userEvent.setup()
+
+    render(<ProjectActionsMenu project={makeProject()} onEdit={() => undefined} />)
+    expect(screen.queryByTestId("duplicate-project-dialog-stub")).not.toBeInTheDocument()
+
+    await user.click(screen.getByTitle("Project actions"))
+    await user.click(screen.getByText("Duplicate project…"))
+
+    expect(screen.getByTestId("duplicate-project-dialog-stub")).toBeInTheDocument()
   })
 })

--- a/src-vnext/features/projects/components/__tests__/ProjectActionsMenu.test.tsx
+++ b/src-vnext/features/projects/components/__tests__/ProjectActionsMenu.test.tsx
@@ -72,6 +72,14 @@ describe("ProjectActionsMenu", () => {
     expect(screen.queryByTitle("Project actions")).not.toBeInTheDocument()
   })
 
+  it("hides 'Duplicate project…' for a viewer role — explicit assertion, not just the menu's early-return", () => {
+    mockRole = "viewer"
+
+    render(<ProjectActionsMenu project={makeProject()} onEdit={() => undefined} />)
+
+    expect(screen.queryByText("Duplicate project…")).not.toBeInTheDocument()
+  })
+
   it("shows 'Duplicate project…' for producer (same predicate that gates project creation UI)", async () => {
     mockRole = "producer"
     const user = userEvent.setup()

--- a/src-vnext/features/projects/lib/duplicateProject.test.ts
+++ b/src-vnext/features/projects/lib/duplicateProject.test.ts
@@ -73,9 +73,33 @@ describe("duplicateProject", () => {
     vi.mocked(firestore.getDoc).mockResolvedValue(
       fakeDocSnap("src-p1", params.project) as unknown as Awaited<ReturnType<typeof firestore.getDoc>>,
     )
-    vi.mocked(firestore.getDocs)
-      .mockResolvedValueOnce(fakeQuerySnap(params.lanes) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>)
-      .mockResolvedValueOnce(fakeQuerySnap(params.shots) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>)
+    // getDocs is dispatched by SHAPE, not call order, so it stays a faithful
+    // stand-in for real Firestore filtering regardless of which query fires
+    // when: `readSourceLanes` calls getDocs(collection(...)) directly (no
+    // query() wrapper -> `__col`); `readSourceShots` calls
+    // getDocs(query(collection(...), ...whereClauses)) (-> `__query`). For
+    // the shots branch, APPLY the recorded where() clauses against each
+    // doc's raw data the same way Firestore's `==` operator would — in
+    // particular, `where("deleted","==",false)` EXCLUDES a doc where the
+    // field is simply absent, not just docs where it's `true`. This is what
+    // makes the predicate-parity tests below meaningful: they fail on the
+    // unfixed code (which sends no `deleted` where-clause at all) and pass
+    // once the query matches useShots.ts's predicate.
+    vi.mocked(firestore.getDocs).mockImplementation(async (target: unknown) => {
+      const t = target as { __col?: string; __query?: readonly unknown[] }
+      if (t.__query) {
+        const whereClauses = t.__query.slice(1) as ReadonlyArray<{
+          readonly field: string
+          readonly op: string
+          readonly value: unknown
+        }>
+        const filtered = params.shots.filter((shot) =>
+          whereClauses.every((w) => (w.op === "==" ? shot.data[w.field] === w.value : true)),
+        )
+        return fakeQuerySnap(filtered) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>
+      }
+      return fakeQuerySnap(params.lanes) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>
+    })
   }
 
   it("source project not found throws a plain Error and writes nothing", async () => {
@@ -174,7 +198,7 @@ describe("duplicateProject", () => {
     expect(payload["title"]).toBe("Hero") // unchanged, no "(Copy)" suffix
   })
 
-  it("query semantics: a legacy shot with NO `deleted` field is still cloned (mutation: add ==false filter -> reddens)", async () => {
+  it("PARITY WITH useShots: a legacy shot with NO `deleted` field is NOT cloned (mutation: drop the ==false where clause -> reddens)", async () => {
     mockReads({
       project: { name: "P", status: "active", shootDates: [] },
       lanes: [],
@@ -182,16 +206,36 @@ describe("duplicateProject", () => {
         {
           id: "legacy-shot",
           data: { title: "Legacy", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1 },
-          // deliberately no `deleted` key at all
+          // deliberately no `deleted` key at all — invisible on useShots.ts
+          // and this dialog's own preview count today; must stay invisible
+          // when duplicating too ("duplicate copies exactly what the shots
+          // list shows" — see readSourceShots's doc).
         },
       ],
     })
     const result = await duplicateProject({
       clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER,
     })
-    expect(result.shotCount).toBe(1)
-    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
-    expect(payload["title"]).toBe("Legacy")
+    expect(result.shotCount).toBe(0)
+    expect(mockBatchSet).toHaveBeenCalledTimes(1) // project doc only — no shot, no lane
+
+    // Belt-and-suspenders: the query sent to Firestore matches useShots.ts's
+    // predicate verbatim, independent of the mock's own filtering.
+    const shotsQueryCall = vi.mocked(firestore.query).mock.calls.find((call) =>
+      (call as unknown[]).some((arg) => (arg as { field?: string })?.field === "deleted"),
+    )
+    expect(shotsQueryCall).toBeDefined()
+    const whereClauses = (shotsQueryCall as unknown[]).slice(1) as Array<{
+      field: string
+      op: string
+      value: unknown
+    }>
+    expect(whereClauses).toEqual(
+      expect.arrayContaining([
+        { field: "projectId", op: "==", value: "src-p1" },
+        { field: "deleted", op: "==", value: false },
+      ]),
+    )
   })
 
   it("skips a genuinely soft-deleted shot (deleted === true)", async () => {
@@ -209,6 +253,58 @@ describe("duplicateProject", () => {
     expect(result.shotCount).toBe(1)
     const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
     expect(payload["title"]).toBe("Kept")
+  })
+
+  it("heroImage passthrough: raw doc with NO stored heroImage (but a derivable look-image) clones with NO heroImage field, so the clone re-derives (mutation: use shot.heroImage instead of the raw override -> reddens)", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        {
+          id: "shot-1",
+          data: {
+            title: "Auto Cover", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1,
+            deleted: false,
+            activeLookId: "look-1",
+            looks: [
+              { id: "look-1", products: [{ familyId: "fam-1", skuImageUrl: "https://img/of/product.jpg" }] },
+            ],
+            // deliberately NO top-level `heroImage` field — mapShot DERIVES
+            // one from the look above, but the RAW doc has none stored.
+          },
+        },
+      ],
+    })
+    await duplicateProject({
+      clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER,
+    })
+    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(payload).not.toHaveProperty("heroImage")
+  })
+
+  it("heroImage passthrough: raw doc WITH a stored heroImage clones it verbatim", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        {
+          id: "shot-1",
+          data: {
+            title: "Fixed Cover", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1,
+            deleted: false,
+            heroImage: { path: "clients/c1/shots/shot-1/hero.jpg", downloadURL: "https://cdn/shots/shot-1/hero.jpg" },
+          },
+        },
+      ],
+    })
+    await duplicateProject({
+      clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER,
+    })
+    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(payload["heroImage"]).toEqual({
+      path: "clients/c1/shots/shot-1/hero.jpg",
+      downloadURL: "https://cdn/shots/shot-1/hero.jpg",
+    })
   })
 
   it("partial failure on the LANES step surfaces a DuplicateProjectPartialFailureError naming 0 shots copied", async () => {

--- a/src-vnext/features/projects/lib/duplicateProject.test.ts
+++ b/src-vnext/features/projects/lib/duplicateProject.test.ts
@@ -1,0 +1,249 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+// All Firestore mocked (getDoc/getDocs/writeBatch) — zero live writes.
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>()
+  return {
+    ...actual,
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    writeBatch: vi.fn(),
+    collection: vi.fn((...args: unknown[]) => ({ __col: args.join("/") })),
+    doc: vi.fn((...args: unknown[]) => {
+      if (args.length === 1) {
+        return { id: `new-${Math.random().toString(36).slice(2, 10)}` }
+      }
+      const segs = args.slice(1) as string[]
+      return { id: segs[segs.length - 1], path: segs.join("/") }
+    }),
+    query: vi.fn((...args: unknown[]) => ({ __query: args })),
+    where: vi.fn((field: string, op: string, value: unknown) => ({ field, op, value })),
+    serverTimestamp: vi.fn(() => ({ _methodName: "serverTimestamp" })),
+  }
+})
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
+import * as firestore from "firebase/firestore"
+import {
+  duplicateProject,
+  DuplicateProjectPartialFailureError,
+} from "@/features/projects/lib/duplicateProject"
+import type { AuthUser } from "@/shared/types"
+
+const USER: AuthUser = { uid: "u1", email: null, displayName: null, photoURL: null }
+
+function fakeDocSnap(id: string, data: Record<string, unknown> | undefined) {
+  return {
+    id,
+    exists: () => data !== undefined,
+    data: () => data,
+  }
+}
+
+function fakeQuerySnap(docs: ReadonlyArray<{ id: string; data: Record<string, unknown> }>) {
+  return { docs: docs.map((d) => fakeDocSnap(d.id, d.data)) }
+}
+
+describe("duplicateProject", () => {
+  let mockBatchSet: ReturnType<typeof vi.fn>
+  let mockBatchCommit: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    // resetAllMocks (not clearAllMocks): getDoc/getDocs are re-armed per test
+    // via mockResolvedValueOnce chains in mockReads() — clearAllMocks only
+    // clears call history, leaving unconsumed "once" queues from a PRIOR
+    // test to leak into the next one and serve stale data.
+    vi.resetAllMocks()
+    mockBatchSet = vi.fn()
+    mockBatchCommit = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(firestore.writeBatch).mockReturnValue({
+      set: mockBatchSet,
+      update: vi.fn(),
+      delete: vi.fn(),
+      commit: mockBatchCommit,
+    } as unknown as ReturnType<typeof firestore.writeBatch>)
+  })
+
+  function mockReads(params: {
+    readonly project: Record<string, unknown> | undefined
+    readonly lanes: ReadonlyArray<{ id: string; data: Record<string, unknown> }>
+    readonly shots: ReadonlyArray<{ id: string; data: Record<string, unknown> }>
+  }) {
+    vi.mocked(firestore.getDoc).mockResolvedValue(
+      fakeDocSnap("src-p1", params.project) as unknown as Awaited<ReturnType<typeof firestore.getDoc>>,
+    )
+    vi.mocked(firestore.getDocs)
+      .mockResolvedValueOnce(fakeQuerySnap(params.lanes) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>)
+      .mockResolvedValueOnce(fakeQuerySnap(params.shots) as unknown as Awaited<ReturnType<typeof firestore.getDocs>>)
+  }
+
+  it("source project not found throws a plain Error and writes nothing", async () => {
+    mockReads({ project: undefined, lanes: [], shots: [] })
+    await expect(
+      duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "Copy", role: "producer", user: USER }),
+    ).rejects.toThrow("Source project not found.")
+    expect(mockBatchCommit).not.toHaveBeenCalled()
+  })
+
+  it("duplicating an ARCHIVED project creates the new project as active (mutation: force source status -> reddens)", async () => {
+    mockReads({
+      project: { name: "Old Job", status: "archived", visibility: "team", shootDates: ["2026-01-01"] },
+      lanes: [],
+      shots: [],
+    })
+    await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "Old Job (Copy)", role: "producer", user: USER })
+
+    const projectPayload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+    expect(projectPayload["status"]).toBe("active")
+    expect(projectPayload["name"]).toBe("Old Job (Copy)")
+    expect(projectPayload["visibility"]).toBe("team")
+    expect(projectPayload["shootDates"]).toEqual(["2026-01-01"])
+  })
+
+  it("auto-membership: non-admin creator gets a producer membership doc", async () => {
+    mockReads({ project: { name: "P", status: "active", shootDates: [] }, lanes: [], shots: [] })
+    await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "crew", user: USER })
+    // Project batch: [0] = project doc, [1] = membership doc (crew is non-admin).
+    expect(mockBatchSet).toHaveBeenCalledTimes(2)
+    const membershipPayload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(membershipPayload["role"]).toBe("producer")
+  })
+
+  it("auto-membership: admin creator does NOT get a membership doc", async () => {
+    mockReads({ project: { name: "P", status: "active", shootDates: [] }, lanes: [], shots: [] })
+    await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER })
+    expect(mockBatchSet).toHaveBeenCalledTimes(1) // project doc only
+  })
+
+  it("clones lanes with new ids and remaps shot laneId through the map; missing lane -> null", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [{ id: "lane-A", data: { name: "Scene A", projectId: "src-p1", clientId: "c1", sortOrder: 0 } }],
+      shots: [
+        {
+          id: "shot-1",
+          data: {
+            title: "In Lane", projectId: "src-p1", clientId: "c1", status: "todo",
+            laneId: "lane-A", sortOrder: 5, deleted: false,
+          },
+        },
+        {
+          id: "shot-2",
+          data: {
+            title: "Orphan Lane", projectId: "src-p1", clientId: "c1", status: "todo",
+            laneId: "lane-MISSING", sortOrder: 6, deleted: false,
+          },
+        },
+      ],
+    })
+
+    await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER })
+
+    // set() calls: [0] project, [1] lane, [2] shot-1, [3] shot-2 (admin -> no membership doc).
+    const lanePayload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    const newLaneRefId = (mockBatchSet.mock.calls[1]![0] as { id: string }).id
+    expect(lanePayload["name"]).toBe("Scene A")
+
+    const shot1Payload = mockBatchSet.mock.calls[2]![1] as Record<string, unknown>
+    expect(shot1Payload["laneId"]).toBe(newLaneRefId)
+
+    const shot2Payload = mockBatchSet.mock.calls[3]![1] as Record<string, unknown>
+    expect(shot2Payload["laneId"]).toBeNull()
+  })
+
+  it("TRUE CLONE: preserves status, date, shotNumber, sortOrder exactly", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        {
+          id: "shot-1",
+          data: {
+            title: "Hero", projectId: "src-p1", clientId: "c1", status: "complete",
+            shotNumber: "14A", sortOrder: 42, date: { seconds: 1000, nanoseconds: 0 }, deleted: false,
+          },
+        },
+      ],
+    })
+    await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER })
+    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown> // [0]=project, [1]=shot (no lanes)
+    expect(payload["status"]).toBe("complete")
+    expect(payload["shotNumber"]).toBe("14A")
+    expect(payload["sortOrder"]).toBe(42)
+    expect(payload["title"]).toBe("Hero") // unchanged, no "(Copy)" suffix
+  })
+
+  it("query semantics: a legacy shot with NO `deleted` field is still cloned (mutation: add ==false filter -> reddens)", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        {
+          id: "legacy-shot",
+          data: { title: "Legacy", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1 },
+          // deliberately no `deleted` key at all
+        },
+      ],
+    })
+    const result = await duplicateProject({
+      clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER,
+    })
+    expect(result.shotCount).toBe(1)
+    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(payload["title"]).toBe("Legacy")
+  })
+
+  it("skips a genuinely soft-deleted shot (deleted === true)", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        { id: "gone", data: { title: "Deleted", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1, deleted: true } },
+        { id: "kept", data: { title: "Kept", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 2, deleted: false } },
+      ],
+    })
+    const result = await duplicateProject({
+      clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER,
+    })
+    expect(result.shotCount).toBe(1)
+    const payload = mockBatchSet.mock.calls[1]![1] as Record<string, unknown>
+    expect(payload["title"]).toBe("Kept")
+  })
+
+  it("partial failure on the LANES step surfaces a DuplicateProjectPartialFailureError naming 0 shots copied", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [{ id: "lane-A", data: { name: "A", projectId: "src-p1", clientId: "c1", sortOrder: 0 } }],
+      shots: [],
+    })
+    // First commit (project batch) succeeds; second commit (lane batch) fails.
+    mockBatchCommit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("network down"))
+
+    await expect(
+      duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER }),
+    ).rejects.toBeInstanceOf(DuplicateProjectPartialFailureError)
+  })
+
+  it("partial failure on the SHOTS step names how many shots landed before it failed", async () => {
+    mockReads({
+      project: { name: "P", status: "active", shootDates: [] },
+      lanes: [],
+      shots: [
+        { id: "s1", data: { title: "A", projectId: "src-p1", clientId: "c1", status: "todo", sortOrder: 1, deleted: false } },
+      ],
+    })
+    // project batch commit ok, shots batch commit fails.
+    mockBatchCommit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("write failed"))
+
+    try {
+      await duplicateProject({ clientId: "c1", sourceProjectId: "src-p1", newName: "P (Copy)", role: "admin", user: USER })
+      expect.unreachable("expected duplicateProject to throw")
+    } catch (err) {
+      expect(err).toBeInstanceOf(DuplicateProjectPartialFailureError)
+      const failure = err as DuplicateProjectPartialFailureError
+      expect(failure.shotsWritten).toBe(0)
+      expect(failure.newProjectId).toBeTruthy()
+    }
+  })
+})

--- a/src-vnext/features/projects/lib/duplicateProject.ts
+++ b/src-vnext/features/projects/lib/duplicateProject.ts
@@ -93,35 +93,85 @@ async function readSourceLanes(sourceProjectId: string, clientId: string): Promi
   return snap.docs.map((d) => mapLane(d.id, d.data()))
 }
 
+interface SourceShotEntry {
+  readonly shot: Shot
+  /**
+   * The RAW stored `heroImage` field straight off the Firestore doc, BEFORE
+   * `mapShot`'s derivation waterfall runs — `null` when the raw doc had
+   * none (whether or not one is derivable from looks/products). Passed to
+   * `buildShotClonePayload` via `heroImageOverride` in `cloneShots` instead
+   * of the mapped `shot.heroImage`, which is often MATERIALIZED (see that
+   * option's doc in shotLifecycleActions.ts).
+   */
+  readonly rawHeroImage: Shot["heroImage"] | null
+}
+
 /**
- * Fetch source shots by projectId. Deliberately NOT `where("deleted","==",
- * false)` — that Firestore operator excludes docs where the field is
- * ABSENT, not just docs where it's true, which would silently drop legacy
- * shots that predate the `deleted` field. Filtered client-side instead,
- * matching the codebase's OWN documented rule (CLAUDE.md: "Always filter
- * deleted products client-side ... never use where('deleted','==',false)
- * which excludes docs missing the field") and the precedent already used
- * by talentDependencies.ts / useLinkedShots.ts.
- *
- * NOTE — spec contradiction found and resolved: the build spec said to
- * "mirror the live shots-list query semantics exactly" and cited
- * useShots.ts as ground truth; useShots.ts DOES use
- * `where("deleted","==",false)` (verified today, not a recent regression —
- * that line dates to 2026-01-31). Mirroring it literally would fail the
- * spec's OWN required test ("legacy shot lacking `deleted` field -> still
- * cloned") and would contradict CLAUDE.md's documented rule. Resolved in
- * favor of the safe client-side filter, which is what both the test matrix
- * and CLAUDE.md require. Flagged in the PR body.
+ * Extract ONLY the "explicitly stored" branch of mapShot's
+ * `normalizeHeroImage` — no derivation from looks/products/attachments.
+ * Deliberately narrower than mapShot: this function answers "did the raw
+ * doc have a heroImage field," not "what would the shot's cover resolve
+ * to," which is exactly the distinction the clone payload needs to make.
  */
-async function readSourceShots(sourceProjectId: string, clientId: string): Promise<Shot[]> {
+function extractStoredHeroImage(data: Record<string, unknown>): Shot["heroImage"] | null {
+  const rawHero = data["heroImage"]
+  if (rawHero && typeof rawHero === "object") {
+    const obj = rawHero as Record<string, unknown>
+    const downloadURL = typeof obj["downloadURL"] === "string" && obj["downloadURL"] ? obj["downloadURL"] : undefined
+    const path = typeof obj["path"] === "string" && obj["path"] ? obj["path"] : undefined
+    const resolved = downloadURL ?? path
+    if (resolved) {
+      return { path: path ?? resolved, downloadURL: resolved }
+    }
+  }
+  return null
+}
+
+/**
+ * Fetch source shots by projectId, using the SAME predicate as the live
+ * shots list — `where("projectId","==",id), where("deleted","==",false)`,
+ * identical to `useShots.ts` and this project's own source-count query
+ * (`DuplicateProjectDialog.tsx`'s `loadSourceCounts`). Contract: **duplicate
+ * copies exactly what the shots list shows.** The composite index this
+ * query needs already exists (verified) — it's the same index `useShots.ts`
+ * uses.
+ *
+ * CORRECTION (2026-08-16, adversarial review): an earlier version of this
+ * function used a client-side `deleted !== true` filter instead (so a
+ * legacy doc lacking the `deleted` field would still be cloned), reasoning
+ * from CLAUDE.md's "always filter deleted products client-side, never
+ * `where('deleted','==',false)`" rule and the talentDependencies.ts /
+ * useLinkedShots.ts precedent. On review that argument does not hold for
+ * this call site:
+ * - CLAUDE.md's rule is scoped to deleted PRODUCTS inside bulk shot
+ *   CREATION (`bulkShotWrites.ts`) — a different collection and a
+ *   different failure mode (silently blocking a create) than this read.
+ * - talentDependencies.ts / useLinkedShots.ts are DEPENDENCY scans ("does
+ *   anything still reference this talent/location") where over-inclusion
+ *   is the SAFE direction — a false-positive dependency just blocks a
+ *   delete one extra time. Over-inclusion here is the OPPOSITE of safe: it
+ *   resurrects a shot that is invisible to every user everywhere in the
+ *   app today into a brand-new project, where it silently counts toward
+ *   totals, exports, and pulls.
+ * - Every shots-DISPLAY path in the app already uses
+ *   `where("deleted","==",false)`. A doc lacking `deleted` is invisible
+ *   app-wide today (the live list, this dialog's own preview counts); the
+ *   client-side variant would have made duplicate-project the ONE path
+ *   that resurrects it — the opposite of "what you see is what you copy."
+ */
+async function readSourceShots(sourceProjectId: string, clientId: string): Promise<ReadonlyArray<SourceShotEntry>> {
   const segs = shotsPath(clientId)
   const snap = await getDocs(
     query(
       collection(db, segs[0]!, ...segs.slice(1)),
       where("projectId", "==", sourceProjectId),
+      where("deleted", "==", false),
     ),
   )
-  return snap.docs.map((d) => mapShot(d.id, d.data())).filter((shot) => shot.deleted !== true)
+  return snap.docs.map((d) => {
+    const data = d.data()
+    return { shot: mapShot(d.id, data), rawHeroImage: extractStoredHeroImage(data) }
+  })
 }
 
 /** New project doc (+ auto-membership for non-admin creators, mirrors CreateProjectDialog.tsx's batch pattern). */
@@ -151,6 +201,14 @@ async function createNewProjectDoc(params: {
     updatedAt: serverTimestamp(),
   })
 
+  // NOTE: an admin duplicating a project they don't otherwise have explicit
+  // membership on gets NO auto-membership doc here (matches
+  // CreateProjectDialog.tsx's create-flow semantics exactly, byte-for-byte —
+  // see that file's own copy of this same batch pattern). So an admin
+  // duplicating a private project ends up as its admin+creator only: no
+  // membership row is written for them either, same as creating one fresh.
+  // This is a known, accepted consequence of mirroring create — not unique
+  // to duplication — and not something to "fix" here.
   if (!isAdmin(role) && user) {
     const memberSegs = projectMembersPath(ref.id, clientId)
     const memberRef = doc(db, memberSegs[0]!, ...memberSegs.slice(1), user.uid)
@@ -216,13 +274,21 @@ async function cloneLanes(params: {
  * `preserveShotNumber` + explicit `sortOrderOverride: shot.sortOrder` keep
  * status/date/number/order exactly; `laneIdOverride` remaps through
  * `laneIdMap` (null if the source lane is missing, e.g. it was itself
- * deleted). Returns how many shots landed before any failure — the caller
- * uses this to build a precise partial-failure error.
+ * deleted); `heroImageOverride: rawHeroImage` passes the RAW stored cover
+ * through (or `null` to omit, when the source had none) instead of
+ * `mapShot`'s often-materialized `shot.heroImage` — see that option's doc
+ * in shotLifecycleActions.ts. Returns how many shots landed before any
+ * failure — the caller uses this to build a precise partial-failure error.
+ *
+ * Version snapshots (createShotVersionSnapshot) are deliberately SKIPPED
+ * here, same as bulkCopyShotsToProject and for the same reason — one
+ * snapshot doc per shot at project-duplication scale is a write-volume cost
+ * nobody reads back immediately after duplicating a whole project.
  */
 async function cloneShots(params: {
   readonly clientId: string
   readonly newProjectId: string
-  readonly sourceShots: ReadonlyArray<Shot>
+  readonly sourceShots: ReadonlyArray<SourceShotEntry>
   readonly laneIdMap: ReadonlyMap<string, string>
   readonly user: AuthUser | null
   readonly shotsCollectionRef: CollectionReference
@@ -234,7 +300,7 @@ async function cloneShots(params: {
     for (let start = 0; start < sourceShots.length; start += BATCH_CHUNK_SIZE) {
       const chunk = sourceShots.slice(start, start + BATCH_CHUNK_SIZE)
       const batch = writeBatch(db)
-      for (const shot of chunk) {
+      for (const { shot, rawHeroImage } of chunk) {
         const newLaneId = shot.laneId ? laneIdMap.get(shot.laneId) ?? null : null
         const payload = buildShotClonePayload({
           shot,
@@ -247,6 +313,7 @@ async function cloneShots(params: {
             laneIdOverride: newLaneId,
             preserveShotNumber: true,
             sortOrderOverride: shot.sortOrder,
+            heroImageOverride: rawHeroImage,
           },
         })
         const ref = doc(shotsCollectionRef)

--- a/src-vnext/features/projects/lib/duplicateProject.ts
+++ b/src-vnext/features/projects/lib/duplicateProject.ts
@@ -1,0 +1,338 @@
+import {
+  collection,
+  doc,
+  getDoc,
+  getDocs,
+  query,
+  serverTimestamp,
+  where,
+  writeBatch,
+  type CollectionReference,
+} from "firebase/firestore"
+import { db } from "@/shared/lib/firebase"
+import { isAdmin } from "@/shared/lib/rbac"
+import {
+  lanesPath,
+  projectMembersPath,
+  projectPath,
+  projectsPath,
+  shotsPath,
+} from "@/shared/lib/paths"
+import { mapLane } from "@/features/shots/lib/mapLane"
+import { mapShot } from "@/features/shots/lib/mapShot"
+import { buildShotClonePayload } from "@/features/shots/lib/shotLifecycleActions"
+import type { AuthUser, Lane, Role, Shot } from "@/shared/types"
+
+/** Maximum documents per Firestore WriteBatch (limit is 500; 250 for safety, house convention). */
+const BATCH_CHUNK_SIZE = 250
+
+/**
+ * Thrown when a chunk of the (deliberately non-atomic) multi-batch write
+ * sequence fails partway through. Carries the new project id + how much
+ * landed, so the caller can surface a precise error and let the user
+ * soft-delete the partial project — this module never auto-retries.
+ */
+export class DuplicateProjectPartialFailureError extends Error {
+  readonly newProjectId: string
+  readonly lanesWritten: number
+  readonly shotsWritten: number
+
+  constructor(
+    message: string,
+    info: { readonly newProjectId: string; readonly lanesWritten: number; readonly shotsWritten: number },
+  ) {
+    super(message)
+    this.name = "DuplicateProjectPartialFailureError"
+    this.newProjectId = info.newProjectId
+    this.lanesWritten = info.lanesWritten
+    this.shotsWritten = info.shotsWritten
+  }
+}
+
+export interface DuplicateProjectResult {
+  readonly newProjectId: string
+  readonly laneCount: number
+  readonly shotCount: number
+}
+
+/** Internal — carries how many docs landed before a chunked-write step failed. */
+class ChunkedWriteError extends Error {
+  constructor(
+    readonly sourceErr: unknown,
+    readonly written: number,
+  ) {
+    super("Chunked write failed partway through.")
+  }
+}
+
+interface DuplicateProjectArgs {
+  readonly clientId: string
+  readonly sourceProjectId: string
+  readonly newName: string
+  /** Global role — governs whether an auto-membership doc is written (mirrors CreateProjectDialog). */
+  readonly role: Role
+  readonly user: AuthUser | null
+}
+
+async function readSourceProject(
+  sourceProjectId: string,
+  clientId: string,
+): Promise<Record<string, unknown>> {
+  const segs = projectPath(sourceProjectId, clientId)
+  const ref = doc(db, segs[0]!, ...segs.slice(1))
+  const snap = await getDoc(ref)
+  if (!snap.exists()) {
+    throw new Error("Source project not found.")
+  }
+  return snap.data() as Record<string, unknown>
+}
+
+async function readSourceLanes(sourceProjectId: string, clientId: string): Promise<Lane[]> {
+  const segs = lanesPath(sourceProjectId, clientId)
+  const snap = await getDocs(collection(db, segs[0]!, ...segs.slice(1)))
+  return snap.docs.map((d) => mapLane(d.id, d.data()))
+}
+
+/**
+ * Fetch source shots by projectId. Deliberately NOT `where("deleted","==",
+ * false)` — that Firestore operator excludes docs where the field is
+ * ABSENT, not just docs where it's true, which would silently drop legacy
+ * shots that predate the `deleted` field. Filtered client-side instead,
+ * matching the codebase's OWN documented rule (CLAUDE.md: "Always filter
+ * deleted products client-side ... never use where('deleted','==',false)
+ * which excludes docs missing the field") and the precedent already used
+ * by talentDependencies.ts / useLinkedShots.ts.
+ *
+ * NOTE — spec contradiction found and resolved: the build spec said to
+ * "mirror the live shots-list query semantics exactly" and cited
+ * useShots.ts as ground truth; useShots.ts DOES use
+ * `where("deleted","==",false)` (verified today, not a recent regression —
+ * that line dates to 2026-01-31). Mirroring it literally would fail the
+ * spec's OWN required test ("legacy shot lacking `deleted` field -> still
+ * cloned") and would contradict CLAUDE.md's documented rule. Resolved in
+ * favor of the safe client-side filter, which is what both the test matrix
+ * and CLAUDE.md require. Flagged in the PR body.
+ */
+async function readSourceShots(sourceProjectId: string, clientId: string): Promise<Shot[]> {
+  const segs = shotsPath(clientId)
+  const snap = await getDocs(
+    query(
+      collection(db, segs[0]!, ...segs.slice(1)),
+      where("projectId", "==", sourceProjectId),
+    ),
+  )
+  return snap.docs.map((d) => mapShot(d.id, d.data())).filter((shot) => shot.deleted !== true)
+}
+
+/** New project doc (+ auto-membership for non-admin creators, mirrors CreateProjectDialog.tsx's batch pattern). */
+async function createNewProjectDoc(params: {
+  readonly clientId: string
+  readonly newName: string
+  readonly sourceProject: Record<string, unknown>
+  readonly role: Role
+  readonly user: AuthUser | null
+}): Promise<{ readonly id: string }> {
+  const { clientId, newName, sourceProject, role, user } = params
+  const segs = projectsPath(clientId)
+  const ref = doc(collection(db, segs[0]!, ...segs.slice(1)))
+
+  const batch = writeBatch(db)
+  batch.set(ref, {
+    name: newName,
+    clientId,
+    // Always active — a duplicate of an archived project must be visible (Ted decision).
+    status: "active",
+    ...(sourceProject["visibility"] ? { visibility: sourceProject["visibility"] } : {}),
+    shootDates: Array.isArray(sourceProject["shootDates"]) ? sourceProject["shootDates"] : [],
+    ...(sourceProject["notes"] ? { notes: sourceProject["notes"] } : {}),
+    ...(sourceProject["briefUrl"] ? { briefUrl: sourceProject["briefUrl"] } : {}),
+    createdBy: user?.uid ?? null,
+    createdAt: serverTimestamp(),
+    updatedAt: serverTimestamp(),
+  })
+
+  if (!isAdmin(role) && user) {
+    const memberSegs = projectMembersPath(ref.id, clientId)
+    const memberRef = doc(db, memberSegs[0]!, ...memberSegs.slice(1), user.uid)
+    batch.set(memberRef, {
+      role: "producer",
+      addedAt: serverTimestamp(),
+      addedBy: user.uid,
+    })
+  }
+
+  await batch.commit()
+  return { id: ref.id }
+}
+
+/** Clone lanes into the new project, chunked. Returns the old->new id map the shots step needs. */
+async function cloneLanes(params: {
+  readonly clientId: string
+  readonly newProjectId: string
+  readonly sourceLanes: ReadonlyArray<Lane>
+  readonly user: AuthUser | null
+}): Promise<Map<string, string>> {
+  const { clientId, newProjectId, sourceLanes, user } = params
+  const segs = lanesPath(newProjectId, clientId)
+  const collectionRef = collection(db, segs[0]!, ...segs.slice(1))
+  const laneIdMap = new Map<string, string>()
+  let written = 0
+
+  try {
+    for (let start = 0; start < sourceLanes.length; start += BATCH_CHUNK_SIZE) {
+      const chunk = sourceLanes.slice(start, start + BATCH_CHUNK_SIZE)
+      const batch = writeBatch(db)
+      for (const lane of chunk) {
+        const newLaneRef = doc(collectionRef)
+        laneIdMap.set(lane.id, newLaneRef.id)
+        batch.set(newLaneRef, {
+          name: lane.name,
+          projectId: newProjectId,
+          clientId,
+          sortOrder: lane.sortOrder,
+          ...(lane.color ? { color: lane.color } : {}),
+          ...(lane.sceneNumber != null ? { sceneNumber: lane.sceneNumber } : {}),
+          ...(lane.direction ? { direction: lane.direction } : {}),
+          ...(lane.notes ? { notes: lane.notes } : {}),
+          ...(lane.locationId ? { locationId: lane.locationId } : {}),
+          ...(lane.locationName ? { locationName: lane.locationName } : {}),
+          createdBy: user?.uid ?? lane.createdBy ?? "",
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+      }
+      await batch.commit()
+      written += chunk.length
+    }
+  } catch (err) {
+    throw new ChunkedWriteError(err, written)
+  }
+
+  return laneIdMap
+}
+
+/**
+ * Clone shots into the new project (TRUE CLONE — Ted decision 2), chunked.
+ * `preserveShotNumber` + explicit `sortOrderOverride: shot.sortOrder` keep
+ * status/date/number/order exactly; `laneIdOverride` remaps through
+ * `laneIdMap` (null if the source lane is missing, e.g. it was itself
+ * deleted). Returns how many shots landed before any failure — the caller
+ * uses this to build a precise partial-failure error.
+ */
+async function cloneShots(params: {
+  readonly clientId: string
+  readonly newProjectId: string
+  readonly sourceShots: ReadonlyArray<Shot>
+  readonly laneIdMap: ReadonlyMap<string, string>
+  readonly user: AuthUser | null
+  readonly shotsCollectionRef: CollectionReference
+}): Promise<number> {
+  const { clientId, newProjectId, sourceShots, laneIdMap, user, shotsCollectionRef } = params
+  let written = 0
+
+  try {
+    for (let start = 0; start < sourceShots.length; start += BATCH_CHUNK_SIZE) {
+      const chunk = sourceShots.slice(start, start + BATCH_CHUNK_SIZE)
+      const batch = writeBatch(db)
+      for (const shot of chunk) {
+        const newLaneId = shot.laneId ? laneIdMap.get(shot.laneId) ?? null : null
+        const payload = buildShotClonePayload({
+          shot,
+          clientId,
+          targetProjectId: newProjectId,
+          title: shot.title,
+          createdByUid: user?.uid ?? null,
+          preserveLane: false,
+          options: {
+            laneIdOverride: newLaneId,
+            preserveShotNumber: true,
+            sortOrderOverride: shot.sortOrder,
+          },
+        })
+        const ref = doc(shotsCollectionRef)
+        batch.set(ref, {
+          ...payload,
+          createdAt: serverTimestamp(),
+          updatedAt: serverTimestamp(),
+        })
+      }
+      await batch.commit()
+      written += chunk.length
+    }
+  } catch (err) {
+    throw new ChunkedWriteError(err, written)
+  }
+
+  return written
+}
+
+/**
+ * Duplicate depth = structure + shots (Ted decision 1): new project doc +
+ * all Sets/lanes + all non-deleted shots. Skips pulls, schedules, export
+ * reports, casting board, shotShares, shotRequests.
+ *
+ * Images = share existing files (Ted decision 3): heroImage/looks carry the
+ * same Storage paths — no file duplication, no code needed here beyond
+ * copying the field (shot-scoped paths + soft deletes make this safe).
+ *
+ * Write order is a SEQUENCE of independent batches (non-atomic by
+ * necessity — Firestore has no cross-collection multi-document transaction
+ * at this scale), chosen so a partial failure is inert: the new project doc
+ * lands first, then lanes (so the shots step can remap laneId), then shots
+ * last (the biggest, most failure-prone step, and the one where a partial
+ * write is least harmful — a project with structure but fewer shots than
+ * expected is legible and recoverable; the reverse would not be). On
+ * failure, the new project is left in place (never auto-retried) so the
+ * user can inspect it or soft-delete it.
+ */
+export async function duplicateProject(args: DuplicateProjectArgs): Promise<DuplicateProjectResult> {
+  const { clientId, sourceProjectId, newName, role, user } = args
+
+  const sourceProject = await readSourceProject(sourceProjectId, clientId)
+  const sourceLanes = await readSourceLanes(sourceProjectId, clientId)
+  const sourceShots = await readSourceShots(sourceProjectId, clientId)
+
+  const newProject = await createNewProjectDoc({ clientId, newName, sourceProject, role, user })
+
+  let laneIdMap: Map<string, string>
+  try {
+    laneIdMap = await cloneLanes({ clientId, newProjectId: newProject.id, sourceLanes, user })
+  } catch (err) {
+    const written = err instanceof ChunkedWriteError ? err.written : 0
+    console.error("[duplicateProject] Lanes step failed partway through:", err)
+    throw new DuplicateProjectPartialFailureError(
+      `Duplicated project "${newName}" but only ${written} of ${sourceLanes.length} sets landed before a write failed. ` +
+        `No shots were copied. The new project was left in place — you can delete it or retry.`,
+      { newProjectId: newProject.id, lanesWritten: written, shotsWritten: 0 },
+    )
+  }
+
+  const shotsSegs = shotsPath(clientId)
+  const shotsCollectionRef = collection(db, shotsSegs[0]!, ...shotsSegs.slice(1))
+
+  let shotsWritten: number
+  try {
+    shotsWritten = await cloneShots({
+      clientId,
+      newProjectId: newProject.id,
+      sourceShots,
+      laneIdMap,
+      user,
+      shotsCollectionRef,
+    })
+  } catch (err) {
+    const written = err instanceof ChunkedWriteError ? err.written : 0
+    console.error("[duplicateProject] Shots step failed partway through:", err)
+    throw new DuplicateProjectPartialFailureError(
+      `Duplicated project "${newName}" but only ${written} of ${sourceShots.length} shots landed before a write failed. ` +
+        `The new project and its sets were created. You can delete it or retry.`,
+      { newProjectId: newProject.id, lanesWritten: sourceLanes.length, shotsWritten: written },
+    )
+  }
+
+  return {
+    newProjectId: newProject.id,
+    laneCount: sourceLanes.length,
+    shotCount: shotsWritten,
+  }
+}

--- a/src-vnext/features/projects/lib/transferTargets.test.ts
+++ b/src-vnext/features/projects/lib/transferTargets.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest"
+import { Timestamp } from "firebase/firestore"
+import type { Project } from "@/shared/types"
+import { filterEligibleTransferTargets, isEligibleTransferTarget } from "./transferTargets"
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  const now = Timestamp.fromMillis(Date.now())
+  return {
+    id: overrides.id ?? "p1",
+    name: overrides.name ?? "Project",
+    clientId: overrides.clientId ?? "c1",
+    status: overrides.status ?? "active",
+    shootDates: overrides.shootDates ?? [],
+    deletedAt: overrides.deletedAt,
+    createdAt: overrides.createdAt ?? now,
+    updatedAt: overrides.updatedAt ?? now,
+  }
+}
+
+describe("isEligibleTransferTarget", () => {
+  it("excludes the current project by id", () => {
+    expect(isEligibleTransferTarget(makeProject({ id: "p1" }), "p1")).toBe(false)
+  })
+
+  it("excludes archived projects", () => {
+    expect(isEligibleTransferTarget(makeProject({ id: "p2", status: "archived" }), "p1")).toBe(false)
+  })
+
+  it("excludes soft-deleted projects (deletedAt set)", () => {
+    expect(isEligibleTransferTarget(makeProject({ id: "p2", deletedAt: "2026-01-01" }), "p1")).toBe(false)
+  })
+
+  it("includes an active, non-deleted, different project", () => {
+    expect(isEligibleTransferTarget(makeProject({ id: "p2", status: "active" }), "p1")).toBe(true)
+  })
+
+  it("includes a completed (non-archived) different project", () => {
+    expect(isEligibleTransferTarget(makeProject({ id: "p2", status: "completed" }), "p1")).toBe(true)
+  })
+})
+
+describe("filterEligibleTransferTargets", () => {
+  it("filters a mixed list down to eligible targets only", () => {
+    const projects = [
+      makeProject({ id: "current", status: "active" }),
+      makeProject({ id: "archived-1", status: "archived" }),
+      makeProject({ id: "deleted-1", status: "active", deletedAt: "2026-01-01" }),
+      makeProject({ id: "eligible-1", status: "active" }),
+      makeProject({ id: "eligible-2", status: "completed" }),
+    ]
+    const result = filterEligibleTransferTargets(projects, "current")
+    expect(result.map((p) => p.id)).toEqual(["eligible-1", "eligible-2"])
+  })
+})

--- a/src-vnext/features/projects/lib/transferTargets.ts
+++ b/src-vnext/features/projects/lib/transferTargets.ts
@@ -1,0 +1,28 @@
+import type { Project } from "@/shared/types"
+
+/**
+ * Whether `project` is a valid destination for a cross-project shot
+ * copy/move — everything except the source project itself, archived
+ * projects, and soft-deleted projects.
+ *
+ * Extracted from ShotLifecycleActionsMenu's single-shot Transfer/Copy
+ * picker so the bulk actions (BulkActionBar) and "Duplicate project…"'s
+ * source-project exclusion reuse the same rule instead of drifting.
+ */
+export function isEligibleTransferTarget(
+  project: Project,
+  excludeProjectId: string,
+): boolean {
+  return (
+    project.id !== excludeProjectId &&
+    project.status !== "archived" &&
+    !project.deletedAt
+  )
+}
+
+export function filterEligibleTransferTargets(
+  projects: ReadonlyArray<Project>,
+  excludeProjectId: string,
+): ReadonlyArray<Project> {
+  return projects.filter((project) => isEligibleTransferTarget(project, excludeProjectId))
+}

--- a/src-vnext/features/shots/components/BulkActionBar.tsx
+++ b/src-vnext/features/shots/components/BulkActionBar.tsx
@@ -43,6 +43,7 @@ import {
   bulkAddTalent,
 } from "@/features/shots/lib/bulkShotUpdates"
 import {
+  BulkCopyPartialFailureError,
   bulkCopyShotsToProject,
   bulkMoveShotsToProject,
 } from "@/features/shots/lib/shotLifecycleActions"
@@ -197,9 +198,17 @@ export function BulkActionBar({
       setTransferOpen(false)
       onClearSelection()
     } catch (err) {
-      toast.error(transferMode === "copy" ? "Failed to copy shots" : "Failed to move shots", {
-        description: err instanceof Error ? err.message : "Unknown error",
-      })
+      // Partial failure (some shots landed before a chunk failed): name the
+      // count and leave the selection intact — the user still needs it to
+      // retry the shots that didn't make it. Any other error: generic
+      // failure toast, selection also left intact (nothing copied/moved).
+      if (err instanceof BulkCopyPartialFailureError) {
+        toast.error("Copy stopped partway", { description: err.message })
+      } else {
+        toast.error(transferMode === "copy" ? "Failed to copy shots" : "Failed to move shots", {
+          description: err instanceof Error ? err.message : "Unknown error",
+        })
+      }
     } finally {
       setTransferBusy(false)
     }

--- a/src-vnext/features/shots/components/BulkActionBar.tsx
+++ b/src-vnext/features/shots/components/BulkActionBar.tsx
@@ -1,6 +1,9 @@
-import { useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
+import { collection, getDocs, query, where } from "firebase/firestore"
 import { GitMerge, Layers, MapPin, Tag, Trash2, User } from "lucide-react"
 import { toast } from "sonner"
+import { db } from "@/shared/lib/firebase"
+import { projectsPath, shotsPath } from "@/shared/lib/paths"
 import { Button } from "@/ui/button"
 import { Checkbox } from "@/ui/checkbox"
 import {
@@ -16,6 +19,14 @@ import {
   PopoverTrigger,
 } from "@/ui/popover"
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from "@/ui/command"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/ui/dialog"
 import { StatusBadge } from "@/shared/components/StatusBadge"
 import {
   SHOT_STATUSES,
@@ -23,13 +34,21 @@ import {
 import { canManageShots } from "@/shared/lib/rbac"
 import { shotWriteErrorDescription } from "@/features/shots/lib/shotWriteError"
 import { useAvailableTags } from "@/features/shots/hooks/useAvailableTags"
+import { mapProject } from "@/features/projects/hooks/useProjects"
+import { filterEligibleTransferTargets } from "@/features/projects/lib/transferTargets"
 import {
   bulkUpdateShotStatus,
   bulkApplyTags,
   bulkUpdateLocation,
   bulkAddTalent,
 } from "@/features/shots/lib/bulkShotUpdates"
-import type { AuthUser, Role, Shot, ShotFirestoreStatus, ShotTag } from "@/shared/types"
+import {
+  bulkCopyShotsToProject,
+  bulkMoveShotsToProject,
+} from "@/features/shots/lib/shotLifecycleActions"
+import type { AuthUser, Project, Role, Shot, ShotFirestoreStatus, ShotTag } from "@/shared/types"
+
+type TransferMode = "copy" | "move"
 
 interface BulkActionBarProps {
   readonly displayShots: ReadonlyArray<Shot>
@@ -53,6 +72,11 @@ interface BulkActionBarProps {
   // Location + talent data
   readonly locations: ReadonlyArray<{ readonly id: string; readonly name: string }>
   readonly talent: ReadonlyArray<{ readonly id: string; readonly name: string }>
+  // Cross-project bulk Copy/Move — same GLOBAL-claim gate as
+  // ShotLifecycleActionsMenu's canTransferAcrossProjects. currentProjectId
+  // excludes the current project from the destination picker.
+  readonly canTransferAcrossProjects?: boolean
+  readonly currentProjectId?: string
 }
 
 export function BulkActionBar({
@@ -74,6 +98,8 @@ export function BulkActionBar({
   canExport,
   locations,
   talent,
+  canTransferAcrossProjects = false,
+  currentProjectId = "",
 }: BulkActionBarProps) {
   const selectedShots = useMemo(
     () => displayShots.filter((s) => selectedIds.has(s.id)),
@@ -86,6 +112,98 @@ export function BulkActionBar({
   const [tagPopoverOpen, setTagPopoverOpen] = useState(false)
   const [locationPopoverOpen, setLocationPopoverOpen] = useState(false)
   const [talentPopoverOpen, setTalentPopoverOpen] = useState(false)
+
+  // -- Cross-project bulk Copy/Move --
+  const [transferMode, setTransferMode] = useState<TransferMode>("copy")
+  const [transferOpen, setTransferOpen] = useState(false)
+  const [targetProjectId, setTargetProjectId] = useState("")
+  const [transferBusy, setTransferBusy] = useState(false)
+  const [projects, setProjects] = useState<ReadonlyArray<Project>>([])
+  const [projectsLoaded, setProjectsLoaded] = useState(false)
+  const [projectsLoading, setProjectsLoading] = useState(false)
+
+  const ensureProjects = useCallback(async () => {
+    if (!clientId || projectsLoaded || projectsLoading) return
+    setProjectsLoading(true)
+    try {
+      const segs = projectsPath(clientId)
+      const snap = await getDocs(collection(db, segs[0]!, ...segs.slice(1)))
+      setProjects(snap.docs.map((d) => mapProject(d.id, d.data())))
+      setProjectsLoaded(true)
+    } catch (err) {
+      console.error("[BulkActionBar] failed to load projects", err)
+      toast.error("Couldn't load projects")
+    } finally {
+      setProjectsLoading(false)
+    }
+  }, [clientId, projectsLoaded, projectsLoading])
+
+  const targetProjects = useMemo(
+    () => filterEligibleTransferTargets(projects, currentProjectId),
+    [projects, currentProjectId],
+  )
+
+  const targetProjectName = useMemo(
+    () => projects.find((p) => p.id === targetProjectId)?.name ?? "project",
+    [projects, targetProjectId],
+  )
+
+  const openTransfer = (mode: TransferMode) => {
+    setTransferMode(mode)
+    setTargetProjectId("")
+    setTransferOpen(true)
+    void ensureProjects()
+  }
+
+  const handleConfirmTransfer = async () => {
+    if (!clientId || !targetProjectId || transferBusy || selectedShots.length === 0) return
+    setTransferBusy(true)
+    try {
+      if (transferMode === "copy") {
+        const shotsSegs = shotsPath(clientId)
+        const titlesSnap = await getDocs(
+          query(
+            collection(db, shotsSegs[0]!, ...shotsSegs.slice(1)),
+            where("projectId", "==", targetProjectId),
+            where("deleted", "==", false),
+          ),
+        )
+        const targetTitles = new Set<string>()
+        for (const d of titlesSnap.docs) {
+          const title = (d.data()["title"] as string | undefined)?.trim()
+          if (title) targetTitles.add(title)
+        }
+        const { copiedCount } = await bulkCopyShotsToProject({
+          clientId,
+          shots: selectedShots,
+          targetProjectId,
+          targetTitles,
+          createdByUid: user?.uid ?? null,
+        })
+        toast.success(`Copied ${copiedCount} shot${copiedCount === 1 ? "" : "s"}`, {
+          description: `Copied to ${targetProjectName}.`,
+        })
+      } else {
+        const { movedCount } = await bulkMoveShotsToProject({
+          clientId,
+          shots: selectedShots,
+          targetProjectId,
+          user,
+        })
+        toast.success(`Moved ${movedCount} shot${movedCount === 1 ? "" : "s"}`, {
+          description: `Moved to ${targetProjectName}.`,
+        })
+      }
+      setTransferOpen(false)
+      onClearSelection()
+    } catch (err) {
+      toast.error(transferMode === "copy" ? "Failed to copy shots" : "Failed to move shots", {
+        description: err instanceof Error ? err.message : "Unknown error",
+      })
+    } finally {
+      setTransferBusy(false)
+    }
+  }
 
   const handleBulkStatus = async (status: ShotFirestoreStatus) => {
     if (!clientId || selectedIds.size === 0) return
@@ -298,6 +416,28 @@ export function BulkActionBar({
         >
           Create pull sheet
         </Button>
+        {/* Cross-project bulk Copy/Move — GLOBAL-claim gated (same shape as
+            ShotLifecycleActionsMenu's Transfer/Copy split). */}
+        {canTransferAcrossProjects && (
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={selectedIds.size === 0}
+              onClick={() => openTransfer("copy")}
+            >
+              Copy to project…
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={selectedIds.size === 0}
+              onClick={() => openTransfer("move")}
+            >
+              Move to project…
+            </Button>
+          </>
+        )}
         {onGroupSceneOpen && canManageShots(role) && (
           <Button
             variant="default"
@@ -332,6 +472,69 @@ export function BulkActionBar({
           </Button>
         )}
       </div>
+
+      <Dialog open={transferOpen} onOpenChange={setTransferOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>
+              {transferMode === "copy" ? "Copy shots to project" : "Move shots to project"}
+            </DialogTitle>
+            <DialogDescription>
+              {targetProjectId
+                ? `${transferMode === "copy" ? "Copy" : "Move"} ${selectedShots.length} shot${selectedShots.length === 1 ? "" : "s"} to «${targetProjectName}»?`
+                : transferMode === "copy"
+                  ? "New shots will be created in the target project. Shot numbers are reset to avoid collisions."
+                  : "The selected shots will move to the target project and be removed from this project's shot list."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {projectsLoading ? (
+            <p className="text-sm text-[var(--color-text-muted)]">Loading projects…</p>
+          ) : targetProjects.length === 0 ? (
+            <p className="text-sm text-[var(--color-text-muted)]">
+              No eligible destination projects are available.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              <p className="text-xs font-medium uppercase tracking-wide text-[var(--color-text-subtle)]">
+                Destination project
+              </p>
+              <Select value={targetProjectId} onValueChange={setTargetProjectId} disabled={transferBusy}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select project" />
+                </SelectTrigger>
+                <SelectContent>
+                  {targetProjects.map((project) => (
+                    <SelectItem key={project.id} value={project.id}>
+                      {project.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setTransferOpen(false)} disabled={transferBusy}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                void handleConfirmTransfer()
+              }}
+              disabled={transferBusy || !targetProjectId || targetProjects.length === 0}
+            >
+              {transferBusy
+                ? transferMode === "copy"
+                  ? "Copying…"
+                  : "Moving…"
+                : transferMode === "copy"
+                  ? "Copy shots"
+                  : "Move shots"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/src-vnext/features/shots/components/ShotLifecycleActionsMenu.tsx
+++ b/src-vnext/features/shots/components/ShotLifecycleActionsMenu.tsx
@@ -11,6 +11,7 @@ import { db } from "@/shared/lib/firebase"
 import { useAuth } from "@/app/providers/AuthProvider"
 import { projectsPath, shotsPath } from "@/shared/lib/paths"
 import { mapProject } from "@/features/projects/hooks/useProjects"
+import { filterEligibleTransferTargets } from "@/features/projects/lib/transferTargets"
 import {
   copyShotToProject,
   duplicateShotInProject,
@@ -133,12 +134,7 @@ export function ShotLifecycleActionsMenu({
   }, [clientId, menuDataLoaded, menuDataLoading, shot.projectId, canTransferAcrossProjects])
 
   const targetProjects = useMemo(() => {
-    return projects.filter(
-      (project) =>
-        project.id !== shot.projectId &&
-        project.status !== "archived" &&
-        !project.deletedAt,
-    )
+    return filterEligibleTransferTargets(projects, shot.projectId)
   }, [projects, shot.projectId])
 
   const targetProjectName = useMemo(() => {

--- a/src-vnext/features/shots/components/ShotListPage.tsx
+++ b/src-vnext/features/shots/components/ShotListPage.tsx
@@ -155,6 +155,11 @@ export default function ShotListPage() {
   // claim (firestore.rules:193-204) — the backend cannot see a project
   // promotion, so the UI must not advertise Share from the effective role.
   const canShare = globalRole === "admin" || globalRole === "producer"
+  // Bulk "Copy to project…" / "Move to project…" — same GLOBAL-claim gate as
+  // ShotLifecycleActionsMenu's canTransferAcrossProjects (5e-II rules-honesty
+  // split): the shots move/create-in-target rules arms are global-claim-only,
+  // no project-promotion path, so this is pinned to globalRole, not `role`.
+  const canTransferAcrossProjects = globalRole === "admin" || globalRole === "producer"
   // NO role gate, by locked decision: export is device-only. The export
   // backend rules (exportTemplates firestore.rules:641-651, exportReports
   // :868-877) don't gate this affordance; the per-share export toggle is 5f.
@@ -575,6 +580,8 @@ export default function ShotListPage() {
           canExport={canExport}
           locations={locationRecords}
           talent={talentRecords}
+          canTransferAcrossProjects={canTransferAcrossProjects}
+          currentProjectId={projectId}
         />
       )}
 

--- a/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, cleanup } from "@testing-library/react"
-import { BulkActionBar } from "@/features/shots/components/BulkActionBar"
+import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { Role, Shot } from "@/shared/types"
 
 // useAvailableTags reads Firestore via useShots — stub it so the bar renders standalone.
@@ -8,14 +8,42 @@ vi.mock("@/features/shots/hooks/useAvailableTags", () => ({
   useAvailableTags: () => ({ tags: [], loading: false, error: null }),
 }))
 
-function makeShot(id: string): Shot {
+const mockGetDocs = vi.fn()
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>()
+  return {
+    ...actual,
+    collection: vi.fn((...args: unknown[]) => ({ __col: args.join("/") })),
+    getDocs: (...args: unknown[]) => mockGetDocs(...args),
+    query: vi.fn((...args: unknown[]) => ({ __query: args })),
+    where: vi.fn((field: string, op: string, value: unknown) => ({ field, op, value })),
+  }
+})
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
+const mockBulkCopy = vi.fn()
+const mockBulkMove = vi.fn()
+vi.mock("@/features/shots/lib/shotLifecycleActions", () => ({
+  bulkCopyShotsToProject: (...args: unknown[]) => mockBulkCopy(...args),
+  bulkMoveShotsToProject: (...args: unknown[]) => mockBulkMove(...args),
+}))
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}))
+
+import { BulkActionBar } from "@/features/shots/components/BulkActionBar"
+
+function makeShot(id: string, overrides: Partial<Shot> = {}): Shot {
   return {
     id,
-    title: `Shot ${id}`,
+    title: overrides.title ?? `Shot ${id}`,
     status: "todo",
     talent: [],
     products: [],
-    sortOrder: 0,
+    sortOrder: overrides.sortOrder ?? 0,
+    ...overrides,
   } as unknown as Shot
 }
 
@@ -29,11 +57,15 @@ function renderBar(opts: {
   selectedIds: ReadonlySet<string>
   role: Role
   onMergeOpen?: () => void
+  onClearSelection?: () => void
+  displayShots?: ReadonlyArray<Shot>
+  canTransferAcrossProjects?: boolean
+  currentProjectId?: string
 }) {
   const onMergeOpen = opts.onMergeOpen
   render(
     <BulkActionBar
-      displayShots={DISPLAY_SHOTS}
+      displayShots={opts.displayShots ?? DISPLAY_SHOTS}
       selectedIds={opts.selectedIds}
       onSelectAll={() => {}}
       onDeselectAll={() => {}}
@@ -44,16 +76,23 @@ function renderBar(opts: {
       onExportClick={() => {}}
       onCreatePullOpen={() => {}}
       onBulkDeleteOpen={() => {}}
-      onClearSelection={() => {}}
+      onClearSelection={opts.onClearSelection ?? (() => {})}
       onGroupSceneOpen={() => {}}
       onMergeOpen={onMergeOpen}
       canShare
       canExport
       locations={[]}
       talent={[]}
+      canTransferAcrossProjects={opts.canTransferAcrossProjects}
+      currentProjectId={opts.currentProjectId ?? "current-project"}
     />,
   )
 }
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mockGetDocs.mockResolvedValue({ docs: [] })
+})
 
 function mergeButton(): HTMLButtonElement | null {
   return screen
@@ -105,5 +144,156 @@ describe("BulkActionBar — Merge action", () => {
     renderBar({ selectedIds: new Set(["a", "b"]), role: "crew", onMergeOpen })
     fireEvent.click(mergeButton()!)
     expect(onMergeOpen).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Radix Select polyfills for JSDOM — used by the destination-project picker.
+if (!HTMLElement.prototype.hasPointerCapture) {
+  HTMLElement.prototype.hasPointerCapture = () => false
+}
+if (!HTMLElement.prototype.setPointerCapture) {
+  HTMLElement.prototype.setPointerCapture = () => {}
+}
+if (!HTMLElement.prototype.releasePointerCapture) {
+  HTMLElement.prototype.releasePointerCapture = () => {}
+}
+if (!HTMLElement.prototype.scrollIntoView) {
+  HTMLElement.prototype.scrollIntoView = () => {}
+}
+
+function buttonByText(text: string): HTMLButtonElement | null {
+  return (
+    (screen.queryAllByRole("button").find((b) => b.textContent?.trim() === text) as
+      | HTMLButtonElement
+      | undefined) ?? null
+  )
+}
+
+describe("BulkActionBar — bulk Copy/Move to project", () => {
+  beforeEach(() => cleanup())
+
+  it("hides Copy/Move buttons when canTransferAcrossProjects is false (default)", () => {
+    renderBar({ selectedIds: new Set(["a"]), role: "producer" })
+    expect(buttonByText("Copy to project…")).toBeNull()
+    expect(buttonByText("Move to project…")).toBeNull()
+  })
+
+  it("shows Copy/Move buttons when canTransferAcrossProjects is true", () => {
+    renderBar({ selectedIds: new Set(["a"]), role: "producer", canTransferAcrossProjects: true })
+    expect(buttonByText("Copy to project…")).not.toBeNull()
+    expect(buttonByText("Move to project…")).not.toBeNull()
+  })
+
+  it("disables Copy/Move at 0 selected", () => {
+    renderBar({ selectedIds: new Set(), role: "producer", canTransferAcrossProjects: true })
+    expect(buttonByText("Copy to project…")?.disabled).toBe(true)
+    expect(buttonByText("Move to project…")?.disabled).toBe(true)
+  })
+
+  it("opening the dialog lazy-loads the project list exactly once", async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }],
+    })
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      currentProjectId: "current-project",
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await waitFor(() => expect(within(dialog).getByText("Select project")).toBeInTheDocument())
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    expect(mockGetDocs).toHaveBeenCalledTimes(1)
+  })
+
+  it("excludes the current project and archived projects from the destination picker", async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [
+        { id: "current-project", data: () => ({ name: "Current", status: "active" }) },
+        { id: "archived-1", data: () => ({ name: "Archived Job", status: "archived" }) },
+        { id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) },
+      ],
+    })
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      currentProjectId: "current-project",
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    expect(screen.queryByRole("option", { name: "Current" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("option", { name: "Archived Job" })).not.toBeInTheDocument()
+  })
+
+  it("copy: fetches target titles, calls bulkCopyShotsToProject with the selected shots, toasts, clears selection", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }] }) // projects list
+      .mockResolvedValueOnce({ docs: [{ id: "x", data: () => ({ title: "Existing" }) }] }) // target titles
+    mockBulkCopy.mockResolvedValue({ copiedCount: 2 })
+    const onClearSelection = vi.fn()
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      onClearSelection,
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+    await user.click(buttonByText("Copy shots")!)
+
+    await waitFor(() => expect(mockBulkCopy).toHaveBeenCalledTimes(1))
+    const call = mockBulkCopy.mock.calls[0]![0] as {
+      targetProjectId: string
+      shots: ReadonlyArray<Shot>
+      targetTitles: ReadonlySet<string>
+    }
+    expect(call.targetProjectId).toBe("target-1")
+    expect(call.shots.map((s) => s.id).sort()).toEqual(["a", "b"])
+    expect(Array.from(call.targetTitles)).toEqual(["Existing"])
+    expect(onClearSelection).toHaveBeenCalledTimes(1)
+  })
+
+  it("move: calls bulkMoveShotsToProject with the selected shots and target, clears selection", async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }],
+    })
+    mockBulkMove.mockResolvedValue({ movedCount: 2 })
+    const onClearSelection = vi.fn()
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      onClearSelection,
+    })
+
+    await user.click(buttonByText("Move to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+    await user.click(buttonByText("Move shots")!)
+
+    await waitFor(() => expect(mockBulkMove).toHaveBeenCalledTimes(1))
+    const call = mockBulkMove.mock.calls[0]![0] as { targetProjectId: string; shots: ReadonlyArray<Shot> }
+    expect(call.targetProjectId).toBe("target-1")
+    expect(call.shots.map((s) => s.id).sort()).toEqual(["a", "b"])
+    // bulkMoveShotsToProject never touches title dedup — only copy does.
+    expect(mockGetDocs).toHaveBeenCalledTimes(1) // projects list only, no target-titles fetch
+    expect(onClearSelection).toHaveBeenCalledTimes(1)
   })
 })

--- a/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { render, screen, fireEvent, cleanup, waitFor, within } from "@testing-library/react"
+import { render, screen, fireEvent, cleanup, waitFor, within, act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { Role, Shot } from "@/shared/types"
 
@@ -24,15 +24,23 @@ vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
 
 const mockBulkCopy = vi.fn()
 const mockBulkMove = vi.fn()
-vi.mock("@/features/shots/lib/shotLifecycleActions", () => ({
-  bulkCopyShotsToProject: (...args: unknown[]) => mockBulkCopy(...args),
-  bulkMoveShotsToProject: (...args: unknown[]) => mockBulkMove(...args),
-}))
+vi.mock("@/features/shots/lib/shotLifecycleActions", async () => {
+  const actual = await vi.importActual<typeof import("@/features/shots/lib/shotLifecycleActions")>(
+    "@/features/shots/lib/shotLifecycleActions",
+  )
+  return {
+    ...actual,
+    bulkCopyShotsToProject: (...args: unknown[]) => mockBulkCopy(...args),
+    bulkMoveShotsToProject: (...args: unknown[]) => mockBulkMove(...args),
+  }
+})
 
 vi.mock("sonner", () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }))
 
+import { toast } from "sonner"
+import { BulkCopyPartialFailureError } from "@/features/shots/lib/shotLifecycleActions"
 import { BulkActionBar } from "@/features/shots/components/BulkActionBar"
 
 function makeShot(id: string, overrides: Partial<Shot> = {}): Shot {
@@ -262,9 +270,78 @@ describe("BulkActionBar — bulk Copy/Move to project", () => {
       targetTitles: ReadonlySet<string>
     }
     expect(call.targetProjectId).toBe("target-1")
-    expect(call.shots.map((s) => s.id).sort()).toEqual(["a", "b"])
+    expect(call.shots.map((s) => s.id)).toEqual(["a", "b"])
     expect(Array.from(call.targetTitles)).toEqual(["Existing"])
     expect(onClearSelection).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith(
+      "Copied 2 shots",
+      expect.objectContaining({ description: "Copied to Q4 Ecomm." }),
+    )
+  })
+
+  it("copy: a generic failure toasts an error and does NOT clear selection", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }] })
+      .mockResolvedValueOnce({ docs: [] })
+    mockBulkCopy.mockRejectedValue(new Error("write failed"))
+    const onClearSelection = vi.fn()
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      onClearSelection,
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+    await user.click(buttonByText("Copy shots")!)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to copy shots",
+        expect.objectContaining({ description: "write failed" }),
+      ),
+    )
+    expect(onClearSelection).not.toHaveBeenCalled()
+  })
+
+  it("copy: a partial-batch failure toasts the copied-count message and does NOT clear selection", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }] })
+      .mockResolvedValueOnce({ docs: [] })
+    mockBulkCopy.mockRejectedValue(
+      new BulkCopyPartialFailureError("Copied 250 of 251 shots before a write failed.", {
+        copiedCount: 250,
+        totalCount: 251,
+      }),
+    )
+    const onClearSelection = vi.fn()
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      onClearSelection,
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+    await user.click(buttonByText("Copy shots")!)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Copy stopped partway",
+        expect.objectContaining({ description: "Copied 250 of 251 shots before a write failed." }),
+      ),
+    )
+    expect(onClearSelection).not.toHaveBeenCalled()
   })
 
   it("move: calls bulkMoveShotsToProject with the selected shots and target, clears selection", async () => {
@@ -291,9 +368,99 @@ describe("BulkActionBar — bulk Copy/Move to project", () => {
     await waitFor(() => expect(mockBulkMove).toHaveBeenCalledTimes(1))
     const call = mockBulkMove.mock.calls[0]![0] as { targetProjectId: string; shots: ReadonlyArray<Shot> }
     expect(call.targetProjectId).toBe("target-1")
-    expect(call.shots.map((s) => s.id).sort()).toEqual(["a", "b"])
+    expect(call.shots.map((s) => s.id)).toEqual(["a", "b"])
     // bulkMoveShotsToProject never touches title dedup — only copy does.
     expect(mockGetDocs).toHaveBeenCalledTimes(1) // projects list only, no target-titles fetch
     expect(onClearSelection).toHaveBeenCalledTimes(1)
+    expect(toast.success).toHaveBeenCalledWith(
+      "Moved 2 shots",
+      expect.objectContaining({ description: "Moved to Q4 Ecomm." }),
+    )
+  })
+
+  it("move: a failure toasts an error and does NOT clear selection", async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }],
+    })
+    mockBulkMove.mockRejectedValue(new Error("network down"))
+    const onClearSelection = vi.fn()
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+      onClearSelection,
+    })
+
+    await user.click(buttonByText("Move to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+    await user.click(buttonByText("Move shots")!)
+
+    await waitFor(() =>
+      expect(toast.error).toHaveBeenCalledWith(
+        "Failed to move shots",
+        expect.objectContaining({ description: "network down" }),
+      ),
+    )
+    expect(onClearSelection).not.toHaveBeenCalled()
+  })
+
+  it("guards against double-submit: re-entering handleConfirmTransfer while a submit is in flight calls bulkCopyShotsToProject once", async () => {
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [{ id: "target-1", data: () => ({ name: "Q4 Ecomm", status: "active" }) }] })
+      .mockResolvedValueOnce({ docs: [] })
+    let resolveCopy!: (val: unknown) => void
+    mockBulkCopy.mockReturnValue(new Promise((r) => { resolveCopy = r }))
+    const user = userEvent.setup()
+    renderBar({
+      selectedIds: new Set(["a", "b"]),
+      role: "producer",
+      canTransferAcrossProjects: true,
+    })
+
+    await user.click(buttonByText("Copy to project…")!)
+    const dialog = await screen.findByRole("dialog")
+    await user.click(within(dialog).getByRole("combobox"))
+    await waitFor(() => expect(screen.getByRole("option", { name: "Q4 Ecomm" })).toBeInTheDocument())
+    await user.click(screen.getByRole("option", { name: "Q4 Ecomm" }))
+
+    // A plain second `fireEvent.click` CANNOT falsify the internal
+    // `transferBusy` check: React reads `disabled` off the fiber's own
+    // memoized props at event-dispatch time (not the live DOM attribute),
+    // and setTransferBusy(true) commits synchronously on "discrete" events
+    // like click — so a disabled button never even reaches the handler a
+    // second time, guard or no guard. That's exactly how this check could
+    // be deleted with every click-based test staying green (the reviewer's
+    // finding). To test the guard that's actually WRITTEN in the code,
+    // invoke the onClick prop directly — this is precisely the scenario
+    // the internal check defends: some other caller re-entering
+    // handleConfirmTransfer while a submit is already in flight, bypassing
+    // the disabled button entirely (e.g. a future keyboard shortcut, or a
+    // second wired-up trigger).
+    const confirmButton = buttonByText("Copy shots")!
+    const getOnClick = (): (() => void) => {
+      const propsKey = Object.keys(confirmButton).find((k) => k.startsWith("__reactProps$"))!
+      return (confirmButton as unknown as Record<string, { onClick: () => void }>)[propsKey]!.onClick
+    }
+
+    act(() => getOnClick()())
+    await waitFor(() => expect(mockBulkCopy).toHaveBeenCalledTimes(1))
+
+    // Re-query onClick: the closure now reflects the COMMITTED
+    // transferBusy=true from the first call, which is exactly what a real
+    // re-entrant caller would see. Flush a macrotask afterward so a broken
+    // guard's re-entrant async chain (its own `await getDocs(...)` then
+    // `await bulkCopyShotsToProject(...)`) has time to actually reach the
+    // second call before we assert — a bare synchronous check right after
+    // `act()` would pass even on unfixed code, for the wrong reason (timing,
+    // not correctness).
+    act(() => getOnClick()())
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(mockBulkCopy).toHaveBeenCalledTimes(1)
+    resolveCopy({ copiedCount: 2 })
   })
 })

--- a/src-vnext/features/shots/lib/shotLifecycleActions.test.ts
+++ b/src-vnext/features/shots/lib/shotLifecycleActions.test.ts
@@ -27,6 +27,7 @@ import { Timestamp } from "firebase/firestore"
 import * as firestore from "firebase/firestore"
 import type { Shot } from "@/shared/types"
 import {
+  BulkCopyPartialFailureError,
   buildDuplicateShotTitle,
   buildShotClonePayload,
   bulkCopyShotsToProject,
@@ -199,6 +200,45 @@ describe("shotLifecycleActions", () => {
       expect(payload["status"]).toBe("todo") // already preserved unconditionally
       expect(payload["date"]).toBeTruthy() // already preserved unconditionally
     })
+
+    it("heroImageOverride WINS over shot.heroImage: a value clones verbatim, null OMITS the field, absent key keeps today's behavior", () => {
+      const materialized = { path: "materialized.jpg", downloadURL: "https://x/materialized.jpg" }
+
+      const overridden = buildShotClonePayload({
+        shot: makeShot({ heroImage: materialized }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        options: { heroImageOverride: { path: "raw.jpg", downloadURL: "https://x/raw.jpg" } },
+      })
+      expect(overridden["heroImage"]).toEqual({ path: "raw.jpg", downloadURL: "https://x/raw.jpg" })
+
+      const omitted = buildShotClonePayload({
+        shot: makeShot({ heroImage: materialized }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        options: { heroImageOverride: null },
+      })
+      expect(omitted).not.toHaveProperty("heroImage")
+
+      const defaulted = buildShotClonePayload({
+        shot: makeShot({ heroImage: materialized }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        // no options at all — existing callers (duplicateShotInProject,
+        // copyShotToProject, bulkCopyShotsToProject) must keep writing the
+        // materialized shot.heroImage byte-for-byte.
+      })
+      expect(defaulted["heroImage"]).toEqual(materialized)
+    })
   })
 })
 
@@ -258,19 +298,15 @@ describe("bulk cross-project transfer", () => {
         createdByUid: "u1",
       })
 
-      // Canonical order (sortOrder asc) is s3(1), s2(2), s1(3), s0(4). Every
-      // bulk-copy title gets buildDuplicateShotTitle's "(Copy)" suffix
-      // unconditionally (same as single-shot duplicate) — titles here don't
-      // collide with each other, so no "(Copy 2)" escalation.
+      // Canonical order (sortOrder asc) is s3(1), s2(2), s1(3), s0(4). No
+      // titles collide (targetTitles is empty and every source title is
+      // distinct), so every title stays BARE — see the dedicated
+      // no-collision test below for that behavior; this test's job is
+      // ORDER, so just assert on the write sequence via title identity.
       const titlesInWriteOrder = mockBatchSet.mock.calls.map(
         (call) => (call[1] as Record<string, unknown>)["title"],
       )
-      expect(titlesInWriteOrder).toEqual([
-        "Shot 3 (Copy)",
-        "Shot 2 (Copy)",
-        "Shot 1 (Copy)",
-        "Shot 0 (Copy)",
-      ])
+      expect(titlesInWriteOrder).toEqual(["Shot 3", "Shot 2", "Shot 1", "Shot 0"])
 
       const sortOrders = mockBatchSet.mock.calls.map(
         (call) => (call[1] as Record<string, unknown>)["sortOrder"] as number,
@@ -278,6 +314,22 @@ describe("bulk cross-project transfer", () => {
       expect(sortOrders[1]! - sortOrders[0]!).toBe(1)
       expect(sortOrders[2]! - sortOrders[1]!).toBe(1)
       expect(sortOrders[3]! - sortOrders[2]!).toBe(1)
+    })
+
+    it("keeps the BARE title when it doesn't collide with target or already-copied titles (mutation: unconditional rename -> reddens)", async () => {
+      const shots = [
+        makeShot({ id: "s1", title: "Product Shot", sortOrder: 1 }),
+        makeShot({ id: "s2", title: "Lifestyle Shot", sortOrder: 2 }),
+      ]
+      await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        targetTitles: new Set(),
+        createdByUid: "u1",
+      })
+      const titles = mockBatchSet.mock.calls.map((call) => (call[1] as Record<string, unknown>)["title"])
+      expect(titles).toEqual(["Product Shot", "Lifestyle Shot"])
     })
 
     it("clears laneId and resets shotNumber on every copy (single-shot copy precedent)", async () => {
@@ -322,6 +374,27 @@ describe("bulk cross-project transfer", () => {
       })
       expect(mockBatchCommit).toHaveBeenCalledTimes(2)
       expect(result.copiedCount).toBe(251)
+    })
+
+    it("a chunk failing partway through throws BulkCopyPartialFailureError carrying how many landed", async () => {
+      const shots = shotsScrambled(251) // 2 chunks: 250 + 1
+      mockBatchCommit.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error("network down"))
+
+      try {
+        await bulkCopyShotsToProject({
+          clientId: "c1",
+          shots,
+          targetProjectId: "p2",
+          targetTitles: new Set(),
+          createdByUid: "u1",
+        })
+        expect.unreachable("expected bulkCopyShotsToProject to throw")
+      } catch (err) {
+        expect(err).toBeInstanceOf(BulkCopyPartialFailureError)
+        const failure = err as BulkCopyPartialFailureError
+        expect(failure.copiedCount).toBe(250)
+        expect(failure.totalCount).toBe(251)
+      }
     })
   })
 
@@ -385,6 +458,21 @@ describe("bulk cross-project transfer", () => {
       })
       expect(mockBatchCommit).toHaveBeenCalledTimes(2)
       expect(result.movedCount).toBe(251)
+    })
+
+    it("tie-breaks by id when sortOrder ties on every shot (all-absent -> 0) — no transient display-order leak (mutation: drop the id tie-break -> reddens)", async () => {
+      const shots = [
+        makeShot({ id: "s2", title: "B", sortOrder: 0, laneId: undefined }),
+        makeShot({ id: "s1", title: "A", sortOrder: 0, laneId: undefined }),
+      ]
+      await bulkMoveShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        user: null,
+      })
+      const idsInWriteOrder = mockBatchUpdate.mock.calls.map((call) => (call[0] as { id: string }).id)
+      expect(idsInWriteOrder).toEqual(["s1", "s2"])
     })
   })
 })

--- a/src-vnext/features/shots/lib/shotLifecycleActions.test.ts
+++ b/src-vnext/features/shots/lib/shotLifecycleActions.test.ts
@@ -1,9 +1,36 @@
+import { describe, expect, it, vi, beforeEach } from "vitest"
+
+// All Firestore mocked — zero live writes. `Timestamp` is kept REAL (spread
+// from the actual module) since `makeShot()` below uses `Timestamp.fromMillis`.
+vi.mock("firebase/firestore", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("firebase/firestore")>()
+  return {
+    ...actual,
+    writeBatch: vi.fn(),
+    collection: vi.fn((...args: unknown[]) => ({ __col: args.join("/") })),
+    doc: vi.fn((...args: unknown[]) => {
+      if (args.length === 1) {
+        // doc(collectionRef) — new auto-id doc (bulk copy / clone paths).
+        return { id: `new-${Math.random().toString(36).slice(2, 10)}` }
+      }
+      // doc(db, ...segments) — existing doc ref (bulk move path).
+      const segs = args.slice(1) as string[]
+      return { id: segs[segs.length - 1], path: segs.join("/") }
+    }),
+    serverTimestamp: vi.fn(() => ({ _methodName: "serverTimestamp" })),
+  }
+})
+
+vi.mock("@/shared/lib/firebase", () => ({ db: {} }))
+
 import { Timestamp } from "firebase/firestore"
-import { describe, expect, it } from "vitest"
+import * as firestore from "firebase/firestore"
 import type { Shot } from "@/shared/types"
 import {
   buildDuplicateShotTitle,
   buildShotClonePayload,
+  bulkCopyShotsToProject,
+  bulkMoveShotsToProject,
 } from "@/features/shots/lib/shotLifecycleActions"
 
 function makeShot(overrides: Partial<Shot> = {}): Shot {
@@ -21,6 +48,7 @@ function makeShot(overrides: Partial<Shot> = {}): Shot {
     locationId: overrides.locationId ?? "loc-1",
     locationName: overrides.locationName ?? "Studio A",
     laneId: overrides.laneId ?? "lane-1",
+    mediaType: overrides.mediaType,
     sortOrder: overrides.sortOrder ?? 1,
     shotNumber: overrides.shotNumber ?? "12A",
     notes: overrides.notes ?? "<p>Legacy notes</p>",
@@ -82,5 +110,281 @@ describe("shotLifecycleActions", () => {
       { id: "lk-1", title: "Lookbook", url: "https://example.com/lookbook.pdf", type: "document" },
     ])
   })
+
+  // -------------------------------------------------------------------
+  // Options seam (project-dup + bulk transfer, 2026-08-16). Every default-
+  // options case above must keep passing unmodified — these add coverage
+  // for the NEW options only.
+  // -------------------------------------------------------------------
+  describe("buildShotClonePayload options", () => {
+    it("mediaType is carried through even without options (bonus fix — was silently dropped)", () => {
+      const payload = buildShotClonePayload({
+        shot: makeShot({ mediaType: "video" }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: true,
+      })
+      expect(payload["mediaType"]).toBe("video")
+    })
+
+    it("laneIdOverride wins over preserveLane (including null)", () => {
+      const payload = buildShotClonePayload({
+        shot: makeShot({ laneId: "lane-1" }),
+        clientId: "c1",
+        targetProjectId: "p2",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: true, // would normally keep lane-1
+        options: { laneIdOverride: "lane-remapped" },
+      })
+      expect(payload["laneId"]).toBe("lane-remapped")
+
+      const cleared = buildShotClonePayload({
+        shot: makeShot({ laneId: "lane-1" }),
+        clientId: "c1",
+        targetProjectId: "p2",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: true,
+        options: { laneIdOverride: null },
+      })
+      expect(cleared["laneId"]).toBeNull()
+    })
+
+    it("preserveShotNumber keeps the source shotNumber instead of nulling it", () => {
+      const payload = buildShotClonePayload({
+        shot: makeShot({ shotNumber: "42B" }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        options: { preserveShotNumber: true },
+      })
+      expect(payload["shotNumber"]).toBe("42B")
+    })
+
+    it("sortOrderOverride is used verbatim instead of Date.now()", () => {
+      const payload = buildShotClonePayload({
+        shot: makeShot({ sortOrder: 7 }),
+        clientId: "c1",
+        targetProjectId: "p1",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        options: { sortOrderOverride: 12345 },
+      })
+      expect(payload["sortOrder"]).toBe(12345)
+    })
+
+    it("true-clone options (all three together) preserve number/order and remap lane", () => {
+      const payload = buildShotClonePayload({
+        shot: makeShot({ shotNumber: "9C", sortOrder: 55, laneId: "old-lane" }),
+        clientId: "c1",
+        targetProjectId: "p-new",
+        title: "Hero Shot",
+        createdByUid: "u2",
+        preserveLane: false,
+        options: {
+          laneIdOverride: "new-lane",
+          preserveShotNumber: true,
+          sortOrderOverride: 55,
+        },
+      })
+      expect(payload["shotNumber"]).toBe("9C")
+      expect(payload["sortOrder"]).toBe(55)
+      expect(payload["laneId"]).toBe("new-lane")
+      expect(payload["status"]).toBe("todo") // already preserved unconditionally
+      expect(payload["date"]).toBeTruthy() // already preserved unconditionally
+    })
+  })
 })
 
+// =====================================================================
+// Bulk cross-project Copy/Move (Feature A). All Firestore mocked — zero
+// live writes.
+// =====================================================================
+describe("bulk cross-project transfer", () => {
+  let mockBatchSet: ReturnType<typeof vi.fn>
+  let mockBatchUpdate: ReturnType<typeof vi.fn>
+  let mockBatchCommit: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockBatchSet = vi.fn()
+    mockBatchUpdate = vi.fn()
+    mockBatchCommit = vi.fn().mockResolvedValue(undefined)
+    vi.mocked(firestore.writeBatch).mockReturnValue({
+      set: mockBatchSet,
+      update: mockBatchUpdate,
+      delete: vi.fn(),
+      commit: mockBatchCommit,
+    } as unknown as ReturnType<typeof firestore.writeBatch>)
+  })
+
+  function shotsScrambled(count: number): Shot[] {
+    // sortOrder DESCENDING while array/insertion order is ASCENDING id —
+    // i.e. iterating this array in place order is the OPPOSITE of
+    // canonical sortOrder order. Any code path that trusts array/Set
+    // insertion order instead of re-sorting by sortOrder will write the
+    // reversed sequence.
+    return Array.from({ length: count }, (_, i) =>
+      makeShot({ id: `s${i}`, title: `Shot ${i}`, sortOrder: count - i, laneId: undefined }),
+    )
+  }
+
+  describe("bulkCopyShotsToProject", () => {
+    it("no-ops on empty input", async () => {
+      const result = await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots: [],
+        targetProjectId: "p2",
+        targetTitles: new Set(),
+        createdByUid: "u1",
+      })
+      expect(result.copiedCount).toBe(0)
+      expect(mockBatchCommit).not.toHaveBeenCalled()
+    })
+
+    it("writes sortOrder = base + i in CANONICAL sortOrder-ascending order, not array order", async () => {
+      const shots = shotsScrambled(4) // array order s0..s3, sortOrder DESC (4,3,2,1)
+      await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        targetTitles: new Set(),
+        createdByUid: "u1",
+      })
+
+      // Canonical order (sortOrder asc) is s3(1), s2(2), s1(3), s0(4). Every
+      // bulk-copy title gets buildDuplicateShotTitle's "(Copy)" suffix
+      // unconditionally (same as single-shot duplicate) — titles here don't
+      // collide with each other, so no "(Copy 2)" escalation.
+      const titlesInWriteOrder = mockBatchSet.mock.calls.map(
+        (call) => (call[1] as Record<string, unknown>)["title"],
+      )
+      expect(titlesInWriteOrder).toEqual([
+        "Shot 3 (Copy)",
+        "Shot 2 (Copy)",
+        "Shot 1 (Copy)",
+        "Shot 0 (Copy)",
+      ])
+
+      const sortOrders = mockBatchSet.mock.calls.map(
+        (call) => (call[1] as Record<string, unknown>)["sortOrder"] as number,
+      )
+      expect(sortOrders[1]! - sortOrders[0]!).toBe(1)
+      expect(sortOrders[2]! - sortOrders[1]!).toBe(1)
+      expect(sortOrders[3]! - sortOrders[2]!).toBe(1)
+    })
+
+    it("clears laneId and resets shotNumber on every copy (single-shot copy precedent)", async () => {
+      const shots = [makeShot({ id: "s1", laneId: "lane-1", shotNumber: "3A" })]
+      await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        targetTitles: new Set(),
+        createdByUid: "u1",
+      })
+      const payload = mockBatchSet.mock.calls[0]![1] as Record<string, unknown>
+      expect(payload["laneId"]).toBeNull()
+      expect(payload["shotNumber"]).toBeNull()
+      expect(payload["projectId"]).toBe("p2")
+    })
+
+    it("dedups titles and ACCUMULATES newly-minted titles across the batch", async () => {
+      const shots = [
+        makeShot({ id: "s1", title: "Look A", sortOrder: 1 }),
+        makeShot({ id: "s2", title: "Look A", sortOrder: 2 }),
+      ]
+      await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        targetTitles: new Set(["Look A"]),
+        createdByUid: "u1",
+      })
+      const titles = mockBatchSet.mock.calls.map((call) => (call[1] as Record<string, unknown>)["title"])
+      expect(titles).toEqual(["Look A (Copy)", "Look A (Copy 2)"])
+    })
+
+    it("chunks at 250: 251 shots write 2 batches", async () => {
+      const shots = shotsScrambled(251)
+      const result = await bulkCopyShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        targetTitles: new Set(),
+        createdByUid: "u1",
+      })
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2)
+      expect(result.copiedCount).toBe(251)
+    })
+  })
+
+  describe("bulkMoveShotsToProject", () => {
+    it("no-ops on empty input", async () => {
+      const result = await bulkMoveShotsToProject({
+        clientId: "c1",
+        shots: [],
+        targetProjectId: "p2",
+        user: { uid: "u1", email: null, displayName: null, photoURL: null },
+      })
+      expect(result.movedCount).toBe(0)
+      expect(mockBatchCommit).not.toHaveBeenCalled()
+    })
+
+    it("writes sortOrder = base + i in CANONICAL sortOrder-ascending order, not array order", async () => {
+      const shots = shotsScrambled(3) // array order s0,s1,s2; sortOrder DESC (3,2,1)
+      await bulkMoveShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        user: null,
+      })
+      // Canonical order (sortOrder asc) is s2(1), s1(2), s0(3) — the REVERSE
+      // of array order. Assert on WHICH shot lands at which position, not
+      // just that sortOrders increment by 1 (that alone can't distinguish
+      // canonical order from array order).
+      const idsInWriteOrder = mockBatchUpdate.mock.calls.map((call) => (call[0] as { id: string }).id)
+      expect(idsInWriteOrder).toEqual(["s2", "s1", "s0"])
+
+      const sortOrders = mockBatchUpdate.mock.calls.map(
+        (call) => (call[1] as Record<string, unknown>)["sortOrder"] as number,
+      )
+      expect(sortOrders[1]! - sortOrders[0]!).toBe(1)
+      expect(sortOrders[2]! - sortOrders[1]!).toBe(1)
+    })
+
+    it("keeps shotNumber (Ted decision 4), nulls laneId, changes projectId", async () => {
+      const shots = [makeShot({ id: "s1", shotNumber: "7Z", laneId: "lane-9" })]
+      await bulkMoveShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        user: null,
+      })
+      const payload = mockBatchUpdate.mock.calls[0]![1] as Record<string, unknown>
+      // shotNumber is absent from the update payload entirely — Firestore
+      // `update()` only touches named fields, so an absent key means KEPT.
+      expect(payload).not.toHaveProperty("shotNumber")
+      expect(payload["laneId"]).toBeNull()
+      expect(payload["projectId"]).toBe("p2")
+    })
+
+    it("chunks at 250: 251 shots write 2 batches", async () => {
+      const shots = shotsScrambled(251)
+      const result = await bulkMoveShotsToProject({
+        clientId: "c1",
+        shots,
+        targetProjectId: "p2",
+        user: null,
+      })
+      expect(mockBatchCommit).toHaveBeenCalledTimes(2)
+      expect(result.movedCount).toBe(251)
+    })
+  })
+})

--- a/src-vnext/features/shots/lib/shotLifecycleActions.ts
+++ b/src-vnext/features/shots/lib/shotLifecycleActions.ts
@@ -61,6 +61,26 @@ export function buildDuplicateShotTitle(
   return `${base} (Copy ${Date.now()})`
 }
 
+/**
+ * Extra clone controls beyond the original preserveLane/title-reset shape.
+ * All fields are optional and unset-by-default, so callers that omit
+ * `options` entirely reproduce today's behavior byte-for-byte (mutation-
+ * tested — see shotLifecycleActions.test.ts).
+ */
+interface BuildShotClonePayloadOptions {
+  /**
+   * Explicit laneId for the clone (e.g. remapped via an old->new lane map
+   * for project duplication). When present — including `null` — this WINS
+   * over `preserveLane`. Existing call sites never set this, so
+   * `preserveLane` alone still governs their laneId.
+   */
+  readonly laneIdOverride?: string | null
+  /** Keep the source shot's shotNumber instead of resetting it to null. */
+  readonly preserveShotNumber?: boolean
+  /** Explicit sortOrder for the clone. Defaults to Date.now() (today's behavior) when absent. */
+  readonly sortOrderOverride?: number
+}
+
 interface BuildShotClonePayloadArgs {
   readonly shot: Shot
   readonly clientId: string
@@ -68,10 +88,22 @@ interface BuildShotClonePayloadArgs {
   readonly title: string
   readonly createdByUid: string | null
   readonly preserveLane: boolean
+  readonly options?: BuildShotClonePayloadOptions
 }
 
 export function buildShotClonePayload(args: BuildShotClonePayloadArgs): Record<string, unknown> {
-  const { shot, clientId, targetProjectId, title, createdByUid, preserveLane } = args
+  const { shot, clientId, targetProjectId, title, createdByUid, preserveLane, options = {} } = args
+
+  const laneId =
+    options.laneIdOverride !== undefined
+      ? options.laneIdOverride
+      : preserveLane
+        ? shot.laneId ?? null
+        : null
+
+  const shotNumber = options.preserveShotNumber ? shot.shotNumber ?? null : null
+
+  const sortOrder = options.sortOrderOverride !== undefined ? options.sortOrderOverride : Date.now()
 
   const payload = {
     title: normalizeTitle(title),
@@ -89,9 +121,13 @@ export function buildShotClonePayload(args: BuildShotClonePayloadArgs): Record<s
     products: shot.products ?? [],
     locationId: shot.locationId ?? null,
     locationName: shot.locationName ?? null,
-    laneId: preserveLane ? shot.laneId ?? null : null,
-    sortOrder: Date.now(),
-    shotNumber: null,
+    laneId,
+    // Sets initiative field — previously dropped by every clone path
+    // (duplicate-in-project, copy-to-project). Included unconditionally now;
+    // no existing test asserts its absence.
+    mediaType: shot.mediaType ?? null,
+    sortOrder,
+    shotNumber,
     notes: shot.notes ?? null,
     notesAddendum: shot.notesAddendum ?? null,
     date: shot.date ?? null,
@@ -277,5 +313,136 @@ export async function bulkSoftDeleteShots(args: BulkSoftDeleteShotsArgs): Promis
 
     await batch.commit()
   }
+}
+
+/** Sort shots by canonical `sortOrder` ascending — never selection/Set-insertion order. */
+function byCanonicalSortOrder(shots: ReadonlyArray<Shot>): readonly Shot[] {
+  return [...shots].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+}
+
+function chunkShots(shots: ReadonlyArray<Shot>): readonly (readonly Shot[])[] {
+  const chunks: Shot[][] = []
+  for (let i = 0; i < shots.length; i += BULK_CHUNK_SIZE) {
+    chunks.push([...shots.slice(i, i + BULK_CHUNK_SIZE)])
+  }
+  return chunks
+}
+
+interface BulkCopyShotsToProjectArgs {
+  readonly clientId: string
+  readonly shots: ReadonlyArray<Shot>
+  readonly targetProjectId: string
+  /** Existing shot titles in the TARGET project, for dedup via buildDuplicateShotTitle. */
+  readonly targetTitles: ReadonlySet<string>
+  readonly createdByUid: string | null
+}
+
+/**
+ * Bulk "Copy to project…" — clones the given shots into `targetProjectId`.
+ * Order: canonical `sortOrder` ascending (NOT selection/Set order), appended
+ * at the end of the target's custom order (`sortOrder: base + i`). Each
+ * clone's laneId is cleared and shotNumber reset, matching the single-shot
+ * copyShotToProject precedent ("reset to avoid collisions"). Titles are
+ * deduped against `targetTitles`, accumulating newly-minted titles so N
+ * copies of the same source title don't collide with each other.
+ */
+export async function bulkCopyShotsToProject(
+  args: BulkCopyShotsToProjectArgs,
+): Promise<{ readonly copiedCount: number }> {
+  const { clientId, shots, targetProjectId, targetTitles, createdByUid } = args
+  if (shots.length === 0) return { copiedCount: 0 }
+
+  const ordered = byCanonicalSortOrder(shots)
+  const base = Date.now()
+  const accumulatedTitles = new Set(targetTitles)
+
+  const path = shotsPath(clientId)
+  const collectionRef = collection(db, path[0]!, ...path.slice(1))
+
+  let copiedCount = 0
+  const chunks = chunkShots(ordered)
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+    const chunk = chunks[chunkIndex]!
+    const batch = writeBatch(db)
+
+    chunk.forEach((shot, i) => {
+      const globalIndex = chunkIndex * BULK_CHUNK_SIZE + i
+      const title = buildDuplicateShotTitle(shot.title, accumulatedTitles)
+      accumulatedTitles.add(title)
+
+      const payload = buildShotClonePayload({
+        shot,
+        clientId,
+        targetProjectId,
+        title,
+        createdByUid,
+        preserveLane: false,
+        options: { sortOrderOverride: base + globalIndex },
+      })
+
+      const ref = doc(collectionRef)
+      batch.set(ref, {
+        ...payload,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp(),
+      })
+    })
+
+    await batch.commit()
+    copiedCount += chunk.length
+  }
+
+  return { copiedCount }
+}
+
+interface BulkMoveShotsToProjectArgs {
+  readonly clientId: string
+  readonly shots: ReadonlyArray<Shot>
+  readonly targetProjectId: string
+  readonly user: AuthUser | null
+}
+
+/**
+ * Bulk "Move to project…" — reassigns the given shots' `projectId` in place.
+ * Order: canonical `sortOrder` ascending, appended at the end of the
+ * target's custom order (`sortOrder: base + i` — deliberate deviation from
+ * the single-shot moveShotToProject, which leaves sortOrder untouched; a
+ * bulk move needs an explicit landing order in the target). `shotNumber` is
+ * KEPT (Ted decision 4 — Renumber tool in target resolves collisions);
+ * `laneId` is cleared, matching the single-shot move.
+ */
+export async function bulkMoveShotsToProject(
+  args: BulkMoveShotsToProjectArgs,
+): Promise<{ readonly movedCount: number }> {
+  const { clientId, shots, targetProjectId, user } = args
+  if (shots.length === 0) return { movedCount: 0 }
+
+  const ordered = byCanonicalSortOrder(shots)
+  const base = Date.now()
+
+  let movedCount = 0
+  const chunks = chunkShots(ordered)
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
+    const chunk = chunks[chunkIndex]!
+    const batch = writeBatch(db)
+
+    chunk.forEach((shot, i) => {
+      const globalIndex = chunkIndex * BULK_CHUNK_SIZE + i
+      const path = shotPath(shot.id, clientId)
+      const ref = doc(db, path[0]!, ...path.slice(1))
+      batch.update(ref, {
+        projectId: targetProjectId,
+        laneId: null,
+        sortOrder: base + globalIndex,
+        updatedAt: serverTimestamp(),
+        ...(user?.uid ? { updatedBy: user.uid } : {}),
+      })
+    })
+
+    await batch.commit()
+    movedCount += chunk.length
+  }
+
+  return { movedCount }
 }
 

--- a/src-vnext/features/shots/lib/shotLifecycleActions.ts
+++ b/src-vnext/features/shots/lib/shotLifecycleActions.ts
@@ -79,6 +79,24 @@ interface BuildShotClonePayloadOptions {
   readonly preserveShotNumber?: boolean
   /** Explicit sortOrder for the clone. Defaults to Date.now() (today's behavior) when absent. */
   readonly sortOrderOverride?: number
+  /**
+   * Explicit heroImage for the clone (project-duplication path only). When
+   * the key is PRESENT — including `null` — this WINS over `shot.heroImage`:
+   * a value clones that heroImage verbatim; `null` OMITS the field from the
+   * payload entirely (see below). Existing call sites never set this, so
+   * `shot.heroImage` (see the default branch's comment) still governs their
+   * payload byte-for-byte.
+   *
+   * Why this exists: `shot.heroImage` comes from `mapShot`, which
+   * MATERIALIZES a cover — it derives one from `activeLookId`/`products`
+   * whenever the raw Firestore doc has no *stored* `heroImage` field.
+   * Writing that materialized value as a literal stored field on a NEW doc
+   * freezes the cover (the new doc no longer re-derives on look/product
+   * changes) and inherits product-image hard-delete exposure. Pass the RAW
+   * doc's stored `heroImage` here (or `null` when the raw doc had none) so
+   * the clone re-derives dynamically, exactly like the source did.
+   */
+  readonly heroImageOverride?: Shot["heroImage"] | null
 }
 
 interface BuildShotClonePayloadArgs {
@@ -104,6 +122,16 @@ export function buildShotClonePayload(args: BuildShotClonePayloadArgs): Record<s
   const shotNumber = options.preserveShotNumber ? shot.shotNumber ?? null : null
 
   const sortOrder = options.sortOrderOverride !== undefined ? options.sortOrderOverride : Date.now()
+
+  // Default (no heroImageOverride key): today's behavior, unchanged — the
+  // MATERIALIZED `shot.heroImage` (mapShot's derived-or-stored value) is
+  // written verbatim. This is pre-existing, known materialization behavior
+  // for single-shot duplicate/copy (duplicateShotInProject/copyShotToProject
+  // below) and bulk copy (bulkCopyShotsToProject) — out of scope to change
+  // here. duplicateProject.ts deliberately differs: it passes the RAW
+  // stored value via heroImageOverride instead (see that option's doc).
+  const heroImage =
+    options.heroImageOverride !== undefined ? (options.heroImageOverride ?? undefined) : (shot.heroImage ?? null)
 
   const payload = {
     title: normalizeTitle(title),
@@ -131,7 +159,7 @@ export function buildShotClonePayload(args: BuildShotClonePayloadArgs): Record<s
     notes: shot.notes ?? null,
     notesAddendum: shot.notesAddendum ?? null,
     date: shot.date ?? null,
-    heroImage: shot.heroImage ?? null,
+    heroImage,
     looks: shot.looks ?? [],
     activeLookId: shot.activeLookId ?? null,
     tags: shot.tags ?? [],
@@ -315,9 +343,18 @@ export async function bulkSoftDeleteShots(args: BulkSoftDeleteShotsArgs): Promis
   }
 }
 
-/** Sort shots by canonical `sortOrder` ascending — never selection/Set-insertion order. */
+/**
+ * Sort shots by canonical `sortOrder` ascending — never selection/Set-
+ * insertion order. Secondary tie-break by `id` (house pattern: reportSort's
+ * `SHOT_TIEBREAK`/`compareByOrder` family — ALWAYS ascending, deterministic).
+ * Without it, shots that tie on `sortOrder` (e.g. every shot lacking the
+ * field, which `mapShot` defaults to 0) fall back to `Array.sort`'s stable
+ * ordering, which is whatever order they arrived in — the toolbar's
+ * transient display/selection order — and that leaks into the written
+ * landing order in the target project.
+ */
 function byCanonicalSortOrder(shots: ReadonlyArray<Shot>): readonly Shot[] {
-  return [...shots].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0))
+  return [...shots].sort((a, b) => (a.sortOrder ?? 0) - (b.sortOrder ?? 0) || a.id.localeCompare(b.id))
 }
 
 function chunkShots(shots: ReadonlyArray<Shot>): readonly (readonly Shot[])[] {
@@ -328,11 +365,49 @@ function chunkShots(shots: ReadonlyArray<Shot>): readonly (readonly Shot[])[] {
   return chunks
 }
 
+/**
+ * Bulk-copy title resolution: keep the BARE (normalized) source title when
+ * it doesn't collide with anything already in the target (`existingTitles` =
+ * target's current titles ∪ titles already minted earlier in this same
+ * batch); only on collision fall back to `buildDuplicateShotTitle`'s
+ * "(Copy)" / "(Copy N)" namer. Case-insensitive, matching
+ * `buildDuplicateShotTitle`'s own comparison. Single-shot duplicate ALWAYS
+ * renames (it's cloning into the SAME project, where the source title is
+ * itself already taken) — bulk copy targets a DIFFERENT project, so an
+ * empty/non-colliding target has no reason to rename anything.
+ */
+function resolveBulkCopyTitle(sourceTitle: string | null | undefined, existingTitles: ReadonlySet<string>): string {
+  const base = typeof sourceTitle === "string" && sourceTitle.trim().length > 0 ? sourceTitle.trim() : "Untitled Shot"
+  const existingLower = new Set(Array.from(existingTitles).map((t) => t.trim().toLowerCase()))
+  if (!existingLower.has(base.toLowerCase())) return base
+  return buildDuplicateShotTitle(sourceTitle, existingTitles)
+}
+
+/**
+ * Thrown when a chunk of `bulkCopyShotsToProject`'s multi-batch write fails
+ * partway through. Mirrors `DuplicateProjectPartialFailureError`
+ * (duplicateProject.ts) — carries how many shots landed so the caller can
+ * show a precise "Copied N of M shots" error instead of a bare failure
+ * toast, and knows NOT to clear the source selection (some shots never
+ * copied).
+ */
+export class BulkCopyPartialFailureError extends Error {
+  readonly copiedCount: number
+  readonly totalCount: number
+
+  constructor(message: string, info: { readonly copiedCount: number; readonly totalCount: number }) {
+    super(message)
+    this.name = "BulkCopyPartialFailureError"
+    this.copiedCount = info.copiedCount
+    this.totalCount = info.totalCount
+  }
+}
+
 interface BulkCopyShotsToProjectArgs {
   readonly clientId: string
   readonly shots: ReadonlyArray<Shot>
   readonly targetProjectId: string
-  /** Existing shot titles in the TARGET project, for dedup via buildDuplicateShotTitle. */
+  /** Existing shot titles in the TARGET project, for dedup via resolveBulkCopyTitle. */
   readonly targetTitles: ReadonlySet<string>
   readonly createdByUid: string | null
 }
@@ -342,9 +417,15 @@ interface BulkCopyShotsToProjectArgs {
  * Order: canonical `sortOrder` ascending (NOT selection/Set order), appended
  * at the end of the target's custom order (`sortOrder: base + i`). Each
  * clone's laneId is cleared and shotNumber reset, matching the single-shot
- * copyShotToProject precedent ("reset to avoid collisions"). Titles are
- * deduped against `targetTitles`, accumulating newly-minted titles so N
- * copies of the same source title don't collide with each other.
+ * copyShotToProject precedent ("reset to avoid collisions"). Titles are kept
+ * BARE unless they collide with `targetTitles` (accumulated as newly-minted
+ * titles are chosen, so N copies of the same source title don't collide
+ * with each other) — see resolveBulkCopyTitle.
+ *
+ * Version snapshots (createShotVersionSnapshot) are deliberately SKIPPED
+ * here, unlike the single-shot copy/duplicate paths — writing one snapshot
+ * doc per shot at bulk scale (up to 500) would double the write volume for
+ * a history feature nobody reads immediately after a bulk transfer.
  */
 export async function bulkCopyShotsToProject(
   args: BulkCopyShotsToProjectArgs,
@@ -367,7 +448,7 @@ export async function bulkCopyShotsToProject(
 
     chunk.forEach((shot, i) => {
       const globalIndex = chunkIndex * BULK_CHUNK_SIZE + i
-      const title = buildDuplicateShotTitle(shot.title, accumulatedTitles)
+      const title = resolveBulkCopyTitle(shot.title, accumulatedTitles)
       accumulatedTitles.add(title)
 
       const payload = buildShotClonePayload({
@@ -388,7 +469,15 @@ export async function bulkCopyShotsToProject(
       })
     })
 
-    await batch.commit()
+    try {
+      await batch.commit()
+    } catch (err) {
+      console.error("[bulkCopyShotsToProject] Chunk failed partway through:", err)
+      throw new BulkCopyPartialFailureError(
+        `Copied ${copiedCount} of ${ordered.length} shot${ordered.length === 1 ? "" : "s"} before a write failed.`,
+        { copiedCount, totalCount: ordered.length },
+      )
+    }
     copiedCount += chunk.length
   }
 


### PR DESCRIPTION
## Summary

Two features on one branch/PR, per spec `Projects/Shot Builder/outputs/2026-08-16-duplicate-move-copy/spec.md` (Ted's 4 locked scope decisions, 2026-08-16):

**Feature A — Bulk "Copy to project…" / "Move to project…"** on the shots list `BulkActionBar`, gated by the same `canTransferAcrossProjects` GLOBAL-claim (admin/producer) as the existing single-shot `ShotLifecycleActionsMenu` split. New `bulkCopyShotsToProject` / `bulkMoveShotsToProject` in `shotLifecycleActions.ts`.

**Feature B — "Duplicate project…"** in `ProjectActionsMenu`, gated by the same predicate (`canManageProjects`) that gates project creation UI. New `features/projects/lib/duplicateProject.ts` + `DuplicateProjectDialog`.

They share the `buildShotClonePayload` seam per spec: extended with an options object rather than a parallel builder.

## Locked scope decisions implemented

1. **Duplicate depth = structure + shots**: new project doc + all Sets/lanes + all non-deleted shots. Skips pulls, schedules, export reports, casting board, shotShares, shotRequests (never read/written).
2. **Duplicate state = TRUE CLONE**: status/date/shotNumber/sortOrder preserved exactly via `buildShotClonePayload({ preserveShotNumber: true, sortOrderOverride: shot.sortOrder, laneIdOverride: <remapped> })`.
3. **Images = share existing files**: `heroImage`/`looks` copied by value (same Storage paths); no file duplication.
4. **Bulk move ordering = append at end, keep numbers**: `sortOrder: base + i` in canonical `sortOrder`-ascending order (never Set/array insertion order); `shotNumber` kept on move, nulled on copy (existing single-shot-copy precedent).

## `buildShotClonePayload` seam

Extended with an optional `options` object (`laneIdOverride`, `preserveShotNumber`, `sortOrderOverride`). Existing call sites (`duplicateShotInProject`, `copyShotToProject`) pass no `options` and are proven byte-identical by the pre-existing test file plus 3 new mutation tests. Also fixes a pre-existing gap: `mediaType` was silently dropped by every clone path — now carried through unconditionally (no existing test asserted its absence).

## Spec contradiction found and resolved — flag this for review

The spec's ground-truth section said to "mirror the live shots-list query semantics exactly," citing `useShots.ts`, and warned about "a `where('deleted','==',false)` that the app doesn't use." **Re-verified by symbol today: `useShots.ts` DOES use `where("deleted","==",false)`** (since 2026-01-31, not a recent regression). Mirroring it literally would:
- Fail the spec's own required test ("legacy shot lacking `deleted` field → still cloned").
- Contradict `CLAUDE.md`'s documented rule: *"Always filter deleted products client-side (`deleted !== true`) — never use `where('deleted','==',false)` which excludes docs missing the field."*
- Diverge from the existing precedent in `talentDependencies.ts` / `useLinkedShots.ts`, which already use the safe client-side-filter pattern for this exact reason.

Resolved in favor of the safe pattern (fetch by `projectId` only, filter `deleted !== true` client-side) — this is what the spec's own test matrix and CLAUDE.md require. `ShotLifecycleActionsMenu.tsx`'s own existing title-dedup fetch (untouched, Feature A precedent) still uses `where("deleted","==",false)`, which is fine there since it's an unrelated existing code path I did not modify.

**Deviation**: `bulkMoveShotsToProject`'s signature takes full `Shot[]` (not the spec's pseudocode `shotIds-in-canonical-order: string[]`) — the function needs each shot's `sortOrder` to sort canonically itself, rather than trusting the caller pre-sorted; matches `bulkCopyShotsToProject`'s shape and makes the canonical-order mutation test meaningful for both.

## Test matrix (spec §Test matrix) — all mutation-verified

| Guard | Test file | Mutation | Result |
|---|---|---|---|
| Default options reproduce today's payload | `shotLifecycleActions.test.ts` | `preserveShotNumber` ignored | 3 tests reddened → restored, green |
| | | `laneIdOverride` ignored | 3 tests reddened → restored, green |
| | | `sortOrderOverride` ignored | 4 tests reddened → restored, green |
| Order preservation: canonical `sortOrder` asc, not Set/array order | `shotLifecycleActions.test.ts` | removed the internal re-sort | 2 tests reddened (copy + move) → restored, green |
| Chunking: 251 shots → 2 batches (both services) | `shotLifecycleActions.test.ts` | `BULK_CHUNK_SIZE` 250→500 | 2 tests reddened → restored, green |
| Move payload: keeps shotNumber, nulls laneId, changes projectId | `shotLifecycleActions.test.ts` | overwrote `laneId`+`shotNumber` in update | 1 test reddened → restored, green |
| | | `projectId` left unchanged | 1 test reddened → restored, green |
| Title dedup accumulates | `shotLifecycleActions.test.ts` | stopped accumulating newly-minted titles | 1 test reddened → restored, green |
| Duplicate always active (archived source) | `duplicateProject.test.ts` | carried source status through | 1 test reddened → restored, green |
| Duplicate query semantics: legacy shot (no `deleted` field) still cloned | `duplicateProject.test.ts` | reproduced the `==false` trap | 1 test reddened → restored, green |
| Lane remap: shot→new id; missing lane→null | `duplicateProject.test.ts` | disabled remap | 1 test reddened → restored, green |
| Bulk actions hidden without `canTransferAcrossProjects` | `BulkActionBar.test.tsx` | removed the gate | 1 test reddened → restored, green |
| Duplicate menu item hidden without project-create rights | `ProjectActionsMenu.test.tsx` | removed `canManage` early-return | 1 test reddened → restored, green |

All Firestore calls mocked (`writeBatch`/`getDoc`/`getDocs`/`query`/`where`); **zero live writes** anywhere in the new tests.

## Test files run (all green)

```
CI=1 npx vitest --run \
  src-vnext/features/shots/lib/shotLifecycleActions.test.ts \
  src-vnext/features/projects/lib/transferTargets.test.ts \
  src-vnext/features/projects/lib/duplicateProject.test.ts \
  src-vnext/features/projects/components/__tests__/DuplicateProjectDialog.test.tsx \
  src-vnext/features/projects/components/__tests__/ProjectActionsMenu.test.tsx \
  src-vnext/features/shots/components/__tests__/BulkActionBar.test.tsx \
  src-vnext/features/shots/components/__tests__/ShotLifecycleActionsMenu.test.tsx \
  src-vnext/features/shots/components/__tests__/ShotListPage.test.tsx \
  src-vnext/features/shots/components/__tests__/ShotListPage.unifiedEditorFork.test.tsx
```
→ 9 files, 96 tests, all passing (includes the pre-existing `shotLifecycleActions`/`ShotLifecycleActionsMenu` suites — byte-identical default behavior confirmed).

## Gates

- `npm run typecheck:baseline` — ✅ no new type errors (161/161 baselined, unchanged)
- `npx eslint --max-warnings=0 <14 changed/new files>` — ✅ clean
- `npm run build` — ✅ built in 21.6s (pre-existing chunk-size warnings only, unrelated)

## Files touched

New: `features/shots/lib/shotLifecycleActions.ts` (+bulk fns), `features/projects/lib/duplicateProject.ts`, `features/projects/lib/transferTargets.ts`, `features/projects/components/DuplicateProjectDialog.tsx`, + their test files.
Modified: `features/shots/components/BulkActionBar.tsx`, `features/shots/components/ShotListPage.tsx`, `features/shots/components/ShotLifecycleActionsMenu.tsx` (refactored to reuse the extracted `filterEligibleTransferTargets`, behavior unchanged), `features/projects/components/ProjectActionsMenu.tsx`.

## Not done / out of scope (per spec)

- No firestore.rules changes (verified: shots create/update rules and lanes create rules already cover admin/global-producer writing into any target project — re-checked by symbol today).
- Known pre-existing behavior kept as-is: moving/copying a shot does not cascade to `Pull.shotIds`, `ScheduleEntry.shotId`, `ShotShare.shotIds`, or export `PageItem.shotId` (same as today's single-shot move/copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)