### PR TITLE
fix(shots): stop destructive card-prefs wipe; add v2 prefs store (dual-write + marker-gated backfill)

### DIFF
--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -41,33 +41,20 @@ import { TooltipProvider } from "@/ui/tooltip"
 import type { TableColumnConfig } from "@/shared/types/table"
 import type { Shot, ProductFamily, ProductSku, ProductSample, Lane } from "@/shared/types"
 import type { ShotGroup } from "@/features/shots/lib/shotListFilters"
+import {
+  mirrorColumnWidthToV2,
+  mirrorColumnOrderToV2,
+  mirrorColumnVisibilityToV2,
+} from "@/features/shots/lib/migrateShotsPrefsV2"
 
 // Threshold above which DnD reorder is automatically disabled — @dnd-kit's
 // sortable overhead becomes noticeable past ~500 items. Exported for tests.
 export const REORDER_SHOT_LIMIT = 500
 
-// ---------------------------------------------------------------------------
-// Migration from old localStorage key format
-// ---------------------------------------------------------------------------
-
-function migrateOldColumnPrefs(clientId: string, projectId: string): void {
-  const oldKey = `sb:shots:list:${clientId}:${projectId}:fields:v1`
-  const newKey = `sb:shots-table:${clientId}:${projectId}`
-  try {
-    if (globalThis.localStorage?.getItem(newKey)) return
-    const oldData = globalThis.localStorage?.getItem(oldKey)
-    if (!oldData) return
-    const fields = JSON.parse(oldData) as Record<string, boolean>
-    const migrated = SHOT_TABLE_COLUMNS.map((col) => ({
-      ...col,
-      visible: col.pinned ? true : (fields[col.key] ?? col.visible),
-    }))
-    globalThis.localStorage?.setItem(newKey, JSON.stringify(migrated))
-    globalThis.localStorage?.removeItem(oldKey)
-  } catch {
-    // Ignore migration errors
-  }
-}
+// NOTE (Phase 1, build plan §1.3b): `migrateOldColumnPrefs` used to live here,
+// forking `:fields:v1` into the table columns key then DESTRUCTIVELY
+// `removeItem`'ing it on every render. Retired — superseded by the
+// non-destructive v2 backfill in useShotListState.ts.
 
 // ---------------------------------------------------------------------------
 // Props
