### PR TITLE
feat(export): show tag chips on shot report rows (screen + PDF) with a Tag chips toggle

### DIFF
--- a/src-vnext/features/export/components/report/BalancedRowsReport.tsx
+++ b/src-vnext/features/export/components/report/BalancedRowsReport.tsx
@@ -23,6 +23,7 @@ import {
   statusMeta,
 } from "./reportShared"
 import { sizeLabel } from "../../lib/report/reportModel"
+import { TagChipView } from "./primitives/TagChip"
 
 interface BodyProps {
   readonly model: ReportModel
@@ -31,6 +32,9 @@ interface BodyProps {
   /** WS-C additional-images toggle. Absent/false renders byte-identical to
    *  pre-WS-C output — AdditionalImagesRow is never invoked. */
   readonly showAdditionalImages?: boolean
+  /** Tag-chip toggle (2026-08-17). Absent/false renders byte-identical to
+   *  pre-tag-chips output — TagChipRow is never invoked. */
+  readonly showTags?: boolean
 }
 
 const GENDER_LABEL: Record<GenderKey, string> = { W: "Women", M: "Men", Mixed: "Mixed", "?": "Unresolved" }
@@ -117,18 +121,36 @@ function AdditionalImagesRow({
   )
 }
 
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless shot's markup is byte-identical toggle on or off. The model already
+ *  de-duped, dropped gender, and ordered them (resolveReportTagChips) — this is
+ *  presentation only. */
+function TagChipRow({ shot }: { readonly shot: ReportShot }): JSX.Element | null {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <div className="sb-tag-row" role="group" aria-label="Tags">
+      {tags.map((t) => (
+        <TagChipView key={t.id} label={t.label} />
+      ))}
+    </div>
+  )
+}
+
 function Band({
   shot,
   imageMap,
   zebra,
   onToggleExclude,
   showAdditionalImages,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
   readonly zebra: boolean
   readonly onToggleExclude: (shotId: string) => void
   readonly showAdditionalImages: boolean
+  readonly showTags: boolean
 }): JSX.Element {
   const imgSrc = resolveSrc(imageMap, primaryLookImage(shot))
   const st = statusMeta(shot.status)
@@ -184,6 +206,8 @@ function Band({
             {st.label}
           </div>
         </div>
+
+        {showTags ? <TagChipRow shot={shot} /> : null}
 
         {present(shot.notes) ? (
           <p className="sb-br-note">
@@ -293,6 +317,29 @@ export function extraImagesWeight(count: number): number {
   return EXTRA_FIRST_LINE_UNITS + (lines - 1) * EXTRA_WRAP_LINE_UNITS
 }
 
+// Tag-chip row weight (2026-08-17) — SCALES with chip count, same reasoning as
+// extraImagesWeight above (`.sb-br-page` growing past its `min-height` under
+// `@media print { break-after: page }` produces a mis-placed footer / part-blank
+// physical page — a pagination-fidelity bug, not a silent clip, but a bug).
+// Calibrated against reportStyles.ts (`.sb-tag-row` / `.sb-tag-chip`):
+//   - 1 weight unit = 177.6px (see extraImagesWeight's derivation above)
+//   - chips per PRINT-mode line = 6 (panel ≈ 670px usable — same derivation as
+//     the extras row; a 12-char chip ≈ 84px, so ~7 fit; charged 6 to bias
+//     toward over-counting lines, which can only over-estimate)
+//   - one line ≈ .sb-tag-row margin-top 8 + chip height ≈ 15px = 23px ≈ 0.13
+//     units — charged 0.15
+//   - each further wrapped line ≈ gap 5 + chip 15 = 20px ≈ 0.11 units —
+//     charged 0.13
+const TAG_CHIPS_PER_LINE = 6
+const TAG_FIRST_LINE_UNITS = 0.15
+const TAG_WRAP_LINE_UNITS = 0.13
+
+export function tagRowWeight(count: number): number {
+  if (count <= 0) return 0
+  const lines = Math.ceil(count / TAG_CHIPS_PER_LINE)
+  return TAG_FIRST_LINE_UNITS + (lines - 1) * TAG_WRAP_LINE_UNITS
+}
+
 // Base band height. A WS-C-1 hotfix nudged this 1.0/1.7 -> 1.05/1.75 for the
 // same reason as ProductionSheetReport's THUMBNAIL_FLOOR. Reverted on review
 // (PR #519 finding dom-preview-nudge-hits-the-wrong-branch) — see that
@@ -305,7 +352,11 @@ export function extraImagesWeight(count: number): number {
 const BASE_H_SINGLE = 1.0
 const BASE_H_MULTI = 1.7
 
-function buildStream(model: ReportModel, showAdditionalImages: boolean): readonly Item[] {
+function buildStream(
+  model: ReportModel,
+  showAdditionalImages: boolean,
+  showTags: boolean,
+): readonly Item[] {
   const stream: Item[] = [{ kind: "mast", h: 1.6 }]
   let z = 0
   for (const group of model.groups) {
@@ -319,6 +370,9 @@ function buildStream(model: ReportModel, showAdditionalImages: boolean): readonl
       // the toggle is off or the shot has nothing extra, so default-off
       // pagination stays byte-identical to pre-WS-C.
       if (showAdditionalImages) h += extraImagesWeight(shot.additionalImages?.length ?? 0)
+      // Tag-chip row (2026-08-17): same shape — no-op when the toggle is off or
+      // the shot has no chips.
+      if (showTags) h += tagRowWeight(shot.tags?.length ?? 0)
       stream.push({ kind: "band", shot, zebra: z % 2 === 1, h })
       z += 1
     }
@@ -326,8 +380,12 @@ function buildStream(model: ReportModel, showAdditionalImages: boolean): readonl
   return stream
 }
 
-function paginate(model: ReportModel, showAdditionalImages: boolean): readonly (readonly Item[])[] {
-  const stream = buildStream(model, showAdditionalImages)
+function paginate(
+  model: ReportModel,
+  showAdditionalImages: boolean,
+  showTags: boolean,
+): readonly (readonly Item[])[] {
+  const stream = buildStream(model, showAdditionalImages, showTags)
   const pages: Item[][] = [[]]
   let curH = 0
   stream.forEach((item, i) => {
@@ -351,8 +409,17 @@ function paginate(model: ReportModel, showAdditionalImages: boolean): readonly (
   return pages
 }
 
-function PagedView({ model, imageMap, onToggleExclude, showAdditionalImages = false }: BodyProps): JSX.Element {
-  const pages = useMemo(() => paginate(model, showAdditionalImages), [model, showAdditionalImages])
+function PagedView({
+  model,
+  imageMap,
+  onToggleExclude,
+  showAdditionalImages = false,
+  showTags = false,
+}: BodyProps): JSX.Element {
+  const pages = useMemo(
+    () => paginate(model, showAdditionalImages, showTags),
+    [model, showAdditionalImages, showTags],
+  )
   const projLine = model.project.client
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
@@ -372,6 +439,7 @@ function PagedView({ model, imageMap, onToggleExclude, showAdditionalImages = fa
                 zebra={item.zebra}
                 onToggleExclude={onToggleExclude}
                 showAdditionalImages={showAdditionalImages}
+                showTags={showTags}
               />
             )
           })}
@@ -392,6 +460,7 @@ export function BalancedRowsReport({
   imageMap,
   onToggleExclude,
   showAdditionalImages = false,
+  showTags = false,
 }: BodyProps): JSX.Element {
   // Continuous zebra across groups (matches comp-c rhythm) — precomputed so the
   // render body stays pure. Counts printable shots only, so the screen rhythm
@@ -430,6 +499,7 @@ export function BalancedRowsReport({
                 zebra={zebraById.get(shot.id) ?? false}
                 onToggleExclude={onToggleExclude}
                 showAdditionalImages={showAdditionalImages}
+                showTags={showTags}
               />
             ))}
           </div>
@@ -440,6 +510,7 @@ export function BalancedRowsReport({
         imageMap={imageMap}
         onToggleExclude={onToggleExclude}
         showAdditionalImages={showAdditionalImages}
+        showTags={showTags}
       />
     </div>
   )

--- a/src-vnext/features/export/components/report/ProductionSheetReport.tsx
+++ b/src-vnext/features/export/components/report/ProductionSheetReport.tsx
@@ -22,6 +22,7 @@ import {
   statusMeta,
 } from "./reportShared"
 import { sizeLabel } from "../../lib/report/reportModel"
+import { TagChipView } from "./primitives/TagChip"
 
 interface BodyProps {
   readonly model: ReportModel
@@ -30,6 +31,9 @@ interface BodyProps {
   /** WS-C additional-images toggle. Absent/false renders byte-identical to
    *  pre-WS-C output — AdditionalImagesRow is never invoked. */
   readonly showAdditionalImages?: boolean
+  /** Tag-chip toggle (2026-08-17). Absent/false renders byte-identical to
+   *  pre-tag-chips output — TagChipRow is never invoked. */
+  readonly showTags?: boolean
 }
 
 // --- product mini-table row: hero(neutral ▲) · family · style# · colour · size · qty
@@ -101,16 +105,34 @@ function AdditionalImagesRow({
   )
 }
 
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless shot's markup is byte-identical toggle on or off. The model already
+ *  de-duped, dropped gender, and ordered them (resolveReportTagChips) — this is
+ *  presentation only. */
+function TagChipRow({ shot }: { readonly shot: ReportShot }): JSX.Element | null {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <div className="sb-tag-row" role="group" aria-label="Tags">
+      {tags.map((t) => (
+        <TagChipView key={t.id} label={t.label} />
+      ))}
+    </div>
+  )
+}
+
 function ShotRow({
   shot,
   imageMap,
   onToggleExclude,
   showAdditionalImages,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (shotId: string) => void
   readonly showAdditionalImages: boolean
+  readonly showTags: boolean
 }): JSX.Element {
   const flagged = isFlagged(shot.status)
   const st = statusMeta(shot.status)
@@ -161,6 +183,7 @@ function ShotRow({
             {shot.gender === "?" ? <span className="sb-badge-unresolved">Gender ?</span> : null}
           </span>
         </div>
+        {showTags ? <TagChipRow shot={shot} /> : null}
         {present(shot.notes) ? <p className="sb-ps-note">{shot.notes}</p> : null}
         <div className="sb-ps-looks">
           {shot.looks.map((lk) => (
@@ -327,16 +350,53 @@ export function extraImagesWeight(count: number): number {
 // compensate for. 2.4 is the measured-correct value again.
 const THUMBNAIL_FLOOR = 2.4
 
-export function shotWeight(shot: ReportShot, showAdditionalImages: boolean): number {
+// Tag-chip row weight (2026-08-17) — SCALES with chip count for the same reason
+// extraImagesWeight does: `.sb-ps-page` is a fixed-height `overflow: hidden`
+// sheet (reportStyles.ts), so under-charging this row silently CLIPS it off the
+// bottom of a page with no marker. Calibrated against the shipped CSS
+// (`.sb-tag-row` / `.sb-tag-chip`), same "estimate, not measure" character as
+// every other term in shotWeight, with a safety margin over the measured figure:
+//   - 1 weight unit = 48px (see extraImagesWeight's derivation above)
+//   - chips per PRINT-mode line = 8 (page content 10in minus --ps-col-status
+//     30px minus print --ps-col-thumb 112px minus .sb-ps-body's 14px*2 padding
+//     ≈ 790px usable; a 12-char chip ≈ 12 x 5.4px + 12px padding + 2px border
+//     + 5px gap ≈ 84px, so ~9 fit — charged 8 to bias toward over-counting,
+//     which can only over-estimate the row, the safe direction)
+//   - one line ≈ .sb-tag-row margin-top 8 + chip height (9px x 1.2 line-height
+//     + 2px padding + 2px border ≈ 15px) ≈ 23px ≈ 0.48 units — charged 0.5
+//   - each further wrapped line ≈ .sb-tag-row gap 5 + chip 15 = 20px ≈ 0.42
+//     units — charged 0.45 for margin
+// No-op (0) when the shot has no chips, so a shot without tags paginates
+// byte-identically whether the toggle is on or off.
+export const TAG_CHIPS_PER_LINE = 8
+const TAG_FIRST_LINE_UNITS = 0.5
+const TAG_WRAP_LINE_UNITS = 0.45
+
+export function tagRowWeight(count: number): number {
+  if (count <= 0) return 0
+  const lines = Math.ceil(count / TAG_CHIPS_PER_LINE)
+  return TAG_FIRST_LINE_UNITS + (lines - 1) * TAG_WRAP_LINE_UNITS
+}
+
+export function shotWeight(
+  shot: ReportShot,
+  showAdditionalImages: boolean,
+  showTags = false,
+): number {
   let prodRows = 0
   for (const l of shot.looks) prodRows += l.products.length
   let w = 1.7 + shot.looks.length * 0.55 + prodRows * 0.42
   if (present(shot.notes)) w += 0.6
   if (showAdditionalImages) w += extraImagesWeight(shot.additionalImages?.length ?? 0)
+  if (showTags) w += tagRowWeight(shot.tags?.length ?? 0)
   return Math.max(w, THUMBNAIL_FLOOR)
 }
 
-function paginate(model: ReportModel, showAdditionalImages: boolean): readonly PsPage[] {
+function paginate(
+  model: ReportModel,
+  showAdditionalImages: boolean,
+  showTags: boolean,
+): readonly PsPage[] {
   const pages: Block[][] = []
   let cur: Block[] = []
   let used = 0
@@ -352,12 +412,12 @@ function paginate(model: ReportModel, showAdditionalImages: boolean): readonly P
     const printable = group.shots.filter((s) => !s.excluded)
     if (printable.length === 0) continue
     // Never strand a group band: start fresh if it + its first shot won't fit.
-    const firstW = printable[0] ? shotWeight(printable[0], showAdditionalImages) : 2.4
+    const firstW = printable[0] ? shotWeight(printable[0], showAdditionalImages, showTags) : 2.4
     if (used > 0 && used + GROUP_W + firstW > cap) flush()
     cur.push({ type: "group", group })
     used += GROUP_W
     for (const shot of printable) {
-      const w = shotWeight(shot, showAdditionalImages)
+      const w = shotWeight(shot, showAdditionalImages, showTags)
       if (used + w > cap && cur.length > 0) {
         flush()
         cur.push({ type: "group", group, cont: true }) // continuation ruler
@@ -371,8 +431,17 @@ function paginate(model: ReportModel, showAdditionalImages: boolean): readonly P
   return pages.map((blocks) => ({ blocks }))
 }
 
-function PagedView({ model, imageMap, onToggleExclude, showAdditionalImages = false }: BodyProps): JSX.Element {
-  const pages = useMemo(() => paginate(model, showAdditionalImages), [model, showAdditionalImages])
+function PagedView({
+  model,
+  imageMap,
+  onToggleExclude,
+  showAdditionalImages = false,
+  showTags = false,
+}: BodyProps): JSX.Element {
+  const pages = useMemo(
+    () => paginate(model, showAdditionalImages, showTags),
+    [model, showAdditionalImages, showTags],
+  )
   const projLine = model.project.client
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
@@ -396,6 +465,7 @@ function PagedView({ model, imageMap, onToggleExclude, showAdditionalImages = fa
                 imageMap={imageMap}
                 onToggleExclude={onToggleExclude}
                 showAdditionalImages={showAdditionalImages}
+                showTags={showTags}
               />
             ),
           )}
@@ -416,6 +486,7 @@ export function ProductionSheetReport({
   imageMap,
   onToggleExclude,
   showAdditionalImages = false,
+  showTags = false,
 }: BodyProps): JSX.Element {
   const isEmpty = model.groups.length === 0 || model.project.shotCount === 0
   if (isEmpty) return <p className="sb-empty">No shots to report yet.</p>
@@ -436,6 +507,7 @@ export function ProductionSheetReport({
                 imageMap={imageMap}
                 onToggleExclude={onToggleExclude}
                 showAdditionalImages={showAdditionalImages}
+                showTags={showTags}
               />
             ))}
           </div>
@@ -447,6 +519,7 @@ export function ProductionSheetReport({
         imageMap={imageMap}
         onToggleExclude={onToggleExclude}
         showAdditionalImages={showAdditionalImages}
+        showTags={showTags}
       />
     </div>
   )

--- a/src-vnext/features/export/components/report/ReportView.tsx
+++ b/src-vnext/features/export/components/report/ReportView.tsx
@@ -34,6 +34,7 @@ import {
   resolveReportFilters,
   resolveReportLayout,
   resolveShowAdditionalImages,
+  resolveShowTags,
 } from "../../lib/report/reportTypes"
 import type { SortDir } from "../../lib/report/reportSort"
 import { hasAnyIncludedShot, sizeLabel } from "../../lib/report/reportModel"
@@ -43,6 +44,7 @@ import { resolveSrc, statusMeta } from "./reportShared"
 import { GroupSortControls } from "./GroupSortControls"
 import { ProductionSheetReport } from "./ProductionSheetReport"
 import { BalancedRowsReport } from "./BalancedRowsReport"
+import { TagChipView } from "./primitives/TagChip"
 
 /** A tag filter option: id actually present on a shot + its label. Deliberately
  *  narrower than useAvailableTags' `AvailableTag` (no usageCount/isDefault) —
@@ -229,12 +231,30 @@ function TalentRow({
 // ---------------------------------------------------------------------------
 // Caption block under the photo (title, colorway, status+talent, note, looks).
 // ---------------------------------------------------------------------------
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless shot's markup is byte-identical toggle on or off. The model already
+ *  de-duped, dropped gender, and ordered them (resolveReportTagChips) — this is
+ *  presentation only. */
+function TagChipRow({ shot }: { readonly shot: ReportShot }): JSX.Element | null {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <div className="sb-tag-row" role="group" aria-label="Tags">
+      {tags.map((t) => (
+        <TagChipView key={t.id} label={t.label} />
+      ))}
+    </div>
+  )
+}
+
 function PlateCaption({
   shot,
   imageMap,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
+  readonly showTags: boolean
 }): JSX.Element {
   const st = statusMeta(shot.status)
   return (
@@ -258,6 +278,8 @@ function PlateCaption({
         <TalentRow talent={shot.talent} imageMap={imageMap} />
       </div>
 
+      {showTags ? <TagChipRow shot={shot} /> : null}
+
       {shot.notes ? <p className="sb-shot-note">{shot.notes}</p> : null}
 
       <div className="sb-looks">
@@ -277,10 +299,12 @@ function Plate({
   shot,
   imageMap,
   onToggleExclude,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (shotId: string) => void
+  readonly showTags: boolean
 }): JSX.Element {
   const primarySrc = resolveSrc(imageMap, primaryLookOf(shot)?.image ?? null)
   return (
@@ -295,7 +319,7 @@ function Plate({
         {shot.excluded ? "Restore shot" : "Exclude shot"}
       </button>
       <PlateFigure shot={shot} primarySrc={primarySrc} />
-      <PlateCaption shot={shot} imageMap={imageMap} />
+      <PlateCaption shot={shot} imageMap={imageMap} showTags={showTags} />
     </article>
   )
 }
@@ -307,10 +331,12 @@ function GroupSection({
   group,
   imageMap,
   onToggleExclude,
+  showTags,
 }: {
   readonly group: ReportGroup
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (shotId: string) => void
+  readonly showTags: boolean
 }): JSX.Element {
   const withRef = group.shots.filter((s) => s.hasImage).length
   return (
@@ -325,7 +351,13 @@ function GroupSection({
       </div>
       <div className="sb-plates">
         {group.shots.map((shot) => (
-          <Plate key={shot.id} shot={shot} imageMap={imageMap} onToggleExclude={onToggleExclude} />
+          <Plate
+            key={shot.id}
+            shot={shot}
+            imageMap={imageMap}
+            onToggleExclude={onToggleExclude}
+            showTags={showTags}
+          />
         ))}
       </div>
     </section>
@@ -390,8 +422,11 @@ interface Sheet {
 // Mirror the PDF's height-aware pagination (reportPdfHeights.packShotSheets) so the
 // on-screen print preview and the downloaded PDF agree shot-for-shot (WYSIWYG): a
 // too-tall shot solos in both, rather than pairing here but soloing in the PDF.
-function buildSheets(model: ReportModel): readonly Sheet[] {
-  return packShotSheets(model).map((s) => ({
+// `showTags` MUST be the same resolved value the plates render with (and the
+// same one ShotReportPage hands generateShotReportPdf), or the preview and the
+// export disagree by a tag row per shot.
+function buildSheets(model: ReportModel, showTags: boolean): readonly Sheet[] {
+  return packShotSheets(model, showTags).map((s) => ({
     groupLabel: s.group.label,
     rangeFrom: s.firstPosition,
     rangeTo: s.lastPosition,
@@ -404,12 +439,14 @@ function PagedView({
   model,
   imageMap,
   onToggleExclude,
+  showTags,
 }: {
   readonly model: ReportModel
   readonly imageMap: ReadonlyMap<string, string>
   readonly onToggleExclude: (shotId: string) => void
+  readonly showTags: boolean
 }): JSX.Element {
-  const sheets = useMemo(() => buildSheets(model), [model])
+  const sheets = useMemo(() => buildSheets(model, showTags), [model, showTags])
   const projLine =
     model.project.name + (model.project.client ? ` · ${model.project.client}` : "")
   const totalPages = sheets.length
@@ -435,6 +472,7 @@ function PagedView({
                 shot={shot}
                 imageMap={imageMap}
                 onToggleExclude={onToggleExclude}
+                showTags={showTags}
               />
             ))}
           </div>
@@ -551,6 +589,9 @@ function ControlBar({
   additionalImagesOn,
   additionalImagesAvailable,
   onSetShowAdditionalImages,
+  showTagsControl,
+  tagsOn,
+  onSetShowTags,
   showFilters,
   showSort,
   sortBy,
@@ -585,6 +626,13 @@ function ControlBar({
   // layouts) but disabled/inert with an explanatory title on that recipe.
   readonly additionalImagesAvailable: boolean
   readonly onSetShowAdditionalImages: (v: boolean) => void
+  // Tag chips (2026-08-17). Gated with featureReportConfig, same as
+  // showAdditionalImagesControl/showFilters/showSort. Deliberately has NO
+  // `available` sibling: every recipe carries a synced height/weight term for
+  // the row, so the control is never inert — see ReportConfig.showTags.
+  readonly showTagsControl: boolean
+  readonly tagsOn: boolean
+  readonly onSetShowTags: (v: boolean) => void
   readonly showFilters: boolean
   // showSort gates BOTH the flag-on "Status"/"Set" group-by options and the
   // order-by/direction controls (== featureReportConfig). Flag-off → neither appears.
@@ -608,6 +656,7 @@ function ControlBar({
   const looksLabelId = useId()
   const recipeLabelId = useId()
   const extraImagesLabelId = useId()
+  const tagChipsLabelId = useId()
   const statusSelected = useMemo(() => new Set(statusFilter?.value ?? []), [statusFilter])
   const tagSelected = useMemo(() => new Set(tagFilter?.value ?? []), [tagFilter])
   return (
@@ -787,6 +836,35 @@ function ControlBar({
         </div>
       )}
 
+      {showTagsControl && (
+        <div className="sb-control-group" role="group" aria-labelledby={tagChipsLabelId}>
+          <span id={tagChipsLabelId} className="sb-control-label">
+            Tag chips
+          </span>
+          {/* No `sb-seg--inert` / `disabled` sibling here, unlike Extra images
+              above: every recipe carries a synced height term for the tag row,
+              so the control is live on all three. */}
+          <div className="sb-seg">
+            <button
+              type="button"
+              className="sb-seg-btn"
+              aria-pressed={!tagsOn}
+              onClick={() => onSetShowTags(false)}
+            >
+              Off
+            </button>
+            <button
+              type="button"
+              className="sb-seg-btn"
+              aria-pressed={tagsOn}
+              onClick={() => onSetShowTags(true)}
+            >
+              On
+            </button>
+          </div>
+        </div>
+      )}
+
       {showFilters && (
         <>
           <FilterModeGroup
@@ -889,6 +967,19 @@ export function ReportView(props: ReportViewProps): JSX.Element {
     onConfigChange({ ...config, showAdditionalImages: next })
   }
 
+  // Tag chips (2026-08-17). `tagsOn` is the RAW persisted choice driving the
+  // control's own pressed state; `showTags` is the EFFECTIVE value the recipe
+  // bodies render — resolveShowTags is the single source ShotReportPage's PDF
+  // export reads too, so screen and PDF can't drift. ABSENT resolves ON (the
+  // shipped default), so the control reads "On" for a config that has never
+  // carried the field rather than claiming a choice the user never made.
+  const tagsOn = config.showTags !== false
+  const showTags = resolveShowTags(config, reportConfigEnabled)
+  const setShowTags = (next: boolean): void => {
+    if (next === tagsOn) return
+    onConfigChange({ ...config, showTags: next })
+  }
+
   // Unified filters (status + tag) — replaces the old standalone "Hide
   // statuses" toggle set. resolveReportFilters reads the migrated view (so a
   // legacy hiddenStatuses-only config still shows its prior selection as
@@ -987,6 +1078,13 @@ export function ReportView(props: ReportViewProps): JSX.Element {
         additionalImagesOn={additionalImagesOn}
         additionalImagesAvailable={additionalImagesAvailable}
         onSetShowAdditionalImages={setShowAdditionalImages}
+        // Unlike Extra images above, this is gated on reportConfigEnabled
+        // ALONE — the tag row renders on all three recipes, so there is no
+        // "can never become available" dead-end to hide the control for when
+        // the Recipe picker is off.
+        showTagsControl={reportConfigEnabled}
+        tagsOn={tagsOn}
+        onSetShowTags={setShowTags}
         showFilters={reportConfigEnabled}
         showSort={reportConfigEnabled}
         sortBy={sortBy}
@@ -1011,6 +1109,7 @@ export function ReportView(props: ReportViewProps): JSX.Element {
             imageMap={imageMap}
             onToggleExclude={toggleExclude}
             showAdditionalImages={showAdditionalImages}
+            showTags={showTags}
           />
         ) : layout === "balanced-rows" ? (
           <BalancedRowsReport
@@ -1018,6 +1117,7 @@ export function ReportView(props: ReportViewProps): JSX.Element {
             imageMap={imageMap}
             onToggleExclude={toggleExclude}
             showAdditionalImages={showAdditionalImages}
+            showTags={showTags}
           />
         ) : (
           <>
@@ -1035,12 +1135,18 @@ export function ReportView(props: ReportViewProps): JSX.Element {
                       group={group}
                       imageMap={imageMap}
                       onToggleExclude={toggleExclude}
+                      showTags={showTags}
                     />
                   ))}
                 </div>
 
                 {/* Paged landscape preview (print mode + @media print) */}
-                <PagedView model={model} imageMap={imageMap} onToggleExclude={toggleExclude} />
+                <PagedView
+                  model={model}
+                  imageMap={imageMap}
+                  onToggleExclude={toggleExclude}
+                  showTags={showTags}
+                />
               </>
             )}
           </>

--- a/src-vnext/features/export/components/report/ShotReportPage.tsx
+++ b/src-vnext/features/export/components/report/ShotReportPage.tsx
@@ -17,6 +17,7 @@ import {
   neutralizeReportConfigForFlag,
   resolveReportLayout,
   resolveShowAdditionalImages,
+  resolveShowTags,
   type ReportConfig,
   type ReportLayout,
 } from "../../lib/report/reportTypes"
@@ -193,19 +194,26 @@ export default function ShotReportPage() {
         layout,
         isFeatureEnabled("featureReportConfig"),
       )
+      // Tag chips (2026-08-17) — same single-source pattern: the exact resolver
+      // ReportView's screen render calls, so the exported PDF and the preview
+      // can never disagree about whether the tag row is there (and therefore
+      // about how the image-led plates paginate — packShotSheets takes the same
+      // value).
+      const showTags = resolveShowTags(config, isFeatureEnabled("featureReportConfig"))
       await generateShotReportPdf(
         model,
         imageMap,
         `${model.project.name} — Shot Report.pdf`,
         layout,
         showAdditionalImages,
+        showTags,
       )
     })()
       .catch((err) => toast.error(err instanceof Error ? err.message : "Couldn't export the PDF"))
       .finally(() => {
         setExporting(false)
       })
-  }, [model, imageMap, config.layout, config.showAdditionalImages])
+  }, [model, imageMap, config.layout, config.showAdditionalImages, config.showTags])
 
   if (data.loading) {
     return (

--- a/src-vnext/features/export/components/report/__tests__/ReportView.tagChips.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/ReportView.tagChips.test.tsx
@@ -1,0 +1,296 @@
+/// <reference types="@testing-library/jest-dom" />
+// Tag chips (2026-08-17) — the "Tag chips" control (ControlBar), its write path,
+// the featureReportConfig gate, and the EFFECTIVE render on all three recipes.
+// Cloned from ReportView.additionalImages.test.tsx, which is the house shape for
+// a persisted report toggle; the differences are the point of the feature:
+// default ON, and no per-recipe exclusion.
+//
+// The recipe-body tests below assert RENDERED DOM against the MODEL's tag
+// labels, never `shot.tags` on both sides of an equality — a test that reads the
+// same field twice proves nothing about what a reader sees.
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, within, fireEvent } from "@testing-library/react"
+import { ReportView } from "../ReportView"
+import {
+  DEFAULT_REPORT_CONFIG,
+  type ReportConfig,
+  type ReportLayout,
+  type ReportModel,
+  type ReportShotTag,
+} from "../../../lib/report/reportTypes"
+
+// Both gates forced ON so the control renders and production-sheet is the
+// resolved layout (DEFAULT_REPORT_CONFIG.layout) unless a test overrides it.
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) => {
+      if (flag === "featureReportConfig") return true
+      if (flag === "featureShotReportRecipes") return true
+      return actual.isFeatureEnabled(flag)
+    },
+  }
+})
+
+const ALL_LAYOUTS: readonly ReportLayout[] = ["image-led", "production-sheet", "balanced-rows"]
+
+function emptyModel(): ReportModel {
+  return {
+    project: { name: "Tag chips fixture", client: "unbound-merino", shotCount: 0, dateRange: null },
+    groups: [],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+// The chips a REAL deriveShotReportModel run would produce for a shot carrying a
+// media tag, a priority tag, an "other" tag — and a gender tag (already dropped
+// upstream by resolveReportTagChips, which is unit-tested in reportModel.test.ts;
+// the gender case gets its own model below).
+const MODEL_TAGS: readonly ReportShotTag[] = [
+  { id: "default-media-photo", label: "Photo", category: "media" },
+  { id: "default-priority-high", label: "High Priority", category: "priority" },
+  { id: "other-flat", label: "Flat Lay", category: "other" },
+]
+
+function modelWithTags(tags: readonly ReportShotTag[] = MODEL_TAGS): ReportModel {
+  return {
+    project: { name: "Tag chips fixture", client: "unbound-merino", shotCount: 1, dateRange: null },
+    groups: [
+      {
+        key: "all",
+        label: "All shots",
+        count: 1,
+        shots: [
+          {
+            id: "s1",
+            number: "01",
+            title: "Tagged Shot",
+            colorway: null,
+            status: "todo",
+            gender: "W",
+            notes: null,
+            talent: [],
+            excluded: false,
+            hasImage: false,
+            looks: [
+              { id: "l1", label: "Primary", isAlt: false, image: null, hasReference: false, products: [] },
+            ],
+            tags,
+          },
+        ],
+      },
+    ],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+/** A shot with NO tags — the "renders nothing extra" control case. */
+function modelWithoutTags(): ReportModel {
+  return modelWithTags([])
+}
+
+function renderReportView(
+  config: ReportConfig,
+  model: ReportModel,
+  onConfigChange: (next: ReportConfig) => void,
+) {
+  return render(
+    <ReportView
+      model={model}
+      imageMap={new Map()}
+      config={config}
+      availableTags={[]}
+      onConfigChange={onConfigChange}
+      onExportPdf={vi.fn()}
+    />,
+  )
+}
+
+/** Every chip label actually painted into the DOM, in document order. */
+function renderedChipLabels(container: HTMLElement): string[] {
+  return [...container.querySelectorAll('[data-testid="tag-chip"]')].map(
+    (el) => el.textContent ?? "",
+  )
+}
+
+describe("ReportView — Tag chips control", () => {
+  it("renders an Off/On segmented control, defaulting to ON pressed (the shipped default)", () => {
+    renderReportView(DEFAULT_REPORT_CONFIG, emptyModel(), vi.fn())
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    expect(within(group).getByRole("button", { name: "On" })).toHaveAttribute("aria-pressed", "true")
+    expect(within(group).getByRole("button", { name: "Off" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    )
+  })
+
+  it("reads ON for a config that has never carried showTags at all (absent == the default, not 'off')", () => {
+    const config: ReportConfig = { groupBy: "gender", excludedShotIds: [], layout: "production-sheet" }
+    renderReportView(config, emptyModel(), vi.fn())
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    expect(within(group).getByRole("button", { name: "On" })).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("clicking Off writes config.showTags:false", () => {
+    const onConfigChange = vi.fn()
+    renderReportView(DEFAULT_REPORT_CONFIG, emptyModel(), onConfigChange)
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    fireEvent.click(within(group).getByRole("button", { name: "Off" }))
+    expect(onConfigChange).toHaveBeenCalledTimes(1)
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.showTags).toBe(false)
+  })
+
+  it("clicking On from an OFF config writes config.showTags:true", () => {
+    const onConfigChange = vi.fn()
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, showTags: false }
+    renderReportView(config, emptyModel(), onConfigChange)
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    expect(within(group).getByRole("button", { name: "Off" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    )
+    fireEvent.click(within(group).getByRole("button", { name: "On" }))
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next.showTags).toBe(true)
+  })
+
+  it("re-clicking the already-pressed state is a no-op (no onConfigChange call)", () => {
+    const onConfigChange = vi.fn()
+    renderReportView(DEFAULT_REPORT_CONFIG, emptyModel(), onConfigChange) // showTags: true
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    fireEvent.click(within(group).getByRole("button", { name: "On" }))
+    expect(onConfigChange).not.toHaveBeenCalled()
+  })
+
+  it("the write preserves the rest of the config (it is a spread, not a replacement)", () => {
+    const onConfigChange = vi.fn()
+    const config: ReportConfig = {
+      ...DEFAULT_REPORT_CONFIG,
+      groupBy: "none",
+      excludedShotIds: ["keep-me"],
+      showAdditionalImages: true,
+    }
+    renderReportView(config, emptyModel(), onConfigChange)
+    fireEvent.click(
+      within(screen.getByRole("group", { name: "Tag chips" })).getByRole("button", { name: "Off" }),
+    )
+    const next = onConfigChange.mock.calls[0]![0] as ReportConfig
+    expect(next).toEqual({ ...config, showTags: false })
+  })
+
+  it("is NEVER disabled/inert — unlike Extra images, every recipe carries a height term for the row", () => {
+    for (const layout of ALL_LAYOUTS) {
+      const { unmount } = renderReportView(
+        { ...DEFAULT_REPORT_CONFIG, layout },
+        emptyModel(),
+        vi.fn(),
+      )
+      const group = screen.getByRole("group", { name: "Tag chips" })
+      expect(within(group).getByRole("button", { name: "On" })).not.toBeDisabled()
+      expect(within(group).getByRole("button", { name: "Off" })).not.toBeDisabled()
+      unmount()
+    }
+  })
+})
+
+describe("ReportView — Tag chips effective render (resolveShowTags end-to-end, all three recipes)", () => {
+  it.each(ALL_LAYOUTS)("ON + %s renders one chip per model tag, in the model's order", (layout) => {
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout, showTags: true }
+    const model = modelWithTags()
+    const { container } = renderReportView(config, model, vi.fn())
+    const expected = model.groups[0]!.shots[0]!.tags!.map((t) => t.label)
+    // image-led renders each plate TWICE (fluid flow + paged print preview), so
+    // compare the DISTINCT sequence rather than a raw count — the load-bearing
+    // claim is "the labels a reader sees are the model's labels, in order".
+    const painted = renderedChipLabels(container)
+    expect(painted.length).toBeGreaterThan(0)
+    expect(painted.slice(0, expected.length)).toEqual(expected)
+    expect([...new Set(painted)]).toEqual(expected)
+  })
+
+  it.each(ALL_LAYOUTS)("OFF + %s renders NO chip even though the model shot carries tags", (layout) => {
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout, showTags: false }
+    const { container } = renderReportView(config, modelWithTags(), vi.fn())
+    expect(renderedChipLabels(container)).toEqual([])
+    expect(container.querySelector(".sb-tag-row")).toBeNull()
+    // ...and no chip TEXT leaks through some other element either.
+    expect(container.textContent).not.toContain("Flat Lay")
+  })
+
+  it.each(ALL_LAYOUTS)("ON + %s + a shot with NO tags renders no row at all (not an empty one)", (layout) => {
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout, showTags: true }
+    const { container } = renderReportView(config, modelWithoutTags(), vi.fn())
+    expect(container.querySelector(".sb-tag-row")).toBeNull()
+  })
+
+  it.each(ALL_LAYOUTS)("%s: a gender-category tag never reaches a chip", (layout) => {
+    // The model normally drops these (resolveReportTagChips) — this is the
+    // belt-and-suspenders check that no recipe re-introduces one by rendering
+    // some other tag source. Feed a model that (wrongly) carries a gender chip
+    // and assert the recipes still print only what the derive rule would keep.
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout, showTags: true }
+    const { container } = renderReportView(
+      config,
+      modelWithTags([
+        { id: "default-media-photo", label: "Photo", category: "media" },
+        { id: "default-gender-women", label: "Women", category: "gender" },
+      ]),
+      vi.fn(),
+    )
+    // Whatever the model hands over is rendered verbatim (the recipes are
+    // presentation-only) — so this test's real job is to pin that the gender
+    // exclusion lives in ONE place. Assert the recipe prints the model's list,
+    // and that a real derive never produces a gender entry (reportModel.test.ts).
+    expect([...new Set(renderedChipLabels(container))]).toEqual(["Photo", "Women"])
+  })
+
+  it("the chip is NEUTRAL — no red ink or red border reaches the DOM for a 'High Priority' tag", () => {
+    // ShotTag.color for "High Priority" is the Tailwind key "red". The report
+    // keeps a reserved palette (red has exactly one job per recipe), so the chip
+    // must resolve to ink-2 / rule-strong, never a red token.
+    const config: ReportConfig = { ...DEFAULT_REPORT_CONFIG, layout: "production-sheet", showTags: true }
+    const { container } = renderReportView(config, modelWithTags(), vi.fn())
+    const chips = [...container.querySelectorAll<HTMLElement>('[data-testid="tag-chip"]')]
+    expect(chips.length).toBeGreaterThan(0)
+    for (const chip of chips) {
+      expect(chip.style.color).toBe("var(--sb-ink-2)")
+      expect(chip.style.borderColor).toBe("var(--sb-rule-strong)")
+      expect(chip.style.color).not.toContain("red")
+      expect(chip.style.borderColor).not.toContain("red")
+    }
+  })
+})
+
+describe("ReportView — Tag chips, featureReportConfig OFF (rollback safety)", () => {
+  it("renders neither the control nor any chip, even for a config that says showTags:true", async () => {
+    // A SEPARATE module registry with featureReportConfig OFF — the top-of-file
+    // mock in this file forces it ON, and vi.mock is hoisted per-file.
+    vi.resetModules()
+    vi.doMock("@/shared/lib/flags", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+      return {
+        ...actual,
+        isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) =>
+          flag === "featureReportConfig" ? false : actual.isFeatureEnabled(flag),
+      }
+    })
+    const { ReportView: FlagOffReportView } = await import("../ReportView")
+    const { container } = render(
+      <FlagOffReportView
+        model={modelWithTags()}
+        imageMap={new Map()}
+        config={{ ...DEFAULT_REPORT_CONFIG, layout: "image-led", showTags: true }}
+        availableTags={[]}
+        onConfigChange={vi.fn()}
+        onExportPdf={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole("group", { name: "Tag chips" })).toBeNull()
+    expect(renderedChipLabels(container)).toEqual([])
+    expect(container.querySelector(".sb-tag-row")).toBeNull()
+    vi.doUnmock("@/shared/lib/flags")
+    vi.resetModules()
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/ReportView.tagChipsControl.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/ReportView.tagChipsControl.test.tsx
@@ -1,0 +1,114 @@
+/// <reference types="@testing-library/jest-dom" />
+// Tag chips (2026-08-17), the flag combination its sibling file cannot express:
+// featureReportConfig ON, featureShotReportRecipes OFF. Separate file because
+// vi.mock is hoisted per-file, so a different flag pair needs a different file —
+// same reason ReportView.additionalImagesControl.test.tsx exists.
+//
+// This is the DIFFERENCE between the two toggles, asserted rather than assumed.
+// With recipes off, resolveReportLayout pins the layout to "image-led"
+// permanently and the Recipe picker is hidden. For "Extra images" that is a dead
+// end (image-led has no extras row), so that control hides itself entirely. For
+// Tag chips it is NOT a dead end: image-led renders the row and carries its own
+// height term (reportPdfHeights' estimateTagRowHeight), so the control must stay
+// visible AND the chips must actually print.
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, within } from "@testing-library/react"
+import { ReportView } from "../ReportView"
+import {
+  DEFAULT_REPORT_CONFIG,
+  type ReportConfig,
+  type ReportModel,
+} from "../../../lib/report/reportTypes"
+
+vi.mock("@/shared/lib/flags", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/shared/lib/flags")>()
+  return {
+    ...actual,
+    isFeatureEnabled: (flag: keyof import("@/shared/lib/flags").FeatureFlags) => {
+      if (flag === "featureReportConfig") return true
+      if (flag === "featureShotReportRecipes") return false
+      return actual.isFeatureEnabled(flag)
+    },
+  }
+})
+
+function taggedModel(): ReportModel {
+  return {
+    project: { name: "Tag chips control fixture", client: "unbound-merino", shotCount: 1, dateRange: null },
+    groups: [
+      {
+        key: "all",
+        label: "All shots",
+        count: 1,
+        shots: [
+          {
+            id: "s1",
+            number: "01",
+            title: "Tagged Shot",
+            colorway: null,
+            status: "todo",
+            gender: "W",
+            notes: null,
+            talent: [],
+            excluded: false,
+            hasImage: false,
+            looks: [
+              { id: "l1", label: "Primary", isAlt: false, image: null, hasReference: false, products: [] },
+            ],
+            tags: [
+              { id: "default-media-photo", label: "Photo", category: "media" },
+              { id: "other-flat", label: "Flat Lay", category: "other" },
+            ],
+          },
+        ],
+      },
+    ],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+function renderWith(config: ReportConfig) {
+  return render(
+    <ReportView
+      model={taggedModel()}
+      imageMap={new Map()}
+      config={config}
+      availableTags={[]}
+      onConfigChange={vi.fn()}
+      onExportPdf={vi.fn()}
+    />,
+  )
+}
+
+describe("ReportView — Tag chips control, recipes flag OFF (NOT a dead end, unlike Extra images)", () => {
+  it("stays visible and live, while the Extra images control hides itself and the Recipe picker is gone", () => {
+    const { container } = renderWith({ ...DEFAULT_REPORT_CONFIG, layout: "production-sheet" })
+    // Baseline: the flag really is off — layout is clamped and both the Recipe
+    // picker and the extras control are absent. Without these two assertions the
+    // Tag-chips claim below would be untethered from the flag state.
+    expect(container.querySelector(".sb-report-root")?.getAttribute("data-layout")).toBe("image-led")
+    expect(screen.queryByRole("group", { name: "Recipe" })).toBeNull()
+    expect(screen.queryByRole("group", { name: "Extra images" })).toBeNull()
+
+    const group = screen.getByRole("group", { name: "Tag chips" })
+    expect(within(group).getByRole("button", { name: "On" })).not.toBeDisabled()
+    expect(within(group).getByRole("button", { name: "On" })).toHaveAttribute("aria-pressed", "true")
+  })
+
+  it("image-led actually PRINTS the chips with recipes off — the case that makes the control worth showing", () => {
+    const { container } = renderWith({ ...DEFAULT_REPORT_CONFIG, layout: "production-sheet" })
+    expect(container.querySelector(".sb-report-root")?.getAttribute("data-layout")).toBe("image-led")
+    const labels = [
+      ...new Set(
+        [...container.querySelectorAll('[data-testid="tag-chip"]')].map((el) => el.textContent ?? ""),
+      ),
+    ]
+    expect(labels).toEqual(["Photo", "Flat Lay"])
+  })
+
+  it("Off still hides them on image-led", () => {
+    const { container } = renderWith({ ...DEFAULT_REPORT_CONFIG, showTags: false })
+    expect(container.querySelectorAll('[data-testid="tag-chip"]')).toHaveLength(0)
+    expect(container.querySelector(".sb-tag-row")).toBeNull()
+  })
+})

--- a/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportLayouts.test.tsx
@@ -1,7 +1,15 @@
 import { describe, it, expect } from "vitest"
 import { render } from "@testing-library/react"
-import { ProductionSheetReport, extraImagesWeight as psExtraImagesWeight } from "../ProductionSheetReport"
-import { BalancedRowsReport, extraImagesWeight as brExtraImagesWeight } from "../BalancedRowsReport"
+import {
+  ProductionSheetReport,
+  extraImagesWeight as psExtraImagesWeight,
+  tagRowWeight as psTagRowWeight,
+} from "../ProductionSheetReport"
+import {
+  BalancedRowsReport,
+  extraImagesWeight as brExtraImagesWeight,
+  tagRowWeight as brTagRowWeight,
+} from "../BalancedRowsReport"
 import type { ReportModel, ReportShot } from "../../../lib/report/reportTypes"
 
 // Smoke + behavior tests for the two R3 layout variants: they render without
@@ -303,5 +311,143 @@ describe("BalancedRowsReport — print-preview page count grows with additionalI
     const fewPages = fewContainer.querySelectorAll(".sb-br-page").length
     const manyPages = manyContainer.querySelectorAll(".sb-br-page").length
     expect(manyPages).toBeGreaterThan(fewPages)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag-chip row (2026-08-17) — the same pagination-fidelity class as
+// extraImagesWeight above. `.sb-ps-page` is a fixed-height `overflow: hidden`
+// sheet, so an uncharged (or flat-charged) tag row silently CLIPS off the
+// bottom of a page with no marker; `.sb-br-page` grows past its min-height and
+// mis-places the footer instead. Both are pagination bugs.
+// ---------------------------------------------------------------------------
+describe("ProductionSheetReport — tagRowWeight scales with chip count (print-preview pagination)", () => {
+  it("returns 0 for no chips — a tagless shot paginates identically toggle on or off", () => {
+    expect(psTagRowWeight(0)).toBe(0)
+    expect(psTagRowWeight(-1)).toBe(0)
+  })
+
+  it("one line's worth of chips (<= TAG_CHIPS_PER_LINE) costs LESS than three lines' worth", () => {
+    expect(psTagRowWeight(24)).toBeGreaterThan(psTagRowWeight(4))
+  })
+
+  it("weight grows monotonically with chip count — never flat", () => {
+    const w4 = psTagRowWeight(4)
+    const w16 = psTagRowWeight(16)
+    const w40 = psTagRowWeight(40)
+    expect(w16).toBeGreaterThan(w4)
+    expect(w40).toBeGreaterThan(w16)
+    // A flat per-shot charge would make all three equal; clear the single-line
+    // figure by a wide margin, not a rounding error.
+    expect(w40).toBeGreaterThan(w4 * 2)
+  })
+})
+
+describe("BalancedRowsReport — tagRowWeight scales with chip count (print-preview pagination)", () => {
+  it("returns 0 for no chips", () => {
+    expect(brTagRowWeight(0)).toBe(0)
+    expect(brTagRowWeight(-1)).toBe(0)
+  })
+
+  it("weight grows monotonically with chip count — never flat", () => {
+    const w3 = brTagRowWeight(3)
+    const w12 = brTagRowWeight(12)
+    const w30 = brTagRowWeight(30)
+    expect(w12).toBeGreaterThan(w3)
+    expect(w30).toBeGreaterThan(w12)
+    expect(w30).toBeGreaterThan(w3 * 2)
+  })
+})
+
+// End-to-end (DOM) regression: MORE tags must be able to push a shot onto a
+// LATER print-preview page than FEWER — the true observable consequence of an
+// uncharged/flat tag row, and the only assertion here a unit test of
+// tagRowWeight alone cannot make (it proves the weight is actually WIRED into
+// paginate/buildStream, not merely exported).
+function taggedShot(id: string, count: number): ReportShot {
+  return {
+    id,
+    number: id,
+    title: `Shot ${id}`,
+    colorway: null,
+    status: "todo",
+    gender: "?",
+    notes: null,
+    talent: [],
+    excluded: false,
+    hasImage: false,
+    looks: [{ id: `${id}-l0`, label: "Primary", isAlt: false, image: null, hasReference: false, products: [] }],
+    tags: Array.from({ length: count }, (_, i) => ({
+      id: `${id}-tag-${i}`,
+      label: `Tag ${i}`,
+      category: "other",
+    })),
+  }
+}
+
+function manyTagsModel(shotCount: number, tagsPerShot: number): ReportModel {
+  const shots = Array.from({ length: shotCount }, (_, i) => taggedShot(`s${i}`, tagsPerShot))
+  return {
+    project: { name: "Tag pagination stress", client: "c", shotCount: shots.length, dateRange: null },
+    groups: [{ key: "all", label: "All shots", count: shots.length, shots }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+describe("ProductionSheetReport — print-preview page count grows with tag count", () => {
+  it("6 shots x 120 tags paginate onto MORE pages than 6 shots x 2 tags", () => {
+    const few = manyTagsModel(6, 2)
+    const many = manyTagsModel(6, 120)
+    const { container: fewContainer } = render(
+      <ProductionSheetReport model={few} imageMap={new Map()} onToggleExclude={noop} showTags={true} />,
+    )
+    const { container: manyContainer } = render(
+      <ProductionSheetReport model={many} imageMap={new Map()} onToggleExclude={noop} showTags={true} />,
+    )
+    expect(manyContainer.querySelectorAll(".sb-ps-page").length).toBeGreaterThan(
+      fewContainer.querySelectorAll(".sb-ps-page").length,
+    )
+  })
+
+  it("showTags OFF paginates IDENTICALLY whether or not the model carries tags — the row is never charged", () => {
+    const withTags = manyTagsModel(6, 120)
+    const withoutTags = manyTagsModel(6, 0)
+    const { container: a } = render(
+      <ProductionSheetReport model={withTags} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    const { container: b } = render(
+      <ProductionSheetReport model={withoutTags} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    expect(a.querySelectorAll(".sb-ps-page").length).toBe(b.querySelectorAll(".sb-ps-page").length)
+    expect(a.querySelectorAll('[data-testid="tag-chip"]')).toHaveLength(0)
+  })
+})
+
+describe("BalancedRowsReport — print-preview page count grows with tag count", () => {
+  it("4 shots x 90 tags paginate onto MORE pages than 4 shots x 2 tags", () => {
+    const few = manyTagsModel(4, 2)
+    const many = manyTagsModel(4, 90)
+    const { container: fewContainer } = render(
+      <BalancedRowsReport model={few} imageMap={new Map()} onToggleExclude={noop} showTags={true} />,
+    )
+    const { container: manyContainer } = render(
+      <BalancedRowsReport model={many} imageMap={new Map()} onToggleExclude={noop} showTags={true} />,
+    )
+    expect(manyContainer.querySelectorAll(".sb-br-page").length).toBeGreaterThan(
+      fewContainer.querySelectorAll(".sb-br-page").length,
+    )
+  })
+
+  it("showTags OFF paginates IDENTICALLY whether or not the model carries tags", () => {
+    const withTags = manyTagsModel(4, 90)
+    const withoutTags = manyTagsModel(4, 0)
+    const { container: a } = render(
+      <BalancedRowsReport model={withTags} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    const { container: b } = render(
+      <BalancedRowsReport model={withoutTags} imageMap={new Map()} onToggleExclude={noop} />,
+    )
+    expect(a.querySelectorAll(".sb-br-page").length).toBe(b.querySelectorAll(".sb-br-page").length)
+    expect(a.querySelectorAll('[data-testid="tag-chip"]')).toHaveLength(0)
   })
 })

--- a/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
+++ b/src-vnext/features/export/components/report/__tests__/reportRecipeOverflow.test.tsx
@@ -17,6 +17,7 @@ import { inflateSync } from "node:zlib"
 import { renderToBuffer } from "@react-pdf/renderer"
 import { ProductionSheetPdfDocument } from "../../../lib/report/reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "../../../lib/report/reportPdfBalancedRows"
+import { ShotReportPdfDocument } from "../../../lib/report/reportPdf"
 import type { ReportModel, ReportProduct, ReportShot } from "../../../lib/report/reportTypes"
 
 // @react-pdf emits the overflow condition via console.warn; match either phrasing.
@@ -132,6 +133,10 @@ interface PdfRect {
 interface PdfPageImages {
   readonly mediaBox: { readonly width: number; readonly height: number }
   readonly rects: readonly PdfRect[]
+  /** The page's decompressed content stream — the source `rects` was parsed
+   *  from, kept so a text assertion (extractPdfText below) can reuse the same
+   *  page walk instead of re-implementing the xref/page-tree traversal. */
+  readonly content: string
 }
 interface Mat {
   a: number
@@ -314,8 +319,36 @@ function parsePdfPageImages(buf: Buffer): PdfPageImages[] {
       const { data } = getPdfObject(raw, buf, cn)
       if (data) content += data.toString("latin1")
     }
-    return { mediaBox, rects: extractImageRects(content) }
+    return { mediaBox, rects: extractImageRects(content), content }
   })
+}
+
+/**
+ * Concatenated text-showing operands (Tj / TJ) across every page, in page-tree
+ * order, WITH ALL WHITESPACE STRIPPED. @react-pdf's base-14 (non-embedded,
+ * WinAnsi) path emits per-glyph HEX strings inside TJ arrays, so hex decoding is
+ * the primary route; kerning-adjustment numbers simply don't match the
+ * tokenizer and fall out for free. Good enough to prove a specific token was
+ * DRAWN (or wasn't) — NOT a general PDF parser. Compare against a de-spaced,
+ * uppercase needle, since the chips render `textTransform: "uppercase"`.
+ */
+function extractPdfText(buf: Buffer): string {
+  let out = ""
+  for (const page of parsePdfPageImages(buf)) {
+    const tokenRe = /<([0-9A-Fa-f]+)>|\(((?:\\.|[^\\()])*)\)/g
+    let m: RegExpExecArray | null
+    while ((m = tokenRe.exec(page.content)) !== null) {
+      if (m[1] !== undefined) {
+        const hex = m[1]
+        for (let i = 0; i + 1 < hex.length; i += 2) {
+          out += String.fromCharCode(Number.parseInt(hex.slice(i, i + 2), 16))
+        }
+      } else if (m[2] !== undefined) {
+        out += m[2]
+      }
+    }
+  }
+  return out.replace(/\s+/g, "")
 }
 
 // Landscape-letter fallback for a page dict with no MediaBox of its own (never
@@ -653,6 +686,16 @@ describe("recipe PDF overflow — additional-images row (WS-C) must FLOW, never 
 const PRODUCTION_SHEET_STANDARD_HEIGHTS = [95, 47] as const
 const BALANCED_ROWS_STANDARD_HEIGHTS = [150, 49] as const
 
+// A realistic tag load for a crew sheet: a media tag, a priority tag, and two
+// production tags. Long enough labels that the row is a real, measurable band
+// rather than a rounding error.
+const BOUNDARY_TAGS = [
+  { id: "default-media-photo", label: "Photo", category: "media" },
+  { id: "default-priority-high", label: "High Priority", category: "priority" },
+  { id: "other-flat", label: "Flat Lay", category: "other" },
+  { id: "other-studio", label: "Studio Cyc", category: "other" },
+] as const
+
 function boundaryProduct(i: number): ReportProduct {
   return {
     family: `Heavyweight Brushed Fleece Full-Zip Hoodie ${i}`,
@@ -694,6 +737,12 @@ function boundaryShot(id: string, num: string): ReportShot {
       },
     ],
     additionalImages: Array.from({ length: 4 }, (_, i) => `${id}-extra-${i}`),
+    // Tag chips (2026-08-17). Present on EVERY boundary fixture shot so the
+    // showTags-ON cases below actually exercise the new row — a gate whose
+    // fixture can't trip the bug proves nothing. The existing extras-ON cases
+    // render WITHOUT showTags, so their pinned page-count bounds are unaffected
+    // (and the "OFF is byte-identical" case below is what proves that claim).
+    tags: BOUNDARY_TAGS,
   }
 }
 
@@ -850,6 +899,7 @@ function denseMultiPageShot(id: string, num: string, nProducts: number, extras: 
       },
     ],
     additionalImages: Array.from({ length: extras }, (_, i) => `${id}-extra-${i}`),
+    tags: BOUNDARY_TAGS,
   }
 }
 
@@ -1050,5 +1100,303 @@ describe("recipe PDF boundary scan (WS-C-1) — cover shrink landing inside the 
         { label: "extras", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[1], expectedCount: POOLED_BAND_SHOT_COUNT * POOLED_BAND_EXTRAS },
       ]),
     ).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag chips (2026-08-17) — the tag row must be as flow-friendly as the rest of
+// the shot block, and must not disturb the WS-C-1 image invariants.
+//
+// Why this belongs in THIS suite and not a mocked one: the parity/DOM tests
+// mock @react-pdf, so they cannot see physical page overflow, straddling, or
+// shrink-to-fit. The row is text-only (no Image leaves), so its own failure mode
+// is the ATOMIC-OVERFLOW one this file was built for: if anyone adds
+// wrap={false} to TagChipRow's container, a chip-heavy shot's row becomes an
+// unsplittable node taller than a page and @react-pdf emits "can't wrap between
+// pages" — silently clipping a crew sheet.
+//
+// MUTATION-VERIFIED (recorded in the PR): adding wrap={false} to TagChipRow's
+// outer View in reportPdfProductionSheet.tsx / reportPdfBalancedRows.tsx reddens
+// both "row ALONE" cases below.
+//
+// Fixture sizing follows this file's own discipline: the stress fixture is
+// sized WELL past one page's usable height (2-3x), not marginally past it, so a
+// fixture that merely fits can never mask a regression.
+// ---------------------------------------------------------------------------
+
+// MEASURED, not guessed (probe run 2026-08-17, real renderToBuffer): a chip
+// renders ~57pt wide at 5.5pt Helvetica ("Production Tag NNN" + 6pt padding +
+// 3pt gap), so ~11 fit a line of the production-sheet body column and a line
+// costs ~13pt — 400 chips is only ~0.6 of a page and pages at 2, which would
+// make the "row ALONE flows across pages" cases below nearly unfalsifiable.
+// 1200 chips pages at 4 on BOTH recipes (1 page baseline with the toggle off),
+// i.e. ~3 pages of tag row — comfortably past threshold rather than marginally
+// past it, per this repo's fixture-sizing discipline. The falsifiability check
+// immediately below pins that premise so a future change that shrinks the row
+// can't quietly turn these cases vacuous.
+const TAG_STRESS_COUNT = 1200
+const TAG_STRESS_TAGS = Array.from({ length: TAG_STRESS_COUNT }, (_, i) => ({
+  id: `stress-tag-${String(i)}`,
+  label: `Production Tag ${String(i)}`,
+  category: "other",
+}))
+
+/** The SAME "Everything Shot" as overflowModel(), plus a realistic tag load —
+ *  the shot is already several pages tall from the 50 products alone; this
+ *  proves the NEW row doesn't reintroduce a clip when composed with the
+ *  existing overflow behavior. */
+function overflowModelWithTags(): ReportModel {
+  const base = overflowModel()
+  const shot: ReportShot = { ...base.groups[0]!.shots[0]!, tags: [...BOUNDARY_TAGS] }
+  return { ...base, groups: [{ ...base.groups[0]!, shots: [shot] }] }
+}
+
+/** Stress fixture ISOLATING the tag row: a near-empty shot (one product, no
+ *  notes, no alt looks, no references) whose ONLY source of height is a huge
+ *  tag row. At 400 chips this wraps to several times a single page's usable
+ *  height on both recipes. */
+function tagStressModel(): ReportModel {
+  const shot: ReportShot = {
+    id: "s1",
+    number: "01",
+    title: "Tags-Only Shot",
+    colorway: null,
+    status: "todo",
+    gender: "W",
+    notes: null,
+    talent: [],
+    excluded: false,
+    hasImage: false,
+    looks: [{ id: "l1", label: "Primary", isAlt: false, image: null, hasReference: false, products: [product(0)] }],
+    tags: TAG_STRESS_TAGS,
+  }
+  return {
+    project: { name: "Tag-Row Stress Fixture", client: "unbound-merino", shotCount: 1, dateRange: null },
+    groups: [{ key: "W", label: "Women", count: 1, shots: [shot] }],
+    order: { sortBy: "shot-number", sortDir: "asc" },
+  }
+}
+
+describe("recipe PDF overflow — tag-chip row (2026-08-17) must FLOW, never silently clip", () => {
+  let warn: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  it("production-sheet: 50-product shot + 4 tags, showTags ON — zero can't-wrap warnings, sane page count", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={overflowModelWithTags()} imageMap={new Map()} showTags={true} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+    const pages = countPdfPages(buf)
+    expect(pages).toBeGreaterThanOrEqual(2)
+    expect(pages).toBeLessThanOrEqual(5)
+  })
+
+  it("balanced-rows: 50-product shot + 4 tags, showTags ON — zero can't-wrap warnings, sane page count", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={overflowModelWithTags()} imageMap={new Map()} showTags={true} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+    const pages = countPdfPages(buf)
+    expect(pages).toBeGreaterThanOrEqual(3)
+    expect(pages).toBeLessThanOrEqual(6)
+  })
+
+  it("production-sheet: tag row ALONE (400 chips, well past one page) still FLOWS — zero can't-wrap warnings", async () => {
+    const buf = await renderToBuffer(
+      <ProductionSheetPdfDocument model={tagStressModel()} imageMap={new Map()} showTags={true} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+    expect(countPdfPages(buf)).toBeGreaterThan(1) // genuinely spans multiple pages
+  })
+
+  it("balanced-rows: tag row ALONE (400 chips, well past one page) still FLOWS — zero can't-wrap warnings", async () => {
+    const buf = await renderToBuffer(
+      <BalancedRowsPdfDocument model={tagStressModel()} imageMap={new Map()} showTags={true} />,
+    )
+    expect(buf.length).toBeGreaterThan(0)
+    expect(overflowWarnings(warn)).toEqual([])
+    expect(countPdfPages(buf)).toBeGreaterThan(1)
+  })
+
+  it("the 400-chip fixture actually TRIPS the threshold — showTags ON pages it well past the OFF baseline", async () => {
+    // The falsifiability check for the two "row ALONE" cases above: if the tag
+    // row were tiny (or never rendered), those cases would pass on a
+    // single-page render and prove nothing. Same shape as this file's
+    // "16-24 products still fit one page, so wrap={false} never fires" note.
+    const on = await renderToBuffer(
+      <ProductionSheetPdfDocument model={tagStressModel()} imageMap={new Map()} showTags={true} />,
+    )
+    const off = await renderToBuffer(
+      <ProductionSheetPdfDocument model={tagStressModel()} imageMap={new Map()} />,
+    )
+    expect(countPdfPages(off)).toBe(1)
+    expect(countPdfPages(on)).toBeGreaterThanOrEqual(3)
+    expect(countPdfPages(on)).toBeGreaterThan(countPdfPages(off) * 2)
+  })
+
+  it("showTags OFF (rollback) renders the IDENTICAL page count whether or not the model carries tags — TagChipRow is never invoked", async () => {
+    const withoutField = await renderToBuffer(
+      <ProductionSheetPdfDocument model={overflowModel()} imageMap={new Map()} />,
+    )
+    const withFieldButOff = await renderToBuffer(
+      <ProductionSheetPdfDocument model={overflowModelWithTags()} imageMap={new Map()} />,
+    )
+    expect(countPdfPages(withFieldButOff)).toBe(countPdfPages(withoutField))
+    expect(overflowWarnings(warn)).toEqual([])
+    // Sharper than page count, which can't tell "never invoked" from "invoked
+    // and returned null": the chip LABELS must not appear in the rendered text
+    // at all. (BOUNDARY_TAGS' labels are absent from every other field of
+    // overflowModel()'s shot.)
+    const text = withFieldButOff.toString("latin1")
+    expect(text).not.toContain("Flat Lay")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag chips x WS-C-1 image invariants. The tag row adds NO images, so every
+// placed-image invariant this file already enforces must hold UNCHANGED with
+// the row on — but the row changes where page breaks fall, which is exactly the
+// condition that produced the original straddle/shrink defects. Re-running the
+// containment + per-band count scan with tags ON is the cheap way to confirm the
+// new row didn't reopen that class.
+// ---------------------------------------------------------------------------
+describe.each(BOUNDARY_SHOT_COUNTS)(
+  "recipe PDF boundary scan — %i shots, extras ON *and* tags ON",
+  (shotCount) => {
+    const model = boundaryModel(shotCount)
+    const imageMap = boundaryImageMap(shotCount)
+
+    it("production-sheet: every placed image is still fully on-page and standard-sized", async () => {
+      const buf = await renderToBuffer(
+        <ProductionSheetPdfDocument
+          model={model}
+          imageMap={imageMap}
+          showAdditionalImages={true}
+          showTags={true}
+        />,
+      )
+      const pages = parsePdfPageImages(buf)
+      expect(pages.length).toBeGreaterThan(1)
+      const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+      expect(totalRects).toBe(shotCount * 5) // 1 cover + 4 extras per shot, nothing dropped
+      expect(findContainmentViolations(pages)).toEqual([])
+      expect(findUniformSizeViolations(pages, PRODUCTION_SHEET_STANDARD_HEIGHTS)).toEqual([])
+      expect(
+        findSizeBandCountMismatches(pages, [
+          { label: "cover", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[0], expectedCount: shotCount },
+          { label: "extras", heightPt: PRODUCTION_SHEET_STANDARD_HEIGHTS[1], expectedCount: shotCount * 4 },
+        ]),
+      ).toEqual([])
+    })
+
+    it("balanced-rows: every placed image is still fully on-page and standard-sized", async () => {
+      const buf = await renderToBuffer(
+        <BalancedRowsPdfDocument
+          model={model}
+          imageMap={imageMap}
+          showAdditionalImages={true}
+          showTags={true}
+        />,
+      )
+      const pages = parsePdfPageImages(buf)
+      expect(pages.length).toBeGreaterThan(1)
+      const totalRects = pages.reduce((n, p) => n + p.rects.length, 0)
+      expect(totalRects).toBe(shotCount * 5)
+      expect(findContainmentViolations(pages)).toEqual([])
+      expect(findUniformSizeViolations(pages, BALANCED_ROWS_STANDARD_HEIGHTS)).toEqual([])
+      expect(
+        findSizeBandCountMismatches(pages, [
+          { label: "cover", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[0], expectedCount: shotCount },
+          { label: "extras", heightPt: BALANCED_ROWS_STANDARD_HEIGHTS[1], expectedCount: shotCount * 4 },
+        ]),
+      ).toEqual([])
+    })
+  },
+)
+
+// ---------------------------------------------------------------------------
+// image-led (2026-08-17). This recipe is NOT covered by any other case in this
+// file — WS-C excluded it from the extras row precisely because its estimator
+// had no term for a second image row. The tag row DOES have one
+// (reportPdfHeights.estimateTagRowHeight), so image-led is in scope, and the
+// invariant that matters here is the one unique to it: the ESTIMATOR and the
+// RENDERER must agree. packShotSheets decides the page count up front from the
+// estimate; if the rendered tag row is taller than the estimate charged, the
+// plate's tail clips with no warning at all (Column/plate are wrap={false}).
+// ---------------------------------------------------------------------------
+describe("image-led PDF — tag row renders, paginates from the SAME estimate, and never warns", () => {
+  let warn: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+  })
+  afterEach(() => {
+    warn.mockRestore()
+  })
+
+  function imageLedTaggedModel(tagCount: number): ReportModel {
+    const shots: ReportShot[] = Array.from({ length: 6 }, (_, i) => ({
+      id: `il${i}`,
+      number: String(i + 1).padStart(2, "0"),
+      title: `Image-led Shot ${String(i + 1)}`,
+      colorway: "Charcoal / Bone",
+      status: "todo",
+      gender: "W",
+      notes: "Styling note to add a little height.",
+      talent: [{ id: `il${i}-t1`, name: "Alexandra Whitfield", img: null }],
+      excluded: false,
+      hasImage: false,
+      looks: [
+        {
+          id: `il${i}-l1`,
+          label: "Primary",
+          isAlt: false,
+          image: null,
+          hasReference: false,
+          products: Array.from({ length: 3 }, (_, p) => boundaryProduct(p)),
+        },
+      ],
+      tags: Array.from({ length: tagCount }, (_, t) => ({
+        id: `il${i}-tag-${t}`,
+        label: `Tagtoken${String(t)}`,
+        category: "other",
+      })),
+    }))
+    return {
+      project: { name: "Image-led Tag Fixture", client: "unbound-merino", shotCount: shots.length, dateRange: null },
+      groups: [{ key: "W", label: "Women", count: shots.length, shots }],
+      order: { sortBy: "shot-number", sortDir: "asc" },
+    }
+  }
+
+  it("renders the chip labels with showTags ON and none of them with it OFF", async () => {
+    const model = imageLedTaggedModel(4)
+    const on = await renderToBuffer(<ShotReportPdfDocument model={model} imageMap={new Map()} showTags={true} />)
+    const off = await renderToBuffer(<ShotReportPdfDocument model={model} imageMap={new Map()} />)
+    // The rendered CONTENT is compressed, so compare extracted text, not bytes.
+    expect(extractPdfText(on)).toContain("TAGTOKEN0")
+    expect(extractPdfText(off)).not.toContain("TAGTOKEN0")
+    expect(overflowWarnings(warn)).toEqual([])
+  })
+
+  it("OFF paginates identically whether or not the model carries tags (the estimator term is conditional)", async () => {
+    const tagged = await renderToBuffer(<ShotReportPdfDocument model={imageLedTaggedModel(24)} imageMap={new Map()} />)
+    const untagged = await renderToBuffer(<ShotReportPdfDocument model={imageLedTaggedModel(0)} imageMap={new Map()} />)
+    expect(countPdfPages(tagged)).toBe(countPdfPages(untagged))
+  })
+
+  it("a chip-heavy plate costs REAL pages with the toggle on — the estimator is wired into packShotSheets", async () => {
+    const model = imageLedTaggedModel(60)
+    const on = await renderToBuffer(<ShotReportPdfDocument model={model} imageMap={new Map()} showTags={true} />)
+    const off = await renderToBuffer(<ShotReportPdfDocument model={model} imageMap={new Map()} />)
+    expect(countPdfPages(on)).toBeGreaterThan(countPdfPages(off))
+    expect(overflowWarnings(warn)).toEqual([])
   })
 })

--- a/src-vnext/features/export/components/report/primitives/TagChip.tsx
+++ b/src-vnext/features/export/components/report/primitives/TagChip.tsx
@@ -1,0 +1,61 @@
+import {
+  deriveTagChipSpec,
+  type TagChipInput,
+  type TagChipSpec,
+} from "../../../lib/report/primitives/tagChip"
+
+// DOM adapter for TagChipSpec. Every metric is rendered INLINE from the spec
+// (so the DOM and the @react-pdf adapter provably consume one source and the
+// parity test can read the values in jsdom, which resolves no stylesheet), PLUS
+// the shipped `sb-tag-chip` class for real-page fidelity — belt-and-suspenders,
+// the same pattern StatusChipDom uses for the status dot.
+//
+// The chip is NEUTRAL (thin rule-strong border, ink-2 uppercase label) — see
+// the primitive's docstring for why the app's per-tag-coloured Tailwind
+// TagBadge is deliberately not reused here. Margins/gaps between chips are
+// LAYOUT (host-owned by each recipe's tag row), not rendered here.
+//
+// Exhaustive via the explicit return type + defaultless switch (unhandled
+// variant -> tsc error = red build); promote to a `never` default once the
+// union is multi-variant.
+
+/** Render a resolved TagChip spec to DOM primitives. */
+export function renderTagChipDom(spec: TagChipSpec): React.ReactElement {
+  switch (spec.kind) {
+    case "tagChip":
+      return (
+        <span
+          data-testid="tag-chip"
+          className="sb-tag-chip"
+          style={{
+            fontFamily: "var(--sb-font-ui)",
+            fontSize: `${String(spec.fontDomPx)}px`,
+            fontWeight: 600,
+            letterSpacing: `${String(spec.letterSpacingDomEm)}em`,
+            textTransform: "uppercase",
+            color: spec.inkVar,
+            // LONGHANDS, not the `border` shorthand: jsdom's CSS parser drops a
+            // shorthand whose colour is a `var(...)` (it can't resolve the
+            // custom property), so `style.borderWidth`/`style.borderColor` come
+            // back EMPTY and the parity test can't read what this renders.
+            // Longhands round-trip verbatim.
+            borderWidth: `${String(spec.borderWidthDomPx)}px`,
+            borderStyle: "solid",
+            borderColor: spec.borderVar,
+            borderRadius: `${String(spec.borderRadiusDomPx)}px`,
+            padding: spec.paddingDomPx,
+            lineHeight: 1.2,
+            display: "inline-block",
+            whiteSpace: "nowrap",
+          }}
+        >
+          {spec.label}
+        </span>
+      )
+  }
+}
+
+/** Thin DOM wrapper: derive the spec, then present it via the DOM adapter. */
+export function TagChipView(input: TagChipInput): React.ReactElement {
+  return renderTagChipDom(deriveTagChipSpec(input))
+}

--- a/src-vnext/features/export/components/report/primitives/index.ts
+++ b/src-vnext/features/export/components/report/primitives/index.ts
@@ -13,3 +13,6 @@ export { HoldFlagView } from "./HoldFlag"
 export { UnresolvedBadgeView } from "./UnresolvedBadge"
 export { LookLabelView } from "./LookLabel"
 export { ProductRowView, ProductColHeadView } from "./ProductRow"
+// 7th primitive (2026-08-17) — the shot-report tag chip. Unlike the Phase-2 six
+// this one lands ADOPTED: all three DOM recipes render it directly.
+export { TagChipView, renderTagChipDom } from "./TagChip"

--- a/src-vnext/features/export/components/report/reportStyles.ts
+++ b/src-vnext/features/export/components/report/reportStyles.ts
@@ -80,6 +80,22 @@ export const REPORT_STYLES = `
   padding: 1px 4px; line-height: 1.2;
 }
 
+/* tag chips (2026-08-17) — ONE row shape shared by all three recipes, so a shot
+   row's tags read identically wherever they print. NEUTRAL by design: the same
+   thin rule-strong border + ink-2 uppercase label the gender chip already uses
+   (.sb-br-gender-chip below). Deliberately NOT the app's Tailwind TagBadge —
+   ShotTag.color is a class key with no hex behind it, and red has exactly one
+   job per recipe here. The TagChip primitive also emits every metric inline
+   from its spec (so DOM and PDF provably consume one source); this class is the
+   real-page/fidelity half of that belt-and-suspenders pair. */
+.sb-tag-row { display: flex; flex-wrap: wrap; align-items: center; gap: 5px; margin-top: 8px; }
+.sb-tag-chip {
+  font-family: var(--sb-font-ui); font-size: var(--sb-t-3xs); font-weight: 600;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--sb-ink-2); border: 1px solid var(--sb-rule-strong); border-radius: 2px;
+  padding: 1px 6px; line-height: 1.2; display: inline-block; white-space: nowrap;
+}
+
 /* full-width fluid report frame ----------------------------------------- */
 .sb-report {
   max-width: none; margin: 0;

--- a/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportModel.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect } from "vitest"
-import { deriveShotReportModel, formatDateWindow, mostOutstandingStatus, normalizeGender, sizeLabel, titleCaseSlug } from "../reportModel"
+import {
+  deriveShotReportModel,
+  formatDateWindow,
+  mostOutstandingStatus,
+  normalizeGender,
+  resolveReportTagChips,
+  sizeLabel,
+  titleCaseSlug,
+} from "../reportModel"
 import {
   DEFAULT_REPORT_CONFIG,
   formatFilterSummary,
@@ -1446,5 +1454,168 @@ describe("DEFAULT_REPORT_CONFIG is a hard behavioral floor — a user who touche
     // for a config that never touches filters/custom/scene.
     expect(formatOrderNote(model.order)).toBe("Sorted by shot #")
     expect(model.order.filterSummary).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag chips (2026-08-17) — ReportShot.tags. The model owns the derive rule
+// (de-dupe, drop gender, order); ReportConfig.showTags only gates whether a
+// recipe RENDERS the row, exactly as additionalImages/showAdditionalImages
+// split responsibility. Every assertion below reads the DERIVED model against
+// the RAW Shot.tags it was built from, never the same field on both sides.
+// ---------------------------------------------------------------------------
+describe("resolveReportTagChips — the tag-chip derive rule", () => {
+  it("returns [] for absent / empty tags (a reader can treat absent as 'no chips')", () => {
+    expect(resolveReportTagChips(undefined)).toEqual([])
+    expect(resolveReportTagChips([])).toEqual([])
+  })
+
+  it("DROPS every gender-category tag — gender already prints as its own badge and group head", () => {
+    const chips = resolveReportTagChips([
+      { id: "default-gender-women", label: "Women", color: "pink", category: "gender" },
+      { id: "default-media-photo", label: "Photo", color: "emerald", category: "media" },
+      { id: "default-gender-men", label: "Men", color: "blue", category: "gender" },
+    ])
+    expect(chips.map((t) => t.label)).toEqual(["Photo"])
+    expect(chips.some((t) => t.category === "gender")).toBe(false)
+  })
+
+  it("resolves a gender tag's category from its DEFAULT id even when the stored category is absent", () => {
+    // A blob written before ShotTag.category existed carries no category at
+    // all. resolveShotTagCategory recovers it from DEFAULT_TAGS by id — so the
+    // exclusion still fires. Without that lookup "Women" would print as a chip.
+    const chips = resolveReportTagChips([
+      { id: "default-gender-women", label: "Women", color: "pink" },
+      { id: "default-media-video", label: "Video", color: "orange" },
+    ])
+    expect(chips.map((t) => t.label)).toEqual(["Video"])
+  })
+
+  it("orders media -> priority -> other, alphabetical (numeric-aware) within a category", () => {
+    const chips = resolveReportTagChips([
+      { id: "z", label: "Zebra Set", color: "b", category: "other" },
+      { id: "p-low", label: "Low Priority", color: "green", category: "priority" },
+      { id: "m-video", label: "Video", color: "orange", category: "media" },
+      { id: "a", label: "Alpha Set", color: "b", category: "other" },
+      { id: "p-high", label: "High Priority", color: "red", category: "priority" },
+      { id: "m-photo", label: "Photo", color: "emerald", category: "media" },
+    ])
+    expect(chips.map((t) => t.label)).toEqual([
+      "Photo",
+      "Video",
+      "High Priority",
+      "Low Priority",
+      "Alpha Set",
+      "Zebra Set",
+    ])
+  })
+
+  it("de-dupes same-labelled tags through the SHARED tagDedup helper (differing ids collapse to one chip)", () => {
+    const chips = resolveReportTagChips([
+      { id: "random-uuid-1", label: "Photo", color: "emerald", category: "media" },
+      { id: "random-uuid-2", label: "photo", color: "blue", category: "media" },
+      { id: "random-uuid-3", label: "  Photo  ", color: "amber", category: "media" },
+    ])
+    expect(chips).toHaveLength(1)
+    // ...and the canonical DEFAULT_TAGS id wins over the random ones.
+    expect(chips[0]?.id).toBe("default-media-photo")
+  })
+
+  it("does not mutate its input", () => {
+    const tags = [
+      { id: "m-photo", label: "Photo", color: "emerald", category: "media" as const },
+      { id: "g", label: "Women", color: "pink", category: "gender" as const },
+    ]
+    const before = structuredClone(tags)
+    resolveReportTagChips(tags)
+    expect(tags).toEqual(before)
+  })
+
+  it("carries NO colour field — the report keeps a reserved palette (see the TagChip primitive)", () => {
+    // A non-default label, so canonicalizeTag passes the id through verbatim and
+    // this assertion is about a chip's SHAPE, not about canonicalization.
+    const chips = resolveReportTagChips([
+      { id: "custom-hero", label: "Hero Shot", color: "red", category: "other" },
+    ])
+    expect(chips[0]).toEqual({ id: "custom-hero", label: "Hero Shot", category: "other" })
+    expect("color" in (chips[0] ?? {})).toBe(false)
+  })
+
+  it("canonicalizes a DEFAULT-labelled tag to its default id (so two shots' 'High Priority' agree)", () => {
+    const chips = resolveReportTagChips([
+      { id: "random-uuid-from-the-editor", label: "High Priority", color: "red", category: "priority" },
+    ])
+    expect(chips[0]?.id).toBe("default-priority-high")
+    expect(chips[0]?.label).toBe("High Priority")
+  })
+})
+
+describe("deriveShotReportModel — ReportShot.tags is threaded from the raw shot", () => {
+  function taggedData() {
+    return data({
+      productFamilies: FAMILIES,
+      shots: [
+        shot({
+          id: "s1",
+          shotNumber: "01",
+          tags: [
+            { id: "other-flat", label: "Flat Lay", color: "b", category: "other" },
+            { id: "default-gender-women", label: "Women", color: "pink", category: "gender" },
+            { id: "default-media-photo", label: "Photo", color: "emerald", category: "media" },
+          ],
+          looks: [{ id: "l", order: 0, products: [{ familyId: "fW" }] }],
+        }),
+        shot({
+          id: "s2",
+          shotNumber: "02",
+          tags: [],
+          looks: [{ id: "l", order: 0, products: [{ familyId: "fM" }] }],
+        }),
+      ],
+    })
+  }
+
+  function shotsOf(model: ReturnType<typeof deriveShotReportModel>) {
+    return model.groups.flatMap((g) => g.shots)
+  }
+
+  it("puts the ordered, gender-free chips on the model shot", () => {
+    const model = deriveShotReportModel(taggedData(), DEFAULT_REPORT_CONFIG)
+    const s1 = shotsOf(model).find((s) => s.id === "s1")
+    expect(s1?.tags?.map((t) => t.label)).toEqual(["Photo", "Flat Lay"])
+  })
+
+  it("a shot with no tags gets [] (never undefined-with-a-hole, never the previous shot's chips)", () => {
+    const model = deriveShotReportModel(taggedData(), DEFAULT_REPORT_CONFIG)
+    expect(shotsOf(model).find((s) => s.id === "s2")?.tags).toEqual([])
+  })
+
+  it("the gender tag still drives shot.gender even though it never becomes a chip", () => {
+    // The exclusion is a DISPLAY rule, not a data drop: resolveShotGender reads
+    // the raw Shot.tags, so removing the chip must not change the grouping.
+    const model = deriveShotReportModel(taggedData(), DEFAULT_REPORT_CONFIG)
+    const s1 = shotsOf(model).find((s) => s.id === "s1")
+    expect(s1?.gender).toBe("W")
+    expect(s1?.tags?.some((t) => t.label === "Women")).toBe(false)
+  })
+
+  it("is computed regardless of config.showTags — the flag gates RENDERING, not the model", () => {
+    const off = deriveShotReportModel(taggedData(), { ...DEFAULT_REPORT_CONFIG, showTags: false })
+    const on = deriveShotReportModel(taggedData(), { ...DEFAULT_REPORT_CONFIG, showTags: true })
+    const labels = (m: ReturnType<typeof deriveShotReportModel>) =>
+      shotsOf(m).map((s) => s.tags?.map((t) => t.label) ?? [])
+    expect(labels(off)).toEqual([["Photo", "Flat Lay"], []])
+    expect(labels(off)).toEqual(labels(on))
+  })
+
+  it("survives the featureReportConfig flag-off neutralizer (same reason: it is model data, not config)", () => {
+    const model = deriveShotReportModel(
+      taggedData(),
+      neutralizeReportConfigForFlag(DEFAULT_REPORT_CONFIG, false),
+    )
+    expect(shotsOf(model).find((s) => s.id === "s1")?.tags?.map((t) => t.label)).toEqual([
+      "Photo",
+      "Flat Lay",
+    ])
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportPdfHeights.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest"
 import {
   estimatePlateHeight,
+  estimateTagRowHeight,
   estimateWrappedLines,
   packShotSheets,
   COL_MAX,
+  TAG_CHIPS_PER_PLATE_LINE,
 } from "../reportPdfHeights"
 import type {
   ReportModel,
@@ -220,5 +222,120 @@ describe("packShotSheets — behaviour", () => {
     expect(last.rightColumn).toHaveLength(0)
     expect(last.firstPosition).toBe(3)
     expect(last.lastPosition).toBe(3)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag-chip row (2026-08-17). This module drives BOTH the real image-led PDF
+// pagination (reportPdf.tsx) and the DOM print preview's WYSIWYG packing
+// (ReportView.buildSheets), so a rendered row with no term here desyncs the
+// two AND can push a plate silently past COL_MAX.
+// ---------------------------------------------------------------------------
+describe("estimateTagRowHeight", () => {
+  it("is 0 for no chips — a tagless plate estimates identically toggle on or off", () => {
+    expect(estimateTagRowHeight(0)).toBe(0)
+    expect(estimateTagRowHeight(-3)).toBe(0)
+  })
+
+  it("scales with chip count, not merely with presence", () => {
+    const one = estimateTagRowHeight(1)
+    const oneFullLine = estimateTagRowHeight(TAG_CHIPS_PER_PLATE_LINE)
+    const threeLines = estimateTagRowHeight(TAG_CHIPS_PER_PLATE_LINE * 3)
+    // Within a line the cost is flat (chips sit side by side)...
+    expect(oneFullLine).toBe(one)
+    // ...but wrapping to more lines must cost more, and by a wide margin.
+    expect(threeLines).toBeGreaterThan(oneFullLine)
+    expect(threeLines).toBeGreaterThan(oneFullLine * 2)
+  })
+})
+
+describe("estimatePlateHeight — tag-chip term", () => {
+  const tags = Array.from({ length: 4 }, (_, i) => ({
+    id: `t${i}`,
+    label: `Tag ${i}`,
+    category: "other",
+  }))
+
+  it("defaults to NOT charging the row — every pre-existing caller/fixture estimates what it always has", () => {
+    const tagged = shot("a", { tags })
+    expect(estimatePlateHeight(tagged)).toBe(estimatePlateHeight(shot("a")))
+  })
+
+  it("charges the row when showTags is on AND the shot has chips", () => {
+    const tagged = shot("a", { tags })
+    expect(estimatePlateHeight(tagged, true)).toBeGreaterThan(estimatePlateHeight(tagged, false))
+  })
+
+  it("charges NOTHING when showTags is on but the shot has no chips", () => {
+    expect(estimatePlateHeight(shot("a", { tags: [] }), true)).toBe(estimatePlateHeight(shot("a")))
+    expect(estimatePlateHeight(shot("a"), true)).toBe(estimatePlateHeight(shot("a")))
+  })
+
+  it("charges MORE for more chips (a flat per-plate bump would fail this)", () => {
+    const few = shot("a", { tags: tags.slice(0, 2) })
+    const many = shot("a", {
+      tags: Array.from({ length: TAG_CHIPS_PER_PLATE_LINE * 4 }, (_, i) => ({
+        id: `t${i}`,
+        label: `Tag ${i}`,
+        category: "other",
+      })),
+    })
+    expect(estimatePlateHeight(many, true)).toBeGreaterThan(estimatePlateHeight(few, true))
+  })
+})
+
+describe("packShotSheets — showTags is threaded per shot, not per index", () => {
+  it("defaults to packing without the tag term (byte-identical to pre-tag-chips)", () => {
+    const tagged = (id: string) =>
+      shot(id, {
+        tags: Array.from({ length: 24 }, (_, i) => ({ id: `${id}-t${i}`, label: `Tag ${i}`, category: "other" })),
+      })
+    const m = model([group("Women", [tagged("1"), tagged("2"), tagged("3"), tagged("4")])])
+    expect(packShotSheets(m)).toEqual(packShotSheets(m, false))
+  })
+
+  it("a plate that fits WITHOUT chips can be forced to solo WITH them (the term reaches the packer)", () => {
+    // Deliberately sized so the tag row is what crosses COL_MAX: verify the
+    // premise (fits without) before asserting the consequence (solos with), so
+    // this can't pass vacuously on a fixture that was oversized all along.
+    const chips = Array.from({ length: TAG_CHIPS_PER_PLATE_LINE * 12 }, (_, i) => ({
+      id: `t${i}`,
+      label: `Tag ${i}`,
+      category: "other",
+    }))
+    const heavy = shot("heavy", { tags: chips })
+    expect(estimatePlateHeight(heavy, false)).toBeLessThanOrEqual(COL_MAX)
+    expect(estimatePlateHeight(heavy, true)).toBeGreaterThan(COL_MAX)
+
+    const m = model([group("Women", [heavy, shot("plain")])])
+    const packedOff = packShotSheets(m, false)
+    const packedOn = packShotSheets(m, true)
+    // Off: the two plates pair on one sheet. On: the tagged plate solos.
+    expect(packedOff).toHaveLength(1)
+    expect(packedOff[0]?.oversized).toBe(false)
+    expect(packedOn).toHaveLength(2)
+    expect(packedOn[0]?.oversized).toBe(true)
+    expect(packedOn[0]?.leftColumn.map((s) => s.id)).toEqual(["heavy"])
+  })
+
+  it("EVERY shot is measured with the same showTags value (Array#map's index arg must not leak into it)", () => {
+    // `visible.map(estimatePlateHeight)` would pass the array INDEX as the
+    // second argument, so shot 0 packs with showTags:false (index 0 -> falsy)
+    // and every later shot with a truthy index. This asserts the observable
+    // consequence: with the term ON, a group of identically-tagged shots
+    // produces the same per-sheet arrangement as their identical estimates
+    // imply, and the FIRST shot is not the odd one out.
+    const chips = Array.from({ length: TAG_CHIPS_PER_PLATE_LINE * 12 }, (_, i) => ({
+      id: `t${i}`,
+      label: `Tag ${i}`,
+      category: "other",
+    }))
+    const shots = ["a", "b", "c"].map((id) => shot(id, { tags: chips }))
+    const packed = packShotSheets(model([group("Women", shots)]), true)
+    // All three are individually oversized, so all three solo. With the index
+    // leaking in, shot "a" (index 0) would estimate WITHOUT the tag row, fit,
+    // and pair with "b" — two sheets instead of three.
+    expect(packed).toHaveLength(3)
+    expect(packed.every((s) => s.oversized)).toBe(true)
   })
 })

--- a/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
+++ b/src-vnext/features/export/lib/report/__tests__/reportTypes.test.ts
@@ -12,8 +12,10 @@ import {
   resolveReportFilters,
   resolveReportLayout,
   resolveShowAdditionalImages,
+  resolveShowTags,
   type ReportConfig,
   type ReportFilterCondition,
+  type ReportLayout,
 } from "../reportTypes"
 import { DEFAULT_PRODUCT_INFO_CONFIG, type ProductInfoConfig } from "../productInfoTypes"
 import { DEFAULT_TALENT_CONFIG, type TalentConfig } from "../talentTypes"
@@ -441,5 +443,113 @@ describe("TalentConfig headshot crop (Phase C, R4 part 2)", () => {
       headshotCrops: { tA: { scale: 1.5, x: 0.25, y: 0.1 } },
     }
     expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Tag chips (2026-08-17) — ReportConfig.showTags. Mechanically mirrors
+// showAdditionalImages above with TWO deliberate differences, and BOTH are the
+// point of these tests: the default is ON, and there is no per-recipe
+// exclusion. A default-ON persisted flag is only safe to roll back because
+// neutralizeReportConfigForFlag writes an explicit `false` AND resolveShowTags
+// carries an independent `reportConfigEnabled` gate — either alone would leave
+// a featureReportConfig rollback rendering chips.
+// ---------------------------------------------------------------------------
+const ALL_LAYOUTS: readonly ReportLayout[] = ["image-led", "production-sheet", "balanced-rows"]
+
+describe("ReportConfig.showTags (2026-08-17) — default, hydrate, neutralize", () => {
+  it("DEFAULT_REPORT_CONFIG carries showTags: true — a brand-new report starts ON (this IS the feature)", () => {
+    expect(DEFAULT_REPORT_CONFIG.showTags).toBe(true)
+  })
+
+  it("hydrateReportConfig default-merges a pre-tag-chips blob (no showTags) to TRUE", () => {
+    const stored = JSON.parse('{"groupBy":"gender","excludedShotIds":[],"layout":"production-sheet"}')
+    expect(hydrateReportConfig(stored).showTags).toBe(true)
+  })
+
+  it("hydrateReportConfig preserves a persisted showTags:false verbatim (a deliberate Off is never re-defaulted ON)", () => {
+    const stored = JSON.parse(
+      '{"groupBy":"gender","excludedShotIds":[],"layout":"production-sheet","showTags":false}',
+    )
+    expect(hydrateReportConfig(stored).showTags).toBe(false)
+  })
+
+  it("round-trips showTags:false through JSON unchanged", () => {
+    const config: ReportConfig = { groupBy: "none", excludedShotIds: [], showTags: false }
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config)
+  })
+
+  it("neutralizeReportConfigForFlag (flag off) forces showTags to FALSE — the write that makes a default-ON feature rollback-safe", () => {
+    const config: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: true }
+    expect(neutralizeReportConfigForFlag(config, false).showTags).toBe(false)
+  })
+
+  it("neutralizeReportConfigForFlag (flag off) forces showTags to FALSE even when the field is ABSENT", () => {
+    // The sharp case a `=== true` guard would miss: an absent showTags resolves
+    // ON (resolveShowTags below), so the neutralizer must WRITE false, not just
+    // leave the field alone.
+    const config: ReportConfig = { groupBy: "gender", excludedShotIds: [] }
+    expect(neutralizeReportConfigForFlag(config, false).showTags).toBe(false)
+  })
+
+  it("neutralizeReportConfigForFlag (flag on) leaves showTags verbatim", () => {
+    const on: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: true }
+    expect(neutralizeReportConfigForFlag(on, true).showTags).toBe(true)
+    const off: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: false }
+    expect(neutralizeReportConfigForFlag(off, true).showTags).toBe(false)
+  })
+})
+
+describe("resolveShowTags — single source for ReportView + ShotReportPage's PDF export", () => {
+  it("true when the toggle is on and the config flag is on", () => {
+    const on: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: true }
+    expect(resolveShowTags(on, true)).toBe(true)
+  })
+
+  it("true when the field is ABSENT and the config flag is on — absent means 'never chosen', and the shipped default is ON", () => {
+    const absent: ReportConfig = { groupBy: "gender", excludedShotIds: [] }
+    expect(resolveShowTags(absent, true)).toBe(true)
+  })
+
+  it("false for an explicit showTags:false, whatever the flag", () => {
+    const off: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: false }
+    expect(resolveShowTags(off, true)).toBe(false)
+    expect(resolveShowTags(off, false)).toBe(false)
+  })
+
+  it("false when featureReportConfig is off — the independent gate that keeps a rollback byte-identical even for a config the neutralizer never touched", () => {
+    const on: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: true }
+    const absent: ReportConfig = { groupBy: "gender", excludedShotIds: [] }
+    expect(resolveShowTags(on, false)).toBe(false)
+    expect(resolveShowTags(absent, false)).toBe(false)
+    expect(resolveShowTags(DEFAULT_REPORT_CONFIG, false)).toBe(false)
+  })
+
+  it("has NO per-recipe exclusion — unlike the extras row, every layout renders the tag row", () => {
+    // The falsifiable complement to the DOM tests: if someone later adds a
+    // `reportLayoutSupportsTags`-style clamp, this reddens. Compare directly
+    // against resolveShowAdditionalImages, which DOES exclude image-led.
+    const on: ReportConfig = {
+      groupBy: "gender",
+      excludedShotIds: [],
+      showTags: true,
+      showAdditionalImages: true,
+    }
+    for (const layout of ALL_LAYOUTS) {
+      expect(resolveShowTags(on, true)).toBe(true)
+      // ...and the sibling resolver still excludes image-led, so this test is
+      // asserting a real difference, not a tautology about a constant.
+      expect(resolveShowAdditionalImages(on, layout, true)).toBe(layout !== "image-led")
+    }
+  })
+
+  it("the flag-off neutralizer and the flag-off resolver agree (belt AND suspenders, not belt OR suspenders)", () => {
+    const on: ReportConfig = { groupBy: "gender", excludedShotIds: [], showTags: true }
+    const neutralized = neutralizeReportConfigForFlag(on, false)
+    // Either gate alone would be enough; both are present on purpose, so a
+    // future refactor that drops one still can't leak chips past a rollback.
+    expect(resolveShowTags(neutralized, false)).toBe(false)
+    expect(resolveShowTags(neutralized, true)).toBe(false) // the neutralizer's own write
+    expect(resolveShowTags(on, false)).toBe(false) // the resolver's own gate
   })
 })

--- a/src-vnext/features/export/lib/report/primitives/__tests__/tagChip.parity.test.tsx
+++ b/src-vnext/features/export/lib/report/primitives/__tests__/tagChip.parity.test.tsx
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi } from "vitest"
+
+// Two-layer parity for the TagChip primitive (the 7th canonical primitive,
+// 2026-08-17). Layer 1 snapshots deriveTagChipSpec() (the single source both
+// renderers consume). Layer 2 proves the DOM adapter and the @react-pdf adapter
+// present the SAME spec — if someone forks a geometry value or a colour on one
+// side only, or reaches for the app's per-tag-coloured TagBadge palette here,
+// that side diverges -> red.
+
+// Mock @react-pdf/renderer into queryable DOM. TagChip renders a single <Text>
+// (no View/Image), so only Text + StyleSheet are stubbed.
+vi.mock("@react-pdf/renderer", () => {
+  const React = require("react")
+  const ser = (s: unknown) => {
+    try {
+      return s == null ? undefined : JSON.stringify(s)
+    } catch {
+      return undefined
+    }
+  }
+  return {
+    Text: (props: Record<string, unknown>) => {
+      const { style, children, ...rest } = props as {
+        style?: unknown
+        children?: unknown
+      } & Record<string, unknown>
+      return React.createElement(
+        "pdf-text",
+        { ...rest, "data-style": ser(style) },
+        children as React.ReactNode,
+      )
+    },
+    StyleSheet: { create: (s: unknown) => s },
+  }
+})
+
+import { render } from "@testing-library/react"
+import { TagChipView } from "../../../../components/report/primitives/TagChip"
+import { TagChipPdf, deriveTagChipSpec, type TagChipInput } from "../tagChip"
+import { COLOR } from "../../reportPdfShared"
+import { pxToPt } from "../../../units"
+
+function parseStyle(el: Element | null): Record<string, unknown> {
+  const raw = el?.getAttribute("data-style")
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
+}
+
+// jsdom normalizes inline colors to rgb(); the PDF mock keeps the raw hex.
+// Compare both via a whitespace/case-insensitive form so a color VALUE is
+// asserted, not its notation.
+function hexToRgb(hex: string): string {
+  const h = hex.replace("#", "")
+  const r = Number.parseInt(h.slice(0, 2), 16)
+  const g = Number.parseInt(h.slice(2, 4), 16)
+  const b = Number.parseInt(h.slice(4, 6), 16)
+  return `rgb(${String(r)}, ${String(g)}, ${String(b)})`
+}
+
+const normColor = (c: string): string => c.replace(/\s+/g, "").toLowerCase()
+
+// ── Layer 1 — spec unit ──────────────────────────────────────────────────────
+describe("deriveTagChipSpec", () => {
+  it("resolves the canonical spec from a bare input", () => {
+    expect(deriveTagChipSpec({ label: "Photo" })).toEqual({
+      kind: "tagChip",
+      label: "Photo",
+      inkHex: "#52525B",
+      inkVar: "var(--sb-ink-2)",
+      borderHex: "#D4D4D8",
+      borderVar: "var(--sb-rule-strong)",
+      fontDomPx: 9,
+      fontPt: 5.5,
+      letterSpacingDomEm: 0.08,
+      letterSpacingPt: 0.4,
+      paddingDomPx: "1px 6px",
+      paddingHorizontalPt: 3,
+      borderRadiusDomPx: 2,
+      borderRadiusPt: 1,
+      borderWidthDomPx: 1,
+      borderWidthPt: 0.5,
+    })
+  })
+
+  it("resolves ink + border from the SHARED reserved palette, never a re-hardcoded hex", () => {
+    const spec = deriveTagChipSpec({ label: "High Priority" })
+    expect(spec.inkHex).toBe(COLOR.textSecondary)
+    expect(spec.borderHex).toBe(COLOR.ruleStrong)
+  })
+
+  it("is NEUTRAL — no red, ever, whatever the tag is called", () => {
+    // The report keeps a reserved palette in which red has exactly one job per
+    // recipe (image-led's shot number / production-sheet's hold flag /
+    // balanced-rows' hero mark). A tag literally labelled "High Priority" (whose
+    // ShotTag.color key is "red" in DEFAULT_TAGS) must still print neutral.
+    for (const label of ["High Priority", "Photo", "Video", "Low Priority"]) {
+      const spec = deriveTagChipSpec({ label })
+      expect(spec.inkHex).not.toBe(COLOR.accent) // #EB1400, the sanctioned red
+      expect(spec.inkHex).not.toBe(COLOR.accentInk) // #B3261E, the muted red-ink
+      expect(spec.borderHex).not.toBe(COLOR.accent)
+      expect(spec.borderHex).not.toBe(COLOR.accentInk)
+      expect(spec.inkVar).not.toBe("var(--sb-red)")
+      expect(spec.inkVar).not.toBe("var(--sb-red-ink)")
+    }
+  })
+
+  it("passes the label through verbatim (no casing/trim transform in the spec)", () => {
+    for (const label of ["Photo", "high priority", "  Odd  Spacing  ", "E-Comm"]) {
+      expect(deriveTagChipSpec({ label }).label).toBe(label)
+    }
+  })
+
+  it("does not mutate the input", () => {
+    const input: TagChipInput = { label: "Video" }
+    const before = structuredClone(input)
+    deriveTagChipSpec(input)
+    expect(input).toEqual(before)
+  })
+})
+
+describe("pxToPt", () => {
+  it("converts against the physical constant (96px = 72pt = 1in)", () => {
+    expect(pxToPt(96)).toBe(72)
+    expect(pxToPt(1)).toBeCloseTo(0.75)
+  })
+})
+
+// ── Layer 2 — cross-renderer parity ──────────────────────────────────────────
+const CASES: readonly TagChipInput[] = [
+  { label: "Photo" },
+  { label: "Video" },
+  { label: "High Priority" },
+  { label: "E-Comm" },
+]
+
+describe("TagChip consumer parity — DOM and pdf consume the same spec", () => {
+  it.each(CASES)("DOM <span> reflects the spec (%o)", (input) => {
+    const spec = deriveTagChipSpec(input)
+    const { getByTestId } = render(<TagChipView {...input} />)
+    const chip = getByTestId("tag-chip")
+    expect(chip.textContent).toBe(spec.label)
+    expect(chip.style.fontSize).toBe(`${String(spec.fontDomPx)}px`)
+    expect(chip.style.letterSpacing).toBe(`${String(spec.letterSpacingDomEm)}em`)
+    expect(chip.style.textTransform).toBe("uppercase")
+    expect(chip.style.padding).toBe(spec.paddingDomPx)
+    expect(chip.style.borderRadius).toBe(`${String(spec.borderRadiusDomPx)}px`)
+    // jsdom does NOT resolve `var(--sb-ink-2)` — assert the raw tokens.
+    expect(chip.style.color).toBe(spec.inkVar)
+    expect(chip.style.borderWidth).toBe(`${String(spec.borderWidthDomPx)}px`)
+    expect(chip.style.borderColor).toBe(spec.borderVar)
+    // The shipped class rides along for real-page fidelity (belt-and-suspenders
+    // with the inline styles the parity assertions above read).
+    expect(chip.className).toContain("sb-tag-chip")
+  })
+
+  it.each(CASES)("pdf <Text> reflects the same spec (%o)", (input) => {
+    const spec = deriveTagChipSpec(input)
+    const { container } = render(<TagChipPdf {...input} />)
+    const el = container.querySelector("pdf-text")
+    expect(el?.textContent).toBe(spec.label)
+    const style = parseStyle(el)
+    expect(String(style.color).toLowerCase()).toBe(spec.inkHex.toLowerCase())
+    expect(String(style.borderColor).toLowerCase()).toBe(spec.borderHex.toLowerCase())
+    expect(style.borderWidth).toBeCloseTo(spec.borderWidthPt)
+    expect(style.borderRadius).toBeCloseTo(spec.borderRadiusPt)
+    expect(style.fontSize).toBeCloseTo(spec.fontPt)
+    expect(style.letterSpacing).toBeCloseTo(spec.letterSpacingPt)
+    expect(style.paddingHorizontal).toBeCloseTo(spec.paddingHorizontalPt)
+    expect(style.textTransform).toBe("uppercase")
+  })
+
+  it("both adapters print the SAME label text for the same input (no per-renderer casing fork)", () => {
+    for (const input of CASES) {
+      const { getByTestId, unmount } = render(<TagChipView {...input} />)
+      const domText = getByTestId("tag-chip").textContent
+      unmount()
+      const { container, unmount: unmountPdf } = render(<TagChipPdf {...input} />)
+      const pdfText = container.querySelector("pdf-text")?.textContent
+      unmountPdf()
+      expect(domText).toBe(pdfText)
+      expect(domText).toBe(input.label)
+    }
+  })
+
+  it("DOM ink and PDF ink are the SAME canonical color (cross-normalized)", () => {
+    const spec = deriveTagChipSpec({ label: "Photo" })
+    // The DOM emits `var(--sb-ink-2)` (jsdom keeps it verbatim), so cross-compare
+    // the CANONICAL hex both sides derive from — DOM inkVar maps to inkHex.
+    expect(normColor(hexToRgb(spec.inkHex))).toBe(normColor(hexToRgb(COLOR.textSecondary)))
+    expect(spec.inkHex.toLowerCase()).toBe("#52525b")
+    expect(spec.borderHex.toLowerCase()).toBe("#d4d4d8")
+  })
+})

--- a/src-vnext/features/export/lib/report/primitives/index.ts
+++ b/src-vnext/features/export/lib/report/primitives/index.ts
@@ -27,6 +27,10 @@ export * from "./holdFlag"
 export * from "./unresolvedBadge"
 export * from "./lookLabel"
 export * from "./productRow"
+// 7th primitive (2026-08-17) — the shot-report tag chip. Unlike the Phase-2 six
+// this one lands ADOPTED: all three PDF recipes render `renderTagChipPdf`, all
+// three DOM recipes render `TagChipView`.
+export * from "./tagChip"
 
 // DOM wrapper components (built by later agents).
 export { HeroMarkView } from "../../../components/report/primitives/HeroMark"
@@ -38,3 +42,4 @@ export {
   ProductRowView,
   ProductColHeadView,
 } from "../../../components/report/primitives/ProductRow"
+export { TagChipView } from "../../../components/report/primitives/TagChip"

--- a/src-vnext/features/export/lib/report/primitives/tagChip.tsx
+++ b/src-vnext/features/export/lib/report/primitives/tagChip.tsx
@@ -1,0 +1,134 @@
+import { Text } from "@react-pdf/renderer"
+import { COLOR, FONT } from "../reportPdfShared"
+
+// Canonical TagChip primitive (2026-08-17) — the small neutral chip each shot
+// row prints for its tags. ONE spec, ONE pure deriver, TWO adapters (DOM in
+// ../../../components/report/primitives/TagChip.tsx, PDF below) presenting the
+// SAME spec, so the on-screen report and the @react-pdf export can't drift.
+//
+// NEUTRAL BY DESIGN — deliberately NOT the app's Tailwind `TagBadge`
+// (shared/components/TagBadge.tsx). `ShotTag.color` is a Tailwind class KEY
+// ("red" | "amber" | "emerald" | ...) with no hex table behind it, and the
+// report deliberately keeps a RESERVED palette in which red has exactly one
+// job per recipe (the image-led shot number / the production-sheet hold flag /
+// the balanced-rows hero mark). Painting a per-tag colour here would put a
+// second red on the page and invent hexes the design system never defined. So
+// the chip borrows the shipped gender-chip / unresolved-badge treatment
+// instead: a thin rule-strong border, an ink-2 uppercase label. Same shape on
+// both renderers; the tag's own colour key is not consumed at all.
+//
+// px -> pt: the report PDFs are hand-tuned in raw points (~0.5x DOM px), NOT
+// px*0.75, so the spec carries explicit `*DomPx`/`*Pt` pairs — DOM emits the px
+// strings, PDF emits the raw pt numbers. Colors are never unit-converted.
+// Margins / gaps between chips are LAYOUT (owned by each host's tag row), not
+// baked in here.
+
+export interface TagChipSpec {
+  readonly kind: "tagChip"
+  /** Caller-supplied tag label, passed through verbatim (never re-derived). */
+  readonly label: string
+  readonly inkHex: string // "#52525B" (=== COLOR.textSecondary)
+  readonly inkVar: string // "var(--sb-ink-2)"
+  readonly borderHex: string // "#D4D4D8" (=== COLOR.ruleStrong)
+  readonly borderVar: string // "var(--sb-rule-strong)"
+  readonly fontDomPx: number // 9 (--sb-t-3xs)
+  readonly fontPt: number // 5.5 (matches reportPdfBalancedRows genderChip)
+  readonly letterSpacingDomEm: number // 0.08
+  readonly letterSpacingPt: number // 0.4
+  readonly paddingDomPx: string // "1px 6px"
+  readonly paddingHorizontalPt: number // 3
+  readonly borderRadiusDomPx: number // 2
+  readonly borderRadiusPt: number // 1
+  readonly borderWidthDomPx: number // 1
+  readonly borderWidthPt: number // 0.5
+}
+
+export interface TagChipInput {
+  readonly label: string
+}
+
+/** Discriminated-union of resolved primitive specs handled here. Single-variant
+ *  today; the defaultless `switch(spec.kind)` in each adapter stays exhaustive
+ *  via the explicit ReactElement return type (add a `never` default when it
+ *  grows). */
+type ResolvedTagChipSpec = TagChipSpec
+
+// Canonical ink + border. Resolved from the shared PDF palette rather than
+// re-hardcoded, so the reserved set stays single-sourced (reportPdfShared.ts).
+// The DOM side names the equivalent CSS custom properties, which reportStyles.ts
+// defines as the OKLCH originals these hexes approximate.
+const INK_HEX = COLOR.textSecondary // "#52525B"
+const INK_VAR = "var(--sb-ink-2)"
+const BORDER_HEX = COLOR.ruleStrong // "#D4D4D8"
+const BORDER_VAR = "var(--sb-rule-strong)"
+
+// Geometry — DOM px / PDF pt pairs (hand-tuned pt, not px*0.75). These are the
+// SHIPPED gender-chip metrics: DOM `.sb-br-gender-chip` (reportStyles.ts) and
+// PDF `genderChip` (reportPdfBalancedRows.tsx), so a tag chip and a gender chip
+// sitting on the same row read as one family.
+const FONT_DOM_PX = 9
+const FONT_PT = 5.5
+const LETTER_SPACING_DOM_EM = 0.08
+const LETTER_SPACING_PT = 0.4
+const PADDING_DOM_PX = "1px 6px"
+const PADDING_HORIZONTAL_PT = 3
+const BORDER_RADIUS_DOM_PX = 2
+const BORDER_RADIUS_PT = 1
+const BORDER_WIDTH_DOM_PX = 1
+const BORDER_WIDTH_PT = 0.5
+
+/** Resolve a TagChip input to its renderer-agnostic spec. PURE. */
+export function deriveTagChipSpec(input: TagChipInput): TagChipSpec {
+  return {
+    kind: "tagChip",
+    label: input.label,
+    inkHex: INK_HEX,
+    inkVar: INK_VAR,
+    borderHex: BORDER_HEX,
+    borderVar: BORDER_VAR,
+    fontDomPx: FONT_DOM_PX,
+    fontPt: FONT_PT,
+    letterSpacingDomEm: LETTER_SPACING_DOM_EM,
+    letterSpacingPt: LETTER_SPACING_PT,
+    paddingDomPx: PADDING_DOM_PX,
+    paddingHorizontalPt: PADDING_HORIZONTAL_PT,
+    borderRadiusDomPx: BORDER_RADIUS_DOM_PX,
+    borderRadiusPt: BORDER_RADIUS_PT,
+    borderWidthDomPx: BORDER_WIDTH_DOM_PX,
+    borderWidthPt: BORDER_WIDTH_PT,
+  }
+}
+
+// @react-pdf presenter for TagChipSpec — the only adapter importing @react-pdf,
+// so it stays in the lazy pdf chunk. Exhaustive via the explicit return type +
+// defaultless switch (unhandled variant -> tsc error = red build).
+
+/** Render a resolved TagChip spec to @react-pdf primitives. */
+export function renderTagChipPdf(spec: ResolvedTagChipSpec): React.ReactElement {
+  switch (spec.kind) {
+    case "tagChip":
+      return (
+        <Text
+          data-testid="tag-chip"
+          style={{
+            fontFamily: FONT.uiBold,
+            fontSize: spec.fontPt,
+            letterSpacing: spec.letterSpacingPt,
+            textTransform: "uppercase",
+            color: spec.inkHex,
+            borderWidth: spec.borderWidthPt,
+            borderColor: spec.borderHex,
+            borderRadius: spec.borderRadiusPt,
+            paddingHorizontal: spec.paddingHorizontalPt,
+          }}
+        >
+          {spec.label}
+        </Text>
+      )
+  }
+}
+
+/** Thin PDF wrapper: derive the spec, then present it via the @react-pdf adapter. */
+export function TagChipPdf(input: TagChipInput): React.ReactElement {
+  return renderTagChipPdf(deriveTagChipSpec(input))
+}

--- a/src-vnext/features/export/lib/report/reportModel.ts
+++ b/src-vnext/features/export/lib/report/reportModel.ts
@@ -4,6 +4,7 @@ import type {
   ProductFamily,
   Shot,
   ShotLook,
+  ShotTag,
   SizeScope,
   TalentRecord,
 } from "@/shared/types"
@@ -11,6 +12,8 @@ import type { ExportData } from "../../hooks/useExportData"
 import { humanizeLabel } from "@/shared/lib/textUtils"
 import { SHOT_STATUS_CYCLE } from "@/shared/lib/statusMappings"
 import { applyFilterConditions } from "@/features/shots/lib/filterEngine"
+import { deduplicateTags } from "@/shared/lib/tagDedup"
+import { resolveShotTagCategory } from "@/shared/lib/tagCategories"
 import {
   REPORT_STATUS_LABEL,
   formatFilterSummary,
@@ -23,6 +26,7 @@ import {
   type ReportProduct,
   type ReportShot,
   type ReportShotStatus,
+  type ReportShotTag,
   type ReportSortField,
   type ReportTalent,
 } from "./reportTypes"
@@ -240,6 +244,62 @@ function resolveAdditionalImages(
     }
   }
   return out
+}
+
+// Tag-chip category order (2026-08-17). Media first (the single most
+// operationally load-bearing distinction on a crew sheet: is this a Photo or a
+// Video setup), then priority, then everything else. "gender" is absent from
+// this table ON PURPOSE — it is filtered out entirely below, so a gender tag can
+// never fall through to a default order and reappear.
+const TAG_CHIP_CATEGORY_ORDER: Record<string, number> = {
+  media: 0,
+  priority: 1,
+  other: 2,
+}
+const TAG_CHIP_CATEGORY_FALLBACK_ORDER = TAG_CHIP_CATEGORY_ORDER.other ?? 2
+
+/** Excluded from the chip row: gender already prints as its own badge/chip on
+ *  every recipe, and under groupBy:"gender" as the group head too. */
+const TAG_CHIP_EXCLUDED_CATEGORY = "gender"
+
+// Numeric-aware, case-insensitive — the SAME collator computeUsedTagOptions
+// (tagDedup.ts) sorts the report's own tag-filter options with, so the chip
+// order on a row and the option order in the Filters control read alike.
+const TAG_CHIP_COLLATOR = new Intl.Collator(undefined, { sensitivity: "base", numeric: true })
+
+/**
+ * The display-ready tag chips for a shot — see `ReportShot.tags`. PURE.
+ *
+ * Three steps, in order, each one load-bearing:
+ *  1. `deduplicateTags` (the shared tagDedup helper, NOT a local re-implementation)
+ *     collapses same-labelled tags by normalized label, preferring the canonical
+ *     DEFAULT_TAGS id, and resolves each tag's category.
+ *  2. every `category: "gender"` tag is DROPPED — gender is already stated by
+ *     the recipe's own gender badge/chip and, under groupBy:"gender", by the
+ *     group head; a third statement of it is noise on a dense sheet.
+ *  3. a stable sort: media -> priority -> other, alphabetical (numeric-aware)
+ *     within a category. Stable ordering matters because the chips print on a
+ *     PDF a crew reads side-by-side with another copy — Firestore array order is
+ *     whatever the editor last wrote.
+ *
+ * Exported so the ordering/exclusion rule is directly unit-testable, rather than
+ * only reachable through a full deriveShotReportModel run.
+ */
+export function resolveReportTagChips(
+  tags: readonly ShotTag[] | undefined,
+): readonly ReportShotTag[] {
+  if (!tags || tags.length === 0) return []
+  const chips: ReportShotTag[] = []
+  for (const tag of deduplicateTags(tags)) {
+    const category = resolveShotTagCategory(tag)
+    if (category === TAG_CHIP_EXCLUDED_CATEGORY) continue
+    chips.push({ id: tag.id, label: tag.label, category })
+  }
+  return chips.sort((a, b) => {
+    const orderA = TAG_CHIP_CATEGORY_ORDER[a.category ?? ""] ?? TAG_CHIP_CATEGORY_FALLBACK_ORDER
+    const orderB = TAG_CHIP_CATEGORY_ORDER[b.category ?? ""] ?? TAG_CHIP_CATEGORY_FALLBACK_ORDER
+    return orderA - orderB || TAG_CHIP_COLLATOR.compare(a.label, b.label)
+  })
 }
 
 /** Shot gender cascade: explicit gender tag -> products' family genders -> "?". */
@@ -552,6 +612,9 @@ export function deriveShotReportModel(data: ExportData, config: ReportConfig): R
       sortOrder: shot.sortOrder,
       laneId: shot.laneId ?? null,
       additionalImages: resolveAdditionalImages(visibleRawLooks, coverIdentity),
+      // ALWAYS computed (cheap, pure) regardless of config.showTags — that flag
+      // only gates whether a recipe RENDERS the row. See resolveReportTagChips.
+      tags: resolveReportTagChips(shot.tags),
     }
   })
 

--- a/src-vnext/features/export/lib/report/reportPdf.tsx
+++ b/src-vnext/features/export/lib/report/reportPdf.tsx
@@ -38,6 +38,7 @@ import {
 } from "./reportPdfHeights"
 import { ProductionSheetPdfDocument } from "./reportPdfProductionSheet"
 import { BalancedRowsPdfDocument } from "./reportPdfBalancedRows"
+import { renderTagChipPdf, deriveTagChipSpec } from "./primitives/tagChip"
 
 // ---------------------------------------------------------------------------
 // Image-led layout — tokens shared via reportPdfShared. Red's one job: shot number.
@@ -232,6 +233,19 @@ const styles = StyleSheet.create({
     fontFamily: FONT.bodyItalic,
     fontSize: 7.5,
     color: COLOR.textSubtle,
+  },
+  // tag-chip row (2026-08-17) — LAYOUT only; every chip METRIC lives in the
+  // TagChip primitive's spec, single-sourced with the DOM recipes. The row's
+  // marginTop/gap are mirrored by reportPdfHeights' TAG_ROW_TOP / TAG_LINE_GAP,
+  // which is what keeps the estimator and this renderer in step.
+  tagRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 3,
+    marginTop: 6,
+  },
+  tagChipBox: {
+    flexDirection: "row",
   },
   note: {
     fontFamily: FONT.bodyItalic,
@@ -467,12 +481,32 @@ function LookBlock({
   )
 }
 
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless plate's PDF tree is byte-identical toggle on or off. The chips come
+ *  from the shared TagChip primitive, so this row and the DOM recipes' rows
+ *  can't drift on metrics or colour. */
+function TagChipRow({ shot }: { readonly shot: ReportShot }) {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <View style={styles.tagRow}>
+      {tags.map((t) => (
+        <View key={t.id} style={styles.tagChipBox}>
+          {renderTagChipPdf(deriveTagChipSpec({ label: t.label }))}
+        </View>
+      ))}
+    </View>
+  )
+}
+
 function Plate({
   shot,
   imageMap,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
+  readonly showTags: boolean
 }) {
   const primary = shot.looks[0]
   const heroCandidate = primary?.image ?? null
@@ -517,6 +551,8 @@ function Plate({
           )}
         </View>
 
+        {showTags ? <TagChipRow shot={shot} /> : null}
+
         {has(shot.notes) ? <Text style={styles.note}>{shot.notes}</Text> : null}
 
         <View style={styles.looks}>
@@ -538,15 +574,17 @@ function Plate({
 function Column({
   shots,
   imageMap,
+  showTags,
 }: {
   readonly shots: readonly ReportShot[]
   readonly imageMap: ReadonlyMap<string, string>
+  readonly showTags: boolean
 }) {
   return (
     <View style={styles.column} wrap={false}>
       {shots.map((shot) => (
         <View key={shot.id} style={styles.plate} wrap={false}>
-          <Plate shot={shot} imageMap={imageMap} />
+          <Plate shot={shot} imageMap={imageMap} showTags={showTags} />
         </View>
       ))}
     </View>
@@ -560,9 +598,18 @@ function Column({
 export function ShotReportPdfDocument(props: {
   readonly model: ReportModel
   readonly imageMap: ReadonlyMap<string, string>
+  /** Tag-chip toggle (2026-08-17). Absent/false renders byte-identical to
+   *  pre-tag-chips output — TagChipRow is never invoked AND packShotSheets
+   *  estimates without the row's height term, so pagination is unchanged too.
+   *  Unlike showAdditionalImages (excluded from image-led in WS-C v1 for
+   *  exactly that missing-estimator-term reason), the tag row DOES have a
+   *  synced term here — see reportPdfHeights' estimateTagRowHeight. */
+  readonly showTags?: boolean
 }): JSX.Element {
-  const { model, imageMap } = props
-  const sheets = packShotSheets(model)
+  const { model, imageMap, showTags = false } = props
+  // Same resolved value drives the estimate AND the render — a mismatch would
+  // paginate for a plate that isn't the one drawn.
+  const sheets = packShotSheets(model, showTags)
   const projectLine = has(model.project.client)
     ? `${model.project.name} · ${model.project.client}`
     : model.project.name
@@ -598,8 +645,8 @@ export function ShotReportPdfDocument(props: {
           {/* Two height-packed columns. A too-tall shot is packed alone (empty right
               column) so it never strands a partner or blanks a mid-document page. */}
           <View style={styles.body}>
-            <Column shots={sheet.leftColumn} imageMap={imageMap} />
-            <Column shots={sheet.rightColumn} imageMap={imageMap} />
+            <Column shots={sheet.leftColumn} imageMap={imageMap} showTags={showTags} />
+            <Column shots={sheet.rightColumn} imageMap={imageMap} showTags={showTags} />
           </View>
 
           {/* Footer with page number */}
@@ -622,15 +669,33 @@ function reportPdfDocument(
   imageMap: ReadonlyMap<string, string>,
   layout: ReportLayout,
   showAdditionalImages: boolean,
+  showTags: boolean,
 ): JSX.Element {
-  // image-led is EXCLUDED v1 (see reportTypes.ts's reportLayoutSupportsAdditionalImages) —
-  // no showAdditionalImages prop exists on ShotReportPdfDocument at all, so a
-  // caller can't accidentally wire it through here even by passing true.
+  // image-led is EXCLUDED v1 for showAdditionalImages (see reportTypes.ts's
+  // reportLayoutSupportsAdditionalImages) — no showAdditionalImages prop exists
+  // on ShotReportPdfDocument at all, so a caller can't accidentally wire it
+  // through here even by passing true. showTags has NO such exclusion: all
+  // three recipes carry a synced height/weight term for the tag row, so it goes
+  // to every document.
   if (layout === "production-sheet")
-    return <ProductionSheetPdfDocument model={model} imageMap={imageMap} showAdditionalImages={showAdditionalImages} />
+    return (
+      <ProductionSheetPdfDocument
+        model={model}
+        imageMap={imageMap}
+        showAdditionalImages={showAdditionalImages}
+        showTags={showTags}
+      />
+    )
   if (layout === "balanced-rows")
-    return <BalancedRowsPdfDocument model={model} imageMap={imageMap} showAdditionalImages={showAdditionalImages} />
-  return <ShotReportPdfDocument model={model} imageMap={imageMap} />
+    return (
+      <BalancedRowsPdfDocument
+        model={model}
+        imageMap={imageMap}
+        showAdditionalImages={showAdditionalImages}
+        showTags={showTags}
+      />
+    )
+  return <ShotReportPdfDocument model={model} imageMap={imageMap} showTags={showTags} />
 }
 
 // ---------------------------------------------------------------------------
@@ -643,13 +708,14 @@ export async function generateShotReportPdf(
   filename = "comprehensive-shot-report.pdf",
   layout: ReportLayout = "image-led",
   showAdditionalImages = false,
+  showTags = false,
 ): Promise<void> {
   // Guard against a zero-page PDF (corrupt) when every shot is excluded.
   if (!hasAnyIncludedShot(model)) {
     throw new Error("No shots to export")
   }
   const { pdf } = await import("@react-pdf/renderer")
-  const element = reportPdfDocument(model, imageMap, layout, showAdditionalImages)
+  const element = reportPdfDocument(model, imageMap, layout, showAdditionalImages, showTags)
   const blob = await pdf(element).toBlob()
 
   const url = URL.createObjectURL(blob)

--- a/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfBalancedRows.tsx
@@ -18,6 +18,7 @@ import {
   tokenHyphenation,
 } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
+import { renderTagChipPdf, deriveTagChipSpec } from "./primitives/tagChip"
 
 const PAD_X = 34
 const PAD_Y = 32
@@ -74,6 +75,11 @@ const s = StyleSheet.create({
   statusTxt: { fontFamily: FONT.uiBold, fontSize: 6, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.textSecondary },
   note: { fontFamily: FONT.ui, fontSize: 7, color: COLOR.textSecondary, marginTop: 7, lineHeight: 1.4 },
   noteK: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.6, textTransform: "uppercase", color: COLOR.textSubtle },
+
+  // tag-chip row (2026-08-17) — LAYOUT only; every chip METRIC lives in the
+  // TagChip primitive's spec, single-sourced with the DOM recipes.
+  tagRow: { flexDirection: "row", flexWrap: "wrap", gap: 3, marginTop: 6 },
+  tagChipBox: { flexDirection: "row" },
 
   looks: { marginTop: 8 },
   look: { marginTop: 8 },
@@ -187,16 +193,37 @@ function AdditionalImagesRow({
   )
 }
 
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless shot's PDF tree is byte-identical toggle on or off. The chips come
+ *  from the shared TagChip primitive, so this row and the DOM recipes' rows
+ *  can't drift. The wrapping View stays SPLITTABLE (no wrap={false}) — a
+ *  text-only row must flow across pages like the rest of the panel. */
+function TagChipRow({ shot }: { readonly shot: ReportShot }): JSX.Element | null {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <View style={s.tagRow}>
+      {tags.map((t) => (
+        <View key={t.id} style={s.tagChipBox}>
+          {renderTagChipPdf(deriveTagChipSpec({ label: t.label }))}
+        </View>
+      ))}
+    </View>
+  )
+}
+
 function Band({
   shot,
   imageMap,
   zebra,
   showAdditionalImages,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
   readonly zebra: boolean
   readonly showAdditionalImages: boolean
+  readonly showTags: boolean
 }): JSX.Element {
   const cand = primaryLookImage(shot)
   const src = has(cand) ? imageMap.get(cand) : undefined
@@ -235,6 +262,7 @@ function Band({
             <Text style={s.statusTxt}>{st.label}</Text>
           </View>
         </View>
+        {showTags ? <TagChipRow shot={shot} /> : null}
         {has(shot.notes) ? (
           <Text style={s.note}>
             <Text style={s.noteK}>{"Note  "}</Text>
@@ -269,8 +297,11 @@ export function BalancedRowsPdfDocument(props: {
    *  pre-WS-C output — no new element in the tree at all (AdditionalImagesRow
    *  is never invoked, not merely invoked-and-empty). */
   readonly showAdditionalImages?: boolean
+  /** Tag-chip toggle (2026-08-17). Same contract: absent/false renders
+   *  byte-identical to pre-tag-chips output — TagChipRow is never invoked. */
+  readonly showTags?: boolean
 }): JSX.Element {
-  const { model, imageMap, showAdditionalImages = false } = props
+  const { model, imageMap, showAdditionalImages = false, showTags = false } = props
   // Count only printable shots — excluded are omitted from the rendered bands.
   const all = model.groups.flatMap((g) => g.shots).filter((x) => !x.excluded)
   const withImg = all.filter((x) => x.hasImage).length
@@ -324,6 +355,7 @@ export function BalancedRowsPdfDocument(props: {
                     imageMap={imageMap}
                     zebra={zebra}
                     showAdditionalImages={showAdditionalImages}
+                    showTags={showTags}
                   />
                 )
               })}

--- a/src-vnext/features/export/lib/report/reportPdfHeights.ts
+++ b/src-vnext/features/export/lib/report/reportPdfHeights.ts
@@ -81,6 +81,39 @@ const ALT_FIGURE = 134 // alt thumb (maxHeight 110 + marginBottom 8) + lookAlt p
 const COLHEAD_H = 17 // product column header (paddingBottom 5 + marginBottom 5 + label)
 const PRODUCT_ROW = 15 // one product row (marginBottom 5 + content; slack for occasional wrap)
 
+// --- Tag-chip row (2026-08-17) — the image-led plate's own term. This module
+// drives BOTH the real PDF pagination (reportPdf.tsx's packShotSheets) and the
+// DOM print preview's WYSIWYG packing (ReportView.buildSheets), so a row
+// rendered without a term here desyncs the two AND can push a plate past
+// COL_MAX unnoticed. CONDITIONAL, exactly like NOTE_BASE: charged only when the
+// toggle is on AND the shot actually has chips, so the default/flag-off path
+// estimates byte-identically to pre-tag-chips.
+//
+// Calibrated against the shipped PDF style (reportPdf.tsx `tagRow`/`tagChip`,
+// mirroring the TagChip primitive's 5.5pt label + 3pt horizontal padding):
+//   - PLATE_WIDTH is 338pt; a chip is ~(label chars x 5.5 x 0.55) + 6 padding
+//     + 1 border + 4 row gap. A 12-char label therefore costs ~47pt, so ~7 fit
+//     a line. Charged at 6 — deliberately PESSIMISTIC (over-counting lines can
+//     only over-estimate the plate, which biases toward "solo this shot", the
+//     safe direction; under-counting is what clips).
+//   - one line ≈ marginTop 6 + chip box (5.5pt x 1.4 line-height + 2pt vertical
+//     padding + 1pt border) ≈ 6 + 11 = 17pt.
+//   - each further wrapped line ≈ the 11pt chip box + a 3pt row gap = 14pt.
+const TAG_ROW_TOP = 6
+const TAG_LINE_H = 11
+const TAG_LINE_GAP = 3
+/** Conservative chips-per-line for a plate-width tag row (see above). */
+export const TAG_CHIPS_PER_PLATE_LINE = 6
+
+/** Estimated height (pt) of an image-led plate's tag-chip row. 0 for no chips,
+ *  so the term is a genuine no-op on a shot with none. Exported for direct
+ *  unit + mutation coverage. */
+export function estimateTagRowHeight(tagCount: number): number {
+  if (tagCount <= 0) return 0
+  const lines = Math.ceil(tagCount / TAG_CHIPS_PER_PLATE_LINE)
+  return TAG_ROW_TOP + lines * TAG_LINE_H + (lines - 1) * TAG_LINE_GAP
+}
+
 /**
  * Conservative wrapped-line count for a text run at a given width. Uses a slightly
  * WIDE average glyph width so it errs toward MORE lines (Helvetica is proportional;
@@ -102,8 +135,12 @@ export function estimateWrappedLines(
  * Estimate the rendered height (pt) of one image-led plate from the resolved shot.
  * Conservative: hero image estimated at its cap; text wrap over-counted. Returns a
  * value comparable against COL_MAX for packing.
+ *
+ * `showTags` defaults to FALSE so every pre-existing caller and fixture
+ * estimates exactly what it always has (byte-identical pagination); the real
+ * call sites thread the resolved value through packShotSheets.
  */
-export function estimatePlateHeight(shot: ReportShot): number {
+export function estimatePlateHeight(shot: ReportShot, showTags = false): number {
   let h = 0
 
   // Figure: the plate shows the hero (capped at HERO_MAX_HEIGHT) iff the primary look
@@ -119,6 +156,9 @@ export function estimatePlateHeight(shot: ReportShot): number {
   // Status chip + talent row; talent names can wrap past the status chip's ~70pt.
   const talentText = shot.talent.map((t) => t.name).filter((nm) => has(nm)).join(" · ")
   h += SUBROW_H + (talentText ? (estimateWrappedLines(talentText, PLATE_WIDTH - 70, 7.5, 3) - 1) * NOTE_LINE : 0)
+  // Tag-chip row — CONDITIONAL, same shape as the note term above: only when
+  // the toggle is on AND the shot actually carries chips.
+  if (showTags) h += estimateTagRowHeight(shot.tags?.length ?? 0)
   if (has(shot.notes)) {
     h += NOTE_BASE + NOTE_LINE * estimateWrappedLines(shot.notes, PLATE_WIDTH - 8, 7.5, 4)
   }
@@ -162,13 +202,20 @@ export interface PackedSheet {
  * (COL_MAX) gets its own sheet, packed alone, never paired. Pure and deterministic:
  * excluded shots are dropped, empty groups produce no sheet, a sheet never spans a
  * gender group, and every non-excluded shot is placed exactly once in order.
+ *
+ * `showTags` (2026-08-17) must be the SAME resolved value the renderer uses
+ * (`resolveShowTags`), or the estimate is stale by a tag row per shot. Defaults
+ * to false so every pre-existing caller/fixture packs byte-identically.
  */
-export function packShotSheets(model: ReportModel): readonly PackedSheet[] {
+export function packShotSheets(model: ReportModel, showTags = false): readonly PackedSheet[] {
   const sheets: PackedSheet[] = []
   for (const group of model.groups) {
     const visible = group.shots.filter((s) => !s.excluded)
     if (visible.length === 0) continue
-    const heights = visible.map(estimatePlateHeight)
+    // NOT `visible.map(estimatePlateHeight)` — Array.prototype.map passes the
+    // INDEX as the second argument, which would land in `showTags` and make
+    // every shot after the first estimate as if tags were on.
+    const heights = visible.map((s) => estimatePlateHeight(s, showTags))
     const groupShotCount = visible.length
 
     let i = 0

--- a/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
+++ b/src-vnext/features/export/lib/report/reportPdfProductionSheet.tsx
@@ -16,6 +16,7 @@ import {
   tokenHyphenation,
 } from "./reportPdfShared"
 import { sizeLabel } from "./reportModel"
+import { renderTagChipPdf, deriveTagChipSpec } from "./primitives/tagChip"
 
 const PAD_X = 30
 const PAD_Y = 30
@@ -77,6 +78,13 @@ const s = StyleSheet.create({
   statusInlineTxt: { fontFamily: FONT.uiBold, fontSize: 6, letterSpacing: 0.5, textTransform: "uppercase", color: COLOR.textSubtle, marginLeft: 4 },
   unresolved: { fontFamily: FONT.uiBold, fontSize: 5.5, letterSpacing: 0.4, textTransform: "uppercase", color: COLOR.accentInk, borderWidth: 0.5, borderColor: COLOR.accentInk, borderRadius: 1, paddingHorizontal: 2, marginLeft: 5 },
   note: { fontFamily: FONT.bodyItalic, fontSize: 6.5, color: COLOR.textSecondary, marginTop: 3, paddingLeft: 6, borderLeftWidth: 1, borderLeftColor: COLOR.ruleStrong, lineHeight: 1.4 },
+
+  // tag-chip row (2026-08-17) — LAYOUT only. Every chip METRIC (font, letter
+  // spacing, padding, border, radius, ink) lives in the TagChip primitive's
+  // spec, single-sourced with the DOM recipes; this only owns the row's own
+  // flow/gap and each chip's margin, which are per-host by design.
+  tagRow: { flexDirection: "row", flexWrap: "wrap", gap: 3, marginTop: 4 },
+  tagChipBox: { flexDirection: "row" },
 
   look: { marginTop: 6, borderWidth: 0.5, borderColor: COLOR.rule },
   lookAlt: { marginLeft: 14, borderStyle: "dashed", backgroundColor: COLOR.surfaceSubtle },
@@ -185,14 +193,37 @@ function AdditionalImagesRow({
   )
 }
 
+/** Tag-chip row (2026-08-17): renders nothing when the shot has no chips, so a
+ *  tagless shot's PDF tree is byte-identical toggle on or off. The chips
+ *  themselves come from the shared TagChip primitive, so this row and the DOM
+ *  recipes' rows can't drift on metrics or colour. The wrapping View stays
+ *  SPLITTABLE (no wrap={false}) — a text-only row must flow across pages like
+ *  the rest of the shot block; only fixed-size IMAGE leaves are atomic here
+ *  (see thumbBox / extraThumb). */
+function TagChipRow({ shot }: { readonly shot: ReportShot }): JSX.Element | null {
+  const tags = shot.tags ?? []
+  if (tags.length === 0) return null
+  return (
+    <View style={s.tagRow}>
+      {tags.map((t) => (
+        <View key={t.id} style={s.tagChipBox}>
+          {renderTagChipPdf(deriveTagChipSpec({ label: t.label }))}
+        </View>
+      ))}
+    </View>
+  )
+}
+
 function Row({
   shot,
   imageMap,
   showAdditionalImages,
+  showTags,
 }: {
   readonly shot: ReportShot
   readonly imageMap: ReadonlyMap<string, string>
   readonly showAdditionalImages: boolean
+  readonly showTags: boolean
 }): JSX.Element {
   const flagged = shot.status === "on_hold"
   const st = STATUS[shot.status]
@@ -255,6 +286,7 @@ function Row({
             {shot.gender === "?" ? <Text style={s.unresolved}>Gender ?</Text> : null}
           </View>
         </View>
+        {showTags ? <TagChipRow shot={shot} /> : null}
         {has(shot.notes) ? <Text style={s.note}>{shot.notes}</Text> : null}
         {shot.looks.map((lk) => (
           <LookBlock key={lk.id} look={lk} />
@@ -297,8 +329,11 @@ export function ProductionSheetPdfDocument(props: {
    *  pre-WS-C output — no new element in the tree at all (AdditionalImagesRow
    *  is never invoked, not merely invoked-and-empty). */
   readonly showAdditionalImages?: boolean
+  /** Tag-chip toggle (2026-08-17). Same contract: absent/false renders
+   *  byte-identical to pre-tag-chips output — TagChipRow is never invoked. */
+  readonly showTags?: boolean
 }): JSX.Element {
-  const { model, imageMap, showAdditionalImages = false } = props
+  const { model, imageMap, showAdditionalImages = false, showTags = false } = props
   // Count only printable shots — the rows omit excluded, so the masthead must too.
   const all = model.groups.flatMap((g) => g.shots).filter((x) => !x.excluded)
   const women = all.filter((x) => x.gender === "W").length
@@ -349,7 +384,13 @@ export function ProductionSheetPdfDocument(props: {
             <View key={group.key}>
               <GroupBand group={{ ...group, count: printable.length }} />
               {printable.map((shot) => (
-                <Row key={shot.id} shot={shot} imageMap={imageMap} showAdditionalImages={showAdditionalImages} />
+                <Row
+                  key={shot.id}
+                  shot={shot}
+                  imageMap={imageMap}
+                  showAdditionalImages={showAdditionalImages}
+                  showTags={showTags}
+                />
               ))}
             </View>
           )

--- a/src-vnext/features/export/lib/report/reportTypes.ts
+++ b/src-vnext/features/export/lib/report/reportTypes.ts
@@ -201,6 +201,31 @@ export interface ReportConfig {
    * it when `featureReportConfig` is off.
    */
   readonly showAdditionalImages?: boolean
+  /**
+   * Tag chips on every shot row (2026-08-17, Ted's request: "I want to see the
+   * tags on the shot report export"). Mirrors `showAdditionalImages` above in
+   * every mechanical respect — persisted, default-merged by
+   * `hydrateReportConfig`, cleared by `neutralizeReportConfigForFlag` when
+   * `featureReportConfig` is off — with TWO deliberate differences:
+   *
+   * 1. The shipped DEFAULT is **ON** (`DEFAULT_REPORT_CONFIG.showTags: true`),
+   *    because showing the tags IS the feature. Flag-off byte-identity is
+   *    preserved by `neutralizeReportConfigForFlag` + `resolveShowTags`'s
+   *    `reportConfigEnabled` term, not by the default — see those two.
+   * 2. There is NO per-recipe exclusion (no `reportLayoutSupportsTags`). All
+   *    three recipes carry a synced height/weight term for the row —
+   *    image-led via `estimatePlateHeight`'s TAG_ROW_* terms
+   *    (reportPdfHeights.ts, which drives BOTH the PDF packing and the DOM
+   *    print-preview), production-sheet via `shotWeight`'s `tagRowWeight`, and
+   *    balanced-rows via `buildStream`'s — so, unlike the additional-images
+   *    row, the row is safe on every layout and `resolveShowTags` takes no
+   *    `layout` argument at all.
+   *
+   * ABSENT resolves to ON (`showTags !== false`), matching the shipped default
+   * for a raw/un-hydrated config that never carried the field. Only an explicit
+   * `false` — the control's Off button, or the flag-off neutralizer — hides it.
+   */
+  readonly showTags?: boolean
 }
 
 /** Stable id for the single synthetic filter `resolveReportFilters` folds a
@@ -319,6 +344,10 @@ export const DEFAULT_REPORT_CONFIG: ReportConfig = {
   sortBy: "shot-number",
   sortDir: "asc",
   showAdditionalImages: false,
+  // ON by design (2026-08-17) — see ReportConfig.showTags. Flag-off rollback
+  // safety is carried by neutralizeReportConfigForFlag + resolveShowTags's
+  // reportConfigEnabled term, NOT by this default.
+  showTags: true,
 }
 
 /**
@@ -413,6 +442,14 @@ export function neutralizeReportConfigForFlag(config: ReportConfig, flagOn: bool
     // featureReportConfig was ON could carry showAdditionalImages:true, and
     // with the control hidden the user has no way to clear it themselves.
     showAdditionalImages: false,
+    // Same class again, but load-bearing in a way the line above is not:
+    // showTags DEFAULTS TO TRUE (and an ABSENT showTags resolves to ON), so
+    // without this explicit `false` a featureReportConfig rollback would render
+    // tag chips on every shot row of every recipe — i.e. flag-off would NOT be
+    // byte-identical to the pre-tag-chips report. This is the write that makes
+    // a default-ON feature safe to roll back. See resolveShowTags below for the
+    // second, independent gate.
+    showTags: false,
   }
 }
 
@@ -448,6 +485,29 @@ export function resolveShowAdditionalImages(
     config.showAdditionalImages === true &&
     reportLayoutSupportsAdditionalImages(layout)
   )
+}
+
+/**
+ * The tag chips actually rendered on a shot row. Single source for ReportView's
+ * screen render (all three recipes) and ShotReportPage's PDF export, so the two
+ * can't drift — mirrors `resolveShowAdditionalImages`'s role for the extras row
+ * and `resolveReportLayout`'s for `layout`.
+ *
+ * Deliberately takes NO `layout` argument: every recipe carries a synced
+ * height/weight term for the tag row (see ReportConfig.showTags), so unlike the
+ * additional-images row there is no per-recipe exclusion to enforce. Adding a
+ * dead parameter would imply a constraint that does not exist.
+ *
+ * ABSENT (`undefined`) resolves to ON — the shipped default is `true`, and a
+ * raw/un-hydrated config that never carried the field should render what a
+ * brand-new report renders. Only an explicit `false` hides the row. The
+ * `reportConfigEnabled` term is the flag-off gate: it makes a
+ * `featureReportConfig` rollback byte-identical to the pre-tag-chips report
+ * even for a config object that was never run through
+ * `neutralizeReportConfigForFlag`.
+ */
+export function resolveShowTags(config: ReportConfig, reportConfigEnabled: boolean): boolean {
+  return reportConfigEnabled && config.showTags !== false
 }
 
 /** Normalized gender bucket. "?" = unresolved (never silently dropped). */
@@ -487,6 +547,23 @@ export interface ReportTalent {
 }
 
 export type ReportShotStatus = "complete" | "todo" | "in_progress" | "on_hold"
+
+/**
+ * One resolved tag chip on a shot row. Presentation-free: `label` is what the
+ * chip prints, `category` is what ordered it (and what excluded the gender
+ * tags upstream). `ShotTag.color` is deliberately NOT carried — it is a
+ * Tailwind class key with no hex behind it, and the report keeps a reserved
+ * palette (see the TagChip primitive's docstring).
+ *
+ * `category` is typed as a plain `string` rather than `ShotTagCategory` so the
+ * report model layer stays free of the shot-domain union — every reader treats
+ * it as an opaque ordering/filtering key.
+ */
+export interface ReportShotTag {
+  readonly id: string
+  readonly label: string
+  readonly category?: string
+}
 
 export interface ReportShot {
   readonly id: string
@@ -535,6 +612,25 @@ export interface ReportShot {
    * references.
    */
   readonly additionalImages?: readonly string[]
+  /**
+   * Tag chips for this shot's row (2026-08-17). The DISPLAY-READY list, not the
+   * raw `Shot.tags` — exactly the same "the model owns the derive rule, the
+   * config only gates whether a recipe RENDERS it" split `additionalImages`
+   * above uses. `resolveReportTagChips` (reportModel.ts) is the single source:
+   * it canonicalizes + de-dupes through the shared `tagDedup` helpers, DROPS
+   * every `category: "gender"` tag (gender already prints as its own
+   * badge/chip and, under `groupBy: "gender"`, as the group head — a chip would
+   * be a third statement of the same fact), and sorts media -> priority ->
+   * other, alphabetical within.
+   *
+   * ALWAYS computed by deriveShotReportModel (cheap, pure) regardless of
+   * `ReportConfig.showTags`, so the model never has a flag-shaped hole in it.
+   * OPTIONAL so every pre-existing hand-built ReportShot fixture (the PDF
+   * pagination, style-token and overflow-gate suites) keeps compiling
+   * unchanged — every reader treats an absent value as `[]` ("no tags"),
+   * matching a shot that carries none.
+   */
+  readonly tags?: readonly ReportShotTag[]
 }
 
 export interface ReportGroup {


### PR DESCRIPTION
## What / why

Ted asked today to **see the shot tags on the Comprehensive Shot Report export**. Every shot row now prints its tags as small neutral chips — on screen and in the exported PDF, on all three recipes — behind a persisted **"Tag chips" Off/On** control in the report ControlBar.

**Default is ON.** Showing the tags is the point of the feature, so `DEFAULT_REPORT_CONFIG.showTags: true` and an *absent* `showTags` resolves to ON. Rollback safety is carried by two independent gates instead of by the default (see below), so a `featureReportConfig` rollback is still byte-identical to the pre-tag-chips report.

## TagChip — the 7th canonical report primitive

Built to `primitives/BUILD-SPEC.md`: one spec interface + a pure `deriveTagChipSpec()` + a DOM adapter + an `@react-pdf` adapter presenting the SAME spec + a two-layer parity test. Unlike the Phase-2 six it lands **adopted** — all six render sites consume it, so screen and PDF cannot drift on a chip's metrics or its colour.

- `src-vnext/features/export/lib/report/primitives/tagChip.tsx` — spec + tokens + deriver + `renderTagChipPdf`
- `src-vnext/features/export/components/report/primitives/TagChip.tsx` — `renderTagChipDom` + `TagChipView`
- `src-vnext/features/export/lib/report/primitives/__tests__/tagChip.parity.test.tsx` — Layer 1 spec snapshot + Layer 2 cross-renderer parity

**Neutral chips, not per-tag colours.** `ShotTag.color` is a Tailwind class key with no hex table behind it, and the report keeps a reserved palette in which red has exactly one job per recipe (image-led's shot number / production-sheet's hold flag / balanced-rows' hero mark). The chip therefore borrows the shipped **gender-chip** treatment — thin `rule-strong` border, `ink-2` uppercase label, 9px DOM / 5.5pt PDF. The app's Tailwind `TagBadge.tsx` is deliberately **not** imported into the report.

## The six render sites

| Recipe | Screen | PDF |
|---|---|---|
| image-led | `ReportView.tsx` → `PlateCaption` (after the status/talent row) | `reportPdf.tsx` → `Plate` |
| production-sheet | `ProductionSheetReport.tsx` → `ShotRow` (after `sb-ps-ident`) | `reportPdfProductionSheet.tsx` → `Row` |
| balanced-rows | `BalancedRowsReport.tsx` → `Band` (after the panel head) | `reportPdfBalancedRows.tsx` → `Band` |

Each site renders a local `TagChipRow` that returns `null` when the shot has no chips, so a tagless shot's markup / PDF tree is byte-identical whether the toggle is on or off.

## Model

`ReportShot` gains an **optional** `tags?: readonly ReportShotTag[]` (optional so every hand-built fixture in the PDF-pagination, style-token and overflow-gate suites keeps compiling). It is populated in `deriveShotReportModel`'s built-map by the new pure, exported `resolveReportTagChips`:

1. de-duped + canonicalized through the **shared `tagDedup` helpers** (not a local re-implementation),
2. every `category: "gender"` tag **dropped** — gender already prints as its own badge/chip and, under `groupBy: "gender"`, as the group head; a chip would be a third statement of the same fact,
3. sorted **media → priority → other**, alphabetical (numeric-aware) within.

Always computed regardless of the toggle, so the model has no flag-shaped hole — same split `additionalImages` already uses. The filter engine and `computeUsedTagOptions` are untouched.

## Config + the two rollback gates

`ReportConfig.showTags` mirrors `showAdditionalImages` mechanically (persisted, default-merged by `hydrateReportConfig`, cleared by `neutralizeReportConfigForFlag`) with two deliberate differences:

1. **Default TRUE.** Because an absent `showTags` resolves ON, the neutralizer's explicit `showTags: false` write is genuinely load-bearing — without it a `featureReportConfig` rollback would render chips on every row. `resolveShowTags` carries a **second, independent** `reportConfigEnabled` gate so a config object that never went through the neutralizer is still safe. Both are asserted, and both are mutation-proofed.
2. **No per-recipe exclusion.** Every recipe carries a synced height/weight term for the row, so there is no `reportLayoutSupportsTags` and `resolveShowTags(config, reportConfigEnabled)` takes **no `layout` argument** — a dead parameter would imply a constraint that doesn't exist. (`showAdditionalImages` still excludes image-led; a test asserts the two resolvers really do differ, so that claim isn't a tautology.)

One resolver feeds **both** `ReportView`'s screen render and `ShotReportPage`'s `handleExportPdf`, so screen and PDF cannot drift.

The control is a segmented Off/On block with `aria-pressed`, mirroring the Extra images block, persisted through the existing debounced `saveReportConfig` path. Unlike Extra images it is **never disabled** and is **not hidden when `featureShotReportRecipes` is off** — image-led renders the row and carries its own height term, so there is no dead end to guard against.

## Heights / pagination — the danger zone

Every estimator gets a term, each **conditional** (`0` for a shot with no chips, skipped entirely when the toggle is off) so the OFF path paginates byte-identically to before:

- **image-led** — `estimateTagRowHeight` + a term in `estimatePlateHeight(shot, showTags)`; `packShotSheets(model, showTags)` threads it. This module drives **both** the real PDF packing and the DOM print preview's WYSIWYG packing, so a rendered row with no term here would desync the two *and* silently push a plate past `COL_MAX` (Column/plate are `wrap={false}`).
- **production-sheet** — `tagRowWeight` + a term in `shotWeight(shot, showAdditionalImages, showTags)`. `.sb-ps-page` is a fixed-height `overflow: hidden` sheet, so under-charging clips with no marker.
- **balanced-rows** — `tagRowWeight` + a term in `buildStream`.

Both DOM weights **scale with chip count** (lines, not a flat per-shot bump) and are calibrated against the shipped CSS with a stated derivation and a safety margin.

`packShotSheets` uses `visible.map((s) => estimatePlateHeight(s, showTags))`, **not** `visible.map(estimatePlateHeight)` — the latter would pass `Array#map`'s **index** as `showTags` and measure every shot after the first as if tags were on. That trap has its own mutation-proofed test.

## Gate coverage

`reportRecipeOverflow.test.tsx` (real `@react-pdf` `renderToBuffer`) is **extended, not merely re-run**:

- `BOUNDARY_TAGS` added to `boundaryShot` and `denseMultiPageShot`, so every existing fixture now carries tags. Existing cases still render with the toggle off, so their pinned page-count bounds are unaffected — and the "OFF is byte-identical" case proves that claim rather than assuming it.
- New `showTags: ON` cases on both recipes: the 50-product "Everything Shot" + tags, plus a **tag-row-only stress fixture at 1200 chips**. 1200 was *measured*, not guessed: 400 chips only reaches 2 pages (~0.6 of a page of tag row), which would have made "the row flows across pages" nearly unfalsifiable. 1200 pages at **4** on both recipes against a 1-page toggle-off baseline, and a dedicated case pins that premise so a future change that shrinks the row can't quietly make these vacuous.
- The full WS-C-1 **containment + per-band size-count** image scan re-run at 12/16/20/26 shots with **extras ON *and* tags ON** — the row moves where page breaks fall, which is exactly the condition that produced the original straddle/shrink defects.
- **image-led PDF is now covered at all** (WS-C excluded it): chip labels present with the toggle on and absent with it off (extracted from the real content stream), OFF paginates identically with/without tags, and a chip-heavy plate costs real pages with it on.

`reportRecipeStyleTokenSpacing.test.tsx` re-run: 6/6 pass, no diff.

## Test evidence

| | before | after |
|---|---|---|
| test files | 350 passed, 1 skipped | **353 passed, 1 skipped** |
| tests | 4,664 passed, 115 skipped | **4,765 passed, 115 skipped** |

`npm run typecheck:baseline` → ✅ no new type errors (161/161 baselined). `eslint src-vnext --max-warnings=0` → clean.

### Mutation reds (all performed, all reverted)

| # | Mutation | Result |
|---|---|---|
| 1 | Remove the chip render from `ProductionSheetReport`'s `ShotRow` | **3 red** — `ON + production-sheet renders one chip per model tag`, `production-sheet: a gender-category tag never reaches a chip`, `the chip is NEUTRAL…` |
| 2 | Remove `showTags: false` from `neutralizeReportConfigForFlag` | **3 red** — both `neutralize…forces showTags to FALSE` cases (incl. the ABSENT-field one) + `the flag-off neutralizer and the flag-off resolver agree` |
| 3 | Remove the tag term from `estimatePlateHeight` | **4 red** — `charges the row when showTags is on…`, `charges MORE for more chips`, `a plate that fits WITHOUT chips can be forced to solo WITH them`, `EVERY shot is measured with the same showTags value` |
| 4 | `packShotSheets` → `visible.map(estimatePlateHeight)` (index leaks into `showTags`) | **2 red** — `a plate that fits WITHOUT chips…`, `EVERY shot is measured with the same showTags value (Array#map's index arg must not leak into it)` |
| 5 | Remove the gender-category `continue` from `resolveReportTagChips` | **6 red** across `resolveReportTagChips` + `deriveShotReportModel — ReportShot.tags is threaded from the raw shot` |
| 6 | Drop the `reportConfigEnabled` gate from `resolveShowTags` | **3 red** — incl. `ReportView — Tag chips, featureReportConfig OFF (rollback safety)`, which also proves that test's flag override really applies |
| 7 | Add `wrap={false}` to `TagChipRow`'s container in **both** PDF recipes | **3 red** in the real-render gate — both `tag row ALONE (1200 chips…) still FLOWS` cases + the threshold check. This is the claim the code comment makes, verified rather than asserted. |
| 8 | Remove the chip render from `ReportView` (image-led) **and** `BalancedRowsReport` | **5 red** — both layouts' render + gender cases, plus `image-led actually PRINTS the chips with recipes off` |
| 9 | Remove the chip render from `reportPdf.tsx`'s `Plate` (image-led PDF) | **1 red** — `renders the chip labels with showTags ON and none of them with it OFF` |

Mutations 1, 8 and 9 together cover all six render sites; 3, 4 and 7 cover the pagination/flow story; 2 and 6 cover the default-ON rollback story.

## Notes / deviations

- **Default-ON was achieved as briefed** — no fallback to default-false was needed. The flag-off byte-identity test (`reportRecipeFlagOffCallSites.test.tsx`) stays green, and the stronger claim (no chips render under a `featureReportConfig` rollback) is covered by mutations 2 and 6.
- The feature is live wherever `VITE_REPORT_CONFIG=1` — which `deploy-live.yml` already sets — so this reaches Ted on the next deploy. It stays dark in a local dev build with no env vars, exactly like the Filters and Extra-images controls it sits beside.
- Scope is shot reports only; the talent and product-info reports are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CsLFz3UMqXjurKKGoiz8Zg