@@ -504,10 +491,6 @@ export function ShotsTable({
     selectionEnabled && shots.length > 0 && shots.every((s) => selection!.selectedIds.has(s.id))
   const someSelected = selectionEnabled && shots.some((s) => selection!.selectedIds.has(s.id))
 
-  // -- Migrate old localStorage column prefs then let useTableColumns read new key --
-  if (clientId && projectId) {
-    migrateOldColumnPrefs(clientId, projectId)
-  }
   const storageKey =
     clientId && projectId ? `shots-table:${clientId}:${projectId}` : `shots-table:${projectId}`
 
@@ -543,12 +526,35 @@ export function ShotsTable({
     setDragWidthOverride({ key, width })
   }, [])
 
+  // Dual-write mirrors (build plan §1.2B, migrateShotsPrefsV2.ts): resize/
+  // reorder mirror into v2 `columns`; visibility mirrors into v2 `fields`
+  // (`handleToggleVisibility` is the shots-local seam `toggleVisibility` lacks).
   const handleColumnResizeEnd = useCallback(
     (key: string, width: number) => {
       setColumnWidth(key, width)
       setDragWidthOverride(null)
+      if (clientId && projectId) mirrorColumnWidthToV2(clientId, projectId, key, width)
     },
-    [setColumnWidth],
+    [setColumnWidth, clientId, projectId],
+  )
+
+  const handleReorderColumns = useCallback(
+    (orderedKeys: readonly string[]) => {
+      reorderColumns(orderedKeys)
+      if (clientId && projectId) mirrorColumnOrderToV2(clientId, projectId, orderedKeys)
+    },
+    [reorderColumns, clientId, projectId],
+  )
+
+  const handleToggleVisibility = useCallback(
+    (key: string) => {
+      toggleVisibility(key)
+      if (clientId && projectId) {
+        const col = columns.find((c) => c.key === key)
+        if (col) mirrorColumnVisibilityToV2(clientId, projectId, key, !col.visible)
+      }
+    },
+    [toggleVisibility, columns, clientId, projectId],
   )
 
   const { startResize } = useColumnResize({
@@ -635,8 +641,8 @@ export function ShotsTable({
       <div className="flex justify-end">
         <ColumnSettingsPopover
           columns={columns}
-          onToggleVisibility={toggleVisibility}
-          onReorder={reorderColumns}
+          onToggleVisibility={handleToggleVisibility}
+          onReorder={handleReorderColumns}
           showReorder={true}
           onReset={resetToDefaults}
         >

--- a/src-vnext/features/shots/components/ShotsTable.tsx
+++ b/src-vnext/features/shots/components/ShotsTable.tsx
@@ -45,6 +45,7 @@ import {
   mirrorColumnWidthToV2,
   mirrorColumnOrderToV2,
   mirrorColumnVisibilityToV2,
+  resetColumnPrefsInV2,
 } from "@/features/shots/lib/migrateShotsPrefsV2"
 
 // Threshold above which DnD reorder is automatically disabled — @dnd-kit's
@@ -491,6 +492,13 @@ export function ShotsTable({
     selectionEnabled && shots.length > 0 && shots.every((s) => selection!.selectedIds.has(s.id))
   const someSelected = selectionEnabled && shots.some((s) => selection!.selectedIds.has(s.id))
 
+  // The clientId-less fallback key is DELIBERATELY outside v2's scope for
+  // Phase 1: every mirror seam below is guarded on `clientId && projectId`, so
+  // a table rendered without a clientId writes legacy Store 3 only and lands in
+  // no `sb:shots:prefs:v2:*` key at all (a v2 key built from a null clientId
+  // would be an orphan no backfill or read-flip could ever find). The exclusion
+  // is covered by ShotsTable.prefsV2DualWrite.test.tsx's key-space assertion,
+  // and is revisited in Phase 2 when reads flip to v2.
   const storageKey =
     clientId && projectId ? `shots-table:${clientId}:${projectId}` : `shots-table:${projectId}`
 
@@ -556,6 +564,15 @@ export function ShotsTable({
     },
     [toggleVisibility, columns, clientId, projectId],
   )
+
+  // Reset is a WRITE like any other and needs its own seam: the shared hook's
+  // `resetToDefaults` removes the Store 3 key, which v2 would never hear about
+  // — leaving the mirrored widths/order/visibility in place to reappear at the
+  // Phase 2 read-flip as prefs the user had explicitly cleared.
+  const handleResetColumns = useCallback(() => {
+    resetToDefaults()
+    if (clientId && projectId) resetColumnPrefsInV2(clientId, projectId)
+  }, [resetToDefaults, clientId, projectId])
 
   const { startResize } = useColumnResize({
     onWidthChange: handleColumnWidthChange,
@@ -644,7 +661,7 @@ export function ShotsTable({
           onToggleVisibility={handleToggleVisibility}
           onReorder={handleReorderColumns}
           showReorder={true}
-          onReset={resetToDefaults}
+          onReset={handleResetColumns}
         >
           <Button
             variant="ghost"

--- a/src-vnext/features/shots/components/__tests__/ShotsTable.prefsV2DualWrite.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotsTable.prefsV2DualWrite.test.tsx
@@ -23,13 +23,20 @@ import { describe, it, expect, beforeEach, vi } from "vitest"
 import { render, screen, fireEvent, within } from "@testing-library/react"
 import type { ReactNode } from "react"
 import { ShotsTable } from "../ShotsTable"
-import { prefsV2Key, tableV3Key, type ShotsPrefsV2 } from "@/features/shots/lib/migrateShotsPrefsV2"
+import {
+  prefsV2Key,
+  tableV3Key,
+  mirrorFieldsPatchToV2,
+  type ShotsPrefsV2,
+} from "@/features/shots/lib/migrateShotsPrefsV2"
 import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
+import { DEFAULT_FIELDS } from "@/features/shots/lib/shotListFilters"
 
 vi.mock("@/shared/components/ColumnSettingsPopover", () => ({
   ColumnSettingsPopover: (props: {
     readonly onToggleVisibility: (key: string) => void
     readonly onReorder: (keys: readonly string[]) => void
+    readonly onReset: () => void
     readonly children: ReactNode
   }) => (
     <div>
@@ -39,6 +46,9 @@ vi.mock("@/shared/components/ColumnSettingsPopover", () => ({
       </button>
       <button type="button" onClick={() => props.onReorder(["talent", "date", "notes"])}>
         mock-reorder
+      </button>
+      <button type="button" onClick={() => props.onReset()}>
+        mock-reset
       </button>
     </div>
   ),
@@ -50,6 +60,14 @@ const PROJECT = "p1"
 function readV2(): ShotsPrefsV2 | null {
   const raw = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
   return raw ? (JSON.parse(raw) as ShotsPrefsV2) : null
+}
+
+/** Legacy Store 3, parsed. The dual-write's legacy half is load-bearing: this
+ *  phase flips NO reads, so a mirror that quietly replaced the legacy write
+ *  instead of extending it would break every surface while leaving v2 green. */
+function readStore3(): ReadonlyArray<{ key: string; visible: boolean; width: number; order: number }> {
+  const raw = window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))
+  return raw ? (JSON.parse(raw) as Array<{ key: string; visible: boolean; width: number; order: number }>) : []
 }
 
 beforeEach(() => {
@@ -86,10 +104,15 @@ describe("ShotsTable — Phase 1 v2 dual-write wiring", () => {
     expect(v2.columns.date?.width).toBe(dateCol3.width)
   })
 
-  it("column VISIBILITY toggle mirrors into v2.fields (not v2.columns)", () => {
+  it("column VISIBILITY toggle writes BOTH halves: legacy Store 3 and v2.fields", () => {
     renderTable()
 
     fireEvent.click(screen.getByText("mock-toggle-date"))
+
+    // Legacy half — deleting `toggleVisibility(key)` from the wrapper must redden here.
+    const store3 = readStore3()
+    expect(store3.length).toBeGreaterThan(0) // the legacy write happened at all
+    expect(store3.find((c) => c.key === "date")!.visible).toBe(false)
 
     const v2 = readV2()!
     // date defaults to visible:true -> toggled to false.
@@ -97,10 +120,16 @@ describe("ShotsTable — Phase 1 v2 dual-write wiring", () => {
     expect(v2.columns.date).toBeUndefined()
   })
 
-  it("column REORDER mirrors order into v2.columns, preserving default widths", () => {
+  it("column REORDER writes BOTH halves: legacy Store 3 order and v2.columns order", () => {
     renderTable()
 
     fireEvent.click(screen.getByText("mock-reorder"))
+
+    // Legacy half — deleting `reorderColumns(orderedKeys)` must redden here.
+    const store3 = readStore3()
+    expect(store3.find((c) => c.key === "talent")!.order).toBe(0)
+    expect(store3.find((c) => c.key === "date")!.order).toBe(1)
+    expect(store3.find((c) => c.key === "notes")!.order).toBe(2)
 
     const v2 = readV2()!
     expect(v2.columns.talent?.order).toBe(0)
@@ -108,12 +137,63 @@ describe("ShotsTable — Phase 1 v2 dual-write wiring", () => {
     expect(v2.columns.notes?.order).toBe(2)
   })
 
-  it("no clientId/projectId: mirrors are skipped (no v2 key written) — matches legacy's own guard", () => {
+  it("no clientId: NO v2 key of any shape is written, while the legacy no-client key still is", () => {
     render(<ShotsTable clientId={null} projectId="" shots={[]} onOpenShot={() => {}} />)
 
     fireEvent.click(screen.getByText("mock-toggle-date"))
     fireEvent.click(screen.getByText("mock-reorder"))
 
-    expect(window.localStorage.getItem(prefsV2Key("c1", "p1"))).toBeNull()
+    // Positive control: the interactions really ran, and landed in the
+    // clientId-less legacy key ShotsTable falls back to. Without this the
+    // negative below could pass on a component that did nothing at all.
+    const legacyNoClient = JSON.parse(window.localStorage.getItem("sb:shots-table:")!) as Array<{
+      key: string
+      visible: boolean
+    }>
+    expect(legacyNoClient.find((c) => c.key === "date")!.visible).toBe(false)
+
+    // F5 — the clientId-less surface is deliberately OUT of v2's scope this
+    // phase. Assert on the KEY SPACE, not one guessed key: `prefsV2Key("c1","p1")`
+    // is a key nothing in this render could ever write, so asserting it is null
+    // stays green even with every clientId guard deleted.
+    const v2Keys = Object.keys(window.localStorage).filter((k) => /^sb:shots:prefs:v2:/.test(k))
+    expect(v2Keys).toEqual([])
+  })
+
+  it("column RESET clears v2 geometry and returns column-domain fields to column defaults", () => {
+    renderTable()
+
+    // Establish non-default v2 state on both halves of the blob.
+    fireEvent.click(screen.getByText("mock-toggle-date")) // fields.date -> false
+    fireEvent.click(screen.getByText("mock-reorder")) // columns.{talent,date,notes}
+    expect(readV2()!.fields.date).toBe(false)
+    expect(Object.keys(readV2()!.columns).length).toBeGreaterThan(0)
+
+    fireEvent.click(screen.getByText("mock-reset"))
+
+    // Legacy half: useTableColumns' reset removes the Store 3 key outright.
+    expect(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))).toBeNull()
+
+    const v2 = readV2()!
+    expect(v2.columns).toEqual({})
+    // Column-domain keys return to the COLUMN defaults (which differ from
+    // DEFAULT_FIELDS on notes/links/updated — Store 3 is what reset restores).
+    expect(v2.fields.date).toBe(true)
+    expect(v2.fields.notes).toBe(true)
+    expect(v2.fields.links).toBe(true)
+    expect(v2.fields.updated).toBe(true)
+    // Card-only fields have no column counterpart — a COLUMN reset must not
+    // touch them.
+    expect(v2.fields.description).toBe(DEFAULT_FIELDS.description)
+    expect(v2.fields.readiness).toBe(DEFAULT_FIELDS.readiness)
+  })
+
+  it("column RESET leaves a card-only field edit intact", () => {
+    renderTable()
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { description: false })
+
+    fireEvent.click(screen.getByText("mock-reset"))
+
+    expect(readV2()!.fields.description).toBe(false)
   })
 })

--- a/src-vnext/features/shots/components/__tests__/ShotsTable.prefsV2DualWrite.test.tsx
+++ b/src-vnext/features/shots/components/__tests__/ShotsTable.prefsV2DualWrite.test.tsx
@@ -1,0 +1,119 @@
+/// <reference types="@testing-library/jest-dom" />
+// Phase 1 — dual-write mirror wiring at ShotsTable's THREE shots-local call
+// sites (build plan §Phase 1, recon corrections #1): column resize
+// (handleColumnResizeEnd), reorder (handleReorderColumns wrapping
+// useTableColumns' reorderColumns), and visibility (handleToggleVisibility,
+// the thin shots-local wrapper since visibility has no seam of its own).
+//
+// Renders with shots=[] (no row mounts — same pattern as
+// ShotsTable.thScope.test.tsx) so no AuthProvider/ShotStatusSelect
+// dependency is needed; these interactions only touch column definitions.
+//
+// Reorder is dnd-kit pointer-drag-based and has no established jsdom
+// simulation pattern anywhere in this repo (verified — not even
+// ColumnSettingsPopover's own test exercises onReorder via drag). Rather
+// than fight dnd-kit/jsdom pointer capture, ColumnSettingsPopover is mocked
+// here to a thin stub that invokes the received onReorder/onToggleVisibility
+// props directly — this test is about ShotsTable's WIRING to those props,
+// not about ColumnSettingsPopover's own DnD mechanics (covered by its own
+// test file) or useColumnResize's mouse mechanics (covered by
+// useColumnResize.test.ts). Resize is driven through the REAL
+// ResizableHeader + useColumnResize path (plain mouse events, no DnD).
+import { describe, it, expect, beforeEach, vi } from "vitest"
+import { render, screen, fireEvent, within } from "@testing-library/react"
+import type { ReactNode } from "react"
+import { ShotsTable } from "../ShotsTable"
+import { prefsV2Key, tableV3Key, type ShotsPrefsV2 } from "@/features/shots/lib/migrateShotsPrefsV2"
+import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
+
+vi.mock("@/shared/components/ColumnSettingsPopover", () => ({
+  ColumnSettingsPopover: (props: {
+    readonly onToggleVisibility: (key: string) => void
+    readonly onReorder: (keys: readonly string[]) => void
+    readonly children: ReactNode
+  }) => (
+    <div>
+      {props.children}
+      <button type="button" onClick={() => props.onToggleVisibility("date")}>
+        mock-toggle-date
+      </button>
+      <button type="button" onClick={() => props.onReorder(["talent", "date", "notes"])}>
+        mock-reorder
+      </button>
+    </div>
+  ),
+}))
+
+const CLIENT = "c1"
+const PROJECT = "p1"
+
+function readV2(): ShotsPrefsV2 | null {
+  const raw = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
+  return raw ? (JSON.parse(raw) as ShotsPrefsV2) : null
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+function renderTable() {
+  return render(
+    <ShotsTable clientId={CLIENT} projectId={PROJECT} shots={[]} onOpenShot={() => {}} />,
+  )
+}
+
+describe("ShotsTable — Phase 1 v2 dual-write wiring", () => {
+  it("column RESIZE (real mouse drag through ResizableHeader/useColumnResize) mirrors width into v2", () => {
+    renderTable()
+
+    const dateHeader = screen.getByText("Date").closest("th")!
+    const separator = within(dateHeader).getByRole("separator")
+
+    fireEvent.mouseDown(separator, { clientX: 100 })
+    fireEvent.mouseMove(document, { clientX: 140 }) // +40px
+    fireEvent.mouseUp(document)
+
+    // Legacy Store 3 (existing behavior) still gets the write.
+    const store3 = JSON.parse(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))!) as Array<{
+      key: string
+      width: number
+    }>
+    const dateCol3 = store3.find((c) => c.key === "date")!
+    expect(dateCol3.width).toBeGreaterThan(SHOT_TABLE_COLUMNS.find((c) => c.key === "date")!.width)
+
+    // v2 mirror carries the SAME resulting width.
+    const v2 = readV2()!
+    expect(v2.columns.date?.width).toBe(dateCol3.width)
+  })
+
+  it("column VISIBILITY toggle mirrors into v2.fields (not v2.columns)", () => {
+    renderTable()
+
+    fireEvent.click(screen.getByText("mock-toggle-date"))
+
+    const v2 = readV2()!
+    // date defaults to visible:true -> toggled to false.
+    expect(v2.fields.date).toBe(false)
+    expect(v2.columns.date).toBeUndefined()
+  })
+
+  it("column REORDER mirrors order into v2.columns, preserving default widths", () => {
+    renderTable()
+
+    fireEvent.click(screen.getByText("mock-reorder"))
+
+    const v2 = readV2()!
+    expect(v2.columns.talent?.order).toBe(0)
+    expect(v2.columns.date?.order).toBe(1)
+    expect(v2.columns.notes?.order).toBe(2)
+  })
+
+  it("no clientId/projectId: mirrors are skipped (no v2 key written) — matches legacy's own guard", () => {
+    render(<ShotsTable clientId={null} projectId="" shots={[]} onOpenShot={() => {}} />)
+
+    fireEvent.click(screen.getByText("mock-toggle-date"))
+    fireEvent.click(screen.getByText("mock-reorder"))
+
+    expect(window.localStorage.getItem(prefsV2Key("c1", "p1"))).toBeNull()
+  })
+})

--- a/src-vnext/features/shots/hooks/__tests__/useShotListState.prefsV2Backfill.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useShotListState.prefsV2Backfill.test.tsx
@@ -7,14 +7,32 @@
 // scopes per (clientId, projectId) rather than firing once for the whole
 // component lifetime.
 import { StrictMode } from "react"
-import { describe, it, expect, beforeEach } from "vitest"
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
 import { act } from "react"
 import { renderHook } from "@testing-library/react"
 import { MemoryRouter } from "react-router-dom"
 import type { ReactNode } from "react"
 import { useShotListState } from "../useShotListState"
 import { DEFAULT_FIELDS, type ShotsListFields } from "@/features/shots/lib/shotListFilters"
-import { fieldsV1Key, prefsV2Key, type ShotsPrefsV2 } from "@/features/shots/lib/migrateShotsPrefsV2"
+import { SHOT_TABLE_COLUMNS } from "@/features/shots/lib/shotTableColumns"
+import type { TableColumnConfig } from "@/shared/types/table"
+import * as prefsV2Module from "@/features/shots/lib/migrateShotsPrefsV2"
+import {
+  fieldsV1Key,
+  tableV3Key,
+  prefsV2Key,
+  type ShotsPrefsV2,
+} from "@/features/shots/lib/migrateShotsPrefsV2"
+
+// Partial module mock: everything real except a call-counting wrapper around
+// `backfillShotsPrefsV2`. The StrictMode test below asserts the INVOCATION
+// COUNT (see its comment for why a state-based assertion cannot see the
+// double-invoke). `vi.fn(actual.…)` keeps the real implementation, so every
+// other test in this file exercises the genuine backfill.
+vi.mock("@/features/shots/lib/migrateShotsPrefsV2", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/features/shots/lib/migrateShotsPrefsV2")>()
+  return { ...actual, backfillShotsPrefsV2: vi.fn(actual.backfillShotsPrefsV2) }
+})
 
 const PARAMS = {
   shots: [],
@@ -45,6 +63,14 @@ function setup(clientId: string, projectId: string, strict = false) {
 
 beforeEach(() => {
   window.localStorage.clear()
+  vi.mocked(prefsV2Module.backfillShotsPrefsV2).mockClear()
+})
+
+// House rule (`testing-discipline.md`): restores live in afterEach ONLY —
+// `mockRestore`/`mockReset` erase `mock.calls`, so a restore between act and
+// assert makes any spy assertion pass unconditionally.
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe("useShotListState — v2 backfill wiring", () => {
@@ -60,12 +86,21 @@ describe("useShotListState — v2 backfill wiring", () => {
     expect(v2?.fields).toEqual(nonDefault)
   })
 
-  it("StrictMode double-mount: single effective backfill, Store 1 not destructively touched", () => {
+  it("StrictMode double-mount: backfill runs exactly ONCE, Store 1 not destructively touched", () => {
     const nonDefault: ShotsListFields = { ...DEFAULT_FIELDS, launch: true }
     window.localStorage.setItem(fieldsV1Key("c1", "p1"), JSON.stringify(nonDefault))
     const rawBefore = window.localStorage.getItem(fieldsV1Key("c1", "p1"))
 
     setup("c1", "p1", /* strict */ true)
+
+    // The falsifiable half. A state assertion cannot see a StrictMode re-run
+    // at all: the marker gate makes the second pass a no-op AND the [fields]
+    // persist effect rewrites Store 1 with byte-identical content, so
+    // "Store 1 unchanged" stays green even with BOTH re-run guards deleted.
+    // The invocation count is the only thing that reddens. Read `mock.calls`
+    // here, BEFORE any restore (afterEach owns that).
+    expect(vi.mocked(prefsV2Module.backfillShotsPrefsV2)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(prefsV2Module.backfillShotsPrefsV2)).toHaveBeenCalledWith("c1", "p1")
 
     // Store 1 must still be present and byte-identical — a destructive
     // re-run under StrictMode's mount->unmount->mount would have wiped it
@@ -100,7 +135,7 @@ describe("useShotListState — v2 backfill wiring", () => {
     expect(readV2("c1", "pA")?.fields.notes).toBe(true)
   })
 
-  it("dual-write: setFields updates v2.fields via the [fields] persist effect", () => {
+  it("dual-write: setFields updates v2.fields via the wrapped setter", () => {
     const { result } = setup("c1", "p1")
 
     act(() => result.current.setFields({ ...DEFAULT_FIELDS, samples: true }))
@@ -117,5 +152,127 @@ describe("useShotListState — v2 backfill wiring", () => {
     act(() => result.current.setViewMode("table"))
 
     expect(readV2("c1", "p1")?.view).toBe("table")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F1 — MOUNT-ECHO CLOBBER. The v2 fields mirror must fire on a WRITE, never
+// as an echo of the hook's mount-time card state. Every fixture below is a
+// PERSISTED BLOB seeded before render (never the empty/seed path), and every
+// assertion reads v2 AFTER mount with no user interaction at all: whatever
+// the backfill computed must still be there.
+//
+// The card `fields` state is derived from Store 1 alone, so on any project
+// where Store 3 disagrees with Store 1 (or Store 1 is absent entirely) a
+// mount-time mirror silently overwrites the backfill's answer with the card's.
+// ---------------------------------------------------------------------------
+
+/** Store 3's own default visibility, projected onto field keys. Differs from
+ *  DEFAULT_FIELDS on exactly notes/links/updated — which is what makes the
+ *  echo visible. Written as a literal (not re-derived through the module
+ *  under test) so a wrong projection cannot satisfy both sides. */
+const FIELDS_FROM_DEFAULT_COLUMNS: ShotsListFields = {
+  ...DEFAULT_FIELDS,
+  notes: true,
+  links: true,
+  updated: true,
+}
+
+function seedTableV3(clientId: string, projectId: string, cols: readonly TableColumnConfig[]): string {
+  const raw = JSON.stringify(cols)
+  window.localStorage.setItem(tableV3Key(clientId, projectId), raw)
+  return raw
+}
+
+describe("useShotListState — v2 fields survive mount (no mount-echo clobber)", () => {
+  it("(a) Store 3 present with DEFAULT columns, NO Store 1: v2.fields keeps the column-derived projection", () => {
+    // The shape the retired destructive migration left behind: it forked
+    // Store 1 into Store 3 and then deleted Store 1.
+    const rawTable = seedTableV3("c1", "p1", SHOT_TABLE_COLUMNS)
+
+    setup("c1", "p1")
+
+    const v2 = readV2("c1", "p1")!
+    expect(v2.fields).toEqual(FIELDS_FROM_DEFAULT_COLUMNS)
+    expect(v2.fields).not.toEqual(DEFAULT_FIELDS) // the mount-echo's wrong answer
+
+    // T4 — nothing on the write path touches geometry or the recovery
+    // snapshot, so both must survive mount untouched as well.
+    expect(v2.columns.date).toEqual({ width: 120, order: 3 })
+    expect(Object.keys(v2.columns).length).toBe(SHOT_TABLE_COLUMNS.length)
+    expect(v2.rawSnapshot).toEqual({ fieldsV1: null, tableV3: rawTable, viewV1: null })
+  })
+
+  it("(b) table-only user who hid `tags`: v2.fields.tags stays false after mount", () => {
+    const cols = SHOT_TABLE_COLUMNS.map((c) => (c.key === "tags" ? { ...c, visible: false } : c))
+    seedTableV3("c1", "p1", cols)
+
+    setup("c1", "p1")
+
+    const v2 = readV2("c1", "p1")!
+    expect(v2.fields.tags).toBe(false)
+    expect(v2.fields).toEqual({ ...FIELDS_FROM_DEFAULT_COLUMNS, tags: false })
+  })
+
+  it("(c) BOTH stores present and disagreeing: the OR-union survives mount, not Store 1 alone", () => {
+    // Store 1: talent visible, date hidden.  Store 3: talent hidden, date visible.
+    const store1: ShotsListFields = { ...DEFAULT_FIELDS, talent: true, date: false, description: false }
+    window.localStorage.setItem(fieldsV1Key("c1", "p1"), JSON.stringify(store1))
+    const cols = SHOT_TABLE_COLUMNS.map((c) => {
+      if (c.key === "talent") return { ...c, visible: false }
+      if (c.key === "date") return { ...c, visible: true }
+      return c
+    })
+    seedTableV3("c1", "p1", cols)
+
+    const { result } = setup("c1", "p1")
+
+    // The card surface still reads Store 1 verbatim (no read flips this phase).
+    expect(result.current.fields.date).toBe(false)
+
+    const v2 = readV2("c1", "p1")!
+    expect(v2.fields.date).toBe(true) // visible in Store 3 -> union true
+    expect(v2.fields.talent).toBe(true) // visible in Store 1 -> union true
+    expect(v2.fields.notes).toBe(true) // column default true, Store 1 false -> union true
+    expect(v2.fields.description).toBe(false) // card-only: Store 1 alone
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F3 — FIELDS OWNERSHIP. Each mirror patches ONLY the keys its own action
+// changed; last write wins per key. A card-field toggle must not resurrect a
+// column the user hid from the table popover, and vice versa.
+// ---------------------------------------------------------------------------
+
+describe("useShotListState — per-key field mirroring", () => {
+  it("a card toggle patches only the changed key, leaving a table-hidden column hidden in v2", () => {
+    seedTableV3("c1", "p1", SHOT_TABLE_COLUMNS)
+    const { result } = setup("c1", "p1")
+
+    // Simulate the table popover having hidden `tags` (ShotsTable's own
+    // visibility mirror — same v2 blob, different surface).
+    act(() => {
+      prefsV2Module.mirrorColumnVisibilityToV2("c1", "p1", "tags", false)
+    })
+    expect(readV2("c1", "p1")!.fields.tags).toBe(false)
+
+    // Now a CARD field toggle, built the way ShotListDisplaySheet builds it.
+    act(() => result.current.setFields({ ...result.current.fields, description: false }))
+
+    const v2 = readV2("c1", "p1")!
+    expect(v2.fields.description).toBe(false) // the key the user changed
+    expect(v2.fields.tags).toBe(false) // NOT resurrected by the card write
+    expect(v2.fields.notes).toBe(true) // column-derived value preserved
+  })
+
+  it("last-write-wins per key: a later table toggle overrides the card's value for that key", () => {
+    const { result } = setup("c1", "p1")
+
+    act(() => result.current.setFields({ ...result.current.fields, talent: true }))
+    act(() => {
+      prefsV2Module.mirrorColumnVisibilityToV2("c1", "p1", "talent", false)
+    })
+
+    expect(readV2("c1", "p1")!.fields.talent).toBe(false)
   })
 })

--- a/src-vnext/features/shots/hooks/__tests__/useShotListState.prefsV2Backfill.test.tsx
+++ b/src-vnext/features/shots/hooks/__tests__/useShotListState.prefsV2Backfill.test.tsx
@@ -1,0 +1,121 @@
+// Phase 1 — v2 prefs backfill invocation + StrictMode safety + per-project
+// isolation + dual-write, exercised through the REAL useShotListState hook
+// (not just the pure migrateShotsPrefsV2 functions — see that module's own
+// test file for the case-matrix/idempotency/rawSnapshot coverage). This
+// file proves the useEffect WIRING in useShotListState.ts actually invokes
+// the backfill, survives a React StrictMode double-invoke, and correctly
+// scopes per (clientId, projectId) rather than firing once for the whole
+// component lifetime.
+import { StrictMode } from "react"
+import { describe, it, expect, beforeEach } from "vitest"
+import { act } from "react"
+import { renderHook } from "@testing-library/react"
+import { MemoryRouter } from "react-router-dom"
+import type { ReactNode } from "react"
+import { useShotListState } from "../useShotListState"
+import { DEFAULT_FIELDS, type ShotsListFields } from "@/features/shots/lib/shotListFilters"
+import { fieldsV1Key, prefsV2Key, type ShotsPrefsV2 } from "@/features/shots/lib/migrateShotsPrefsV2"
+
+const PARAMS = {
+  shots: [],
+  reorderOptimistic: null,
+  talentNameById: new Map<string, string>(),
+  locationNameById: new Map<string, string>(),
+  productNameById: new Map<string, string>(),
+} as const
+
+function readV2(clientId: string, projectId: string): ShotsPrefsV2 | null {
+  const raw = window.localStorage.getItem(prefsV2Key(clientId, projectId))
+  return raw ? (JSON.parse(raw) as ShotsPrefsV2) : null
+}
+
+function setup(clientId: string, projectId: string, strict = false) {
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <MemoryRouter initialEntries={[`/projects/${projectId}/shots`]}>{children}</MemoryRouter>
+  )
+  const wrapper = strict
+    ? ({ children }: { children: ReactNode }) => (
+        <StrictMode>
+          <Wrapper>{children}</Wrapper>
+        </StrictMode>
+      )
+    : Wrapper
+  return renderHook(() => useShotListState({ ...PARAMS, clientId, projectId }), { wrapper })
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+describe("useShotListState — v2 backfill wiring", () => {
+  it("mounting the hook backfills v2 for the real clientId/projectId, and the hook still loads the card fields", () => {
+    const nonDefault: ShotsListFields = { ...DEFAULT_FIELDS, notes: true, talent: false }
+    window.localStorage.setItem(fieldsV1Key("c1", "p1"), JSON.stringify(nonDefault))
+
+    const { result } = setup("c1", "p1")
+
+    expect(result.current.fields).toEqual(nonDefault) // legacy read path, unchanged
+    const v2 = readV2("c1", "p1")
+    expect(v2?._mig.v2).toBe(true)
+    expect(v2?.fields).toEqual(nonDefault)
+  })
+
+  it("StrictMode double-mount: single effective backfill, Store 1 not destructively touched", () => {
+    const nonDefault: ShotsListFields = { ...DEFAULT_FIELDS, launch: true }
+    window.localStorage.setItem(fieldsV1Key("c1", "p1"), JSON.stringify(nonDefault))
+    const rawBefore = window.localStorage.getItem(fieldsV1Key("c1", "p1"))
+
+    setup("c1", "p1", /* strict */ true)
+
+    // Store 1 must still be present and byte-identical — a destructive
+    // re-run under StrictMode's mount->unmount->mount would have wiped it
+    // the same way the retired migrateOldColumnPrefs bug did.
+    expect(window.localStorage.getItem(fieldsV1Key("c1", "p1"))).toBe(rawBefore)
+    const v2 = readV2("c1", "p1")!
+    expect(v2._mig.v2).toBe(true)
+    expect(v2.fields).toEqual(nonDefault)
+  })
+
+  it("per-project isolation: switching projectId prop backfills the NEW project too (not a single-fire ref)", () => {
+    window.localStorage.setItem(fieldsV1Key("c1", "pA"), JSON.stringify({ ...DEFAULT_FIELDS, notes: true }))
+    window.localStorage.setItem(fieldsV1Key("c1", "pB"), JSON.stringify({ ...DEFAULT_FIELDS, launch: true }))
+
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <MemoryRouter initialEntries={["/projects/pA/shots"]}>{children}</MemoryRouter>
+    )
+    const { result, rerender } = renderHook(
+      (props: { projectId: string }) => useShotListState({ ...PARAMS, clientId: "c1", projectId: props.projectId }),
+      { wrapper: Wrapper, initialProps: { projectId: "pA" } },
+    )
+
+    expect(readV2("c1", "pA")?._mig.v2).toBe(true)
+    expect(readV2("c1", "pB")).toBeNull() // not yet backfilled
+
+    rerender({ projectId: "pB" })
+
+    expect(result.current.fields.launch).toBe(true)
+    expect(readV2("c1", "pB")?._mig.v2).toBe(true)
+    expect(readV2("c1", "pB")?.fields.launch).toBe(true)
+    // Project A's v2 blob is untouched by switching away from it.
+    expect(readV2("c1", "pA")?.fields.notes).toBe(true)
+  })
+
+  it("dual-write: setFields updates v2.fields via the [fields] persist effect", () => {
+    const { result } = setup("c1", "p1")
+
+    act(() => result.current.setFields({ ...DEFAULT_FIELDS, samples: true }))
+
+    expect(readV2("c1", "p1")?.fields.samples).toBe(true)
+    // Legacy key still the one written too — dual-write, not a read-flip.
+    const legacy = JSON.parse(window.localStorage.getItem(fieldsV1Key("c1", "p1"))!) as ShotsListFields
+    expect(legacy.samples).toBe(true)
+  })
+
+  it("dual-write: setViewMode updates v2.view via the mirror", () => {
+    const { result } = setup("c1", "p1")
+
+    act(() => result.current.setViewMode("table"))
+
+    expect(readV2("c1", "p1")?.view).toBe("table")
+  })
+})

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -28,6 +28,11 @@ import { deserializeFilters, serializeFilters, migrateLegacyParams } from "@/fea
 import { applyFilterConditions } from "@/features/shots/lib/filterEngine"
 import type { FilterCondition } from "@/features/shots/lib/filterConditions"
 import { OPERATOR_LABELS } from "@/features/shots/lib/filterConditions"
+import {
+  backfillShotsPrefsV2,
+  mirrorFieldsToV2,
+  mirrorViewToV2,
+} from "@/features/shots/lib/migrateShotsPrefsV2"
 
 // ---------------------------------------------------------------------------
 // Constants (badge label lookups)
@@ -247,6 +252,23 @@ export function useShotListState(params: {
   // -- localStorage persistence --
   const storageKeyBase = clientId && projectId ? `sb:shots:list:${clientId}:${projectId}` : null
 
+  // -- Phase 1 (build plan §1.2A) — one-time v2 prefs backfill, per project.
+  // `backfillShotsPrefsV2` is itself idempotent (marker-gated on `_mig.v2`),
+  // so this ref is defense-in-depth against a redundant localStorage
+  // read/write on a StrictMode double-invoke — NOT a correctness
+  // requirement. Keyed by `clientId:projectId` (not a single boolean, unlike
+  // the legacy-params `migrationDone` ref above) because the backfill is
+  // scoped per project: switching projects within one mounted component must
+  // still backfill the newly-selected project's stores.
+  const prefsV2BackfilledKeys = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    if (!clientId || !projectId) return
+    const key = `${clientId}:${projectId}`
+    if (prefsV2BackfilledKeys.current.has(key)) return
+    prefsV2BackfilledKeys.current.add(key)
+    backfillShotsPrefsV2(clientId, projectId)
+  }, [clientId, projectId])
+
   const [fields, setFields] = useState<ShotsListFields>(() => {
     if (!storageKeyBase) return DEFAULT_FIELDS
     try {
@@ -273,11 +295,16 @@ export function useShotListState(params: {
     }
   }, [storageKeyBase])
 
-  // Persist fields to localStorage on change
+  // Persist fields to localStorage on change — dual-write (build plan
+  // §1.2B): legacy `:fields:v1` stays the read path this phase; the v2
+  // mirror keeps `sb:shots:prefs:v2:*` from going stale before Phase 2's
+  // read-flip. A one-shot backfill snapshot WITHOUT this mirror would freeze
+  // at backfill time and silently lose any card edit made before Phase 2.
   useEffect(() => {
     if (!storageKeyBase) return
     try { window.localStorage.setItem(`${storageKeyBase}:fields:v1`, JSON.stringify(fields)) } catch { /* ignore */ }
-  }, [fields, storageKeyBase])
+    if (clientId && projectId) mirrorFieldsToV2(clientId, projectId, fields)
+  }, [fields, storageKeyBase, clientId, projectId])
 
   const storedDefaultView = useMemo((): ViewMode => {
     if (!storageKeyBase) return "card"
@@ -383,7 +410,9 @@ export function useShotListState(params: {
     if (storageKeyBase) {
       try { window.localStorage.setItem(`${storageKeyBase}:view:v1`, mode) } catch { /* ignore */ }
     }
-  }, [searchParams, setSearchParams, storageKeyBase])
+    // Dual-write mirror (build plan §1.2B) — see the [fields] effect above.
+    if (clientId && projectId) mirrorViewToV2(clientId, projectId, mode)
+  }, [searchParams, setSearchParams, storageKeyBase, clientId, projectId])
 
   const setGroupKey = useCallback((key: GroupKey) => {
     const next = new URLSearchParams(searchParams)

--- a/src-vnext/features/shots/hooks/useShotListState.ts
+++ b/src-vnext/features/shots/hooks/useShotListState.ts
@@ -30,7 +30,8 @@ import type { FilterCondition } from "@/features/shots/lib/filterConditions"
 import { OPERATOR_LABELS } from "@/features/shots/lib/filterConditions"
 import {
   backfillShotsPrefsV2,
-  mirrorFieldsToV2,
+  fieldsDelta,
+  mirrorFieldsPatchToV2,
   mirrorViewToV2,
 } from "@/features/shots/lib/migrateShotsPrefsV2"
 
@@ -269,7 +270,7 @@ export function useShotListState(params: {
     backfillShotsPrefsV2(clientId, projectId)
   }, [clientId, projectId])
 
-  const [fields, setFields] = useState<ShotsListFields>(() => {
+  const [fields, setFieldsState] = useState<ShotsListFields>(() => {
     if (!storageKeyBase) return DEFAULT_FIELDS
     try {
       const raw = window.localStorage.getItem(`${storageKeyBase}:fields:v1`)
@@ -280,31 +281,60 @@ export function useShotListState(params: {
     }
   })
 
-  // Rehydrate fields when project/client changes
+  // Latest-value ref for the v2 mirror's delta base (see `setFields` below).
+  // Written by EVERY path that changes `fields`, so two writes inside one tick
+  // diff against what was actually stored rather than a render-stale closure.
+  const fieldsRef = useRef<ShotsListFields>(fields)
+
+  // Rehydrate fields when project/client changes. Uses the RAW setter, never
+  // the wrapped `setFields`: this is a LOAD, not a user write, and mirroring it
+  // would echo one surface's load-time state over the backfill's answer.
   useEffect(() => {
     if (!storageKeyBase) return
+    const apply = (next: ShotsListFields) => {
+      fieldsRef.current = next
+      setFieldsState(next)
+    }
     try {
       const raw = window.localStorage.getItem(`${storageKeyBase}:fields:v1`)
       if (raw) {
-        setFields({ ...DEFAULT_FIELDS, ...JSON.parse(raw) as Partial<ShotsListFields> })
+        apply({ ...DEFAULT_FIELDS, ...JSON.parse(raw) as Partial<ShotsListFields> })
       } else {
-        setFields(DEFAULT_FIELDS)
+        apply(DEFAULT_FIELDS)
       }
     } catch {
-      setFields(DEFAULT_FIELDS)
+      apply(DEFAULT_FIELDS)
     }
   }, [storageKeyBase])
 
-  // Persist fields to localStorage on change — dual-write (build plan
-  // §1.2B): legacy `:fields:v1` stays the read path this phase; the v2
-  // mirror keeps `sb:shots:prefs:v2:*` from going stale before Phase 2's
-  // read-flip. A one-shot backfill snapshot WITHOUT this mirror would freeze
-  // at backfill time and silently lose any card edit made before Phase 2.
+  // Persist fields to legacy Store 1 on change. Legacy `:fields:v1` stays the
+  // read path this phase, and this effect's semantics are byte-for-byte what
+  // they were before Phase 1.
+  //
+  // The v2 mirror deliberately does NOT live here. This effect runs on MOUNT
+  // (after the backfill effect above), so mirroring from it would overwrite
+  // `v2.fields` with the card surface's load-time state on every first load —
+  // silently discarding the column-derived / OR-unioned answer the backfill
+  // had just computed from Store 3. v2 is mirrored from the WRITE path
+  // (`setFields`) instead.
   useEffect(() => {
     if (!storageKeyBase) return
     try { window.localStorage.setItem(`${storageKeyBase}:fields:v1`, JSON.stringify(fields)) } catch { /* ignore */ }
-    if (clientId && projectId) mirrorFieldsToV2(clientId, projectId, fields)
-  }, [fields, storageKeyBase, clientId, projectId])
+  }, [fields, storageKeyBase])
+
+  /** Card-surface field write. Dual-write (build plan §1.2B): the state change
+   *  drives the legacy Store 1 persist effect above; v2 gets a PER-KEY PATCH of
+   *  only the keys this write actually changed, so it never clobbers a value
+   *  the table surface owns (the card's state is derived from Store 1 alone and
+   *  cannot see a column hidden from the table popover). */
+  const setFields = useCallback((next: ShotsListFields) => {
+    const prev = fieldsRef.current
+    fieldsRef.current = next
+    setFieldsState(next)
+    if (clientId && projectId) {
+      mirrorFieldsPatchToV2(clientId, projectId, fieldsDelta(prev, next))
+    }
+  }, [clientId, projectId])
 
   const storedDefaultView = useMemo((): ViewMode => {
     if (!storageKeyBase) return "card"

--- a/src-vnext/features/shots/lib/__tests__/migrateShotsPrefsV2.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/migrateShotsPrefsV2.test.ts
@@ -5,11 +5,13 @@
 import { describe, it, expect, beforeEach } from "vitest"
 import {
   backfillShotsPrefsV2,
-  mirrorFieldsToV2,
+  fieldsDelta,
+  mirrorFieldsPatchToV2,
   mirrorViewToV2,
   mirrorColumnWidthToV2,
   mirrorColumnOrderToV2,
   mirrorColumnVisibilityToV2,
+  resetColumnPrefsInV2,
   resolveViewV2FromRaw,
   fieldsV1Key,
   viewV1Key,
@@ -225,7 +227,7 @@ describe("backfillShotsPrefsV2 — idempotency", () => {
 
     // Simulate a user edit landing in v2 between two backfill invocations
     // (e.g. via a dual-write mirror) — the marker MUST protect it.
-    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { notes: true })
 
     backfillShotsPrefsV2(CLIENT, PROJECT)
 
@@ -269,17 +271,17 @@ describe("resolveViewV2FromRaw — null-preserving view reader", () => {
 // ---------------------------------------------------------------------------
 
 describe("dual-write mirrors", () => {
-  it("mirrorFieldsToV2 updates v2.fields and preserves the existing _mig marker", () => {
+  it("mirrorFieldsPatchToV2 updates v2.fields and preserves the existing _mig marker", () => {
     backfillShotsPrefsV2(CLIENT, PROJECT) // establishes _mig.v2: true baseline
-    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, samples: true })
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { samples: true })
 
     const v2 = readV2()!
     expect(v2.fields.samples).toBe(true)
     expect(v2._mig.v2).toBe(true)
   })
 
-  it("mirrorFieldsToV2 before any backfill still writes a usable v2 blob (does not claim _mig.v2)", () => {
-    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+  it("mirrorFieldsPatchToV2 before any backfill still writes a usable v2 blob (does not claim _mig.v2)", () => {
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { notes: true })
 
     const v2 = readV2()!
     expect(v2.fields.notes).toBe(true)
@@ -355,12 +357,166 @@ describe("no sweeps", () => {
     seedTableV3(nonDefaultTableV3())
 
     backfillShotsPrefsV2(CLIENT, PROJECT)
-    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { notes: true })
     mirrorViewToV2(CLIENT, PROJECT, "table")
     mirrorColumnWidthToV2(CLIENT, PROJECT, "date", 200)
 
     expect(window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))).not.toBeNull()
     expect(window.localStorage.getItem(viewV1Key(CLIENT, PROJECT))).not.toBeNull()
     expect(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))).not.toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F3 — per-key patch semantics. `fieldsDelta` + `mirrorFieldsPatchToV2` are
+// what let the card and table surfaces share one blob: each writes only the
+// keys its own action changed, last write wins per key.
+// ---------------------------------------------------------------------------
+
+describe("fieldsDelta", () => {
+  it("returns only the changed keys, with their NEW values", () => {
+    const prev: ShotsListFields = { ...DEFAULT_FIELDS }
+    const next: ShotsListFields = { ...DEFAULT_FIELDS, notes: true, talent: false }
+
+    expect(fieldsDelta(prev, next)).toEqual({ notes: true, talent: false })
+  })
+
+  it("returns an empty patch for an unchanged object", () => {
+    expect(fieldsDelta({ ...DEFAULT_FIELDS }, { ...DEFAULT_FIELDS })).toEqual({})
+  })
+})
+
+describe("mirrorFieldsPatchToV2 — per-key patch, not whole-object replace", () => {
+  it("leaves untouched keys alone (a card write cannot resurrect a table-hidden column)", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorColumnVisibilityToV2(CLIENT, PROJECT, "tags", false)
+
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { description: false })
+
+    const v2 = readV2()!
+    expect(v2.fields.description).toBe(false)
+    expect(v2.fields.tags).toBe(false) // NOT reverted to the card's idea of it
+  })
+
+  it("an empty patch writes nothing at all", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    const before = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
+
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, {})
+
+    expect(window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))).toBe(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F2 — column reset (ShotsTable's `handleResetColumns` seam).
+// ---------------------------------------------------------------------------
+
+describe("resetColumnPrefsInV2", () => {
+  it("clears geometry and returns COLUMN-domain fields to the column defaults", () => {
+    seedTableV3(nonDefaultTableV3())
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    expect(Object.keys(readV2()!.columns).length).toBeGreaterThan(0)
+
+    resetColumnPrefsInV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.columns).toEqual({})
+    // Spelled out rather than re-derived from SHOT_TABLE_COLUMNS: three of
+    // these (notes/links/updated) differ from DEFAULT_FIELDS, which is exactly
+    // the mistake a reset that reached for DEFAULT_FIELDS would make.
+    expect(v2.fields).toMatchObject({
+      heroThumb: true,
+      date: true,
+      notes: true,
+      location: true,
+      products: true,
+      links: true,
+      talent: true,
+      tags: true,
+      launch: false,
+      reqs: false,
+      samples: false,
+      updated: true,
+      scene: false,
+    })
+  })
+
+  it("does NOT touch card-only fields (description/readiness/shotNumber)", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { description: false, readiness: false, shotNumber: false })
+
+    resetColumnPrefsInV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.fields.description).toBe(false)
+    expect(v2.fields.readiness).toBe(false)
+    expect(v2.fields.shotNumber).toBe(false)
+  })
+
+  it("preserves the marker, view and rawSnapshot", () => {
+    seedFieldsV1({ ...DEFAULT_FIELDS })
+    seedViewV1("table")
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    const before = readV2()!
+
+    resetColumnPrefsInV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2._mig.v2).toBe(true)
+    expect(v2.view).toBe("table")
+    expect(v2.rawSnapshot).toEqual(before.rawSnapshot)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// F4 — a CORRUPT v2 blob must not be read-modify-written by any mirror. Doing
+// so rewrites it with `_mig.v2: false` and `rawSnapshot: null`, destroying the
+// marker AND the only recovery copy of the legacy stores. Mirrors skip; the
+// next mount's backfill rebuilds from the (still authoritative) legacy stores.
+// ---------------------------------------------------------------------------
+
+describe("corrupt v2 blob", () => {
+  const CORRUPT = '{"fields":{"notes":true},'
+
+  function seedCorrupt(raw: string): void {
+    window.localStorage.setItem(prefsV2Key(CLIENT, PROJECT), raw)
+  }
+
+  it.each([
+    ["unparseable", CORRUPT],
+    ["an array", '[{"key":"date"}]'],
+    ["a JSON null", "null"],
+    ["a JSON string", '"nope"'],
+  ])("every mirror writes NOTHING when the blob is %s", (_label, raw) => {
+    seedCorrupt(raw)
+
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { notes: true })
+    mirrorViewToV2(CLIENT, PROJECT, "table")
+    mirrorColumnWidthToV2(CLIENT, PROJECT, "date", 321)
+    mirrorColumnOrderToV2(CLIENT, PROJECT, ["talent", "date"])
+    mirrorColumnVisibilityToV2(CLIENT, PROJECT, "date", false)
+    resetColumnPrefsInV2(CLIENT, PROJECT)
+
+    expect(window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))).toBe(raw)
+  })
+
+  it("the NEXT backfill rebuilds it from the legacy stores (corrupt reads as unstamped)", () => {
+    const fields: ShotsListFields = { ...DEFAULT_FIELDS, launch: true }
+    seedFieldsV1(fields)
+    seedCorrupt(CORRUPT)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2._mig.v2).toBe(true)
+    expect(v2.fields).toEqual(fields)
+    expect(v2.rawSnapshot?.fieldsV1).toBe(JSON.stringify(fields))
+  })
+
+  it("an ABSENT blob is not corrupt — mirrors still write it (that distinction is the point)", () => {
+    mirrorFieldsPatchToV2(CLIENT, PROJECT, { notes: true })
+
+    expect(readV2()!.fields.notes).toBe(true)
   })
 })

--- a/src-vnext/features/shots/lib/__tests__/migrateShotsPrefsV2.test.ts
+++ b/src-vnext/features/shots/lib/__tests__/migrateShotsPrefsV2.test.ts
@@ -1,0 +1,366 @@
+// Phase 1 — three-store localStorage preference consolidation (shots build
+// plan §Phase 1). Every test seeds a PERSISTED-BLOB fixture directly into
+// localStorage before calling the module — never the empty/seed path (the
+// old destructive migration's bug was invisible from an empty origin).
+import { describe, it, expect, beforeEach } from "vitest"
+import {
+  backfillShotsPrefsV2,
+  mirrorFieldsToV2,
+  mirrorViewToV2,
+  mirrorColumnWidthToV2,
+  mirrorColumnOrderToV2,
+  mirrorColumnVisibilityToV2,
+  resolveViewV2FromRaw,
+  fieldsV1Key,
+  viewV1Key,
+  tableV3Key,
+  prefsV2Key,
+  type ShotsPrefsV2,
+} from "../migrateShotsPrefsV2"
+import { DEFAULT_FIELDS, type ShotsListFields } from "../shotListFilters"
+import { SHOT_TABLE_COLUMNS } from "../shotTableColumns"
+import type { TableColumnConfig } from "@/shared/types/table"
+
+const CLIENT = "c1"
+const PROJECT = "p1"
+
+function readV2(): ShotsPrefsV2 | null {
+  const raw = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
+  return raw ? (JSON.parse(raw) as ShotsPrefsV2) : null
+}
+
+function seedFieldsV1(fields: Partial<ShotsListFields>): void {
+  window.localStorage.setItem(fieldsV1Key(CLIENT, PROJECT), JSON.stringify(fields))
+}
+
+function seedViewV1(view: string): void {
+  window.localStorage.setItem(viewV1Key(CLIENT, PROJECT), view)
+}
+
+function seedTableV3(cols: readonly TableColumnConfig[]): void {
+  window.localStorage.setItem(tableV3Key(CLIENT, PROJECT), JSON.stringify(cols))
+}
+
+/** A full, non-default TableColumnConfig[] fixture — every visibility flip
+ *  from SHOT_TABLE_COLUMNS' defaults, plus distinct widths/orders so the
+ *  sidecar-capture assertions aren't accidentally satisfied by defaults. */
+function nonDefaultTableV3(): readonly TableColumnConfig[] {
+  return SHOT_TABLE_COLUMNS.map((col, idx) => ({
+    ...col,
+    visible: col.pinned ? true : !col.visible,
+    width: col.width + 10,
+    order: idx,
+  }))
+}
+
+beforeEach(() => {
+  window.localStorage.clear()
+})
+
+// ---------------------------------------------------------------------------
+// Anchor test — the one that would have caught the live destructive-delete
+// bug. Mutation target is the LIVE backfill pass (not the retired
+// ShotsTable.tsx:66 line — restoring that line stays green and proves
+// nothing, since its call site no longer exists).
+// ---------------------------------------------------------------------------
+
+describe("backfillShotsPrefsV2 — anchor test (SI-3)", () => {
+  it("card-only fixture: Store 1 (:fields:v1) is STILL readable and byte-equal after backfill runs", () => {
+    const nonDefault: ShotsListFields = { ...DEFAULT_FIELDS, notes: true, launch: true, talent: false }
+    seedFieldsV1(nonDefault)
+    const rawBefore = window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const rawAfter = window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))
+    expect(rawAfter).toBe(rawBefore) // still present, byte-identical — NOT deleted
+    expect(JSON.parse(rawAfter!)).toEqual(nonDefault)
+
+    // And the backfill actually carried those fields into v2, so a future
+    // read-flip (Phase 2) loads the SAME prefs the card was showing.
+    const v2 = readV2()
+    expect(v2?.fields).toEqual(nonDefault)
+    expect(v2?._mig.v2).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Case matrix (build plan §1.2A)
+// ---------------------------------------------------------------------------
+
+describe("backfillShotsPrefsV2 — case matrix", () => {
+  it("card Store 1 only: fields copied verbatim, columns = defaults (empty sidecar), Store 1 preserved", () => {
+    const fields: ShotsListFields = { ...DEFAULT_FIELDS, description: false, readiness: false }
+    seedFieldsV1(fields)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.fields).toEqual(fields)
+    expect(v2.columns).toEqual({})
+    expect(v2.view).toBeNull()
+    expect(v2._mig.v2).toBe(true)
+    expect(window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))).not.toBeNull()
+    expect(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))).toBeNull()
+  })
+
+  it("table Store 3 only: fields projected via columnKeyToFieldKey, columns = Store 3 sidecar", () => {
+    const cols = nonDefaultTableV3()
+    seedTableV3(cols)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    // Every non-pinned column's flipped visibility should show up in fields.
+    const dateCol = cols.find((c) => c.key === "date")!
+    expect(v2.fields.date).toBe(dateCol.visible)
+    const talentCol = cols.find((c) => c.key === "talent")!
+    expect(v2.fields.talent).toBe(talentCol.visible)
+    // Card-only fields have no column counterpart — fall back to defaults.
+    expect(v2.fields.description).toBe(DEFAULT_FIELDS.description)
+    expect(v2.fields.readiness).toBe(DEFAULT_FIELDS.readiness)
+    // Geometry carried verbatim.
+    expect(v2.columns.date).toEqual({ width: dateCol.width, order: dateCol.order })
+    expect(v2.columns.talent).toEqual({ width: talentCol.width, order: talentCol.order })
+    expect(v2._mig.v2).toBe(true)
+  })
+
+  it("BOTH present, DISAGREEING on ≥2 overlapping keys: OR-union result exactly", () => {
+    // Store 1: talent visible, date hidden.
+    // Store 3: talent hidden, date visible.
+    // Union must show BOTH visible (visible in EITHER store).
+    const fields: ShotsListFields = { ...DEFAULT_FIELDS, talent: true, date: false, description: false }
+    seedFieldsV1(fields)
+    const cols = SHOT_TABLE_COLUMNS.map((col) => {
+      if (col.key === "talent") return { ...col, visible: false }
+      if (col.key === "date") return { ...col, visible: true }
+      return col
+    })
+    seedTableV3(cols)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.fields.talent).toBe(true) // visible in Store 1 -> union true
+    expect(v2.fields.date).toBe(true) // visible in Store 3 -> union true
+    // Card-only field: Store 1 alone, not union'd against anything.
+    expect(v2.fields.description).toBe(false)
+    // Geometry from Store 3.
+    const dateCol = cols.find((c) => c.key === "date")!
+    expect(v2.columns.date).toEqual({ width: dateCol.width, order: dateCol.order })
+    expect(window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))).not.toBeNull()
+    expect(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))).not.toBeNull()
+  })
+
+  it("BOTH present, a key hidden in BOTH stores stays hidden (union is not always true)", () => {
+    const fields: ShotsListFields = { ...DEFAULT_FIELDS, reqs: false }
+    seedFieldsV1(fields)
+    const cols = SHOT_TABLE_COLUMNS.map((col) => (col.key === "reqs" ? { ...col, visible: false } : col))
+    seedTableV3(cols)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    expect(readV2()!.fields.reqs).toBe(false)
+  })
+
+  it("NEITHER present: defaults written, empty rawSnapshot, marker stamped (no-match stamp)", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.fields).toEqual(DEFAULT_FIELDS)
+    expect(v2.columns).toEqual({})
+    expect(v2.view).toBeNull()
+    expect(v2.rawSnapshot).toEqual({ fieldsV1: null, tableV3: null, viewV1: null })
+    expect(v2._mig.v2).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// rawSnapshot capture (build plan §1.3d)
+// ---------------------------------------------------------------------------
+
+describe("backfillShotsPrefsV2 — rawSnapshot capture", () => {
+  it("captures the raw legacy strings on first write, across all three stores", () => {
+    const fields: ShotsListFields = { ...DEFAULT_FIELDS, tags: false }
+    seedFieldsV1(fields)
+    seedViewV1("table")
+    const cols = nonDefaultTableV3()
+    seedTableV3(cols)
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    const v2 = readV2()!
+    expect(v2.rawSnapshot).toEqual({
+      fieldsV1: JSON.stringify(fields),
+      tableV3: JSON.stringify(cols),
+      viewV1: "table",
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Idempotency (build plan §1.3a, §1.5)
+// ---------------------------------------------------------------------------
+
+describe("backfillShotsPrefsV2 — idempotency", () => {
+  it("running twice produces a byte-identical v2 blob, no duplicated columns", () => {
+    seedFieldsV1({ ...DEFAULT_FIELDS, notes: true })
+    seedTableV3(nonDefaultTableV3())
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    const firstRaw = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    const secondRaw = window.localStorage.getItem(prefsV2Key(CLIENT, PROJECT))
+
+    expect(secondRaw).toBe(firstRaw)
+    expect(Object.keys(JSON.parse(secondRaw!).columns).length).toBe(
+      Object.keys(JSON.parse(firstRaw!).columns).length,
+    )
+  })
+
+  it("a second run never re-derives over a live user edit (marker gate short-circuits)", () => {
+    seedFieldsV1({ ...DEFAULT_FIELDS })
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    // Simulate a user edit landing in v2 between two backfill invocations
+    // (e.g. via a dual-write mirror) — the marker MUST protect it.
+    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+
+    expect(readV2()!.fields.notes).toBe(true) // edit survived
+  })
+})
+
+// ---------------------------------------------------------------------------
+// View reader semantics (build plan §1.5) — NOT through resolveSurface. This
+// guards the null-preserving contract the backfill's `view` field needs
+// (mirrors useShotListState's resolver reader `storedExplicitView`, which is
+// untouched by Phase 1 and not exported — this is a standalone, directly
+// testable copy of the same contract, owned by this module).
+// ---------------------------------------------------------------------------
+
+describe("resolveViewV2FromRaw — null-preserving view reader", () => {
+  it("returns null for an absent (never-stored) value — preserves 'unset', does NOT collapse to card", () => {
+    expect(resolveViewV2FromRaw(null)).toBeNull()
+  })
+
+  it("returns 'table' for a stored 'table'", () => {
+    expect(resolveViewV2FromRaw("table")).toBe("table")
+  })
+
+  it("returns 'card' for a stored 'card' and for the legacy 'gallery'/'visual' aliases", () => {
+    expect(resolveViewV2FromRaw("card")).toBe("card")
+    expect(resolveViewV2FromRaw("gallery")).toBe("card")
+    expect(resolveViewV2FromRaw("visual")).toBe("card")
+  })
+
+  it("backfill NEITHER-store case: v2.view is null, not 'card' — proves preservation end-to-end", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    expect(readV2()!.view).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dual-write mirrors (build plan §1.2B) — each proves the mirror lands in v2
+// WITHOUT touching (or requiring) the legacy key, and preserves whatever
+// `_mig` marker state already existed.
+// ---------------------------------------------------------------------------
+
+describe("dual-write mirrors", () => {
+  it("mirrorFieldsToV2 updates v2.fields and preserves the existing _mig marker", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT) // establishes _mig.v2: true baseline
+    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, samples: true })
+
+    const v2 = readV2()!
+    expect(v2.fields.samples).toBe(true)
+    expect(v2._mig.v2).toBe(true)
+  })
+
+  it("mirrorFieldsToV2 before any backfill still writes a usable v2 blob (does not claim _mig.v2)", () => {
+    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+
+    const v2 = readV2()!
+    expect(v2.fields.notes).toBe(true)
+    expect(v2._mig.v2).toBe(false)
+  })
+
+  it("mirrorViewToV2 updates v2.view without touching Store 2", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorViewToV2(CLIENT, PROJECT, "table")
+
+    expect(readV2()!.view).toBe("table")
+    expect(window.localStorage.getItem(viewV1Key(CLIENT, PROJECT))).toBeNull()
+  })
+
+  it("mirrorColumnWidthToV2 sets width, preserves prior order for that key", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorColumnOrderToV2(CLIENT, PROJECT, ["talent", "date"]) // date gets order 1
+    mirrorColumnWidthToV2(CLIENT, PROJECT, "date", 321)
+
+    expect(readV2()!.columns.date).toEqual({ width: 321, order: 1 })
+  })
+
+  it("mirrorColumnWidthToV2 falls back to the SHOT_TABLE_COLUMNS default order when no prior geometry exists", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorColumnWidthToV2(CLIENT, PROJECT, "talent", 999)
+
+    const talentDefault = SHOT_TABLE_COLUMNS.find((c) => c.key === "talent")!
+    expect(readV2()!.columns.talent).toEqual({ width: 999, order: talentDefault.order })
+  })
+
+  it("mirrorColumnOrderToV2 sets order per key by index, preserves prior widths", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorColumnWidthToV2(CLIENT, PROJECT, "date", 500)
+
+    mirrorColumnOrderToV2(CLIENT, PROJECT, ["talent", "date", "notes"])
+
+    const v2 = readV2()!
+    expect(v2.columns.talent!.order).toBe(0)
+    expect(v2.columns.date).toEqual({ width: 500, order: 1 })
+    expect(v2.columns.notes!.order).toBe(2)
+  })
+
+  it("mirrorColumnVisibilityToV2 sets the mapped field, not the columns sidecar", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorColumnVisibilityToV2(CLIENT, PROJECT, "date", false)
+
+    const v2 = readV2()!
+    expect(v2.fields.date).toBe(false)
+    expect(v2.columns.date).toBeUndefined()
+  })
+
+  it("mirrorColumnVisibilityToV2 is a no-op for pinned columns (shot/shotNumber — no field counterpart)", () => {
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    const before = readV2()
+
+    mirrorColumnVisibilityToV2(CLIENT, PROJECT, "shot", false)
+    mirrorColumnVisibilityToV2(CLIENT, PROJECT, "shotNumber", false)
+
+    expect(readV2()).toEqual(before)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// No sweeps in Phase 1 (build plan §1.3g) — every dual-write / backfill path
+// above leaves Store 1/2/3 untouched when they existed; this suite adds one
+// more explicit end-to-end check across all three at once.
+// ---------------------------------------------------------------------------
+
+describe("no sweeps", () => {
+  it("all three legacy keys survive a full backfill + dual-write cycle", () => {
+    seedFieldsV1({ ...DEFAULT_FIELDS })
+    seedViewV1("card")
+    seedTableV3(nonDefaultTableV3())
+
+    backfillShotsPrefsV2(CLIENT, PROJECT)
+    mirrorFieldsToV2(CLIENT, PROJECT, { ...DEFAULT_FIELDS, notes: true })
+    mirrorViewToV2(CLIENT, PROJECT, "table")
+    mirrorColumnWidthToV2(CLIENT, PROJECT, "date", 200)
+
+    expect(window.localStorage.getItem(fieldsV1Key(CLIENT, PROJECT))).not.toBeNull()
+    expect(window.localStorage.getItem(viewV1Key(CLIENT, PROJECT))).not.toBeNull()
+    expect(window.localStorage.getItem(tableV3Key(CLIENT, PROJECT))).not.toBeNull()
+  })
+})

--- a/src-vnext/features/shots/lib/migrateShotsPrefsV2.ts
+++ b/src-vnext/features/shots/lib/migrateShotsPrefsV2.ts
@@ -1,0 +1,372 @@
+/**
+ * Phase 1 — three-store localStorage preference consolidation (shots build
+ * plan §Phase 1, `2026-08-10-shots-build-plan.md`).
+ *
+ * Today the shots list/table preferences live in THREE independent
+ * localStorage keys ("Store 1/2/3" below) that can disagree, and one of
+ * them (the legacy `migrateOldColumnPrefs` in ShotsTable.tsx) actively
+ * DELETES another's live key on render. This module introduces a fourth,
+ * consolidated key (v2) as a **dual-write mirror + one-time backfill** —
+ * it does NOT change what anyone reads yet. Store 1/2/3 stay the read
+ * path for every surface until Phase 2 flips reads to v2 and sweeps them.
+ *
+ * Reconciliation-discipline safeguards encoded here (build plan §1.3):
+ *   (a) gate the backfill on the `_mig.v2` MARKER, never on a field value.
+ *   (b) never delete a legacy key (handled at the ShotsTable.tsx call site
+ *       — the destructive `removeItem` this module replaces is deleted
+ *       there, not migrated here).
+ *   (c) a NEW marker (`_mig.v2`), stamped even on the "neither store
+ *       present" no-match case — a future correction is `_mig.v3`, never
+ *       an edit to this pass.
+ *   (d) capture `rawSnapshot` (the raw legacy strings) on first v2 write,
+ *       so a future `_mig.v3` can recover from whatever the pre-existing
+ *       destructive migration already collapsed.
+ *   (e)/(g) tested from persisted-blob fixtures; this module never sweeps
+ *       Store 1/2/3 — see the test file for the "no sweep" assertions.
+ */
+
+import type { TableColumnConfig } from "@/shared/types/table"
+import { SHOT_TABLE_COLUMNS, columnKeyToFieldKey } from "./shotTableColumns"
+import { DEFAULT_FIELDS, type ShotsListFields, type ViewMode } from "./shotListFilters"
+
+// ---------------------------------------------------------------------------
+// Key templates (verbatim — see build plan §1.0/§1.4 and the Phase-1 recon
+// corrections). `tableV3Key` already includes the `sb:` prefix that
+// `useTableColumns` applies internally to the `shots-table:{c}:{p}`
+// storageKey ShotsTable passes it — do not double-prefix.
+// ---------------------------------------------------------------------------
+
+export function fieldsV1Key(clientId: string, projectId: string): string {
+  return `sb:shots:list:${clientId}:${projectId}:fields:v1`
+}
+
+export function viewV1Key(clientId: string, projectId: string): string {
+  return `sb:shots:list:${clientId}:${projectId}:view:v1`
+}
+
+export function tableV3Key(clientId: string, projectId: string): string {
+  return `sb:shots-table:${clientId}:${projectId}`
+}
+
+export function prefsV2Key(clientId: string, projectId: string): string {
+  return `sb:shots:prefs:v2:${clientId}:${projectId}`
+}
+
+// ---------------------------------------------------------------------------
+// v2 shape
+// ---------------------------------------------------------------------------
+
+export type ColumnGeometry = {
+  readonly width: number
+  readonly order: number
+}
+
+export type ShotsPrefsV2RawSnapshot = {
+  readonly fieldsV1: string | null
+  readonly tableV3: string | null
+  readonly viewV1: string | null
+}
+
+export type ShotsPrefsV2 = {
+  readonly fields: ShotsListFields
+  /** Dense-only geometry sidecar — width/order only; visibility lives in `fields`. */
+  readonly columns: Readonly<Record<string, ColumnGeometry>>
+  /** null = never explicitly set (absorbs Store 2; preserves the "unset" distinction). */
+  readonly view: ViewMode | null
+  /** The raw legacy blobs captured on first v2 write. null once a fresh-install
+   *  ("neither store present") user is stamped — still captured, just empty fields. */
+  readonly rawSnapshot: ShotsPrefsV2RawSnapshot | null
+  readonly _mig: { readonly v2: boolean }
+}
+
+const EMPTY_PREFS_V2: ShotsPrefsV2 = {
+  fields: DEFAULT_FIELDS,
+  columns: {},
+  view: null,
+  rawSnapshot: null,
+  _mig: { v2: false },
+}
+
+// ---------------------------------------------------------------------------
+// Safe storage helpers — never let a migration failure break the shots surface.
+// ---------------------------------------------------------------------------
+
+function safeGetItem(key: string): string | null {
+  try {
+    return globalThis.localStorage?.getItem(key) ?? null
+  } catch {
+    return null
+  }
+}
+
+function safeSetItem(key: string, value: string): void {
+  try {
+    globalThis.localStorage?.setItem(key, value)
+  } catch {
+    // Ignore storage errors (private mode, quota, etc.) — v2 is a mirror,
+    // never the only copy of a preference.
+  }
+}
+
+/** Read the current v2 blob, tolerantly. Missing/malformed → the empty shape
+ *  with `_mig.v2: false`, so callers can safely read-modify-write. */
+function readPrefsV2(clientId: string, projectId: string): ShotsPrefsV2 {
+  const raw = safeGetItem(prefsV2Key(clientId, projectId))
+  if (!raw) return EMPTY_PREFS_V2
+  try {
+    const parsed = JSON.parse(raw) as Partial<ShotsPrefsV2> | null
+    if (!parsed || typeof parsed !== "object") return EMPTY_PREFS_V2
+    const columns =
+      parsed.columns && typeof parsed.columns === "object" ? parsed.columns : {}
+    return {
+      fields: { ...DEFAULT_FIELDS, ...(parsed.fields ?? {}) },
+      columns,
+      view: parsed.view === "table" || parsed.view === "card" ? parsed.view : null,
+      rawSnapshot: parsed.rawSnapshot ?? null,
+      _mig: { v2: parsed._mig?.v2 === true },
+    }
+  } catch {
+    return EMPTY_PREFS_V2
+  }
+}
+
+function writePrefsV2(clientId: string, projectId: string, prefs: ShotsPrefsV2): void {
+  safeSetItem(prefsV2Key(clientId, projectId), JSON.stringify(prefs))
+}
+
+// ---------------------------------------------------------------------------
+// View field resolution — preserves "never stored" as `null`. This mirrors
+// the CONTRACT of useShotListState's resolver reader (`storedExplicitView`,
+// useShotListState.ts:301-311), duplicated here on purpose: the hook's
+// existing readers are untouched by Phase 1 (verified against main), so this
+// module owns its own copy rather than reaching into the hook's internals.
+// ---------------------------------------------------------------------------
+
+export function resolveViewV2FromRaw(raw: string | null): ViewMode | null {
+  // Backward compat: "gallery" and "visual" both migrate to "card".
+  if (raw === "card" || raw === "gallery" || raw === "visual") return "card"
+  return raw === "table" ? "table" : null
+}
+
+// ---------------------------------------------------------------------------
+// Fields <-> columns key ladder (build plan §1.2 "the fields↔columns key
+// ladder"). Built once from the single source of truth (COLUMN_TO_FIELD via
+// the exported `columnKeyToFieldKey`), not re-declared here.
+// ---------------------------------------------------------------------------
+
+function buildFieldToColumnMap(): ReadonlyMap<keyof ShotsListFields, string> {
+  const map = new Map<keyof ShotsListFields, string>()
+  for (const col of SHOT_TABLE_COLUMNS) {
+    const fieldKey = columnKeyToFieldKey(col.key)
+    if (fieldKey) map.set(fieldKey, col.key)
+  }
+  return map
+}
+
+const FIELD_TO_COLUMN = buildFieldToColumnMap()
+const FIELD_KEYS = Object.keys(DEFAULT_FIELDS) as ReadonlyArray<keyof ShotsListFields>
+
+// ---------------------------------------------------------------------------
+// Legacy blob parsing (tolerant — a malformed blob is treated as absent)
+// ---------------------------------------------------------------------------
+
+function parseTableV3(raw: string | null): readonly TableColumnConfig[] | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? (parsed as readonly TableColumnConfig[]) : null
+  } catch {
+    return null
+  }
+}
+
+function parseFieldsV1(raw: string | null): Partial<ShotsListFields> | null {
+  if (!raw) return null
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    return typeof parsed === "object" && parsed !== null
+      ? (parsed as Partial<ShotsListFields>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Case-matrix builders (build plan §1.2A) — each returns a fresh object;
+// never mutates its inputs.
+// ---------------------------------------------------------------------------
+
+function columnsSidecarFromTableV3(
+  cols: readonly TableColumnConfig[],
+): Readonly<Record<string, ColumnGeometry>> {
+  return Object.fromEntries(cols.map((col) => [col.key, { width: col.width, order: col.order }]))
+}
+
+/** Field visibility projected from Store 3's column list. A field with no
+ *  corresponding column entry (shouldn't normally happen — `normalizeColumns`
+ *  auto-appends new default columns) falls back to DEFAULT_FIELDS. */
+function fieldsFromTableV3(cols: readonly TableColumnConfig[]): ShotsListFields {
+  const byKey = new Map(cols.map((c) => [c.key, c]))
+  const entries = FIELD_KEYS.map((key) => {
+    const columnKey = FIELD_TO_COLUMN.get(key)
+    const col = columnKey ? byKey.get(columnKey) : undefined
+    return [key, col ? col.visible : DEFAULT_FIELDS[key]] as const
+  })
+  return Object.fromEntries(entries) as unknown as ShotsListFields
+}
+
+/** BOTH-stores case: card-only fields (description, readiness) come from
+ *  Store 1 alone; every field with a column counterpart is OR-unioned
+ *  (visible if visible in EITHER store) — no double-count, just boolean OR. */
+function unionFields(
+  store1: Partial<ShotsListFields>,
+  tableProjected: ShotsListFields,
+): ShotsListFields {
+  const entries = FIELD_KEYS.map((key) => {
+    const fromStore1 = store1[key]
+    if (!FIELD_TO_COLUMN.has(key)) {
+      return [key, fromStore1 ?? DEFAULT_FIELDS[key]] as const
+    }
+    return [key, Boolean(fromStore1) || Boolean(tableProjected[key])] as const
+  })
+  return Object.fromEntries(entries) as unknown as ShotsListFields
+}
+
+// ---------------------------------------------------------------------------
+// (A) One-time backfill — marker-gated, absent-safe, idempotent.
+// ---------------------------------------------------------------------------
+
+/**
+ * Backfill `sb:shots:prefs:v2:{clientId}:{projectId}` from whatever legacy
+ * stores exist, exactly once per project. Gated on the `_mig.v2` marker
+ * INSIDE the v2 blob itself — never on any legacy field's value — so it
+ * fires correctly even for blobs that predate every field (absent-safe).
+ *
+ * Never deletes or mutates Store 1/2/3. Safe to call redundantly (e.g. from
+ * a StrictMode double-invoked effect): the second call sees `_mig.v2: true`
+ * and returns immediately, so a user edit made between two calls is never
+ * clobbered by a stale re-derivation.
+ */
+export function backfillShotsPrefsV2(clientId: string, projectId: string): void {
+  try {
+    const existing = readPrefsV2(clientId, projectId)
+    if (existing._mig.v2) return // idempotent — marker already stamped
+
+    const fieldsRaw = safeGetItem(fieldsV1Key(clientId, projectId))
+    const tableRaw = safeGetItem(tableV3Key(clientId, projectId))
+    const viewRaw = safeGetItem(viewV1Key(clientId, projectId))
+
+    const store1Fields = parseFieldsV1(fieldsRaw)
+    const store3Cols = parseTableV3(tableRaw)
+    const view = resolveViewV2FromRaw(viewRaw)
+
+    const rawSnapshot: ShotsPrefsV2RawSnapshot = {
+      fieldsV1: fieldsRaw,
+      tableV3: tableRaw,
+      viewV1: viewRaw,
+    }
+
+    let fields: ShotsListFields
+    let columns: Readonly<Record<string, ColumnGeometry>>
+
+    if (store1Fields && store3Cols) {
+      // BOTH present — geometry from Store 3, OR-unioned visibility.
+      const tableProjected = fieldsFromTableV3(store3Cols)
+      fields = unionFields(store1Fields, tableProjected)
+      columns = columnsSidecarFromTableV3(store3Cols)
+    } else if (store1Fields) {
+      // card Store 1 only — Store 1 preserved as-is; columns = defaults (empty sidecar).
+      fields = { ...DEFAULT_FIELDS, ...store1Fields }
+      columns = {}
+    } else if (store3Cols) {
+      // table Store 3 only — project visibility into fields; carry geometry.
+      fields = fieldsFromTableV3(store3Cols)
+      columns = columnsSidecarFromTableV3(store3Cols)
+    } else {
+      // NEITHER — fresh-install path.
+      fields = DEFAULT_FIELDS
+      columns = {}
+    }
+
+    writePrefsV2(clientId, projectId, {
+      fields,
+      columns,
+      view,
+      rawSnapshot,
+      _mig: { v2: true },
+    })
+  } catch {
+    // A migration failure must never break the shots surface — legacy
+    // stores remain the read path this phase regardless.
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (B) Dual-write mirrors — extend the existing legacy persist paths so v2
+// never goes stale before the Phase 2 read-flip. Each is a read-modify-write
+// against whatever v2 blob currently exists (defaulting to the empty shape),
+// and never touches `_mig` except the backfill above.
+// ---------------------------------------------------------------------------
+
+export function mirrorFieldsToV2(clientId: string, projectId: string, fields: ShotsListFields): void {
+  const current = readPrefsV2(clientId, projectId)
+  writePrefsV2(clientId, projectId, { ...current, fields })
+}
+
+export function mirrorViewToV2(clientId: string, projectId: string, view: ViewMode): void {
+  const current = readPrefsV2(clientId, projectId)
+  writePrefsV2(clientId, projectId, { ...current, view })
+}
+
+/** Mirrors a column width write (ShotsTable's `handleColumnResizeEnd`). */
+export function mirrorColumnWidthToV2(
+  clientId: string,
+  projectId: string,
+  columnKey: string,
+  width: number,
+): void {
+  const current = readPrefsV2(clientId, projectId)
+  const prevGeom = current.columns[columnKey]
+  const order = prevGeom?.order ?? SHOT_TABLE_COLUMNS.find((c) => c.key === columnKey)?.order ?? 0
+  writePrefsV2(clientId, projectId, {
+    ...current,
+    columns: { ...current.columns, [columnKey]: { width, order } },
+  })
+}
+
+/** Mirrors a full column-order write (ShotsTable's `reorderColumns`/`onReorder`). */
+export function mirrorColumnOrderToV2(
+  clientId: string,
+  projectId: string,
+  orderedKeys: readonly string[],
+): void {
+  const current = readPrefsV2(clientId, projectId)
+  const updates = orderedKeys.map((key, idx) => {
+    const prevGeom = current.columns[key]
+    const width = prevGeom?.width ?? SHOT_TABLE_COLUMNS.find((c) => c.key === key)?.width ?? 0
+    return [key, { width, order: idx }] as const
+  })
+  writePrefsV2(clientId, projectId, {
+    ...current,
+    columns: { ...current.columns, ...Object.fromEntries(updates) },
+  })
+}
+
+/** Mirrors a column visibility toggle into `fields` (not `columns` — visibility
+ *  lives in the field model). No-op for pinned columns (`shot`/`shotNumber`),
+ *  which have no field counterpart and are always visible. */
+export function mirrorColumnVisibilityToV2(
+  clientId: string,
+  projectId: string,
+  columnKey: string,
+  visible: boolean,
+): void {
+  const fieldKey = columnKeyToFieldKey(columnKey)
+  if (!fieldKey) return
+  const current = readPrefsV2(clientId, projectId)
+  writePrefsV2(clientId, projectId, {
+    ...current,
+    fields: { ...current.fields, [fieldKey]: visible },
+  })
+}

--- a/src-vnext/features/shots/lib/migrateShotsPrefsV2.ts
+++ b/src-vnext/features/shots/lib/migrateShotsPrefsV2.ts
@@ -108,25 +108,44 @@ function safeSetItem(key: string, value: string): void {
   }
 }
 
-/** Read the current v2 blob, tolerantly. Missing/malformed → the empty shape
- *  with `_mig.v2: false`, so callers can safely read-modify-write. */
-function readPrefsV2(clientId: string, projectId: string): ShotsPrefsV2 {
+/**
+ * Read the current v2 blob. Three outcomes, deliberately distinguished:
+ *
+ *   ABSENT   (no key)            → `EMPTY_PREFS_V2` — a valid starting point;
+ *                                  a mirror may safely read-modify-write it.
+ *   OK       (well-formed blob)  → the parsed prefs.
+ *   CORRUPT  (unparseable, or a
+ *             non-object such as
+ *             an array / `null`) → `null`.
+ *
+ * CORRUPT must NOT collapse into ABSENT. A mirror that read-modify-writes an
+ * unparseable blob would silently rewrite it as `_mig.v2: false` +
+ * `rawSnapshot: null` — destroying both the marker and the ONLY recovery copy
+ * of the legacy stores, on a code path nobody is watching. Mirrors therefore
+ * skip entirely on CORRUPT; the next mount's backfill (which treats an
+ * unstamped-or-unreadable blob as unstamped) rebuilds from the legacy stores,
+ * which are still the authoritative read path this phase.
+ */
+function readPrefsV2(clientId: string, projectId: string): ShotsPrefsV2 | null {
   const raw = safeGetItem(prefsV2Key(clientId, projectId))
   if (!raw) return EMPTY_PREFS_V2
   try {
-    const parsed = JSON.parse(raw) as Partial<ShotsPrefsV2> | null
-    if (!parsed || typeof parsed !== "object") return EMPTY_PREFS_V2
+    const parsed: unknown = JSON.parse(raw)
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null
+    const blob = parsed as Partial<ShotsPrefsV2>
     const columns =
-      parsed.columns && typeof parsed.columns === "object" ? parsed.columns : {}
+      blob.columns && typeof blob.columns === "object" && !Array.isArray(blob.columns)
+        ? blob.columns
+        : {}
     return {
-      fields: { ...DEFAULT_FIELDS, ...(parsed.fields ?? {}) },
+      fields: { ...DEFAULT_FIELDS, ...(blob.fields ?? {}) },
       columns,
-      view: parsed.view === "table" || parsed.view === "card" ? parsed.view : null,
-      rawSnapshot: parsed.rawSnapshot ?? null,
-      _mig: { v2: parsed._mig?.v2 === true },
+      view: blob.view === "table" || blob.view === "card" ? blob.view : null,
+      rawSnapshot: blob.rawSnapshot ?? null,
+      _mig: { v2: blob._mig?.v2 === true },
     }
   } catch {
-    return EMPTY_PREFS_V2
+    return null
   }
 }
 
@@ -165,6 +184,46 @@ function buildFieldToColumnMap(): ReadonlyMap<keyof ShotsListFields, string> {
 
 const FIELD_TO_COLUMN = buildFieldToColumnMap()
 const FIELD_KEYS = Object.keys(DEFAULT_FIELDS) as ReadonlyArray<keyof ShotsListFields>
+
+/** A subset of `ShotsListFields` — the unit every mirror writes (see the
+ *  per-key patch invariant on the mirrors below). `ShotsListFields` is
+ *  readonly, so the builders below accumulate into the mutable twin. */
+export type ShotsFieldsPatch = Readonly<Partial<ShotsListFields>>
+type MutableFieldsPatch = { -readonly [K in keyof ShotsListFields]?: ShotsListFields[K] }
+
+/** The COLUMN domain's own default visibility, keyed by field. Deliberately
+ *  NOT `DEFAULT_FIELDS` — the two disagree (notes/links/updated are visible by
+ *  column default and hidden by card default), and a *column* reset must
+ *  restore what `useTableColumns.resetToDefaults` restores: SHOT_TABLE_COLUMNS.
+ *  Card-only keys (`description`, `readiness`, `shotNumber`) are absent here,
+ *  which is what keeps a column reset from touching them. */
+function buildColumnDomainDefaults(): ShotsFieldsPatch {
+  const out: MutableFieldsPatch = {}
+  for (const col of SHOT_TABLE_COLUMNS) {
+    const fieldKey = columnKeyToFieldKey(col.key)
+    if (fieldKey) out[fieldKey] = col.visible
+  }
+  return out
+}
+
+const COLUMN_DOMAIN_DEFAULT_FIELDS = buildColumnDomainDefaults()
+
+/**
+ * The keys whose values differ between `prev` and `next`, as a patch.
+ *
+ * This is what makes card writes co-exist with table writes in ONE v2 blob:
+ * the card surface's state is derived from Store 1 alone and knows nothing
+ * about a column the user hid from the table popover, so mirroring the card's
+ * WHOLE fields object would resurrect that column every time any card field
+ * was toggled. Mirroring only the delta gives last-write-wins per key.
+ */
+export function fieldsDelta(prev: ShotsListFields, next: ShotsListFields): ShotsFieldsPatch {
+  const patch: MutableFieldsPatch = {}
+  for (const key of FIELD_KEYS) {
+    if (prev[key] !== next[key]) patch[key] = next[key]
+  }
+  return patch
+}
 
 // ---------------------------------------------------------------------------
 // Legacy blob parsing (tolerant — a malformed blob is treated as absent)
@@ -251,7 +310,10 @@ function unionFields(
 export function backfillShotsPrefsV2(clientId: string, projectId: string): void {
   try {
     const existing = readPrefsV2(clientId, projectId)
-    if (existing._mig.v2) return // idempotent — marker already stamped
+    // Idempotent — marker already stamped. A CORRUPT blob (`null`) reads as
+    // unstamped on purpose: rebuilding it from the still-authoritative legacy
+    // stores is the recovery path the mirrors deliberately defer to.
+    if (existing?._mig.v2) return
 
     const fieldsRaw = safeGetItem(fieldsV1Key(clientId, projectId))
     const tableRaw = safeGetItem(tableV3Key(clientId, projectId))
@@ -304,18 +366,41 @@ export function backfillShotsPrefsV2(clientId: string, projectId: string): void 
 
 // ---------------------------------------------------------------------------
 // (B) Dual-write mirrors — extend the existing legacy persist paths so v2
-// never goes stale before the Phase 2 read-flip. Each is a read-modify-write
-// against whatever v2 blob currently exists (defaulting to the empty shape),
-// and never touches `_mig` except the backfill above.
+// never goes stale before the Phase 2 read-flip.
+//
+// TWO invariants hold across every mirror below:
+//
+//   1. PER-KEY PATCH. A mirror writes only the keys the user's action actually
+//      changed, so the card surface and the table surface — which have
+//      independent legacy stores and therefore independent, disagreeing ideas
+//      of "the current fields" — can share one v2 blob under last-write-wins
+//      per key. Never replace a whole sub-object.
+//   2. WRITES ONLY. A mirror fires from a write path, never from a mount
+//      effect. A mount-time mirror is an ECHO of one surface's load-time
+//      state and silently overwrites whatever the backfill computed from the
+//      OTHER stores (see useShotListState's `setFields` for the seam).
+//
+// Each is a read-modify-write against whatever v2 blob currently exists
+// (defaulting to the empty shape when ABSENT, skipped entirely when CORRUPT —
+// see `readPrefsV2`), and never touches `_mig` except the backfill above.
 // ---------------------------------------------------------------------------
 
-export function mirrorFieldsToV2(clientId: string, projectId: string, fields: ShotsListFields): void {
+/** Mirrors a CARD field write, as a per-key patch of just the changed keys
+ *  (build a patch with `fieldsDelta`, not the whole `ShotsListFields`). */
+export function mirrorFieldsPatchToV2(
+  clientId: string,
+  projectId: string,
+  patch: ShotsFieldsPatch,
+): void {
+  if (Object.keys(patch).length === 0) return
   const current = readPrefsV2(clientId, projectId)
-  writePrefsV2(clientId, projectId, { ...current, fields })
+  if (!current) return
+  writePrefsV2(clientId, projectId, { ...current, fields: { ...current.fields, ...patch } })
 }
 
 export function mirrorViewToV2(clientId: string, projectId: string, view: ViewMode): void {
   const current = readPrefsV2(clientId, projectId)
+  if (!current) return
   writePrefsV2(clientId, projectId, { ...current, view })
 }
 
@@ -327,6 +412,7 @@ export function mirrorColumnWidthToV2(
   width: number,
 ): void {
   const current = readPrefsV2(clientId, projectId)
+  if (!current) return
   const prevGeom = current.columns[columnKey]
   const order = prevGeom?.order ?? SHOT_TABLE_COLUMNS.find((c) => c.key === columnKey)?.order ?? 0
   writePrefsV2(clientId, projectId, {
@@ -342,6 +428,7 @@ export function mirrorColumnOrderToV2(
   orderedKeys: readonly string[],
 ): void {
   const current = readPrefsV2(clientId, projectId)
+  if (!current) return
   const updates = orderedKeys.map((key, idx) => {
     const prevGeom = current.columns[key]
     const width = prevGeom?.width ?? SHOT_TABLE_COLUMNS.find((c) => c.key === key)?.width ?? 0
@@ -365,8 +452,31 @@ export function mirrorColumnVisibilityToV2(
   const fieldKey = columnKeyToFieldKey(columnKey)
   if (!fieldKey) return
   const current = readPrefsV2(clientId, projectId)
+  if (!current) return
   writePrefsV2(clientId, projectId, {
     ...current,
     fields: { ...current.fields, [fieldKey]: visible },
+  })
+}
+
+/**
+ * Mirrors a column RESET (ShotsTable's `handleResetColumns`, wrapping
+ * `useTableColumns.resetToDefaults`, which removes the Store 3 key outright).
+ *
+ * Clears the geometry sidecar and returns the COLUMN-DOMAIN field keys to the
+ * column defaults. Card-only keys (`description`, `readiness`, `shotNumber`)
+ * are deliberately untouched: they have no column counterpart, they are not
+ * shown in the column popover, and a table reset has never meant "throw away
+ * the card's display prefs". Without this seam a reset would clear Store 3
+ * while leaving v2 carrying the pre-reset widths/order/visibility forever —
+ * the divergence would only surface at the Phase 2 read-flip.
+ */
+export function resetColumnPrefsInV2(clientId: string, projectId: string): void {
+  const current = readPrefsV2(clientId, projectId)
+  if (!current) return
+  writePrefsV2(clientId, projectId, {
+    ...current,
+    columns: {},
+    fields: { ...current.fields, ...COLUMN_DOMAIN_DEFAULT_FIELDS },
   })
 }


### PR DESCRIPTION
## Summary

Phase 1 of the shots-surface build plan (`2026-08-10-shots-build-plan.md` §Phase 1) — **the anchor / highest-risk phase**. Today the shots list/table preferences live in three independent localStorage keys that can disagree, and one of them actively **deleted** another's live key on every render. This PR:

1. Deletes the destructive delete outright (no dead-coding).
2. Introduces a fourth, consolidated key as a **dual-write mirror + one-time marker-gated backfill**. It does **not** change what anyone reads — that's Phase 2.

Both ship **live, unflagged**, per plan §1.6 (Ted confirmed 2026-08-10): this is a data-safety fix + a non-destructive write-path change, not a UI a user opts into.

## The store map (today)

| # | Key template | Holds | Writer | Reader |
|---|---|---|---|---|
| 1 | `sb:shots:list:{c}:{p}:fields:v1` | `ShotsListFields` (card visibility) | `useShotListState.ts` | `useShotListState.ts`; was **read + DELETED** by `migrateOldColumnPrefs` |
| 2 | `sb:shots:list:{c}:{p}:view:v1` | `ViewMode` | `useShotListState.setViewMode` | two readers (legacy null→card, resolver preserves null) |
| 3 | `sb:shots-table:{c}:{p}` | `TableColumnConfig[]` (visible/width/order) | `useTableColumns.persist` | `useTableColumns.getSnapshot` |

**New (v2):** `sb:shots:prefs:v2:{clientId}:{projectId}` → `{ fields, columns: {[key]: {width, order}}, view: "table"|"card"|null, rawSnapshot, _mig: {v2} }`.

## What ships live and why it's safe

- **Destructive delete removed.** `migrateOldColumnPrefs` (ShotsTable.tsx) and its render-body call site are deleted outright. Store 1 (`:fields:v1`) is never touched again.
- **Backfill is marker-gated, not value-gated.** Gated on `_mig.v2` inside the v2 blob itself, so it fires correctly on blobs that predate every legacy field (absent-safe).
- **Backfill never deletes or mutates Store 1/2/3.** Only writes the new v2 key.
- **Backfill is idempotent.** A second call short-circuits on the marker, so a user edit written between two invocations (e.g. by StrictMode's double-invoke, or a dual-write mirror) is never clobbered.
- **`rawSnapshot` captured on first write** (the raw legacy strings from all three stores) — insurance for a future `_mig.v3` recovery pass, since a user who already hit the old destructive migration can't be distinguished from a genuine table-only user.
- **Dual-write mirrors** extend every existing legacy persist path (`useShotListState`'s `setFields` and `setViewMode`; `ShotsTable`'s column resize / reorder / visibility / **reset** handlers) so v2 never goes stale before the Phase 2 read-flip. Store 1/2/3 remain the sole read path this phase. Two invariants hold across every mirror, both added in review (see **Review findings addressed** below):
  - **WRITES ONLY** — a mirror fires from a write path, never from a mount effect. A mount-time mirror is an *echo* of one surface's load-time state and silently overwrites whatever the backfill computed from the other stores.
  - **PER-KEY PATCH** — a mirror writes only the keys the user's action actually changed (for a card `setFields`, the `prev`→`next` delta), so the card and table surfaces share one blob under last-write-wins per key. Legacy Store 1/Store 3 behavior is unchanged — they stay independent; only v2 unifies.
- **No column key renames.** Confirmed explicitly — `normalizeColumns` keys off `col.key` and none were touched.
- **No sweeps in this PR.** `:fields:v1`, `:view:v1`, and `sb:shots-table:*` are all still read live (flag-off) exactly as before; sweeping any of them now would strand customized users on defaults for the Phase-1→Phase-6 window. All sweeps are Phase 2, conditioned on that store's read path having flipped to v2.

## Case matrix (build plan §1.2A) — all 4 rows + idempotency, from persisted-blob fixtures

| Row | Behavior | Test |
|---|---|---|
| Card Store 1 only | `fields` copied verbatim; `columns` = defaults (empty sidecar); Store 1 preserved | `migrateShotsPrefsV2.test.ts` › "card Store 1 only" |
| Table Store 3 only | `fields` projected via `columnKeyToFieldKey`; `columns` = Store 3 sidecar; card-only fields fall back to defaults | `migrateShotsPrefsV2.test.ts` › "table Store 3 only" |
| Both present | geometry from Store 3; card-only fields from Store 1; overlapping visibility **OR-unioned** | `migrateShotsPrefsV2.test.ts` › "BOTH present, DISAGREEING…" + "…stays hidden" |
| Neither | defaults written, empty `rawSnapshot`, marker stamped | `migrateShotsPrefsV2.test.ts` › "NEITHER present" |
| Idempotency | two runs byte-identical; a live edit between runs survives | `migrateShotsPrefsV2.test.ts` › "idempotency" (2 tests) |
| `rawSnapshot` capture | all three raw legacy strings captured on first write | `migrateShotsPrefsV2.test.ts` › "rawSnapshot capture" |
| View null-preservation | `view` stays `null` for a never-set Store 2, not collapsed to `"card"` | `migrateShotsPrefsV2.test.ts` › "resolveViewV2FromRaw" (4 tests) |

Plus hook-level wiring (`useShotListState.prefsV2Backfill.test.tsx`): real backfill invocation, **StrictMode double-mount** safety, **per-project isolation** (switching `projectId` re-fires the backfill for the new project, not a single-fire ref), and dual-write via `setFields`/`setViewMode`. And `ShotsTable.prefsV2DualWrite.test.tsx`: resize (real mouse-drag through `ResizableHeader`/`useColumnResize`), reorder, and visibility-toggle mirrors, plus a no-clientId/projectId guard.

## Review findings addressed

Two adversarial review passes (production-code lens + test lens) produced nine confirmed findings. All are fixed in `a8a03cb` — red-first, with the fix verified by mutation.

| # | Sev | Finding | Fix |
|---|---|---|---|
| **F1** | P1 | **Mount-echo clobber.** The v2 fields mirror lived inside the `[fields]` persist effect, which runs on MOUNT — *after* the backfill effect — so every first load overwrote `v2.fields` with the card surface's load-time state. Confirmed on three real fixtures: (a) Store 3 default columns + no Store 1 (the shape the retired destructive migration left behind) → backfill wrote `notes/links/updated = true`, post-mount `v2.fields` was byte-identical to `DEFAULT_FIELDS`; (b) a table-only user who hid `tags` read back `true`; (c) both stores disagreeing → the OR-union was replaced by Store 1 alone. | `a8a03cb` — mirror moved out of the effect onto the write path: `setFields` is now a wrapped setter. The persist effect keeps only its (semantically unchanged) legacy Store 1 write. |
| **F3** | P2 | **Fields ownership.** `mirrorFieldsToV2` replaced the *whole* `fields` object while `mirrorColumnVisibilityToV2` patched one key, so hiding `tags` from the table popover and then toggling any card field put `tags` back to `true` in v2 while Store 3 still said hidden. | `a8a03cb` — `mirrorFieldsPatchToV2` + `fieldsDelta`; every mirror is a per-key patch, last-write-wins per key. |
| **F2** | P2 | **Reset unmirrored.** `onReset={resetToDefaults}` passed the shared hook's reset straight through; it removed the Store 3 key with no v2 update, leaving the mirrored widths/order/visibility to reappear at the Phase 2 read-flip as prefs the user had explicitly cleared. | `a8a03cb` — shots-local `handleResetColumns` seam clearing `v2.columns` and returning the **column-domain** field keys to the *column* defaults (which differ from `DEFAULT_FIELDS` on `notes`/`links`/`updated`). Card-only keys (`description`/`readiness`/`shotNumber`) untouched. |
| **F4** | P3 | **Corrupt-blob marker loss.** `readPrefsV2` returned the empty shape on parse failure, so the next mirror read-modify-wrote the blob with `_mig.v2: false, rawSnapshot: null` — destroying the marker **and** the only recovery snapshot. | `a8a03cb` — `readPrefsV2` now distinguishes ABSENT / OK / CORRUPT. Mirrors skip entirely on CORRUPT; the next mount's backfill rebuilds from the still-authoritative legacy stores. Arrays and JSON scalars rejected explicitly. |
| **F5** | P3 | **No-clientId key.** The `sb:shots-table:{projectId}` fallback is invisible to v2, since every mirror seam is guarded on `clientId && projectId`. | `a8a03cb` — deliberate for Phase 1; documented at the call site and pinned by a key-space test (see T2). Revisited in Phase 2. |
| **T1** | P1 | The dual-write tests asserted only the **v2** half — deleting `toggleVisibility(key)` / `reorderColumns(orderedKeys)` from the wrapper handlers left all 31 tests green. | `a8a03cb` — both now assert legacy Store 3 as well (visibility flag; the three reordered keys' exact `order`). |
| **T2** | P1 | The no-clientId test asserted `prefsV2Key("c1","p1")` was null — a key nothing in that render could ever write, so removing the clientId guards entirely stayed green. | `a8a03cb` — asserts **no key matching `/^sb:shots:prefs:v2:/` exists at all**, plus a positive control that the interactions really ran (the legacy no-client key was written). |
| **T3** | P2 | The StrictMode test mounted under `StrictMode` honestly but caught nothing: removing **both** re-run guards left it green, and its "Store 1 byte-identical" assertion is unfalsifiable because the persist effect rewrites Store 1 with identical content. | `a8a03cb` — partial `vi.mock` of the module asserts `backfillShotsPrefsV2` is invoked **exactly once** across the double-mount. `mock.calls` is read before any restore; restores live in `afterEach`. |
| **T4** | P2 | Hook-level `v2.fields` assertions were being satisfied *by the mount echo*, not by the backfill. | `a8a03cb` — persisted-blob fixtures for the Store-3-only and both-stores rows assert `fields`, `columns` and `rawSnapshot` all survive mount untouched. |

### Disclosure — accepted transient behavior for the Phase-1→2 window (H3)

Deleting the old forking migration has one visible consequence, and it is intended per build plan §1.3(b): **a card-only user's FIRST table render during the Phase-1→Phase-2 window shows the default column set rather than columns derived from their card field prefs.** The retired `migrateOldColumnPrefs` used to fork `:fields:v1` into the table-columns key on that first render — which is exactly the code path that then *deleted* the card prefs, the data-loss bug this PR exists to stop. There is no way to keep the fork without keeping the read-then-delete shape or introducing a second forking writer.

The user's card-derived visibility is **not lost**: the v2 backfill captures it (plus `rawSnapshot` of all three raw legacy blobs), and Phase 2's read-flip surfaces it. The window is one phase long, the affected surface is the table's column visibility only (widths and order were never derivable from card prefs anyway), and the user can re-hide columns from the popover at any time — which now mirrors correctly into v2 per key.

## Mutation-evidence table

Every mutation below was applied to the **final** code, run, confirmed red, and reverted; the suite was confirmed green (51/51) after each revert. Test command: `CI=1 npx vitest --run` on the three named files.

**Review-round mutations (all seven required by the fix brief — all CAUGHT):**

| # | Mutation | Caught by |
|---|---|---|
| i | Reintroduce the v2 mirror into the `[fields]` effect (mount echo back) | 4 tests — `useShotListState.prefsV2Backfill` › mount-echo (a), (b), (c) + per-key mirroring |
| ii | **M11** — delete `reorderColumns(orderedKeys)` from `handleReorderColumns` | `ShotsTable.prefsV2DualWrite` › "column REORDER writes BOTH halves" |
| iii | **M14** — delete `toggleVisibility(key)` from `handleToggleVisibility` | `ShotsTable.prefsV2DualWrite` › "column VISIBILITY writes BOTH halves" **and** › "no clientId…" (its positive control) |
| iv | **M7** — remove the `clientId && projectId` guards from all four ShotsTable seams | `ShotsTable.prefsV2DualWrite` › "no clientId…" — orphan key `sb:shots:prefs:v2:null:` appears |
| v | **M12** — store1-only backfill branch returns `DEFAULT_FIELDS` | 6 tests, **3 of them hook-level** (`useShotListState.prefsV2Backfill` › backfill wiring / StrictMode / per-project). Measured control: re-applying M12 *with the mount echo restored* turns all three green again — i.e. the echo was masking M12 at the hook level before this fix. |
| vi | Delete the reset seam's `resetColumnPrefsInV2` call | `ShotsTable.prefsV2DualWrite` › "column RESET clears v2 geometry…" |
| vii | Make mirrors write on parse failure (F4 regression) | 4 tests — `migrateShotsPrefsV2` › corrupt blob × {unparseable, array, JSON null, JSON string} |

**Original PR mutations, all re-verified against the final code:**

| # | Mutation | Caught by |
|---|---|---|
| 1 (anchor) | Backfill deletes Store 1 after writing v2 | 7 tests, incl. `migrateShotsPrefsV2` › "card-only fixture: Store 1 is STILL readable…" and 3 hook-level |
| 2 | OR-union → "Store 3 wins" | `migrateShotsPrefsV2` › "BOTH present, DISAGREEING…" + `useShotListState.prefsV2Backfill` › mount-echo (c) |
| 3′ | Delete the v2 mirror from `setFields` (replaces the original "remove the mirror from the `[fields]` effect" — that mirror no longer lives there) | `useShotListState.prefsV2Backfill` › "dual-write: setFields updates v2.fields" + › per-key mirroring |
| 4 | Remove the `_mig.v2` early-return | `migrateShotsPrefsV2` › "a second run never re-derives over a live user edit" |
| 5 | Gate on a field VALUE instead of the marker | 3 tests, incl. `migrateShotsPrefsV2` › "NEITHER present…" |
| 6 | Collapse `null` → `"card"` in the view reader | 4 tests, incl. both `resolveViewV2FromRaw` null-preservation tests |

## Gate results

- `CI=1 npx vitest --run` on the three Phase-1 files: **51/51 pass** (was 31 — 20 added in review).
- `CI=1 npx vitest --run` on every sibling suite whose subject was touched (14 files: `ShotListPage`, `ShotListPage.unifiedEditorFork`, `ShotListToolbar`, `ShootShotList`, `ShotsTable.rowMemo`, `ShotsTable.thScope`, `useShotListState.{missing,resolver,surface}`, `resolveSurface`, `useTableColumns`, + the three above): **843/843 pass**, no regressions.
- `npm run typecheck:baseline`: **✅ no new type errors (161/161 baselined)**.
- `npx eslint --max-warnings=0` on all changed files: **clean**.
- `npm run build`: **succeeds**.

## Files touched

- NEW `src-vnext/features/shots/lib/migrateShotsPrefsV2.ts` — backfill + per-key dual-write mirrors + reset mirror + key templates + marker; three-way ABSENT/OK/CORRUPT blob read.
- NEW `src-vnext/features/shots/lib/__tests__/migrateShotsPrefsV2.test.ts` (**35 tests**).
- `src-vnext/features/shots/hooks/useShotListState.ts` — invokes the backfill in a StrictMode-safe `useEffect`; mirrors `view` writes and, via a wrapped `setFields`, the per-key `fields` delta.
- NEW `src-vnext/features/shots/hooks/__tests__/useShotListState.prefsV2Backfill.test.tsx` (**10 tests**).
- `src-vnext/features/shots/components/ShotsTable.tsx` — destructive migration deleted; **four** shots-local dual-write seams (resize / reorder / visibility / reset).
- NEW `src-vnext/features/shots/components/__tests__/ShotsTable.prefsV2DualWrite.test.tsx` (**6 tests**).

No shared file was touched: `shared/hooks/useTableColumns.ts` and `shared/types/table.ts` are unchanged (confirmed by diff).

## Test plan

- [x] All named gate files pass (51/51), plus every sibling suite (843/843)
- [x] All 9 review findings (F1-F5, T1-T4) fixed red-first
- [x] All 7 review-round mutations + all 6 original mutations applied to the FINAL code, confirmed red, reverted, confirmed green
- [x] Blast-radius check: no shared hook/component (`useTableColumns.ts`, `table.ts`, `ResizableHeader.tsx`) touched — confirmed via diff
- [x] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
